### PR TITLE
Changes for single relay P2P release.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -197,8 +197,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: f49879a79098d9372d63baa13b94a941a56eda34
-  --sha256: 0i9x66yqkrvx2w79dy6lzlya82yxc8567rgjj828vc2d46d6nvx6
+  tag: 389b266d6226dedf3d2aec7af640b3ca4984c5ea
+  --sha256: 0i9zirl5pll9bwfp3l1zy8lhivmfmm8jpaprfx5jdjcnyha3ixrx
   subdir:
     eras/alonzo/impl
     eras/alonzo/test-suite
@@ -227,7 +227,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 6ea36cf2247ac0bc33e08c327abec34dfd05bd99
+  tag: 533aec85c1ca05c7d171da44b89341fb736ecfe5
   --sha256: 0z2y3wzppc12bpn9bl48776ms3nszw8j58xfsdxf97nzjgrmd62g
   subdir:
     cardano-prelude
@@ -263,8 +263,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: c764553561bed8978d2c6753d1608dc65449617a
-  --sha256: 0hdh7xdrvxw943r6qr0xr4kwszindh5mnsn1lww6qdnxnmn7wcsc
+  tag: e975b9b4d122b25e1ee5b39122796eacf90104be
+  --sha256: 1gvd8agjpa6zxcmq8i293vzww66gka8594hijyaw02q8lrny1c45
   subdir:
     monoidal-synchronisation
     network-mux
@@ -300,8 +300,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/plutus
-  tag: f680ac6979e069fcc013e4389ee607ff5fa6672f
-  --sha256: 180jq8hd0jlg48ya7b5yw3bnd2d5czy0b1agy9ng3mgnzpyq747i
+  tag: 8ab4c3355c5fdf67dcf6acc1f5a14668d5e6f0a9
+  --sha256: 12d6bndmj0dxl6xlaqmf78326yp5hw093bmybmqfpdkvk4mgz03j
   subdir:
     plutus-core
     plutus-ledger-api

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -488,11 +488,7 @@ handleSimpleNode runP p2pMode tracers nc onKernel = do
   logStartupWarnings = do
     (case p2pMode of
       DisabledP2PMode -> return ()
-      EnabledP2PMode  -> do
-        traceWith (startupTracer tracers) P2PWarning
-        when (not $ ncTestEnableDevelopmentNetworkProtocols nc)
-          $ traceWith (startupTracer tracers)
-                      P2PWarningDevelopementNetworkProtocols
+      EnabledP2PMode  -> traceWith (startupTracer tracers) P2PWarning
       ) :: IO () -- annoying, but unavoidable for GADT type inference
 
     let developmentNtnVersions =

--- a/cardano-node/src/Cardano/Node/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Startup.hs
@@ -97,11 +97,6 @@ data StartupTrace blk =
   -- | Warn when 'EnableP2P' is set.
   | P2PWarning
 
-  -- | Warn that peer-to-peer requires
-  -- 'TestEnableDevelopmentNetworkProtocols' to be set.
-  --
-  | P2PWarningDevelopementNetworkProtocols
-
   -- | Warn when 'TestEnableDevelopmentNetworkProtocols' is set.
   --
   | WarningDevelopmentNetworkProtocols [NodeToNodeVersion] [NodeToClientVersion]

--- a/cardano-node/src/Cardano/Node/Tracing/StateRep.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/StateRep.hs
@@ -92,7 +92,6 @@ data StartupState
   | NetworkConfigUpdate
   | NetworkConfigUpdateError Text
   | P2PWarning
-  | P2PWarningDevelopementNetworkProtocols
   | WarningDevelopmentNetworkProtocols [NPV.NodeToNodeVersion] [NPV.NodeToClientVersion]
   deriving (Generic, FromJSON, ToJSON)
 
@@ -228,10 +227,6 @@ traceNodeStateStartup tr ev =
       traceWith tr $ NodeStartup $ NetworkConfigUpdateError e
     Startup.P2PWarning ->
       traceWith tr $ NodeStartup P2PWarning
-    Startup.P2PWarningDevelopementNetworkProtocols ->
-      traceWith tr $ NodeStartup P2PWarningDevelopementNetworkProtocols
-    Startup.WarningDevelopmentNetworkProtocols n2ns n2cs ->
-      traceWith tr $ NodeStartup $ WarningDevelopmentNetworkProtocols n2ns n2cs
     _ -> return ()
 
 traceNodeStateShutdown

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
@@ -351,8 +351,8 @@ ppStartupInfoTrace (BICommon BasicInfoCommon {..}) =
 
 p2pWarningMessage :: Text
 p2pWarningMessage =
-      "unsupported and unverified version of "
-   <> "`cardano-node` with peer-to-peer networking capabilities"
+      "You are using an early release of peer-to-peer capabilities, "
+   <> "please report any issues."
 
 
 docStartupInfo :: Documented (StartupTrace blk)

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
@@ -134,7 +134,6 @@ namesStartupInfo = \case
   NetworkConfigUpdateError {}               -> ["NetworkConfigUpdateError"]
   NetworkConfig {}                          -> ["NetworkConfig"]
   P2PWarning {}                             -> ["P2PWarning"]
