### PR TITLE
nix: Fix result script to add socket-path option

### DIFF
--- a/nix/nixos/cardano-node-options.nix
+++ b/nix/nixos/cardano-node-options.nix
@@ -18,6 +18,7 @@ in {
             --genesis-hash ${cfg.genesisHash} \
             --log-config ${cfg.logger.configFile} \
             --database-path ${cfg.stateDir}/${cfg.dbPrefix} \
+            --socket-path ${cfg.stateDir}/node.socket \
             node \
             --topology ${cfg.topology} \
             --${cfg.consensusProtocol} \


### PR DESCRIPTION
Put it in `state-node-mainnet` directory along with the block DB.