### PR TITLE
Update understanding-config-files.md

### DIFF
--- a/doc/getting-started/understanding-config-files.md
+++ b/doc/getting-started/understanding-config-files.md
@@ -217,7 +217,6 @@ Here is a brief description of each parameter. You can learn more in the [spec](
 | updateQuorum | Determines the quorum needed for votes on the protocol parameter updates |
 | initialFunds | Mapping address to values |
 | maxLovelaceSupply | The total number of lovelace in the system, used in the reward calculation. |
-| networkMagic | To identify the testnet |
 | epochLength | Number of slots in an epoch. |
 | staking | Initial delegation |
 | slotsPerKESPeriod | Number of slots in an KES period |


### PR DESCRIPTION
duplicate line (missing an s)

# Description

Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` for to get the `hlint` version
- [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` for to get the `stylish-haskell` version
- [ ] Self-reviewed the diff