-  P2PWarningDevelopementNetworkProtocols {} -> ["P2PWarningDevelopementNetworkProtocols"]
   WarningDevelopmentNetworkProtocols {}     -> ["WarningDevelopmentNetworkProtocols"]
   BICommon {}                               -> ["Common"]
   BIShelley {}                              -> ["ShelleyBased"]
@@ -215,9 +214,6 @@ instance ( Show (BlockNodeToNodeVersion blk)
   forMachine _dtal P2PWarning =
       mconcat [ "kind" .= String "P2PWarning"
                , "message" .= String p2pWarningMessage ]
-  forMachine _dtal P2PWarningDevelopementNetworkProtocols =
-      mconcat [ "kind" .= String "P2PWarningDevelopementNetworkProtocols"
-               , "message" .= String p2pWarningDevelopmentNetworkProtocolsMessage ]
   forMachine _ver (WarningDevelopmentNetworkProtocols ntnVersions ntcVersions) =
       mconcat [ "kind" .= String "WarningDevelopmentNetworkProtocols"
                , "message" .= String "enabled development network protocols"
@@ -322,9 +318,6 @@ ppStartupInfoTrace (NetworkConfig localRoots publicRoots useLedgerAfter) =
 
 ppStartupInfoTrace P2PWarning = p2pWarningMessage
 
-ppStartupInfoTrace P2PWarningDevelopementNetworkProtocols =
-    p2pWarningDevelopmentNetworkProtocolsMessage
-
 ppStartupInfoTrace (WarningDevelopmentNetworkProtocols ntnVersions ntcVersions) =
      "enabled development network protocols: "
   <> showT ntnVersions
@@ -360,10 +353,6 @@ p2pWarningMessage :: Text
 p2pWarningMessage =
       "unsupported and unverified version of "
    <> "`cardano-node` with peer-to-peer networking capabilities"
-
-p2pWarningDevelopmentNetworkProtocolsMessage :: Text
-p2pWarningDevelopmentNetworkProtocolsMessage =
-    "peer-to-peer requires TestEnableDevelopmentNetworkProtocols to be set to True"
 
 
 docStartupInfo :: Documented (StartupTrace blk)

--- a/cardano-node/src/Cardano/Tracing/Startup.hs
+++ b/cardano-node/src/Cardano/Tracing/Startup.hs
@@ -29,7 +29,6 @@ instance HasSeverityAnnotation (StartupTrace blk) where
     getSeverityAnnotation (NetworkConfigUpdateError _) = Error
     getSeverityAnnotation NetworkConfigUpdateUnsupported = Warning
     getSeverityAnnotation P2PWarning = Warning
-    getSeverityAnnotation P2PWarningDevelopementNetworkProtocols = Warning
     getSeverityAnnotation WarningDevelopmentNetworkProtocols {} = Warning
     getSeverityAnnotation _ = Info
 

--- a/doc/getting-started/understanding-config-files.md
+++ b/doc/getting-started/understanding-config-files.md
@@ -19,7 +19,8 @@ Tells your node to which nodes in the network it should talk to. A minimal versi
 
 * `valency` tells the node how many connections your node should have. It only has an effect for dns addresses. If a dns address is given, valency governs to how many resolved ip addresses should we maintain active (hot) connection; for ip addresses, valency is used as a Boolean value, where `0` means to ignore the address.
 
-Your __block-producing__ node must __ONLY__ talk to your __relay nodes__, and the relay node should talk to other relay nodes in the network. Go to our telegram channel to find out IP addresses and ports of peers.
+Your __block-producing__ node must __ONLY__ talk to your __relay nodes__, and
+the relay node should talk to other relay nodes in the network.
 
 #### The P2P topology.json file
 
@@ -101,6 +102,17 @@ You __can__ tell the node that the topology configuration file changed by sendin
 signal to the `cardano-node` process, e.g. `pkill -HUP cardano-node`. After receiving the
 signal, `cardano-node` will re-read the file and restart all dns resolution. Please
 **note** that this only applies to the topology configuration file!
+
+If you are synchronizing the network for the first time, please connect to IOG
+relays `relays.cardano-node.iohk.io` by adding it to your local root peers and
+set `useLedgerAfterSlot` to `0` (to disable ledger peers).   You can use
+different relays as long as you trust them to provide you the honest chain.
+When the node is synced, you can remove it from the local root peers, you
+should also manually check if other stake pool relays are on the same chain as
+you are.  Once you enabled ledger peers by setting `useLedgerAfterSlot` the
+node will connect to relays registered on the chain, and churn through them by
+randomly picking new peers (weighted by stake distribution) and forgetting 20%
+least performing ones.
 
 #### The genesis.json file
 


### PR DESCRIPTION
Requires:

* [x] input-output-hk/ouroboros-network#3859 to be merged
* [x] input-output-hk/ouroboros-network#3891 to be merged
* [x] update `ouroboros-network` hash once the above PRs are merged

- Removed P2PWarningDevelopmentNetworkProtocols
- Modify P2PWarning message
- Updated ouroboros-network dependency
