### PR TITLE
Add possibility to query local node to load protocol parameters - `transaction build`

### DIFF
--- a/cardano-api/src/Cardano/Api/Modes.hs
+++ b/cardano-api/src/Cardano/Api/Modes.hs
@@ -50,6 +50,7 @@ import           Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON), Value)
 import           Data.Aeson.Types (Parser, prependFailure, typeMismatch)
 import           Data.SOP.Strict (K (K), NS (S, Z))
 import           Data.Text (Text)
+import           Data.Type.Equality (TestEquality (..), (:~:) (Refl))
 
 import qualified Ouroboros.Consensus.Byron.Ledger as Consensus
 import qualified Ouroboros.Consensus.Cardano.Block as Consensus
@@ -98,6 +99,12 @@ data AnyConsensusModeParams where
   AnyConsensusModeParams :: ConsensusModeParams mode -> AnyConsensusModeParams
 
 deriving instance Show AnyConsensusModeParams
+instance Eq AnyConsensusModeParams where
+  (AnyConsensusModeParams cmp1) == (AnyConsensusModeParams cmp2) =
+    case testEquality cmp1 cmp2 of
+      Just Refl -> cmp1 == cmp2
+      Nothing -> False
+
 
 -- | This GADT provides a value-level representation of all the consensus modes.
 -- This enables pattern matching on the era to allow them to be treated in a
@@ -298,6 +305,13 @@ data ConsensusModeParams mode where
        -> ConsensusModeParams CardanoMode
 
 deriving instance Show (ConsensusModeParams mode)
+deriving instance Eq (ConsensusModeParams mode)
+
+instance TestEquality ConsensusModeParams where
+  testEquality (ByronModeParams _) (ByronModeParams _)     = Just Refl
+  testEquality ShelleyModeParams ShelleyModeParams         = Just Refl
+  testEquality (CardanoModeParams _) (CardanoModeParams _) = Just Refl
+  testEquality _ _                                         = Nothing
 
 -- ----------------------------------------------------------------------------
 -- Consensus conversion functions

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -30,6 +30,7 @@ module Cardano.CLI.Shelley.Commands
   , SomeKeyFile (..)
   , OpCertCounterFile (..)
   , OutputFile (..)
+  , ProtocolParamsSource (..)
   , ProtocolParamsFile (..)
   , WitnessFile (..)
   , TxFile (..)
@@ -185,7 +186,7 @@ data TransactionCmd
       [ScriptFile]
       -- ^ Auxiliary scripts
       [MetadataFile]
-      (Maybe ProtocolParamsFile)
+      (Maybe ProtocolParamsSource)
       (Maybe UpdateProposalFile)
       TxBodyFile
 
@@ -227,7 +228,7 @@ data TransactionCmd
       [ScriptFile]
       -- ^ Auxiliary scripts
       [MetadataFile]
-      (Maybe ProtocolParamsFile)
+      (Maybe ProtocolParamsSource)
       (Maybe UpdateProposalFile)
       TxBuildOutputOptions
   | TxSign InputTxBodyOrTxFile [WitnessSigningData] (Maybe NetworkId) TxFile
@@ -238,14 +239,14 @@ data TransactionCmd
   | TxCalculateMinFee
       TxBodyFile
       (Maybe NetworkId)
-      ProtocolParamsFile
+      ProtocolParamsSource
       TxInCount
       TxOutCount
       TxShelleyWitnessCount
       TxByronWitnessCount
   | TxCalculateMinRequiredUTxO
       AnyCardanoEra
-      ProtocolParamsFile
+      ProtocolParamsSource
       TxOutAnyEra
   | TxHashScriptData
       ScriptDataOrFile
@@ -469,6 +470,11 @@ renderGenesisCmd cmd =
 -- Shelley CLI flag/option data types
 --
 
+data ProtocolParamsSource
+  = ProtocolParamsFromFile !ProtocolParamsFile
+  | ProtocolParamsQueryNode !NetworkId !AnyConsensusModeParams
+  deriving (Show, Eq)
+
 newtype ProtocolParamsFile
   = ProtocolParamsFile FilePath
   deriving (Show, Eq)
@@ -497,8 +503,8 @@ newtype GenesisKeyFile
   = GenesisKeyFile FilePath
   deriving Show
 
-data MetadataFile = MetadataFileJSON FilePath
-                  | MetadataFileCBOR FilePath
+data MetadataFile = MetadataFileJSON !FilePath
+                  | MetadataFileCBOR !FilePath
 
   deriving Show
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -1462,15 +1462,24 @@ pAddressKeyType =
   <|>
     pure AddressKeyShelley
 
+pProtocolParamsSource :: Parser ProtocolParamsSource
+pProtocolParamsSource =
+  asum [ pProtocolParamsFile
+       , Opt.flag' ProtocolParamsQueryNode $ mconcat
+         [ Opt.long "protocol-params-node"
+         , Opt.help "Retrieve protocol parameters using local node."
+         ]
+       ]
+
 pProtocolParamsFile :: Parser ProtocolParamsFile
 pProtocolParamsFile =
   ProtocolParamsFile <$>
-    Opt.strOption
-      (  Opt.long "protocol-params-file"
-      <> Opt.metavar "FILE"
-      <> Opt.help "Filepath of the JSON-encoded protocol parameters file"
-      <> Opt.completer (Opt.bashCompleter "file")
-      )
+    (Opt.strOption . mconcat)
+      [ Opt.long "protocol-params-file"
+      , Opt.metavar "FILE"
+      , Opt.help "Filepath of the JSON-encoded protocol parameters file"
+      , Opt.completer (Opt.bashCompleter "file")
+      ]
 
 pCalculatePlutusScriptCost :: Parser TxBuildOutputOptions
 pCalculatePlutusScriptCost =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
@@ -1374,10 +1374,11 @@ renderProtocolParamsError (ProtocolParamsErrorJSON fp jsonErr) =
 
 --TODO: eliminate this and get only the necessary params, and get them in a more
 -- helpful way rather than requiring them as a local file.
-readProtocolParameters :: ProtocolParamsFile
+readProtocolParameters :: ProtocolParamsSource
                        -> ExceptT ProtocolParamsError IO ProtocolParameters
 readProtocolParameters (ProtocolParamsFile fpath) = do
   pparams <- handleIOExceptT (ProtocolParamsErrorFile . FileIOError fpath) $ LBS.readFile fpath
   firstExceptT (ProtocolParamsErrorJSON fpath . Text.pack) . hoistEither $
     Aeson.eitherDecode' pparams
+readProtocolParameters (ProtocolParamsQueryNode _ _) = undefined
 


### PR DESCRIPTION
This PR adds possibility to query local node for protocol parameters for `transaction build` command. This is a first part of implementation for #5052.