### PR TITLE
trace-dispatcher: active/passive mode.

### DIFF
--- a/trace-dispatcher/examples/Examples/Configuration.hs
+++ b/trace-dispatcher/examples/Examples/Configuration.hs
@@ -46,6 +46,7 @@ config1 = TraceConfig {
           , (["tracer2","bubble"], [ConfSeverity (SeverityF (Just Info))])
           ]
     , tcForwarder = LocalSocket "forwarder.log"
+    , tcForwarderMode = Responder
     , tcForwarderQueueSize = 100
     , tcNodeName = Nothing
     }
@@ -58,6 +59,7 @@ config2 = TraceConfig {
         , (["tracer2","bubble"], [ConfSeverity (SeverityF (Just Debug))])
         ]
     , tcForwarder = LocalSocket "forwarder.log"
+    , tcForwarderMode = Responder
     , tcForwarderQueueSize = 100
     , tcNodeName = Just "node-1"
     }

--- a/trace-dispatcher/src/Cardano/Logging/Configuration.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Configuration.hs
@@ -362,7 +362,7 @@ parseRepresentation bs = transform (decodeEither' bs)
     transform (Left e)   = Left e
     transform (Right rl) = Right $ transform' emptyTraceConfig rl
     transform' :: TraceConfig -> ConfigRepresentation -> TraceConfig
-    transform' (TraceConfig tc _fc _fcc _) cr =
+    transform' (TraceConfig tc _fc _fcc _ _) cr =
       let tc'  = foldl' (\ tci (TraceOptionSeverity ns severity') ->
                           let ns' = split (=='.') ns
                               ns'' = if ns' == [""] then [] else ns'
@@ -390,6 +390,7 @@ parseRepresentation bs = transform (decodeEither' bs)
       in TraceConfig
           tc''''
           (traceOptionForwarder cr)
+          (traceOptionForwarderMode cr)
           (traceOptionForwardQueueSize cr)
           (traceOptionNodeName cr)
 
@@ -463,6 +464,7 @@ data ConfigRepresentation = ConfigRepresentation {
   , traceOptionBackend          :: [TraceOptionBackend]
   , traceOptionLimiter          :: [TraceOptionLimiter]
   , traceOptionForwarder        :: ForwarderAddr
+  , traceOptionForwarderMode    :: ForwarderMode
   , traceOptionForwardQueueSize :: Int
   , traceOptionNodeName         :: Maybe Text
   }
@@ -475,5 +477,6 @@ instance AE.FromJSON ConfigRepresentation where
                            <*> obj .: "TraceOptionBackend"
                            <*> obj .: "TraceOptionLimiter"
                            <*> obj .: "TraceOptionForwarder"
+                           <*> obj .: "TraceOptionForwarderMode"
                            <*> obj .: "TraceOptionForwardQueueSize"
                            <*> obj .:? "TraceOptionNodeName"


### PR DESCRIPTION
Now `trace-dispatcher` can _initiates_ connection with `cardano-tracer` or _accepts_ connection from `cardano-tracer`. So now we have two scenarios:

1. passive node <--- active tracer 
2. active node ---> passive tracer