### PR TITLE
UTxO-HD for node 8.2.1-pre

### DIFF
--- a/.github/workflows/haskell-linux.yml
+++ b/.github/workflows/haskell-linux.yml
@@ -83,6 +83,7 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install libsodium23 libsodium-dev
         sudo apt-get -y install libsystemd0 libsystemd-dev
+        sudo apt-get -y install liblmdb-dev
         sudo apt-get -y remove --purge software-properties-common
         sudo apt-get -y autoremove
 

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -72,6 +72,7 @@ jobs:
           mingw-w64-x86_64-pkg-config
           mingw-w64-x86_64-libsodium
           mingw-w64-x86_64-openssl
+          mingw-w64-x86_64-lmdb
           base-devel
           autoconf-wrapper
           autoconf
@@ -94,7 +95,8 @@ jobs:
     - name: "MAC: Install build environment (brew)"
       if: runner.os == 'macOS'
       run: |
-        brew install libsodium
+        brew install libsodium pkg-config lmdb
+        sudo cp ./.github/workflows/lmdb.pc /usr/local/lib/pkgconfig
 
     - name: "MAC: Install build environment (for secp256k1)"
       if: runner.os == 'macOS'

--- a/.github/workflows/lmdb.pc
+++ b/.github/workflows/lmdb.pc
@@ -1,0 +1,11 @@
+prefix=/usr/local
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${exec_prefix}/include
+
+Name: liblmdb
+Description: Lightning Memory-Mapped Database
+URL: https://symas.com/products/lightning-memory-mapped-database/
+Version: 0.9.29
+Libs: -L${libdir} -llmdb
+Cflags: -I${includedir}

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ stack.yaml.lock
 /db
 /db-[0-9]
 /logs
-/mainnet
+/mainnet*
 /profile
 /launch_*
 /state-*

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,7 @@
 /cabal.project.old
 configuration/defaults/simpleview/genesis/
 configuration/defaults/liveview/genesis/
-dist-newstyle/
-dist-profiled/
+dist-*
 dist/
 *~
 \#*

--- a/cabal.project
+++ b/cabal.project
@@ -67,8 +67,8 @@ if impl(ghc >= 9.6)
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-consensus
-  tag: 54105aac98596d94be805d608a60294d74e2c710
-  --sha256: 1ijfrg3161w8fzd4aqsvp2jdx0vcbbdl7h6v38h8r4ifg151384p
+  tag: b081836c84301167d2e5038ecf92fdb6a8408c06
+  --sha256: 04cpvyl0l9gqczw4f3wpl50gmwihhiqpvfpf1q9x0gjy66gcx4my
   subdir:
    ouroboros-consensus
    ouroboros-consensus-protocol
@@ -81,7 +81,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-api
-  tag: be0635fd2b4b28c7f2554120a924a4b31f17e01c
-  --sha256: 007cyw7wm0fd5cj3vxyz8r3v1hwra1rk0ksp4yqqs0f1ssbl6gxd
+  tag: edbde1e63139add04905ce313eed668e596a2f91
+  --sha256: 0dffz6w5pwjf4zqgznfaqcdc7qvg6gjbq2jq6f6g82nkqdsvwq18
   subdir:
     cardano-api

--- a/cabal.project
+++ b/cabal.project
@@ -67,8 +67,8 @@ if impl(ghc >= 9.6)
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-consensus
-  tag: 5f94982bd6400b2dca3cfc3619e6bb9896775e68
-  --sha256: 1prkxx0bwfcy8ss61hxnxk94zfkyx653l28h6bhc08hsg7pbd58z
+  tag: 54105aac98596d94be805d608a60294d74e2c710
+  --sha256: 1ijfrg3161w8fzd4aqsvp2jdx0vcbbdl7h6v38h8r4ifg151384p
   subdir:
    ouroboros-consensus
    ouroboros-consensus-protocol

--- a/cabal.project
+++ b/cabal.project
@@ -67,8 +67,8 @@ if impl(ghc >= 9.6)
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-consensus
-  tag: b081836c84301167d2e5038ecf92fdb6a8408c06
-  --sha256: 04cpvyl0l9gqczw4f3wpl50gmwihhiqpvfpf1q9x0gjy66gcx4my
+  tag: c774073df58b1e1cab092c11383aa4ff947f0f9c
+  --sha256: 19kbfck56awl0984wd7m1mra6gbjyq1f4ipjq7bmalk8mnwdwyhv
   subdir:
    ouroboros-consensus
    ouroboros-consensus-protocol
@@ -81,7 +81,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-api
-  tag: edbde1e63139add04905ce313eed668e596a2f91
-  --sha256: 0dffz6w5pwjf4zqgznfaqcdc7qvg6gjbq2jq6f6g82nkqdsvwq18
+  tag: 5e61aef0164a463133381d21c697d24d20be5925
+  --sha256: 0ws81j3lj03lbz89wksr7skczprialhfa4fw54l9y3nayw5h4knv
   subdir:
     cardano-api

--- a/cabal.project
+++ b/cabal.project
@@ -67,7 +67,7 @@ if impl(ghc >= 9.6)
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-consensus
-  tag: 94db19231307c21ae531f452203a996535c945db
+  tag: 7bb90dfd43e350a14423ddeedb372a51e0369fe6
   --sha256: 10idxgzbvkmnmshpga4l8mj6hv4pxxl7bpgmjsbkjxlgh73p2kqs
   subdir:
    ouroboros-consensus
@@ -81,7 +81,15 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-api
-  tag: 311b77e166b796bea1b315e7c086c69f29015bab
+  tag: 4be11a4540a9c908fbbd2b6c55c891b913ba1036
   --sha256: 15bwrf27jsgxn3pw6mxxdhkbvngcal1zwpyi1bvdh2p4g9mj0rhs
   subdir:
     cardano-api
+
+source-repository-package
+  type: git
+  location: https://github.com/jasagredo/latex-svg
+  tag: 05dc866baadcdd04a23ed1a488440372f97afb70
+  --sha256: 1amaipl1f516m4yh9x02cqsbv50riszmbdjdmvfpw19vspv1szsx
+  subdir:
+    latex-svg-image

--- a/cabal.project
+++ b/cabal.project
@@ -67,8 +67,8 @@ if impl(ghc >= 9.6)
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-consensus
-  tag: 78b998bd29d4b933e6843d767ab66e5e70cb009e
-  --sha256: 02rx406drs61y62bpw5x1qnilnmpwfzwaafbqn1xprlcykjlibk6
+  tag: 94db19231307c21ae531f452203a996535c945db
+  --sha256: 10idxgzbvkmnmshpga4l8mj6hv4pxxl7bpgmjsbkjxlgh73p2kqs
   subdir:
    ouroboros-consensus
    ouroboros-consensus-protocol
@@ -81,7 +81,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-api
-  tag: 5e61aef0164a463133381d21c697d24d20be5925
-  --sha256: 0ws81j3lj03lbz89wksr7skczprialhfa4fw54l9y3nayw5h4knv
+  tag: 311b77e166b796bea1b315e7c086c69f29015bab
+  --sha256: 15bwrf27jsgxn3pw6mxxdhkbvngcal1zwpyi1bvdh2p4g9mj0rhs
   subdir:
     cardano-api

--- a/cabal.project
+++ b/cabal.project
@@ -33,60 +33,7 @@ packages:
   trace-resources
   trace-forward
 
-package cardano-api
-  ghc-options: -Werror
-
-package cardano-cli
-  ghc-options: -Werror
-  -- TODO delete the following when the warning is fixed
-  ghc-options: -Wno-redundant-constraints
-
-package cardano-client-demo
-  ghc-options: -Werror
-
-package cardano-git-rev
-  ghc-options: -Werror
-
-package cardano-node-capi
-  ghc-options: -Werror
-
-package cardano-node-chairman
-  ghc-options: -Werror
-
-package cardano-node
-  ghc-options: -Werror
-
-package cardano-submit-api
-  ghc-options: -Werror
-
-package cardano-testnet
-  ghc-options: -Werror
-
-package cardano-topology
-  ghc-options: -Werror
-
-package cardano-tracer
-  ghc-options: -Werror
-
-package locli
-  ghc-options: -Werror
-
-package plutus-scripts-bench
-  ghc-options: -Werror
-
-package trace-analyzer
-  ghc-options: -Werror
-
-package trace-dispatcher
-  ghc-options: -Werror
-
-package trace-forward
-  ghc-options: -Werror
-
-package trace-resources
-  ghc-options: -Werror
-
-package tx-generator
+program-options
   ghc-options: -Werror
 
 package cryptonite
@@ -111,3 +58,30 @@ if impl(ghc >= 9.6)
     -- of `cardano-ledger-byron-test` also do not permit the version of `base` that `ghc-9.6`
     -- provides.
     , *:base
+
+-- IMPORTANT
+-- Do NOT add more source-repository-package stanzas here unless they are strictly
+-- temporary! Please read the section in CONTRIBUTING about updating dependencies.
+
+-- utxo-hd
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/ouroboros-consensus
+  tag: 5f94982bd6400b2dca3cfc3619e6bb9896775e68
+  --sha256: 1prkxx0bwfcy8ss61hxnxk94zfkyx653l28h6bhc08hsg7pbd58z
+  subdir:
+   ouroboros-consensus
+   ouroboros-consensus-protocol
+   ouroboros-consensus-cardano-legacy-block
+   ouroboros-consensus-diffusion
+   ouroboros-consensus-cardano-legacy-block
+   ouroboros-consensus-cardano
+
+-- utxo-hd on 8.12.0.0
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-api
+  tag: be0635fd2b4b28c7f2554120a924a4b31f17e01c
+  --sha256: 007cyw7wm0fd5cj3vxyz8r3v1hwra1rk0ksp4yqqs0f1ssbl6gxd
+  subdir:
+    cardano-api

--- a/cabal.project
+++ b/cabal.project
@@ -67,8 +67,8 @@ if impl(ghc >= 9.6)
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-consensus
-  tag: c774073df58b1e1cab092c11383aa4ff947f0f9c
-  --sha256: 19kbfck56awl0984wd7m1mra6gbjyq1f4ipjq7bmalk8mnwdwyhv
+  tag: 78b998bd29d4b933e6843d767ab66e5e70cb009e
+  --sha256: 02rx406drs61y62bpw5x1qnilnmpwfzwaafbqn1xprlcykjlibk6
   subdir:
    ouroboros-consensus
    ouroboros-consensus-protocol

--- a/cardano-client-demo/ChainSyncClientWithLedgerState.hs
+++ b/cardano-client-demo/ChainSyncClientWithLedgerState.hs
@@ -16,11 +16,13 @@ import           Control.Monad.Trans.Except
 import           Data.Kind
 import           Data.Proxy
 import qualified Data.SOP as SOP
+import           Data.SOP.Functors
 import           Data.Text (Text)
 import qualified Data.Text as T
 import           Data.Time
 import           Data.Word (Word32)
 import qualified GHC.TypeLits as GHC
+import           Ouroboros.Consensus.Ledger.Tables (EmptyMK)
 import           System.Environment (getArgs)
 import           System.FilePath ((</>))
 
@@ -127,7 +129,7 @@ chainSyncClient = ChainSyncClient $ do
             return clientStIdle
         }
 
-    printLedgerState :: TSP.Telescope (SOP.K C.Past) (C.Current C.LedgerState) xs -> IO ()
+    printLedgerState :: TSP.Telescope (SOP.K C.Past) (C.Current (Flip C.LedgerState EmptyMK)) xs -> IO ()
     printLedgerState ls = case ls of
       TSP.TZ (C.Current bound _) -> putStrLn $ "curren't era bounds: " <> show bound
       TSP.TS _ ls' -> printLedgerState ls'

--- a/cardano-client-demo/LedgerState.hs
+++ b/cardano-client-demo/LedgerState.hs
@@ -43,7 +43,7 @@ main = do
       (BlockInMode (Block (BlockHeader _slotNo _blockHeaderHash (BlockNo blockNoI)) _transactions) _era)
       blockCount -> do
         case ledgerState of
-            LedgerStateShelley (Shelley.ShelleyLedgerState shelleyTipWO _ _) -> case shelleyTipWO of
+            LedgerStateShelley (Shelley.ShelleyLedgerState shelleyTipWO _ _ _) -> case shelleyTipWO of
               Origin -> putStrLn "."
               At (Shelley.ShelleyTip _ _ hash) -> print hash
             _ -> when (blockNoI `mod` 100 == 0) (print blockNoI)

--- a/cardano-client-demo/StakeCredentialHistory.hs
+++ b/cardano-client-demo/StakeCredentialHistory.hs
@@ -276,17 +276,17 @@ main = do
                    case ledgerState of
                      LedgerStateByron _                                     ->
                        ("byron",   EpochNo 0, Nothing)
-                     LedgerStateShelley (Shelley.ShelleyLedgerState _ ls _) ->
+                     LedgerStateShelley (Shelley.ShelleyLedgerState _ ls _ _) ->
                        ("shelley", L.nesEL ls, Just (L.nesRu ls, getGoSnapshot ls, getBalances ls, getPV ls))
-                     LedgerStateAllegra (Shelley.ShelleyLedgerState _ ls _) ->
+                     LedgerStateAllegra (Shelley.ShelleyLedgerState _ ls _ _) ->
                        ("allegra", L.nesEL ls, Just (L.nesRu ls, getGoSnapshot ls, getBalances ls, getPV ls))
-                     LedgerStateMary    (Shelley.ShelleyLedgerState _ ls _) ->
+                     LedgerStateMary    (Shelley.ShelleyLedgerState _ ls _ _) ->
                        ("mary",    L.nesEL ls, Just (L.nesRu ls, getGoSnapshot ls, getBalances ls, getPV ls))
-                     LedgerStateAlonzo    (Shelley.ShelleyLedgerState _ ls _) ->
+                     LedgerStateAlonzo    (Shelley.ShelleyLedgerState _ ls _ _) ->
                        ("alonzo",  L.nesEL ls, Just (L.nesRu ls, getGoSnapshot ls, getBalances ls, getPV ls))
-                     LedgerStateBabbage  (Shelley.ShelleyLedgerState _ ls _) ->
+                     LedgerStateBabbage  (Shelley.ShelleyLedgerState _ ls _ _) ->
                        ("babbage", L.nesEL ls, Just (L.nesRu ls, getGoSnapshot ls, getBalances ls, getPV ls))
-                     LedgerStateConway  (Shelley.ShelleyLedgerState _ ls _) ->
+                     LedgerStateConway  (Shelley.ShelleyLedgerState _ ls _ _) ->
                        ("conway", L.nesEL ls, Just (L.nesRu ls, getGoSnapshot ls, getBalances ls, getPV ls))
 
              let txBodyComponents = map ( (\(TxBody txbc) -> txbc) . getTxBody ) transactions

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -192,6 +192,7 @@ library
                       , si-timers
                       , stm
                       , strict-stm
+                      , sop-core
                       , text >= 2.0
                       , time
                       , trace-dispatcher ^>= 2.0

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -64,6 +64,7 @@ library
   exposed-modules:      Cardano.Node.Configuration.Logging
                         Cardano.Node.Configuration.NodeAddress
                         Cardano.Node.Configuration.POM
+                        Cardano.Node.Configuration.LedgerDB
                         Cardano.Node.Configuration.Socket
                         Cardano.Node.Configuration.Topology
                         Cardano.Node.Configuration.TopologyP2P

--- a/cardano-node/src/Cardano/Node/Configuration/LedgerDB.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/LedgerDB.hs
@@ -13,7 +13,7 @@ module Cardano.Node.Configuration.LedgerDB (
 import           Prelude
 
 import qualified Data.Aeson.Types as Aeson (FromJSON)
-import           Ouroboros.Consensus.Storage.LedgerDB.BackingStore.Impl.LMDB (LMDBLimits (..))
+import           Ouroboros.Consensus.Storage.LedgerDB.V1.BackingStore.Impl.LMDB (LMDBLimits (..))
 
 -- | Choose the LedgerDB Backend
 --

--- a/cardano-node/src/Cardano/Node/Configuration/LedgerDB.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/LedgerDB.hs
@@ -1,0 +1,89 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.Node.Configuration.LedgerDB (
+    BackingStoreSelectorFlag(..)
+  , Gigabytes
+  , toBytes
+  , defaultLMDBLimits
+  ) where
+
+import           Prelude
+
+import qualified Data.Aeson.Types as Aeson (FromJSON)
+import           Ouroboros.Consensus.Storage.LedgerDB.BackingStore.LMDB (LMDBLimits (..))
+
+-- | Choose the LedgerDB Backend
+--
+-- As of UTxO-HD, the LedgerDB now uses either an in-memory backend or LMDB to
+-- keep track of differences in the UTxO set.
+--
+-- - 'InMemory': uses more memory than the minimum requirements but is somewhat
+--   faster.
+-- - 'LMDB': uses less memory but is somewhat slower.
+--
+-- See 'Ouroboros.Consnesus.Storage.LedgerDB.OnDisk.BackingStoreSelector'.
+data BackingStoreSelectorFlag =
+    LMDB (Maybe Gigabytes) -- ^ A map size can be specified, this is the maximum
+                          -- disk space the LMDB database can fill. If not
+                          -- provided, the default of 16GB will be used.
+  | InMemory
+  deriving (Eq, Show)
+
+-- | A number of gigabytes.
+newtype Gigabytes = Gigabytes Int
+  deriving stock (Eq, Show)
+  deriving newtype (Read, Aeson.FromJSON)
+
+-- | Convert a number of Gigabytes to the equivalent number of bytes.
+toBytes :: Gigabytes -> Int
+toBytes (Gigabytes x) = x * 1024 * 1024 * 1024
+
+-- | Recommended settings for the LMDB backing store.
+--
+-- === @'lmdbMapSize'@
+-- The default @'LMDBLimits'@ uses an @'lmdbMapSize'@ of @1024 * 1024 * 1024 * 16@
+-- bytes, or 16 Gigabytes. @'lmdbMapSize'@ sets the size of the memory map
+-- that is used internally by the LMDB backing store, and is also the
+-- maximum size of the on-disk database. 16 GB should be sufficient for the
+-- medium term, i.e., it is sufficient until a more performant alternative to
+-- the LMDB backing store is implemented, which will probably replace the LMDB
+-- backing store altogether.
+--
+-- Note(jdral): It is recommended not to set the @'lmdbMapSize'@ to a value
+-- that is much smaller than 16 GB through manual configuration: the node will
+-- die with a fatal error as soon as the database size exceeds the
+-- @'lmdbMapSize'@. If this fatal error were to occur, we would expect that
+-- the node can continue normal operation if it is restarted with a higher
+-- @'lmdbMapSize'@ configured. Nonetheless, this situation should be avoided.
+--
+-- === @'lmdbMaxDatabases'@
+-- The @'lmdbMaxDatabases'@ is set to 10, which means that the LMDB backing
+-- store will allow up @<= 10@ internal databases. We say /internal/
+-- databases, since they are not exposed outside the backing store interface,
+-- such that from the outside view there is just one /logical/ database.
+-- Two of these internal databases are reserved for normal operation of the
+-- backing store, while the remaining databases will be used to store ledger
+-- tables. At the moment, there is at most one ledger table that will be
+-- stored in an internal database: the UTxO. Nonetheless, we set
+-- @'lmdbMaxDatabases'@ to @10@ in order to future-proof these limits.
+--
+-- === @'lmdbMaxReaders'@
+-- The @'lmdbMaxReaders'@ limit sets the maximum number of threads that can
+-- read from the LMDB database. Currently, there should only be a single reader
+-- active. Again, we set @'lmdbMaxReaders'@ to @16@ in order to future-proof
+-- these limits.
+--
+-- === References
+-- For more information about LMDB limits, one should inspect:
+-- * The @lmdb-simple@ and @haskell-lmdb@ forked repositories.
+-- * The official LMDB API documentation at
+--    <http://www.lmdb.tech/doc/group__mdb.html>.
+defaultLMDBLimits :: LMDBLimits
+defaultLMDBLimits = LMDBLimits {
+    lmdbMapSize = 16 * 1024 * 1024 * 1024
+  , lmdbMaxDatabases = 10
+  , lmdbMaxReaders = 16
+  }

--- a/cardano-node/src/Cardano/Node/Configuration/LedgerDB.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/LedgerDB.hs
@@ -13,7 +13,7 @@ module Cardano.Node.Configuration.LedgerDB (
 import           Prelude
 
 import qualified Data.Aeson.Types as Aeson (FromJSON)
-import           Ouroboros.Consensus.Storage.LedgerDB.BackingStore.LMDB (LMDBLimits (..))
+import           Ouroboros.Consensus.Storage.LedgerDB.BackingStore.Impl.LMDB (LMDBLimits (..))
 
 -- | Choose the LedgerDB Backend
 --

--- a/cardano-node/src/Cardano/Node/Configuration/Logging.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/Logging.hs
@@ -44,6 +44,7 @@ import           Data.Maybe (isJust)
 import           Data.Text (Text, pack)
 import           Data.Time.Clock (UTCTime, getCurrentTime)
 import           Data.Version (showVersion)
+import           GHC.Conc (labelThread, myThreadId)
 import           System.Metrics.Counter (Counter)
 import           System.Metrics.Gauge (Gauge)
 import           System.Metrics.Label (Label)
@@ -284,12 +285,13 @@ createLoggingLayer ver nodeConfig' p = do
       pure ()
 
    startCapturingMetrics _ tr = do
-     void . Async.async . forever $ do
-       readResourceStats
-         >>= maybe (pure ())
-                   (traceResourceStats
-                      (appendName "node" tr))
-       Conc.threadDelay 1000000 -- TODO:  make configurable
+     void . Async.async $ myThreadId >>= flip labelThread "MetricsCapturing"
+      >> forever (do
+            readResourceStats
+              >>= maybe (pure ())
+                        (traceResourceStats
+                            (appendName "node" tr))
+            Conc.threadDelay 1000000) -- TODO:  make configurable
 
    traceResourceStats :: Trace IO Text -> ResourceStats -> IO ()
    traceResourceStats tr rs = do

--- a/cardano-node/src/Cardano/Node/Configuration/POM.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/POM.hs
@@ -49,8 +49,9 @@ import           Cardano.Tracing.Config
 import           Ouroboros.Consensus.Mempool (MempoolCapacityBytes (..),
                    MempoolCapacityBytesOverride (..))
 import qualified Ouroboros.Consensus.Node as Consensus (NetworkP2PMode (..))
-import           Ouroboros.Consensus.Storage.LedgerDB (FlushFrequency (..),
-                   QueryBatchSize (..), SnapshotInterval (..))
+import           Ouroboros.Consensus.Storage.LedgerDB.V1.Args (FlushFrequency (..),
+                   QueryBatchSize (..))
+import           Ouroboros.Consensus.Storage.LedgerDB.Impl.Snapshots (SnapshotInterval (..))
 import           Ouroboros.Network.NodeToNode (AcceptedConnectionsLimit (..), DiffusionMode (..))
 import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
 

--- a/cardano-node/src/Cardano/Node/Configuration/POM.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/POM.hs
@@ -39,6 +39,7 @@ import           System.FilePath (takeDirectory, (</>))
 
 import           Cardano.Crypto (RequiresNetworkMagic (..))
 import           Cardano.Logging.Types
+import           Cardano.Node.Configuration.LedgerDB
 import           Cardano.Node.Configuration.NodeAddress (SocketPath)
 import           Cardano.Node.Configuration.Socket (SocketConfig (..))
 import           Cardano.Node.Handlers.Shutdown
@@ -48,7 +49,8 @@ import           Cardano.Tracing.Config
 import           Ouroboros.Consensus.Mempool (MempoolCapacityBytes (..),
                    MempoolCapacityBytesOverride (..))
 import qualified Ouroboros.Consensus.Node as Consensus (NetworkP2PMode (..))
-import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy (SnapshotInterval (..))
+import           Ouroboros.Consensus.Storage.LedgerDB.Config (FlushFrequency (..),
+                   QueryBatchSize (..), SnapshotInterval (..))
 import           Ouroboros.Network.NodeToNode (AcceptedConnectionsLimit (..), DiffusionMode (..))
 import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
 
@@ -94,7 +96,6 @@ data NodeConfiguration
 
          -- Node parameters, not protocol-specific:
        , ncDiffusionMode    :: !DiffusionMode
-       , ncSnapshotInterval :: !SnapshotInterval
 
          -- | During the development and integration of new network protocols
          -- (node-to-node and node-to-client) we wish to be able to test them
@@ -121,6 +122,12 @@ data NodeConfiguration
        , ncTraceForwardSocket :: !(Maybe (SocketPath, ForwarderMode))
 
        , ncMaybeMempoolCapacityOverride :: !(Maybe MempoolCapacityBytesOverride)
+
+         -- LedgerDB configuration
+       , ncSnapshotInterval :: !SnapshotInterval
+       , ncLedgerDBBackend  :: !BackingStoreSelectorFlag
+       , ncFlushFrequency   :: !FlushFrequency
+       , ncQueryBatchSize   :: !QueryBatchSize
 
          -- | Protocol idleness timeout, see
          -- 'Ouroboros.Network.Diffusion.daProtocolIdleTimeout'.
@@ -168,7 +175,6 @@ data PartialNodeConfiguration
 
          -- Node parameters, not protocol-specific:
        , pncDiffusionMode    :: !(Last DiffusionMode)
-       , pncSnapshotInterval :: !(Last SnapshotInterval)
        , pncExperimentalProtocolsEnabled :: !(Last Bool)
 
          -- BlockFetch configuration
@@ -183,6 +189,12 @@ data PartialNodeConfiguration
 
          -- Configuration for testing purposes
        , pncMaybeMempoolCapacityOverride :: !(Last MempoolCapacityBytesOverride)
+
+         -- LedgerDB configuration
+       , pncSnapshotInterval :: !(Last SnapshotInterval)
+       , pncLedgerDBBackend  :: !(Last BackingStoreSelectorFlag)
+       , pncFlushFrequency   :: !(Last FlushFrequency)
+       , pncQueryBatchSize   :: !(Last QueryBatchSize)
 
          -- Network timeouts
        , pncProtocolIdleTimeout   :: !(Last DiffTime)
@@ -221,8 +233,6 @@ instance FromJSON PartialNodeConfiguration where
       pncSocketPath <- Last <$> v .:? "SocketPath"
       pncDiffusionMode
         <- Last . fmap getDiffusionMode <$> v .:? "DiffusionMode"
-      pncSnapshotInterval
-        <- Last . fmap RequestedSnapshotInterval <$> v .:? "SnapshotInterval"
       pncExperimentalProtocolsEnabled <- fmap Last $ do
         mValue <- v .:? "ExperimentalProtocolsEnabled"
 
@@ -268,6 +278,12 @@ instance FromJSON PartialNodeConfiguration where
                                                                <*> parseHardForkProtocol v)
       pncMaybeMempoolCapacityOverride <- Last <$> parseMempoolCapacityBytesOverride v
 
+      -- LedgerDB configuration
+      pncSnapshotInterval <- Last . fmap RequestedSnapshotInterval <$> v .:? "SnapshotInterval"
+      pncLedgerDBBackend  <- Last <$> parseLedgerDBBackend v
+      pncFlushFrequency   <- Last . fmap RequestedFlushFrequency <$> v .:? "FlushFrequency"
+      pncQueryBatchSize   <- Last . fmap RequestedQueryBatchSize <$> v .:? "QueryBatchSize"
+
       -- Network timeouts
       pncProtocolIdleTimeout   <- Last <$> v .:? "ProtocolIdleTimeout"
       pncTimeWaitTimeout       <- Last <$> v .:? "TimeWaitTimeout"
@@ -299,7 +315,6 @@ instance FromJSON PartialNodeConfiguration where
              pncProtocolConfig
            , pncSocketConfig = Last . Just $ SocketConfig mempty mempty mempty pncSocketPath
            , pncDiffusionMode
-           , pncSnapshotInterval
            , pncExperimentalProtocolsEnabled
            , pncMaxConcurrencyBulkSync
            , pncMaxConcurrencyDeadline
@@ -315,6 +330,10 @@ instance FromJSON PartialNodeConfiguration where
            , pncShutdownConfig = mempty
            , pncStartAsNonProducingNode = Last $ Just False
            , pncMaybeMempoolCapacityOverride
+           , pncSnapshotInterval
+           , pncLedgerDBBackend
+           , pncFlushFrequency
+           , pncQueryBatchSize
            , pncProtocolIdleTimeout
            , pncTimeWaitTimeout
            , pncAcceptedConnectionsLimit
@@ -339,6 +358,17 @@ instance FromJSON PartialNodeConfiguration where
                 , show invalid
                 ]
               Nothing -> return Nothing
+
+      parseLedgerDBBackend v = do
+        maybeString :: Maybe String <- v .:? "LedgerDBBackend"
+        case maybeString of
+           Just "InMemory" -> return $ Just InMemory
+           Just "LMDB"     -> do
+             mapSize :: Maybe Gigabytes <- v .:? "LMDBMapSize"
+             return . Just . LMDB $ mapSize
+           Nothing         -> return Nothing
+           Just whatever   -> fail $ "Malformed LedgerDBBackend" <> whatever
+
       parseByronProtocol v = do
         primary   <- v .:? "ByronGenesisFile"
         secondary <- v .:? "GenesisFile"
@@ -465,7 +495,6 @@ defaultPartialNodeConfiguration =
     , pncLoggingSwitch = Last $ Just True
     , pncSocketConfig = Last . Just $ SocketConfig mempty mempty mempty mempty
     , pncDiffusionMode = Last $ Just InitiatorAndResponderDiffusionMode
-    , pncSnapshotInterval = Last $ Just DefaultSnapshotInterval
     , pncExperimentalProtocolsEnabled = Last $ Just False
     , pncTopologyFile = Last . Just $ TopologyFile "configuration/cardano/mainnet-topology.json"
     , pncProtocolFiles = mempty
@@ -479,6 +508,10 @@ defaultPartialNodeConfiguration =
     , pncTraceConfig = mempty
     , pncTraceForwardSocket = mempty
     , pncMaybeMempoolCapacityOverride = mempty
+    , pncSnapshotInterval = Last $ Just DefaultSnapshotInterval
+    , pncLedgerDBBackend  = Last $ Just InMemory
+    , pncFlushFrequency   = Last $ Just DefaultFlushFrequency
+    , pncQueryBatchSize   = Last $ Just DefaultQueryBatchSize
     , pncProtocolIdleTimeout   = Last (Just 5)
     , pncTimeWaitTimeout       = Last (Just 60)
     , pncAcceptedConnectionsLimit =
@@ -528,6 +561,15 @@ makeNodeConfiguration pnc = do
   ncTargetNumberOfActivePeers <-
     lastToEither "Missing TargetNumberOfActivePeers"
     $ pncTargetNumberOfActivePeers pnc
+  ncLedgerDBBackend <-
+    lastToEither "Missing LedgerDBBackend"
+    $ pncLedgerDBBackend pnc
+  ncFlushFrequency <-
+    lastToEither "Missing FlushFrequency"
+    $ pncFlushFrequency pnc
+  ncQueryBatchSize <-
+    lastToEither "Missing QueryBatchSize"
+    $ pncQueryBatchSize pnc
   ncProtocolIdleTimeout <-
     lastToEither "Missing ProtocolIdleTimeout"
     $ pncProtocolIdleTimeout pnc
@@ -566,7 +608,6 @@ makeNodeConfiguration pnc = do
              , ncProtocolConfig = protocolConfig
              , ncSocketConfig = socketConfig
              , ncDiffusionMode = diffusionMode
-             , ncSnapshotInterval = snapshotInterval
              , ncExperimentalProtocolsEnabled = experimentalProtocols
              , ncMaxConcurrencyBulkSync = getLast $ pncMaxConcurrencyBulkSync pnc
              , ncMaxConcurrencyDeadline = getLast $ pncMaxConcurrencyDeadline pnc
@@ -576,6 +617,10 @@ makeNodeConfiguration pnc = do
                                                 else TracingOff
              , ncTraceForwardSocket = getLast $ pncTraceForwardSocket pnc
              , ncMaybeMempoolCapacityOverride = getLast $ pncMaybeMempoolCapacityOverride pnc
+             , ncSnapshotInterval = snapshotInterval
+             , ncLedgerDBBackend
+             , ncFlushFrequency
+             , ncQueryBatchSize
              , ncProtocolIdleTimeout
              , ncTimeWaitTimeout
              , ncAcceptedConnectionsLimit

--- a/cardano-node/src/Cardano/Node/Configuration/POM.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/POM.hs
@@ -49,7 +49,7 @@ import           Cardano.Tracing.Config
 import           Ouroboros.Consensus.Mempool (MempoolCapacityBytes (..),
                    MempoolCapacityBytesOverride (..))
 import qualified Ouroboros.Consensus.Node as Consensus (NetworkP2PMode (..))
-import           Ouroboros.Consensus.Storage.LedgerDB.Config (FlushFrequency (..),
+import           Ouroboros.Consensus.Storage.LedgerDB (FlushFrequency (..),
                    QueryBatchSize (..), SnapshotInterval (..))
 import           Ouroboros.Network.NodeToNode (AcceptedConnectionsLimit (..), DiffusionMode (..))
 import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))

--- a/cardano-node/src/Cardano/Node/Parsers.hs
+++ b/cardano-node/src/Cardano/Node/Parsers.hs
@@ -27,8 +27,9 @@ import           Text.Read (readMaybe)
 
 import           Ouroboros.Consensus.Mempool (MempoolCapacityBytes (..),
                    MempoolCapacityBytesOverride (..))
-import           Ouroboros.Consensus.Storage.LedgerDB (FlushFrequency (..),
-                   QueryBatchSize (..), SnapshotInterval (..))
+import           Ouroboros.Consensus.Storage.LedgerDB.V1.Args (FlushFrequency (..),
+                   QueryBatchSize (..))
+import           Ouroboros.Consensus.Storage.LedgerDB.Impl.Snapshots (SnapshotInterval (..))
 
 import           Cardano.Logging.Types
 import           Cardano.Node.Configuration.LedgerDB

--- a/cardano-node/src/Cardano/Node/Parsers.hs
+++ b/cardano-node/src/Cardano/Node/Parsers.hs
@@ -27,7 +27,7 @@ import           Text.Read (readMaybe)
 
 import           Ouroboros.Consensus.Mempool (MempoolCapacityBytes (..),
                    MempoolCapacityBytesOverride (..))
-import           Ouroboros.Consensus.Storage.LedgerDB.Config (FlushFrequency (..),
+import           Ouroboros.Consensus.Storage.LedgerDB (FlushFrequency (..),
                    QueryBatchSize (..), SnapshotInterval (..))
 
 import           Cardano.Logging.Types

--- a/cardano-node/src/Cardano/Node/Queries.hs
+++ b/cardano-node/src/Cardano/Node/Queries.hs
@@ -69,7 +69,7 @@ import           Ouroboros.Consensus.HardFork.Combinator
 import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras (OneEraForgeStateInfo (..),
                    OneEraForgeStateUpdateError (..))
 import           Ouroboros.Consensus.HardFork.Combinator.Embed.Unary
-import           Ouroboros.Consensus.Ledger.Abstract (EmptyMK, IsLedger)
+import           Ouroboros.Consensus.Ledger.Abstract (EmptyMK)
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState)
 import           Ouroboros.Consensus.Node (NodeKernel (..))
 import qualified Ouroboros.Consensus.Protocol.Ledger.HotKey as HotKey
@@ -306,8 +306,7 @@ mapNodeKernelDataIO f (NodeKernelData ref) =
   readIORef ref >>= traverse f
 
 nkQueryLedger ::
-     IsLedger (LedgerState blk)
-  => (ExtLedgerState blk EmptyMK -> a)
+     (ExtLedgerState blk EmptyMK -> a)
   -> NodeKernel IO RemoteAddress LocalConnectionId blk
   -> IO a
 nkQueryLedger f NodeKernel{getChainDB} =

--- a/cardano-node/src/Cardano/Node/Queries.hs
+++ b/cardano-node/src/Cardano/Node/Queries.hs
@@ -40,6 +40,7 @@ import           Control.Monad.STM (atomically)
 import           Data.ByteString (ByteString)
 import           Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import qualified Data.Map.Strict as Map
+import           Data.SOP.Functors
 import           Data.SOP.Strict
 import           Data.Word (Word64)
 
@@ -68,7 +69,7 @@ import           Ouroboros.Consensus.HardFork.Combinator
 import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras (OneEraForgeStateInfo (..),
                    OneEraForgeStateUpdateError (..))
 import           Ouroboros.Consensus.HardFork.Combinator.Embed.Unary
-import           Ouroboros.Consensus.Ledger.Abstract (IsLedger)
+import           Ouroboros.Consensus.Ledger.Abstract (EmptyMK, IsLedger)
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState)
 import           Ouroboros.Consensus.Node (NodeKernel (..))
 import qualified Ouroboros.Consensus.Protocol.Ledger.HotKey as HotKey
@@ -232,8 +233,8 @@ instance All GetKESInfo xs => GetKESInfo (HardForkBlock xs) where
 -- * General ledger
 --
 class LedgerQueries blk where
-  ledgerUtxoSize     :: LedgerState blk -> Int
-  ledgerDelegMapSize :: LedgerState blk -> Int
+  ledgerUtxoSize     :: LedgerState blk EmptyMK -> Int
+  ledgerDelegMapSize :: LedgerState blk EmptyMK -> Int
 
 instance LedgerQueries Byron.ByronBlock where
   ledgerUtxoSize = Map.size . Byron.unUTxO . Byron.cvsUtxo . Byron.byronLedgerState
@@ -259,8 +260,8 @@ instance LedgerQueries (Shelley.ShelleyBlock protocol era) where
 
 instance (LedgerQueries x, NoHardForks x)
       => LedgerQueries (HardForkBlock '[x]) where
-  ledgerUtxoSize = ledgerUtxoSize . project
-  ledgerDelegMapSize = ledgerDelegMapSize . project
+  ledgerUtxoSize = ledgerUtxoSize . unFlip . project . Flip
+  ledgerDelegMapSize = ledgerDelegMapSize . unFlip . project . Flip
 
 instance LedgerQueries (Cardano.CardanoBlock c) where
   ledgerUtxoSize = \case
@@ -306,7 +307,7 @@ mapNodeKernelDataIO f (NodeKernelData ref) =
 
 nkQueryLedger ::
      IsLedger (LedgerState blk)
-  => (ExtLedgerState blk -> a)
+  => (ExtLedgerState blk EmptyMK -> a)
   -> NodeKernel IO RemoteAddress LocalConnectionId blk
   -> IO a
 nkQueryLedger f NodeKernel{getChainDB} =

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -123,6 +123,10 @@ import           Cardano.Tracing.Tracers
 import           Ouroboros.Network.PeerSelection.LocalRootPeers (HotValency, WarmValency)
 import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
 
+import           Cardano.Node.Configuration.LedgerDB
+import           Ouroboros.Consensus.Storage.LedgerDB.BackingStore.Init
+import           Ouroboros.Consensus.Storage.LedgerDB.BackingStore.LMDB (LMDBLimits (..))
+
 {- HLINT ignore "Fuse concatMap/map" -}
 {- HLINT ignore "Redundant <$>" -}
 {- HLINT ignore "Use fewer imports" -}
@@ -424,6 +428,10 @@ handleSimpleNode blockType runP p2pMode tracers nc onKernel = do
               onKernel nodeKernel
           , rnEnableP2P      = p2pMode
           , rnPeerSharing    = ncPeerSharing nc
+          , rnBackingStoreSelector = case ncLedgerDBBackend nc of
+              LMDB newLimit -> LMDBBackingStore $
+                maybe id (\y x -> x { lmdbMapSize = toBytes y }) newLimit defaultLMDBLimits
+              InMemory      -> InMemoryBackingStore
           }
     in case p2pMode of
       EnabledP2PMode -> do
@@ -471,7 +479,6 @@ handleSimpleNode blockType runP p2pMode tracers nc onKernel = do
               { srnBfcMaxConcurrencyBulkSync    = unMaxConcurrencyBulkSync <$> ncMaxConcurrencyBulkSync nc
               , srnBfcMaxConcurrencyDeadline    = unMaxConcurrencyDeadline <$> ncMaxConcurrencyDeadline nc
               , srnChainDbValidateOverride      = ncValidateDB nc
-              , srnSnapshotInterval             = ncSnapshotInterval nc
               , srnDatabasePath                 = dbPath
               , srnDiffusionArguments           = diffusionArguments
               , srnDiffusionArgumentsExtra      = diffusionArgumentsExtra
@@ -480,6 +487,9 @@ handleSimpleNode blockType runP p2pMode tracers nc onKernel = do
               , srnEnableInDevelopmentVersions  = ncExperimentalProtocolsEnabled nc
               , srnTraceChainDB                 = chainDBTracer tracers
               , srnMaybeMempoolCapacityOverride = ncMaybeMempoolCapacityOverride nc
+              , srnSnapshotInterval             = ncSnapshotInterval nc
+              , srnFlushFrequency               = ncFlushFrequency nc
+              , srnQueryBatchSize               = ncQueryBatchSize nc
               }
       DisabledP2PMode -> do
         nt <- TopologyNonP2P.readTopologyFileOrError nc
@@ -520,7 +530,6 @@ handleSimpleNode blockType runP p2pMode tracers nc onKernel = do
               { srnBfcMaxConcurrencyBulkSync   = unMaxConcurrencyBulkSync <$> ncMaxConcurrencyBulkSync nc
               , srnBfcMaxConcurrencyDeadline   = unMaxConcurrencyDeadline <$> ncMaxConcurrencyDeadline nc
               , srnChainDbValidateOverride     = ncValidateDB nc
-              , srnSnapshotInterval            = ncSnapshotInterval nc
               , srnDatabasePath                = dbPath
               , srnDiffusionArguments          = diffusionArguments
               , srnDiffusionArgumentsExtra     = mkNonP2PArguments ipProducers dnsProducers
@@ -529,6 +538,9 @@ handleSimpleNode blockType runP p2pMode tracers nc onKernel = do
               , srnEnableInDevelopmentVersions = ncExperimentalProtocolsEnabled nc
               , srnTraceChainDB                = chainDBTracer tracers
               , srnMaybeMempoolCapacityOverride = ncMaybeMempoolCapacityOverride nc
+              , srnSnapshotInterval            = ncSnapshotInterval nc
+              , srnFlushFrequency              = ncFlushFrequency nc
+              , srnQueryBatchSize              = ncQueryBatchSize nc
               }
  where
   logStartupWarnings :: IO ()

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -125,8 +125,8 @@ import           Ouroboros.Network.PeerSelection.LocalRootPeers (HotValency, War
 import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
 
 import           Cardano.Node.Configuration.LedgerDB
-import           Ouroboros.Consensus.Storage.LedgerDB.BackingStore.Init
-import           Ouroboros.Consensus.Storage.LedgerDB.BackingStore.LMDB (LMDBLimits (..))
+import           Ouroboros.Consensus.Storage.LedgerDB.BackingStore
+import           Ouroboros.Consensus.Storage.LedgerDB.BackingStore.Impl.LMDB (LMDBLimits (..))
 
 {- HLINT ignore "Fuse concatMap/map" -}
 {- HLINT ignore "Redundant <$>" -}

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -92,6 +92,7 @@ import           Ouroboros.Consensus.Node (NetworkP2PMode (..), RunNodeArgs (..)
                    StdRunNodeArgs (..))
 import qualified Ouroboros.Consensus.Node as Node (getChainDB, run)
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
+import qualified Ouroboros.Consensus.Node.Tracers as Consensus
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Util.Orphans ()
 import qualified Ouroboros.Network.Diffusion as Diffusion
@@ -486,6 +487,7 @@ handleSimpleNode blockType runP p2pMode tracers nc onKernel = do
               , srnDiffusionTracersExtra        = diffusionTracersExtra tracers
               , srnEnableInDevelopmentVersions  = ncExperimentalProtocolsEnabled nc
               , srnTraceChainDB                 = chainDBTracer tracers
+              , srnTraceBackingStore           = Consensus.backingStoreTracer $ consensusTracers tracers
               , srnMaybeMempoolCapacityOverride = ncMaybeMempoolCapacityOverride nc
               , srnSnapshotInterval             = ncSnapshotInterval nc
               , srnFlushFrequency               = ncFlushFrequency nc
@@ -537,6 +539,7 @@ handleSimpleNode blockType runP p2pMode tracers nc onKernel = do
               , srnDiffusionTracersExtra       = diffusionTracersExtra tracers
               , srnEnableInDevelopmentVersions = ncExperimentalProtocolsEnabled nc
               , srnTraceChainDB                = chainDBTracer tracers
+              , srnTraceBackingStore           = Consensus.backingStoreTracer $ consensusTracers tracers
               , srnMaybeMempoolCapacityOverride = ncMaybeMempoolCapacityOverride nc
               , srnSnapshotInterval            = ncSnapshotInterval nc
               , srnFlushFrequency              = ncFlushFrequency nc

--- a/cardano-node/src/Cardano/Node/Tracing/Documentation.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Documentation.hs
@@ -175,7 +175,7 @@ docTracers :: forall blk peer remotePeer.
   , Show peer
   , Show (ForgeStateUpdateError blk)
   , Show (CannotForge blk)
-  , ShowQuery (BlockQuery blk)
+  , forall fp. ShowQuery (BlockQuery blk fp)
   )
   => FilePath
   -> FilePath

--- a/cardano-node/src/Cardano/Node/Tracing/StateRep.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/StateRep.hs
@@ -34,11 +34,12 @@ import qualified Ouroboros.Consensus.Node.NetworkProtocolVersion as NPV
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal
 import qualified Ouroboros.Consensus.Storage.LedgerDB as LgrDb
+import qualified Ouroboros.Consensus.Storage.LedgerDB as LedgerDB
 import           Ouroboros.Network.Block (pointSlot)
 
 import           Cardano.Node.Handlers.Shutdown (ShutdownTrace)
 import qualified Cardano.Node.Startup as Startup
-import           Cardano.Slotting.Slot (EpochNo, SlotNo (..), WithOrigin)
+import           Cardano.Slotting.Slot (EpochNo, SlotNo (..), WithOrigin, withOrigin)
 import           Cardano.Tracing.OrphanInstances.Network ()
 
 instance FromJSON ChunkNo
@@ -55,8 +56,8 @@ data OpeningDbs
   deriving (Generic, FromJSON, ToJSON)
 
 data Replays
-  = ReplayFromGenesis  (WithOrigin SlotNo)
-  | ReplayFromSnapshot SlotNo (WithOrigin SlotNo) (WithOrigin SlotNo)
+  = ReplayFromGenesis
+  | ReplayFromSnapshot SlotNo
   | ReplayedBlock      SlotNo (WithOrigin SlotNo) (WithOrigin SlotNo)
   deriving (Generic, FromJSON, ToJSON)
 
@@ -194,21 +195,23 @@ traceNodeStateChainDB _scp tr ev =
           traceWith tr $ NodeOpeningDbs $ OpenedImmutableDB (pointSlot p) chunk
         ChainDB.StartedOpeningVolatileDB ->
           traceWith tr $ NodeOpeningDbs StartedOpeningVolatileDB
-        ChainDB.OpenedVolatileDB ->
+        ChainDB.OpenedVolatileDB {} ->
           traceWith tr $ NodeOpeningDbs OpenedVolatileDB
         ChainDB.StartedOpeningLgrDB ->
           traceWith tr $ NodeOpeningDbs StartedOpeningLgrDB
         ChainDB.OpenedLgrDB ->
           traceWith tr $ NodeOpeningDbs OpenedLgrDB
         _ -> return ()
-    ChainDB.TraceLedgerReplayEvent ev' ->
+    ChainDB.TraceLedgerDBEvent (LedgerDB.LedgerReplayEvent ev') ->
       case ev' of
-        LgrDb.ReplayFromGenesis (LgrDb.ReplayGoal p) ->
-          traceWith tr $ NodeReplays $ ReplayFromGenesis (pointSlot p)
-        LgrDb.ReplayFromSnapshot _ (RP.RealPoint s _) (LgrDb.ReplayStart rs) (LgrDb.ReplayGoal rp) ->
-          traceWith tr $ NodeReplays $ ReplayFromSnapshot s (pointSlot rs) (pointSlot rp)
-        LgrDb.ReplayedBlock (RP.RealPoint s _) _ (LgrDb.ReplayStart rs) (LgrDb.ReplayGoal rp) ->
-          traceWith tr $ NodeReplays $ ReplayedBlock s (pointSlot rs) (pointSlot rp)
+        LedgerDB.TraceReplayStartEvent ev'' -> case ev'' of
+          LgrDb.ReplayFromGenesis ->
+            traceWith tr $ NodeReplays $ ReplayFromGenesis
+          LgrDb.ReplayFromSnapshot _ (LgrDb.ReplayStart rs) ->
+            traceWith tr $ NodeReplays $ ReplayFromSnapshot (withOrigin undefined id $ pointSlot rs)
+        LedgerDB.TraceReplayProgressEvent ev'' -> case ev'' of
+          LgrDb.ReplayedBlock (RP.RealPoint s _) _ (LgrDb.ReplayStart rs) (LgrDb.ReplayGoal rp) ->
+            traceWith tr $ NodeReplays $ ReplayedBlock s (pointSlot rs) (pointSlot rp)
     ChainDB.TraceInitChainSelEvent ev' ->
       case ev' of
         ChainDB.StartedInitChainSelection ->

--- a/cardano-node/src/Cardano/Node/Tracing/StateRep.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/StateRep.hs
@@ -33,7 +33,7 @@ import qualified Ouroboros.Consensus.Block.RealPoint as RP
 import qualified Ouroboros.Consensus.Node.NetworkProtocolVersion as NPV
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal
-import qualified Ouroboros.Consensus.Storage.LedgerDB.Impl as LgrDb
+import qualified Ouroboros.Consensus.Storage.LedgerDB as LgrDb
 import           Ouroboros.Network.Block (pointSlot)
 
 import           Cardano.Node.Handlers.Shutdown (ShutdownTrace)

--- a/cardano-node/src/Cardano/Node/Tracing/StateRep.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/StateRep.hs
@@ -33,7 +33,7 @@ import qualified Ouroboros.Consensus.Block.RealPoint as RP
 import qualified Ouroboros.Consensus.Node.NetworkProtocolVersion as NPV
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal
-import qualified Ouroboros.Consensus.Storage.LedgerDB as LgrDb
+import qualified Ouroboros.Consensus.Storage.LedgerDB.Impl as LgrDb
 import           Ouroboros.Network.Block (pointSlot)
 
 import           Cardano.Node.Handlers.Shutdown (ShutdownTrace)

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
@@ -122,8 +122,9 @@ mkDispatchTracers nodeKernel trBase trForward mbTrEKG trDataPoint trConfig enabl
     configureTracers configReflection trConfig [chainDBTr]
     -- Filter out replayed blocks for this tracer
     let chainDBTr' = filterTrace
-                      (\case (_, ChainDB.TraceLedgerReplayEvent
-                                            LedgerDB.ReplayedBlock {}) -> False
+                      (\case (_, ChainDB.TraceLedgerDBEvent
+                                            (LedgerDB.LedgerReplayEvent (LedgerDB.TraceReplayProgressEvent
+                                                                        (LedgerDB.ReplayedBlock {})))) -> False
                              (_, _) -> True)
                       chainDBTr
 
@@ -270,11 +271,6 @@ mkConsensusTracers configReflection trBase trForward mbTrEKG _trDataPoint trConf
                 ["Mempool"]
     configureTracers configReflection trConfig [mempoolTr]
 
-    backingStoreTr <- mkCardanoTracer
-                trBase trForward mbTrEKG
-                ["BackingStore"]
-    configureTracers configReflection trConfig [mempoolTr]
-
     forgeTr    <- mkCardanoTracer'
                 trBase trForward mbTrEKG
                 ["Forge", "Loop"]
@@ -327,8 +323,6 @@ mkConsensusTracers configReflection trBase trForward mbTrEKG _trDataPoint trConf
           traceWith localTxSubmissionServerTr
       , Consensus.mempoolTracer = Tracer $
           traceWith mempoolTr
-      , Consensus.backingStoreTracer = Tracer $
-          traceWith backingStoreTr
       , Consensus.forgeTracer =
            Tracer (\(Consensus.TraceLabelCreds _ x) -> traceWith (contramap Left forgeTr) x)
            <>

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
@@ -270,6 +270,11 @@ mkConsensusTracers configReflection trBase trForward mbTrEKG _trDataPoint trConf
                 ["Mempool"]
     configureTracers configReflection trConfig [mempoolTr]
 
+    backingStoreTr <- mkCardanoTracer
+                trBase trForward mbTrEKG
+                ["BackingStore"]
+    configureTracers configReflection trConfig [mempoolTr]
+
     forgeTr    <- mkCardanoTracer'
                 trBase trForward mbTrEKG
                 ["Forge", "Loop"]
@@ -322,6 +327,8 @@ mkConsensusTracers configReflection trBase trForward mbTrEKG _trDataPoint trConf
           traceWith localTxSubmissionServerTr
       , Consensus.mempoolTracer = Tracer $
           traceWith mempoolTr
+      , Consensus.backingStoreTracer = Tracer $
+          traceWith backingStoreTr
       , Consensus.forgeTracer =
            Tracer (\(Consensus.TraceLabelCreds _ x) -> traceWith (contramap Left forgeTr) x)
            <>

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
@@ -53,7 +53,7 @@ import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import qualified Ouroboros.Consensus.Node.Run as Consensus
 import qualified Ouroboros.Consensus.Node.Tracers as Consensus
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
-import qualified Ouroboros.Consensus.Storage.LedgerDB.Impl as LedgerDB
+import qualified Ouroboros.Consensus.Storage.LedgerDB as LedgerDB
 
 import           Network.Mux.Trace (TraceLabelPeer (..))
 

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
@@ -53,7 +53,7 @@ import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import qualified Ouroboros.Consensus.Node.Run as Consensus
 import qualified Ouroboros.Consensus.Node.Tracers as Consensus
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
-import qualified Ouroboros.Consensus.Storage.LedgerDB as LedgerDB
+import qualified Ouroboros.Consensus.Storage.LedgerDB.Impl as LedgerDB
 
 import           Network.Mux.Trace (TraceLabelPeer (..))
 

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/BlockReplayProgress.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/BlockReplayProgress.hs
@@ -76,8 +76,10 @@ replayBlockStats :: MonadIO m
   -> ChainDB.TraceEvent blk
   -> m ReplayBlockStats
 replayBlockStats ReplayBlockStats {..} _context
-    (ChainDB.TraceLedgerReplayEvent (LedgerDB.ReplayedBlock pt []
-                                      (LedgerDB.ReplayStart replayTo) _)) = do
+    (ChainDB.TraceLedgerDBEvent
+     (LedgerDB.LedgerReplayEvent
+      (LedgerDB.TraceReplayProgressEvent
+       (LedgerDB.ReplayedBlock pt [] (LedgerDB.ReplayStart replayTo) _)))) = do
       let slotno = toInteger $ unSlotNo (realPointSlot pt)
           endslot = toInteger $ withOrigin 0 unSlotNo (pointSlot replayTo)
           progress' = (fromInteger slotno * 100.0) / fromInteger (max slotno endslot)

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/BlockReplayProgress.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/BlockReplayProgress.hs
@@ -18,7 +18,7 @@ import           Ouroboros.Network.Block (pointSlot, unSlotNo)
 import           Ouroboros.Network.Point (withOrigin)
 
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
-import qualified Ouroboros.Consensus.Storage.LedgerDB.Impl as LedgerDB
+import qualified Ouroboros.Consensus.Storage.LedgerDB as LedgerDB
 
 data ReplayBlockStats = ReplayBlockStats
   { rpsDisplay      :: Bool

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/BlockReplayProgress.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/BlockReplayProgress.hs
@@ -18,7 +18,7 @@ import           Ouroboros.Network.Block (pointSlot, unSlotNo)
 import           Ouroboros.Network.Point (withOrigin)
 
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
-import qualified Ouroboros.Consensus.Storage.LedgerDB as LedgerDB
+import qualified Ouroboros.Consensus.Storage.LedgerDB.Impl as LedgerDB
 
 data ReplayBlockStats = ReplayBlockStats
   { rpsDisplay      :: Bool

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
@@ -1649,7 +1649,7 @@ instance LogFormatting BS.BackingStoreTrace where
   forMachine _dtals BS.BSCreatingValueHandle =
     mconcat [ "kind" .= String "BSCreatingValueHandle" ]
   forMachine dtals (BS.BSValueHandleTrace i p) =
-    mconcat ([ "kind" .= String "BSCopied"
+    mconcat ([ "kind" .= String "BSValueHandleTrace"
              , "event" .= forMachine dtals p
              ] ++ maybe [] (\i' -> [ "index" .= show i' ]) i)
   forMachine _dtals BS.BSCreatedValueHandle =

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
@@ -44,10 +44,9 @@ import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal (chunkN
 import qualified Ouroboros.Consensus.Storage.ImmutableDB.Impl.Types as ImmDB
 import qualified Ouroboros.Consensus.Storage.LedgerDB as LedgerDB
 import qualified Ouroboros.Consensus.Storage.LedgerDB.BackingStore as BS
-import           Ouroboros.Consensus.Storage.LedgerDB.DbChangelog.Update
+import           Ouroboros.Consensus.Storage.LedgerDB.DbChangelog
                    (UpdateLedgerDbTraceEvent (..))
-import qualified Ouroboros.Consensus.Storage.LedgerDB.DbChangelog.Update as LedgerDB
-import qualified Ouroboros.Consensus.Storage.LedgerDB.Impl as LedgerDB
+import qualified Ouroboros.Consensus.Storage.LedgerDB.DbChangelog as LedgerDB
 import qualified Ouroboros.Consensus.Storage.VolatileDB as VolDB
 import           Ouroboros.Consensus.Util.Condense (condense)
 import           Ouroboros.Consensus.Util.Enclose

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
@@ -1440,40 +1440,29 @@ instance ( StandardHash blk
     mconcat [ "kind" .= String "SnapshotEvent"
             , "event" .= forMachine dtals ev
             ]
-  forMachine dtals (LedgerDB.BackingStoreEvent ev) =
-    mconcat [ "kind" .= String "BackingStore"
-            , "event" .= forMachine dtals ev
-            ]
   forMachine dtals (LedgerDB.BackingStoreInitEvent ev) =
     mconcat [ "kind" .= String "BackingStoreInit"
             , "event" .= forMachine dtals ev
             ]
 
   forHuman (LedgerDB.LedgerDBSnapshotEvent ev) = forHuman ev
-  forHuman (LedgerDB.BackingStoreEvent ev) = forHuman ev
   forHuman (LedgerDB.BackingStoreInitEvent ev) = forHuman ev
 
 instance MetaTrace (LedgerDB.TraceLedgerDBEvent blk) where
 
   namespaceFor (LedgerDB.LedgerDBSnapshotEvent ev) =
     nsPrependInner "Snapshot" (namespaceFor ev)
-  namespaceFor (LedgerDB.BackingStoreEvent ev) =
-    nsPrependInner "BackingStore" (namespaceFor ev)
   namespaceFor (LedgerDB.BackingStoreInitEvent ev) =
     nsPrependInner "BackingStoreInit" (namespaceFor ev)
 
   severityFor (Namespace out ("Snapshot" : tl)) Nothing =
     severityFor (Namespace out tl :: Namespace (LedgerDB.TraceSnapshotEvent blk)) Nothing
-  severityFor (Namespace out ("BackingStore" : tl)) Nothing =
-    severityFor (Namespace out tl :: Namespace LedgerDB.BackingStoreTrace) Nothing
   severityFor (Namespace out ("BackingStoreInit" : tl)) Nothing =
     severityFor (Namespace out tl :: Namespace LedgerDB.TraceBackingStoreInitEvent) Nothing
   severityFor _ _ = Nothing
 
   documentFor (Namespace o ("Snapshot" : tl)) =
     documentFor (Namespace o tl :: Namespace (LedgerDB.TraceSnapshotEvent blk))
-  documentFor (Namespace out ("BackingStore" : tl)) =
-    documentFor (Namespace out tl :: Namespace LedgerDB.BackingStoreTrace)
   documentFor (Namespace out ("BackingStoreInit" : tl)) =
     documentFor (Namespace out tl :: Namespace LedgerDB.TraceBackingStoreInitEvent)
   documentFor _ = Nothing
@@ -1481,8 +1470,6 @@ instance MetaTrace (LedgerDB.TraceLedgerDBEvent blk) where
   allNamespaces =
        map (nsPrependInner "Snapshot")
          (allNamespaces :: [Namespace (LedgerDB.TraceSnapshotEvent blk)])
-    ++ map (nsPrependInner "BackingStore")
-         (allNamespaces :: [Namespace LedgerDB.BackingStoreTrace])
     ++ map (nsPrependInner "BackingStoreInit")
          (allNamespaces :: [Namespace LedgerDB.TraceBackingStoreInitEvent])
 
@@ -1571,7 +1558,7 @@ instance MetaTrace LedgerDB.TraceBackingStoreInitEvent where
     , Namespace [] ["LMDB"]
     ]
 
-instance LogFormatting LedgerDB.BackingStoreTrace where
+instance LogFormatting LedgerDB.BackingStoreTraceByBackend where
 
   forMachine dtals (LedgerDB.LMDBTrace ev) =
     mconcat [ "kind" .= String "BackingStore.LMDBTrace"
@@ -1585,7 +1572,7 @@ instance LogFormatting LedgerDB.BackingStoreTrace where
   forHuman (LedgerDB.LMDBTrace ev) = forHuman ev
   forHuman (LedgerDB.InMemoryTrace ev) = forHuman ev
 
-instance MetaTrace LedgerDB.BackingStoreTrace where
+instance MetaTrace LedgerDB.BackingStoreTraceByBackend where
   namespaceFor (LedgerDB.LMDBTrace ev) =
     nsPrependInner "LMDB" (namespaceFor ev)
   namespaceFor (LedgerDB.InMemoryTrace ev) =

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
@@ -831,6 +831,7 @@ instance
   , LogFormatting (GenTx blk)
   , ToJSON (GenTxId blk)
   , LedgerSupportsMempool blk
+  , ConvertRawHash blk
   ) => LogFormatting (TraceEventMempool blk) where
   forMachine dtal (TraceMempoolAddedTx tx _mpSzBefore mpSzAfter) =
     mconcat
@@ -858,6 +859,34 @@ instance
       , "txsInvalidated" .= map (forMachine dtal . txForgetValidated) txs1
       , "mempoolSize" .= forMachine dtal mpSz
       ]
+  forMachine _ TraceMempoolAttemptingSync =
+    mconcat
+      [ "kind" .= String "TraceMempoolAttemptingSync"
+      ]
+  forMachine dtal (TraceMempoolSyncNotNeeded t _) =
+    mconcat
+      [ "kind" .= String "TraceMempoolSyncNotNeeded"
+      , "tip" .= forMachine dtal t
+      ]
+  forMachine _ TraceMempoolSyncDone =
+    mconcat
+      [ "kind" .= String "TraceMempoolSyncDone"
+      ]
+  forMachine dtal (TraceMempoolAttemptingAdd tx) =
+    mconcat
+      [ "kind" .= String "TraceMempoolAttemptingAdd"
+      , "tx" .= forMachine dtal tx
+      ]
+  forMachine dtal (TraceMempoolLedgerFound p) =
+    mconcat
+      [ "kind" .= String "TraceMempoolLedgerFound"
+      , "tip" .= forMachine dtal p
+      ]
+  forMachine dtal (TraceMempoolLedgerNotFound p) =
+    mconcat
+      [ "kind" .= String "TraceMempoolLedgerNotFound"
+      , "tip" .= forMachine dtal p
+      ]
 
   asMetrics (TraceMempoolAddedTx _tx _mpSzBefore mpSz) =
     [ IntM "Mempool.TxsInMempool" (fromIntegral $ msNumTxs mpSz)
@@ -867,19 +896,22 @@ instance
     [ IntM "Mempool.TxsInMempool" (fromIntegral $ msNumTxs mpSz)
     , IntM "Mempool.MempoolBytes" (fromIntegral $ msNumBytes mpSz)
     ]
-  asMetrics (TraceMempoolRemoveTxs _txs mpSz) =
+  asMetrics (TraceMempoolRemoveTxs txs mpSz) =
     [ IntM "Mempool.TxsInMempool" (fromIntegral $ msNumTxs mpSz)
     , IntM "Mempool.MempoolBytes" (fromIntegral $ msNumBytes mpSz)
-    ]
-  asMetrics (TraceMempoolManuallyRemovedTxs [] _txs1 mpSz) =
-    [ IntM "Mempool.TxsInMempool" (fromIntegral $ msNumTxs mpSz)
-    , IntM "Mempool.MempoolBytes" (fromIntegral $ msNumBytes mpSz)
+    , CounterM "Mempool.TxsRemovedNum" (Just (fromIntegral $ length txs))
     ]
   asMetrics (TraceMempoolManuallyRemovedTxs txs _txs1 mpSz) =
     [ IntM "Mempool.TxsInMempool" (fromIntegral $ msNumTxs mpSz)
     , IntM "Mempool.MempoolBytes" (fromIntegral $ msNumBytes mpSz)
-    , CounterM "Mempool.TxsProcessedNum" (Just (fromIntegral $ length txs))
+    , CounterM "Mempool.TxsRemovedNum" (Just (fromIntegral $ length txs))
     ]
+  asMetrics TraceMempoolAttemptingSync = []
+  asMetrics TraceMempoolSyncNotNeeded {} = []
+  asMetrics TraceMempoolSyncDone = []
+  asMetrics TraceMempoolAttemptingAdd {} = []
+  asMetrics TraceMempoolLedgerFound {} = []
+  asMetrics TraceMempoolLedgerNotFound {} = []
 
 instance LogFormatting MempoolSize where
   forMachine _dtal MempoolSize{msNumTxs, msNumBytes} =
@@ -894,11 +926,23 @@ instance MetaTrace (TraceEventMempool blk) where
     namespaceFor TraceMempoolRejectedTx {} = Namespace [] ["RejectedTx"]
     namespaceFor TraceMempoolRemoveTxs {} = Namespace [] ["RemoveTxs"]
     namespaceFor TraceMempoolManuallyRemovedTxs {} = Namespace [] ["ManuallyRemovedTxs"]
+    namespaceFor TraceMempoolAttemptingSync = Namespace [] ["MempoolAttemptingSync"]
+    namespaceFor TraceMempoolSyncNotNeeded {} = Namespace [] ["MempoolSyncNotNeeded"]
+    namespaceFor TraceMempoolSyncDone = Namespace [] ["MempoolSyncDone"]
+    namespaceFor TraceMempoolAttemptingAdd {} = Namespace [] ["MepoolAttemptAdd"]
+    namespaceFor TraceMempoolLedgerFound {} = Namespace [] ["MempoolLedgerFound"]
+    namespaceFor TraceMempoolLedgerNotFound {} = Namespace [] ["MempoolLedgerNotFound"]
 
     severityFor (Namespace _ ["AddedTx"]) _ = Just Info
-    severityFor (Namespace _ ["RejectedTx"]) _ = Just Info
-    severityFor (Namespace _ ["RemoveTxs"]) _ = Just Info
-    severityFor (Namespace _ ["ManuallyRemovedTxs"]) _ = Just Info
+    severityFor (Namespace _ ["RejectedTx"]) _ = Just Warning
+    severityFor (Namespace _ ["RemoveTxs"]) _ = Just Debug
+    severityFor (Namespace _ ["ManuallyRemovedTxs"]) _ = Just Warning
+    severityFor (Namespace _ ["MempoolAttemptingSync"]) _ = Just Debug
+    severityFor (Namespace _ ["MempoolSyncNotNeeded"]) _ = Just Debug
+    severityFor (Namespace _ ["MempoolSyncDone"]) _ = Just Debug
+    severityFor (Namespace _ ["MempoolAttemptAdd"]) _ = Just Debug
+    severityFor (Namespace _ ["MempoolLedgerFound"]) _ = Just Debug
+    severityFor (Namespace _ ["MempoolLedgerNotFound"]) _ = Just Debug
     severityFor _ _ = Nothing
 
     metricsDocFor (Namespace _ ["AddedTx"]) =
@@ -923,7 +967,7 @@ instance MetaTrace (TraceEventMempool blk) where
     documentFor (Namespace _ ["AddedTx"]) = Just
       "New, valid transaction that was added to the Mempool."
     documentFor (Namespace _ ["RejectedTx"]) = Just $ mconcat
-      [ "New, invalid transaction thas was rejected and thus not added to"
+      [ "New, invalid transaction that was rejected and thus not added to"
       , " the Mempool."
       ]
     documentFor (Namespace _ ["RemoveTxs"]) = Just $ mconcat
@@ -933,6 +977,20 @@ instance MetaTrace (TraceEventMempool blk) where
       ]
     documentFor (Namespace _ ["ManuallyRemovedTxs"]) = Just
       "Transactions that have been manually removed from the Mempool."
+    documentFor (Namespace _ ["MempoolAttemptingSync"]) = Just
+      "Mempool attempting to perform a sync with the LedgerDB."
+    documentFor (Namespace _ ["MempoolSyncNotNeeded"]) = Just
+      "The mempool and the LedgerDB are in sync already."
+    documentFor (Namespace _ ["MempoolSyncDone"]) = Just
+      "The mempool and the LedgerDB are in sync now."
+    documentFor (Namespace _ ["MempoolAttemptAdd"]) = Just
+      "Mempool is about to try to validate and add a transaction."
+    documentFor (Namespace _ ["MempoolLedgerNotFound"]) = Just $ mconcat
+      [ "Ledger state requested by the mempool no longer in LedgerDB."
+      , " Will have to re-sync."
+      ]
+    documentFor (Namespace _ ["MempoolLedgerFound"]) = Just
+      "Ledger state requested by the mempool is in the LedgerDB."
     documentFor _ = Nothing
 
     allNamespaces =
@@ -940,6 +998,12 @@ instance MetaTrace (TraceEventMempool blk) where
       , Namespace [] ["RejectedTx"]
       , Namespace [] ["RemoveTxs"]
       , Namespace [] ["ManuallyRemovedTxs"]
+      , Namespace [] ["MempoolAttemptingSync"]
+      , Namespace [] ["MempoolSyncNotNeeded"]
+      , Namespace [] ["MempoolSyncDone"]
+      , Namespace [] ["MempoolAttemptAdd"]
+      , Namespace [] ["MempoolLedgerNotFound"]
+      , Namespace [] ["MempoolLedgerFound"]
       ]
 
 --------------------------------------------------------------------------------

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
@@ -934,7 +934,7 @@ instance MetaTrace (TraceEventMempool blk) where
     namespaceFor TraceMempoolLedgerNotFound {} = Namespace [] ["MempoolLedgerNotFound"]
 
     severityFor (Namespace _ ["AddedTx"]) _ = Just Info
-    severityFor (Namespace _ ["RejectedTx"]) _ = Just Warning
+    severityFor (Namespace _ ["RejectedTx"]) _ = Just Info
     severityFor (Namespace _ ["RemoveTxs"]) _ = Just Debug
     severityFor (Namespace _ ["ManuallyRemovedTxs"]) _ = Just Warning
     severityFor (Namespace _ ["MempoolAttemptingSync"]) _ = Just Debug

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
@@ -929,7 +929,7 @@ instance MetaTrace (TraceEventMempool blk) where
     namespaceFor TraceMempoolAttemptingSync = Namespace [] ["MempoolAttemptingSync"]
     namespaceFor TraceMempoolSyncNotNeeded {} = Namespace [] ["MempoolSyncNotNeeded"]
     namespaceFor TraceMempoolSyncDone = Namespace [] ["MempoolSyncDone"]
-    namespaceFor TraceMempoolAttemptingAdd {} = Namespace [] ["MepoolAttemptAdd"]
+    namespaceFor TraceMempoolAttemptingAdd {} = Namespace [] ["MempoolAttemptAdd"]
     namespaceFor TraceMempoolLedgerFound {} = Namespace [] ["MempoolLedgerFound"]
     namespaceFor TraceMempoolLedgerNotFound {} = Namespace [] ["MempoolLedgerNotFound"]
 

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Peer.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Peer.hs
@@ -4,14 +4,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PackageImports #-}
 
-module Cardano.Node.Tracing.Tracers.Peer where
---   ( PeerT (..)
---   , startPeerTracer
---   , namesForPeers
---   , severityPeers
---   , docPeers
---   , ppPeer
---   ) where
+module Cardano.Node.Tracing.Tracers.Peer
+  ( PeerT (..)
+  , startPeerTracer
+  , ppPeer
+  ) where
 
 import           Cardano.Node.Orphans ()
 
@@ -29,6 +26,7 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import           Data.Text (Text)
 import qualified Data.Text as Text
+import           GHC.Conc (labelThread, myThreadId)
 import           Text.Printf (printf)
 
 import           Ouroboros.Consensus.Block (Header)
@@ -55,7 +53,7 @@ startPeerTracer
   -> Int
   -> IO ()
 startPeerTracer tr nodeKern delayMilliseconds = do
-    as <- async peersThread
+    as <- async $ myThreadId >>= flip labelThread "PeersCapturing" >> peersThread
     link as
   where
     peersThread :: IO ()

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Resources.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Resources.hs
@@ -8,6 +8,7 @@ import           Control.Concurrent (threadDelay)
 import           Control.Concurrent.Async (async)
 import           Control.Monad (forM_, forever)
 import           Control.Monad.Class.MonadAsync (link)
+import           GHC.Conc (labelThread, myThreadId)
 
 import           "contra-tracer" Control.Tracer
 
@@ -18,13 +19,11 @@ startResourceTracer
   -> Int
   -> IO ()
 startResourceTracer tr delayMilliseconds = do
-    as <- async resourceThread
+    as <- async (myThreadId >>= flip labelThread "ResourceCapturing" >> resourceThread)
     link as
   where
     resourceThread :: IO ()
     resourceThread = forever $ do
       mbrs <- readResourceStats
-      forM_ mbrs $ \rs -> traceWith tr rs
-      threadDelay (delayMilliseconds * 1000)
       forM_ mbrs $ \rs -> traceWith tr rs
       threadDelay (delayMilliseconds * 1000)

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/StartLeadershipCheck.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/StartLeadershipCheck.hs
@@ -27,13 +27,13 @@ import           Ouroboros.Network.NodeToNode (RemoteAddress)
 
 import           Ouroboros.Consensus.Block (SlotNo (..))
 import           Ouroboros.Consensus.HardFork.Combinator
-import           Ouroboros.Consensus.Ledger.Abstract (EmptyMK, IsLedger)
+import           Ouroboros.Consensus.Ledger.Abstract (EmptyMK)
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState, ledgerState)
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Node (NodeKernel (..))
 import           Ouroboros.Consensus.Node.Tracers
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
-import qualified Ouroboros.Consensus.Storage.LedgerDB.BackingStore as Stats
+import qualified Ouroboros.Consensus.Storage.LedgerDB.API as LedgerDB
 
 import           Cardano.Node.Queries (LedgerQueries (..), NodeKernelData (..))
 import           Cardano.Slotting.Slot (fromWithOrigin)
@@ -65,7 +65,7 @@ forgeTracerTransform nodeKern (Trace tr) = pure $ Trace $ T.arrow $ T.emit $
         query <- mapNodeKernelDataIO
                     (\nk ->
                        (,,)
-                         <$> fmap Stats.numEntries (ChainDB.getStatistics (getChainDB nk))
+                         <$> fmap (maybe 0 LedgerDB.ledgerTableSize) (ChainDB.getStatistics (getChainDB nk))
                          <*> nkQueryLedger (ledgerDelegMapSize . ledgerState) nk
                          <*> nkQueryChain fragmentChainDensity nk)
                     nodeKern
@@ -84,8 +84,7 @@ forgeTracerTransform nodeKern (Trace tr) = pure $ Trace $ T.arrow $ T.emit $
           T.traceWith tr (lc, Left control)
 
 nkQueryLedger ::
-     IsLedger (LedgerState blk)
-  => (ExtLedgerState blk EmptyMK -> a)
+     (ExtLedgerState blk EmptyMK -> a)
   -> NodeKernel IO RemoteAddress LocalConnectionId blk
   -> IO a
 nkQueryLedger f NodeKernel{getChainDB} =

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/StartLeadershipCheck.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/StartLeadershipCheck.hs
@@ -27,7 +27,7 @@ import           Ouroboros.Network.NodeToNode (RemoteAddress)
 
 import           Ouroboros.Consensus.Block (SlotNo (..))
 import           Ouroboros.Consensus.HardFork.Combinator
-import           Ouroboros.Consensus.Ledger.Abstract (IsLedger)
+import           Ouroboros.Consensus.Ledger.Abstract (EmptyMK, IsLedger)
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState, ledgerState)
 import           Ouroboros.Consensus.Node (NodeKernel (..))
 import           Ouroboros.Consensus.Node.Tracers
@@ -86,7 +86,7 @@ forgeTracerTransform nodeKern (Trace tr) = pure $ Trace $ T.arrow $ T.emit $
 
 nkQueryLedger ::
      IsLedger (LedgerState blk)
-  => (ExtLedgerState blk -> a)
+  => (ExtLedgerState blk EmptyMK -> a)
   -> NodeKernel IO RemoteAddress LocalConnectionId blk
   -> IO a
 nkQueryLedger f NodeKernel{getChainDB} =

--- a/cardano-node/src/Cardano/Tracing/Config.hs
+++ b/cardano-node/src/Cardano/Tracing/Config.hs
@@ -159,6 +159,7 @@ type TraceLocalTxMonitorProtocol = ("TraceLocalTxMonitorProtocol" :: Symbol)
 type TraceLocalTxSubmissionProtocol = ("TraceLocalTxSubmissionProtocol" :: Symbol)
 type TraceLocalTxSubmissionServer = ("TraceLocalTxSubmissionServer" :: Symbol)
 type TraceMempool = ("TraceMempool" :: Symbol)
+type TraceBackingStore = ("TraceBackingStore" :: Symbol)
 type TraceMux = ("TraceMux" :: Symbol)
 type TraceLocalMux = ("TraceLocalMux" :: Symbol)
 type TracePeerSelection = ("TracePeerSelection" :: Symbol)
@@ -231,6 +232,7 @@ data TraceSelection
   , traceLocalTxSubmissionProtocol :: OnOff TraceLocalTxSubmissionProtocol
   , traceLocalTxSubmissionServer :: OnOff TraceLocalTxSubmissionServer
   , traceMempool :: OnOff TraceMempool
+  , traceBackingStore :: OnOff TraceBackingStore
   , traceMux :: OnOff TraceMux
   , tracePeerSelection :: OnOff TracePeerSelection
   , tracePeerSelectionCounters :: OnOff TracePeerSelectionCounters
@@ -293,6 +295,7 @@ data PartialTraceSelection
       , pTraceLocalTxSubmissionProtocol :: Last (OnOff TraceLocalTxSubmissionProtocol)
       , pTraceLocalTxSubmissionServer :: Last (OnOff TraceLocalTxSubmissionServer)
       , pTraceMempool :: Last (OnOff TraceMempool)
+      , pTraceBackingStore :: Last (OnOff TraceBackingStore)
       , pTraceMux :: Last (OnOff TraceMux)
       , pTracePeerSelection :: Last (OnOff TracePeerSelection)
       , pTracePeerSelectionCounters :: Last (OnOff TracePeerSelectionCounters)
@@ -356,6 +359,7 @@ instance FromJSON PartialTraceSelection where
       <*> parseTracer (Proxy @TraceLocalTxSubmissionProtocol) v
       <*> parseTracer (Proxy @TraceLocalTxSubmissionServer) v
       <*> parseTracer (Proxy @TraceMempool) v
+      <*> parseTracer (Proxy @TraceBackingStore) v
       <*> parseTracer (Proxy @TraceMux) v
       <*> parseTracer (Proxy @TracePeerSelection) v
       <*> parseTracer (Proxy @TracePeerSelectionCounters) v
@@ -416,6 +420,7 @@ defaultPartialTraceConfiguration =
     , pTraceLocalTxSubmissionProtocol = pure $ OnOff False
     , pTraceLocalTxSubmissionServer = pure $ OnOff False
     , pTraceMempool = pure $ OnOff True
+    , pTraceBackingStore = pure $ OnOff False
     , pTraceMux = pure $ OnOff True
     , pTracePeerSelection = pure $ OnOff True
     , pTracePeerSelectionCounters = pure $ OnOff True
@@ -478,6 +483,7 @@ partialTraceSelectionToEither (Last (Just (PartialTraceDispatcher pTraceSelectio
    traceLocalTxSubmissionProtocol <- proxyLastToEither (Proxy @TraceLocalTxSubmissionProtocol) pTraceLocalTxSubmissionProtocol
    traceLocalTxSubmissionServer <- proxyLastToEither (Proxy @TraceLocalTxSubmissionServer) pTraceLocalTxSubmissionServer
    traceMempool <- proxyLastToEither (Proxy @TraceMempool) pTraceMempool
+   traceBackingStore <- proxyLastToEither (Proxy @TraceBackingStore) pTraceBackingStore
    traceMux <- proxyLastToEither (Proxy @TraceMux) pTraceMux
    tracePeerSelection <- proxyLastToEither (Proxy @TracePeerSelection) pTracePeerSelection
    tracePeerSelectionCounters <- proxyLastToEither (Proxy @TracePeerSelectionCounters) pTracePeerSelectionCounters
@@ -533,6 +539,7 @@ partialTraceSelectionToEither (Last (Just (PartialTraceDispatcher pTraceSelectio
              , traceLocalTxSubmissionProtocol = traceLocalTxSubmissionProtocol
              , traceLocalTxSubmissionServer = traceLocalTxSubmissionServer
              , traceMempool = traceMempool
+             , traceBackingStore = traceBackingStore
              , traceMux = traceMux
              , tracePeerSelection = tracePeerSelection
              , tracePeerSelectionCounters = tracePeerSelectionCounters
@@ -592,6 +599,7 @@ partialTraceSelectionToEither (Last (Just (PartialTracingOnLegacy pTraceSelectio
   traceLocalTxSubmissionProtocol <- proxyLastToEither (Proxy @TraceLocalTxSubmissionProtocol) pTraceLocalTxSubmissionProtocol
   traceLocalTxSubmissionServer <- proxyLastToEither (Proxy @TraceLocalTxSubmissionServer) pTraceLocalTxSubmissionServer
   traceMempool <- proxyLastToEither (Proxy @TraceMempool) pTraceMempool
+  traceBackingStore <- proxyLastToEither (Proxy @TraceBackingStore) pTraceBackingStore
   traceMux <- proxyLastToEither (Proxy @TraceMux) pTraceMux
   tracePeerSelection <- proxyLastToEither (Proxy @TracePeerSelection) pTracePeerSelection
   tracePeerSelectionCounters <- proxyLastToEither (Proxy @TracePeerSelectionCounters) pTracePeerSelectionCounters
@@ -647,6 +655,7 @@ partialTraceSelectionToEither (Last (Just (PartialTracingOnLegacy pTraceSelectio
             , traceLocalTxSubmissionProtocol = traceLocalTxSubmissionProtocol
             , traceLocalTxSubmissionServer = traceLocalTxSubmissionServer
             , traceMempool = traceMempool
+            , traceBackingStore = traceBackingStore
             , traceMux = traceMux
             , tracePeerSelection = tracePeerSelection
             , tracePeerSelectionCounters = tracePeerSelectionCounters

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Common.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Common.hs
@@ -42,7 +42,7 @@ module Cardano.Tracing.OrphanInstances.Common
 import           Data.Aeson hiding (Value)
 import           Data.Scientific (coefficient)
 import           Data.Text (Text)
-import qualified Data.Text as Text
+-- import qualified Data.Text as Text
 import           Data.Void (Void)
 import           Network.Socket (PortNumber)
 import           Text.Read (readMaybe)
@@ -62,18 +62,6 @@ import           Cardano.Node.Handlers.Shutdown ()
 --
 instance ToObject Void where
   toObject _verb x = case x of {}
-
-deriving instance Show TracingVerbosity
-
-instance FromJSON TracingVerbosity where
-  parseJSON (String str) = case str of
-    "MinimalVerbosity" -> pure MinimalVerbosity
-    "MaximalVerbosity" -> pure MaximalVerbosity
-    "NormalVerbosity" -> pure NormalVerbosity
-    invalid -> fail $ "Parsing of TracingVerbosity failed, "
-                    <> Text.unpack invalid <> " is not a valid TracingVerbosity"
-  parseJSON invalid  = fail $ "Parsing of TracingVerbosity failed due to type mismatch. "
-                            <> "Encountered: " <> show invalid
 
 instance FromJSON PortNumber where
   parseJSON (Number portNum) = case readMaybe . show $ coefficient portNum of

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
@@ -122,6 +122,10 @@ instance ConvertRawHash blk => ConvertRawHash (Header blk) where
 --
 -- NOTE: this list is sorted by the unqualified name of the outermost type.
 
+instance HasPrivacyAnnotation LedgerDB.BackingStoreTraceByBackend
+instance HasSeverityAnnotation LedgerDB.BackingStoreTraceByBackend where
+  getSeverityAnnotation _ = Debug
+
 instance HasPrivacyAnnotation (ChainDB.TraceEvent blk)
 instance HasSeverityAnnotation (ChainDB.TraceEvent blk) where
   getSeverityAnnotation (ChainDB.TraceAddBlockEvent ev) = case ev of
@@ -158,7 +162,6 @@ instance HasSeverityAnnotation (ChainDB.TraceEvent blk) where
       LedgerDB.TookSnapshot {} -> Info
       LedgerDB.DeletedSnapshot {} -> Debug
       LedgerDB.InvalidSnapshot {} -> Error
-    LedgerDB.BackingStoreEvent {} -> Debug
     LedgerDB.BackingStoreInitEvent {} -> Info
 
   getSeverityAnnotation (ChainDB.TraceCopyToImmutableDBEvent ev) = case ev of
@@ -256,7 +259,7 @@ instance HasSeverityAnnotation (TraceChainSyncServerEvent blk) where
 instance HasPrivacyAnnotation (TraceEventMempool blk)
 instance HasSeverityAnnotation (TraceEventMempool blk) where
   getSeverityAnnotation TraceMempoolAddedTx{} = Info
-  getSeverityAnnotation TraceMempoolRejectedTx{} = Warning
+  getSeverityAnnotation TraceMempoolRejectedTx{} = Info
   getSeverityAnnotation TraceMempoolRemoveTxs{} = Debug
   getSeverityAnnotation TraceMempoolManuallyRemovedTxs{} = Warning
   getSeverityAnnotation TraceMempoolAttemptingSync = Debug
@@ -488,6 +491,14 @@ instance ( ConvertRawHash blk
       => Transformable Text IO (ChainDB.TraceEvent blk) where
   trTransformer = trStructuredText
 
+instance Transformable Text IO LedgerDB.BackingStoreTraceByBackend where
+  trTransformer = trStructuredText
+
+instance HasTextFormatter LedgerDB.BackingStoreTraceByBackend where
+    formatText ev _obj = case ev of
+      LedgerDB.LMDBTrace ev' -> "LMDB: " <> showT ev'
+      LedgerDB.InMemoryTrace ev' -> "InMemory: " <> showT ev'
+
 instance ( ConvertRawHash blk
          , LedgerSupportsProtocol blk
          , InspectLedger blk)
@@ -589,9 +600,6 @@ instance ( ConvertRawHash blk
             " at " <> renderRealPointAsPhrase pt
           LedgerDB.DeletedSnapshot snap ->
             "Deleted old snapshot " <> showT snap
-        LedgerDB.BackingStoreEvent ev' -> case ev' of
-          LedgerDB.LMDBTrace ev'' -> "LMDB: " <> showT ev''
-          LedgerDB.InMemoryTrace ev'' -> "InMemory: " <> showT ev''
         LedgerDB.BackingStoreInitEvent ev' -> case ev' of
           LedgerDB.BackingStoreInitialisedInMemory ->
             "Using In-Memory backing store"
@@ -1027,7 +1035,6 @@ instance ( ConvertRawHash blk
         mconcat [ "kind" .= String "TraceLedgerDBEvent.LedgerDBSnapshotEvent.InvalidSnapshot"
                  , "snapshot" .= toObject verb snap
                  , "failure" .= show failure ]
-    LedgerDB.BackingStoreEvent ev' -> toObject verb ev'
     LedgerDB.BackingStoreInitEvent ev' -> case ev' of
       LedgerDB.BackingStoreInitialisedLMDB limits ->
         mconcat [ "kind" .= String "TraceLedgerDBEvent.BackingStoreInitialisedLMDB"
@@ -1622,7 +1629,7 @@ instance ToObject BS.BackingStoreValueHandleTrace where
   toObject _verb BS.BSVHStatting      = mconcat [ "kind" .= String "BSVHStatting" ]
   toObject _verb BS.BSVHStatted       = mconcat [ "kind" .= String "BSVHStatted" ]
 
-instance ToObject LedgerDB.BackingStoreTrace where
+instance ToObject LedgerDB.BackingStoreTraceByBackend where
   toObject verb ev = case ev of
     LedgerDB.LMDBTrace ev' -> mconcat [ "backend" .= String "LMDB"
                                       , "event" .= toObject verb ev'

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
@@ -1599,7 +1599,7 @@ instance ToObject BS.BackingStoreTrace where
                                            , "path" .= show p
                                            ]
   toObject _verb BS.BSCreatingValueHandle = mconcat [ "kind" .= String "BSCreatingValueHandle" ]
-  toObject  verb (BS.BSValueHandleTrace i p) = mconcat ([ "kind" .= String "BSCopied"
+  toObject  verb (BS.BSValueHandleTrace i p) = mconcat ([ "kind" .= String "BSValueHandleTrace"
                                                        , "event" .= toObject verb p
                                                        ] ++ maybe [] (\i' -> [ "index" .= show i' ]) i)
   toObject _verb BS.BSCreatedValueHandle = mconcat [ "kind" .= String "BSCreatedValueHandle" ]

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
@@ -71,9 +71,8 @@ import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal (ChunkN
                    chunkNoToInt)
 import qualified Ouroboros.Consensus.Storage.LedgerDB as LedgerDB
 import qualified Ouroboros.Consensus.Storage.LedgerDB.BackingStore as BS
-import           Ouroboros.Consensus.Storage.LedgerDB.DbChangelog.Update (PushGoal (..),
+import           Ouroboros.Consensus.Storage.LedgerDB.DbChangelog (PushGoal (..),
                    PushStart (..), Pushing (..), UpdateLedgerDbTraceEvent (..))
-import qualified Ouroboros.Consensus.Storage.LedgerDB.Impl as LedgerDB
 import qualified Ouroboros.Consensus.Storage.VolatileDB.Impl as VolDb
 import           Ouroboros.Network.BlockFetch.ClientState (TraceLabelPeer (..))
 

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
@@ -69,8 +69,11 @@ import qualified Ouroboros.Consensus.Protocol.BFT as BFT
 import qualified Ouroboros.Consensus.Protocol.PBFT as PBFT
 import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal (ChunkNo (..),
                    chunkNoToInt)
-import           Ouroboros.Consensus.Storage.LedgerDB (PushGoal (..), PushStart (..), Pushing (..))
 import qualified Ouroboros.Consensus.Storage.LedgerDB as LedgerDB
+import qualified Ouroboros.Consensus.Storage.LedgerDB.BackingStore as BS
+import           Ouroboros.Consensus.Storage.LedgerDB.DbChangelog.Update (PushGoal (..),
+                   PushStart (..), Pushing (..), UpdateLedgerDbTraceEvent (..))
+import qualified Ouroboros.Consensus.Storage.LedgerDB.Impl as LedgerDB
 import qualified Ouroboros.Consensus.Storage.VolatileDB.Impl as VolDb
 import           Ouroboros.Network.BlockFetch.ClientState (TraceLabelPeer (..))
 
@@ -127,7 +130,6 @@ instance HasSeverityAnnotation (ChainDB.TraceEvent blk) where
     ChainDB.IgnoreInvalidBlock {} -> Info
     ChainDB.AddedBlockToQueue {} -> Debug
     ChainDB.PoppedBlockFromQueue {} -> Debug
-    ChainDB.BlockInTheFuture {} -> Info
     ChainDB.AddedBlockToVolatileDB {} -> Debug
     ChainDB.TryAddToCurrentChain {} -> Debug
     ChainDB.TrySwitchToAFork {} -> Info
@@ -151,10 +153,13 @@ instance HasSeverityAnnotation (ChainDB.TraceEvent blk) where
     LedgerDB.ReplayFromSnapshot {} -> Info
     LedgerDB.ReplayedBlock {} -> Info
 
-  getSeverityAnnotation (ChainDB.TraceSnapshotEvent ev) = case ev of
-    LedgerDB.TookSnapshot {} -> Info
-    LedgerDB.DeletedSnapshot {} -> Debug
-    LedgerDB.InvalidSnapshot {} -> Error
+  getSeverityAnnotation (ChainDB.TraceLedgerDBEvent ev) = case ev of
+    LedgerDB.LedgerDBSnapshotEvent ev' -> case ev' of
+      LedgerDB.TookSnapshot {} -> Info
+      LedgerDB.DeletedSnapshot {} -> Debug
+      LedgerDB.InvalidSnapshot {} -> Error
+    LedgerDB.BackingStoreEvent {} -> Debug
+    LedgerDB.BackingStoreInitEvent {} -> Info
 
   getSeverityAnnotation (ChainDB.TraceCopyToImmutableDBEvent ev) = case ev of
     ChainDB.CopiedBlockToImmutableDB {} -> Debug
@@ -250,7 +255,16 @@ instance HasSeverityAnnotation (TraceChainSyncServerEvent blk) where
 
 instance HasPrivacyAnnotation (TraceEventMempool blk)
 instance HasSeverityAnnotation (TraceEventMempool blk) where
-  getSeverityAnnotation _ = Info
+  getSeverityAnnotation TraceMempoolAddedTx{} = Info
+  getSeverityAnnotation TraceMempoolRejectedTx{} = Warning
+  getSeverityAnnotation TraceMempoolRemoveTxs{} = Debug
+  getSeverityAnnotation TraceMempoolManuallyRemovedTxs{} = Warning
+  getSeverityAnnotation TraceMempoolAttemptingSync = Debug
+  getSeverityAnnotation TraceMempoolSyncNotNeeded{} = Debug
+  getSeverityAnnotation TraceMempoolSyncDone = Debug
+  getSeverityAnnotation TraceMempoolAttemptingAdd{} = Debug
+  getSeverityAnnotation TraceMempoolLedgerFound{} = Debug
+  getSeverityAnnotation TraceMempoolLedgerNotFound{} = Debug
 
 instance HasPrivacyAnnotation ()
 instance HasSeverityAnnotation () where
@@ -329,7 +343,8 @@ instance (StandardHash blk, Show peer)
 
 
 instance ( ToObject (ApplyTxErr blk), ToObject (GenTx blk),
-           ToJSON (GenTxId blk), LedgerSupportsMempool blk)
+           ToJSON (GenTxId blk), LedgerSupportsMempool blk,
+           ConvertRawHash blk)
       => Transformable Text IO (TraceEventMempool blk) where
   trTransformer = trStructured
 
@@ -497,8 +512,6 @@ instance ( ConvertRawHash blk
               "Popping block from queue"
             FallingEdgeWith pt ->
               "Popped block from queue: " <> renderRealPointAsPhrase pt
-        ChainDB.BlockInTheFuture pt slot ->
-          "Ignoring block from future: " <> renderRealPointAsPhrase pt <> ", slot " <> condenseT slot
         ChainDB.StoreButDontChange pt ->
           "Ignoring block: " <> renderRealPointAsPhrase pt
         ChainDB.TryAddToCurrentChain pt ->
@@ -526,7 +539,7 @@ instance ( ConvertRawHash blk
             "Candidate contains blocks from future exceeding clock skew limit: " <>
             renderPointAsPhrase (AF.headPoint c) <> ", slots " <>
             Text.intercalate ", " (map (renderPoint . headerPoint) hdrs)
-          ChainDB.UpdateLedgerDbTraceEvent (LedgerDB.StartedPushingBlockToTheLedgerDb  (PushStart start) (PushGoal goal) (Pushing curr)) ->
+          ChainDB.UpdateLedgerDbTraceEvent (StartedPushingBlockToTheLedgerDb  (PushStart start) (PushGoal goal) (Pushing curr)) ->
             let fromSlot = unSlotNo $ realPointSlot start
                 atSlot   = unSlotNo $ realPointSlot curr
                 atDiff   = atSlot - fromSlot
@@ -567,14 +580,23 @@ instance ( ConvertRawHash blk
           <> ". Progress: "
           <> showProgressT (fromIntegral atDiff) (fromIntegral toDiff)
           <> "%"
-      ChainDB.TraceSnapshotEvent ev -> case ev of
-        LedgerDB.InvalidSnapshot snap failure ->
-          "Invalid snapshot " <> showT snap <> showT failure
-        LedgerDB.TookSnapshot snap pt ->
-          "Took ledger snapshot " <> showT snap <>
-          " at " <> renderRealPointAsPhrase pt
-        LedgerDB.DeletedSnapshot snap ->
-          "Deleted old snapshot " <> showT snap
+      ChainDB.TraceLedgerDBEvent ev -> case ev of
+        LedgerDB.LedgerDBSnapshotEvent ev' -> case ev' of
+          LedgerDB.InvalidSnapshot snap failure ->
+            "Invalid snapshot " <> showT snap <> showT failure
+          LedgerDB.TookSnapshot snap pt ->
+            "Took ledger snapshot " <> showT snap <>
+            " at " <> renderRealPointAsPhrase pt
+          LedgerDB.DeletedSnapshot snap ->
+            "Deleted old snapshot " <> showT snap
+        LedgerDB.BackingStoreEvent ev' -> case ev' of
+          LedgerDB.LMDBTrace ev'' -> "LMDB: " <> showT ev''
+          LedgerDB.InMemoryTrace ev'' -> "InMemory: " <> showT ev''
+        LedgerDB.BackingStoreInitEvent ev' -> case ev' of
+          LedgerDB.BackingStoreInitialisedInMemory ->
+            "Using In-Memory backing store"
+          LedgerDB.BackingStoreInitialisedLMDB limits ->
+            "Using LMDB backing store " <> showT limits
       ChainDB.TraceCopyToImmutableDBEvent ev -> case ev of
         ChainDB.CopiedBlockToImmutableDB pt ->
           "Copied block " <> renderPointAsPhrase pt <> " to the ImmutableDB"
@@ -614,7 +636,7 @@ instance ( ConvertRawHash blk
           ChainDB.ValidCandidate af     -> "Valid candidate at tip " <> renderPointAsPhrase (AF.lastPoint af)
           ChainDB.CandidateContainsFutureBlocks {} -> "Found a candidate containing future blocks during Initial chain selection, truncating the candidate and retrying to select a best candidate."
           ChainDB.CandidateContainsFutureBlocksExceedingClockSkew {} -> "Found a candidate containing future blocks exceeding clock skew during Initial chain selection, truncating the candidate and retrying to select a best candidate."
-          ChainDB.UpdateLedgerDbTraceEvent (LedgerDB.StartedPushingBlockToTheLedgerDb (PushStart start) (PushGoal goal) (Pushing curr)) ->
+          ChainDB.UpdateLedgerDbTraceEvent (StartedPushingBlockToTheLedgerDb (PushStart start) (PushGoal goal) (Pushing curr)) ->
             let fromSlot = unSlotNo $ realPointSlot start
                 atSlot   = unSlotNo $ realPointSlot curr
                 atDiff   = atSlot - fromSlot
@@ -886,10 +908,6 @@ instance ( ConvertRawHash blk
                , case edgePt of
                    RisingEdge         -> "risingEdge" .= True
                    FallingEdgeWith pt -> "block" .= toObject verb pt ]
-    ChainDB.BlockInTheFuture pt slot ->
-      mconcat [ "kind" .= String "TraceAddBlockEvent.BlockInTheFuture"
-               , "block" .= toObject verb pt
-               , "slot" .= toObject verb slot ]
     ChainDB.StoreButDontChange pt ->
       mconcat [ "kind" .= String "TraceAddBlockEvent.StoreButDontChange"
                , "block" .= toObject verb pt ]
@@ -940,7 +958,7 @@ instance ( ConvertRawHash blk
         mconcat [ "kind" .= String "TraceAddBlockEvent.AddBlockValidation.CandidateContainsFutureBlocksExceedingClockSkew"
                  , "block"   .= renderPointForVerbosity verb (AF.headPoint c)
                  , "headers" .= map (renderPointForVerbosity verb . headerPoint) hdrs ]
-      ChainDB.UpdateLedgerDbTraceEvent (LedgerDB.StartedPushingBlockToTheLedgerDb (PushStart start) (PushGoal goal) (Pushing curr)) ->
+      ChainDB.UpdateLedgerDbTraceEvent (StartedPushingBlockToTheLedgerDb (PushStart start) (PushGoal goal) (Pushing curr)) ->
         mconcat [ "kind" .= String "TraceAddBlockEvent.AddBlockValidation.UpdateLedgerDb"
                  , "startingBlock" .= renderRealPoint start
                  , "currentBlock" .= renderRealPoint curr
@@ -995,19 +1013,28 @@ instance ( ConvertRawHash blk
                , "slot" .= unSlotNo (realPointSlot pt)
                , "tip"  .= withOrigin 0 unSlotNo (pointSlot replayTo) ]
 
-  toObject MinimalVerbosity (ChainDB.TraceSnapshotEvent _ev) = mempty -- no output
-  toObject verb (ChainDB.TraceSnapshotEvent ev) = case ev of
-    LedgerDB.TookSnapshot snap pt ->
-      mconcat [ "kind" .= String "TraceSnapshotEvent.TookSnapshot"
-               , "snapshot" .= toObject verb snap
-               , "tip" .= show pt ]
-    LedgerDB.DeletedSnapshot snap ->
-      mconcat [ "kind" .= String "TraceSnapshotEvent.DeletedSnapshot"
-               , "snapshot" .= toObject verb snap ]
-    LedgerDB.InvalidSnapshot snap failure ->
-      mconcat [ "kind" .= String "TraceSnapshotEvent.InvalidSnapshot"
-               , "snapshot" .= toObject verb snap
-               , "failure" .= show failure ]
+  toObject MinimalVerbosity (ChainDB.TraceLedgerDBEvent _ev) = mempty -- no output
+  toObject verb (ChainDB.TraceLedgerDBEvent ev) = case ev of
+    LedgerDB.LedgerDBSnapshotEvent ev' -> case ev' of
+      LedgerDB.TookSnapshot snap pt ->
+        mconcat [ "kind" .= String "TraceLedgerDBEvent.LedgerDBSnapshotEvent.TookSnapshot"
+                 , "snapshot" .= toObject verb snap
+                 , "tip" .= show pt ]
+      LedgerDB.DeletedSnapshot snap ->
+        mconcat [ "kind" .= String "TraceLedgerDBEvent.LedgerDBSnapshotEvent.DeletedSnapshot"
+                 , "snapshot" .= toObject verb snap ]
+      LedgerDB.InvalidSnapshot snap failure ->
+        mconcat [ "kind" .= String "TraceLedgerDBEvent.LedgerDBSnapshotEvent.InvalidSnapshot"
+                 , "snapshot" .= toObject verb snap
+                 , "failure" .= show failure ]
+    LedgerDB.BackingStoreEvent ev' -> toObject verb ev'
+    LedgerDB.BackingStoreInitEvent ev' -> case ev' of
+      LedgerDB.BackingStoreInitialisedLMDB limits ->
+        mconcat [ "kind" .= String "TraceLedgerDBEvent.BackingStoreInitialisedLMDB"
+                , "limits" .= String (showT limits)
+                ]
+      LedgerDB.BackingStoreInitialisedInMemory ->
+        mconcat [ "kind" .= String "TraceLedgerDBEvent.BackingStoreInitialisedInMemory" ]
 
   toObject verb (ChainDB.TraceCopyToImmutableDBEvent ev) = case ev of
     ChainDB.CopiedBlockToImmutableDB pt ->
@@ -1082,7 +1109,7 @@ instance ( ConvertRawHash blk
                  , "block"   .= renderPointForVerbosity verb (AF.headPoint c)
                  , "headers" .= map (renderPointForVerbosity verb . headerPoint) hdrs ]
       ChainDB.UpdateLedgerDbTraceEvent
-        (LedgerDB.StartedPushingBlockToTheLedgerDb (PushStart start) (PushGoal goal) (Pushing curr) ) ->
+        (StartedPushingBlockToTheLedgerDb (PushStart start) (PushGoal goal) (Pushing curr) ) ->
           mconcat [ "kind" .= String "TraceAddBlockEvent.AddBlockValidation.UpdateLedgerDbTraceEvent.StartedPushingBlockToTheLedgerDb"
                    , "startingBlock" .= renderRealPoint start
                    , "currentBlock" .= renderRealPoint curr
@@ -1307,7 +1334,8 @@ instance ConvertRawHash blk
         <> [ "risingEdge" .= True | RisingEdge <- [enclosing] ]
 
 instance ( ToObject (ApplyTxErr blk), ToObject (GenTx blk),
-           ToJSON (GenTxId blk), LedgerSupportsMempool blk
+           ToJSON (GenTxId blk), LedgerSupportsMempool blk,
+           ConvertRawHash blk
          ) => ToObject (TraceEventMempool blk) where
   toObject verb (TraceMempoolAddedTx tx _mpSzBefore mpSzAfter) =
     mconcat
@@ -1335,6 +1363,58 @@ instance ( ToObject (ApplyTxErr blk), ToObject (GenTx blk),
       , "txsInvalidated" .= map (toObject verb . txForgetValidated) txs1
       , "mempoolSize" .= toObject verb mpSz
       ]
+  toObject _ TraceMempoolAttemptingSync =
+    mconcat
+      [ "kind" .= String "TraceMempoolAttemptingSync"
+      ]
+  toObject verb (TraceMempoolSyncNotNeeded t _) =
+    mconcat
+      [ "kind" .= String "TraceMempoolSyncNotNeeded"
+      , "tip" .= toObject verb t
+      ]
+  toObject _ TraceMempoolSyncDone =
+    mconcat
+      [ "kind" .= String "TraceMempoolSyncDone"
+      ]
+  toObject verb (TraceMempoolAttemptingAdd tx) =
+    mconcat
+      [ "kind" .= String "TraceMempoolAttemptingAdd"
+      , "tx" .= toObject verb tx
+      ]
+  toObject verb (TraceMempoolLedgerFound p) =
+    mconcat
+      [ "kind" .= String "TraceMempoolLedgerFound"
+      , "tip" .= toObject verb p
+      ]
+  toObject verb (TraceMempoolLedgerNotFound p) =
+    mconcat
+      [ "kind" .= String "TraceMempoolLedgerNotFound"
+      , "tip" .= toObject verb p
+      ]
+
+instance (LedgerSupportsMempool blk, HasTxId (GenTx blk))
+      => HasTextFormatter (TraceEventMempool blk) where
+  formatText tev _obj = case tev of
+    TraceMempoolAddedTx tx _sz1 sz2 ->
+      "Added transaction " <> showT (txId $ txForgetValidated tx) <> ". Current size: " <> showT sz2
+    TraceMempoolRejectedTx tx err sz ->
+      "Rejected transaction " <> showT (txId tx) <> ". Error: " <> showT err <> ". Current size: " <> showT sz
+    TraceMempoolRemoveTxs txs sz ->
+      "Removed transactions " <> showT (map (txId . txForgetValidated) txs) <> ". Current size: " <> showT sz
+    TraceMempoolManuallyRemovedTxs txs txs2 sz ->
+      "Manually removed transactions " <> showT txs <> " which removed " <> showT (map (txId . txForgetValidated) txs2) <>". Current size: " <> showT sz
+    TraceMempoolAttemptingSync ->
+      "Mempool is checking if a sync with the LedgerDB is needed"
+    TraceMempoolSyncNotNeeded p1 _p2 ->
+      "Mempool sync is not needed becase both the mempool and the LedgerDB are at " <> showT p1
+    TraceMempoolSyncDone ->
+      "Mempool sync done"
+    TraceMempoolAttemptingAdd tx ->
+      "Attempting to add transaction " <> showT (txId tx)
+    TraceMempoolLedgerFound pt ->
+      "Ledger state at " <> showT pt <> " (requested by the mempool) is in the LedgerDB"
+    TraceMempoolLedgerNotFound pt ->
+      "Ledger state at " <> showT pt <> " (requested by the mempool) is not in the LedgerDB"
 
 instance ToObject MempoolSize where
   toObject _verb MempoolSize{msNumTxs, msNumBytes} =
@@ -1493,3 +1573,60 @@ instance ( RunNode blk
 instance ToObject (TraceLocalTxSubmissionServerEvent blk) where
   toObject _verb _ =
     mconcat [ "kind" .= String "TraceLocalTxSubmissionServerEvent" ]
+
+instance ToObject BS.BackingStoreTrace where
+  toObject _verb BS.BSOpening = mconcat [ "kind" .= String "BSOpening" ]
+  toObject _verb (BS.BSOpened p) = mconcat ([ "kind" .= String "BSOpened" ] ++ maybe [] (\p' -> ["path" .= show p']) p)
+  toObject _verb (BS.BSInitialisingFromCopy p) = mconcat [ "kind" .= String "BSInitialisingFromCopy"
+                                                         , "path" .= show p
+                                                         ]
+  toObject _verb (BS.BSInitialisedFromCopy p) = mconcat [ "kind" .= String "BSInitialisedFromCopy"
+                                                        , "path" .= show p
+                                                        ]
+  toObject _verb (BS.BSInitialisingFromValues s) = mconcat [ "kind" .= String "BSInitialisingFromValues"
+                                                           , "slot" .= show s
+                                                           ]
+  toObject _verb (BS.BSInitialisedFromValues s) = mconcat [ "kind" .= String "BSInitialisedFromValues"
+                                                          , "slot" .= show s
+                                                          ]
+  toObject _verb BS.BSClosing = mconcat [ "kind" .= String "BSClosing" ]
+  toObject _verb BS.BSAlreadyClosed = mconcat [ "kind" .= String "BSAlreadyClosed" ]
+  toObject _verb BS.BSClosed = mconcat [ "kind" .= String "BSClosed" ]
+  toObject _verb (BS.BSCopying p) = mconcat [ "kind" .= String "BSCopying"
+                                            , "path" .= show p
+                                            ]
+  toObject _verb (BS.BSCopied p) = mconcat [ "kind" .= String "BSCopied"
+                                           , "path" .= show p
+                                           ]
+  toObject _verb BS.BSCreatingValueHandle = mconcat [ "kind" .= String "BSCreatingValueHandle" ]
+  toObject  verb (BS.BSValueHandleTrace i p) = mconcat ([ "kind" .= String "BSCopied"
+                                                       , "event" .= toObject verb p
+                                                       ] ++ maybe [] (\i' -> [ "index" .= show i' ]) i)
+  toObject _verb BS.BSCreatedValueHandle = mconcat [ "kind" .= String "BSCreatedValueHandle" ]
+  toObject _verb (BS.BSWriting s) = mconcat [ "kind" .= String "BSWriting"
+                                            , "slot" .= show s
+                                            ]
+  toObject _verb (BS.BSWritten s1 s2) = mconcat [ "kind" .= String "BSWritten"
+                                                , "from" .= show s1
+                                                , "to" .= show s2
+                                                ]
+
+instance ToObject BS.BackingStoreValueHandleTrace where
+  toObject _verb BS.BSVHClosing       = mconcat [ "kind" .= String "BSVHClosing " ]
+  toObject _verb BS.BSVHAlreadyClosed = mconcat [ "kind" .= String "BSVHAlreadyClosed" ]
+  toObject _verb BS.BSVHClosed        = mconcat [ "kind" .= String "BSVHClosed" ]
+  toObject _verb BS.BSVHRangeReading  = mconcat [ "kind" .= String "BSVHRangeReading" ]
+  toObject _verb BS.BSVHRangeRead     = mconcat [ "kind" .= String "BSVHRangeRead" ]
+  toObject _verb BS.BSVHReading       = mconcat [ "kind" .= String "BSVHReading" ]
+  toObject _verb BS.BSVHRead          = mconcat [ "kind" .= String "BSVHRead" ]
+  toObject _verb BS.BSVHStatting      = mconcat [ "kind" .= String "BSVHStatting" ]
+  toObject _verb BS.BSVHStatted       = mconcat [ "kind" .= String "BSVHStatted" ]
+
+instance ToObject LedgerDB.BackingStoreTrace where
+  toObject verb ev = case ev of
+    LedgerDB.LMDBTrace ev' -> mconcat [ "backend" .= String "LMDB"
+                                      , "event" .= toObject verb ev'
+                                      ]
+    LedgerDB.InMemoryTrace ev' -> mconcat [ "backend" .= String "InMemory"
+                                          , "event" .= toObject verb ev'
+                                          ]

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
@@ -18,6 +18,7 @@
 
 module Cardano.Tracing.OrphanInstances.Consensus () where
 
+import Ouroboros.Network.Block (MaxSlotNo(..))
 import           Cardano.Prelude (maximumDef)
 import           Data.Aeson (Value (..))
 import qualified Data.Aeson as Aeson
@@ -70,9 +71,10 @@ import qualified Ouroboros.Consensus.Protocol.PBFT as PBFT
 import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal (ChunkNo (..),
                    chunkNoToInt)
 import qualified Ouroboros.Consensus.Storage.LedgerDB as LedgerDB
-import qualified Ouroboros.Consensus.Storage.LedgerDB.BackingStore as BS
-import           Ouroboros.Consensus.Storage.LedgerDB.DbChangelog (PushGoal (..),
-                   PushStart (..), Pushing (..), UpdateLedgerDbTraceEvent (..))
+import qualified Ouroboros.Consensus.Storage.LedgerDB.Impl.Snapshots as LedgerDB
+import qualified Ouroboros.Consensus.Storage.LedgerDB.V1.BackingStore as BS
+import           Ouroboros.Consensus.Storage.LedgerDB.API (PushGoal (..),
+                   PushStart (..), Pushing (..), TraceValidateEvent (..))
 import qualified Ouroboros.Consensus.Storage.VolatileDB.Impl as VolDb
 import           Ouroboros.Network.BlockFetch.ClientState (TraceLabelPeer (..))
 
@@ -121,10 +123,6 @@ instance ConvertRawHash blk => ConvertRawHash (Header blk) where
 --
 -- NOTE: this list is sorted by the unqualified name of the outermost type.
 
-instance HasPrivacyAnnotation LedgerDB.BackingStoreTraceByBackend
-instance HasSeverityAnnotation LedgerDB.BackingStoreTraceByBackend where
-  getSeverityAnnotation _ = Debug
-
 instance HasPrivacyAnnotation (ChainDB.TraceEvent blk)
 instance HasSeverityAnnotation (ChainDB.TraceEvent blk) where
   getSeverityAnnotation (ChainDB.TraceAddBlockEvent ev) = case ev of
@@ -151,17 +149,14 @@ instance HasSeverityAnnotation (ChainDB.TraceEvent blk) where
     ChainDB.ChainSelectionForFutureBlock{} -> Debug
     ChainDB.PipeliningEvent {} -> Debug
 
-  getSeverityAnnotation (ChainDB.TraceLedgerReplayEvent ev) = case ev of
-    LedgerDB.ReplayFromGenesis {} -> Info
-    LedgerDB.ReplayFromSnapshot {} -> Info
-    LedgerDB.ReplayedBlock {} -> Info
-
   getSeverityAnnotation (ChainDB.TraceLedgerDBEvent ev) = case ev of
     LedgerDB.LedgerDBSnapshotEvent ev' -> case ev' of
       LedgerDB.TookSnapshot {} -> Info
       LedgerDB.DeletedSnapshot {} -> Debug
       LedgerDB.InvalidSnapshot {} -> Error
-    LedgerDB.BackingStoreInitEvent {} -> Info
+    LedgerDB.LedgerReplayEvent {} -> Info
+    LedgerDB.LedgerDBForkerEvent {} -> Debug
+    LedgerDB.LedgerDBFlavorImplEvent {} -> Debug
 
   getSeverityAnnotation (ChainDB.TraceCopyToImmutableDBEvent ev) = case ev of
     ChainDB.CopiedBlockToImmutableDB {} -> Debug
@@ -175,7 +170,7 @@ instance HasSeverityAnnotation (ChainDB.TraceEvent blk) where
     ChainDB.OpenedDB {} -> Info
     ChainDB.ClosedDB {} -> Info
     ChainDB.OpenedImmutableDB {} -> Info
-    ChainDB.OpenedVolatileDB -> Info
+    ChainDB.OpenedVolatileDB {} -> Info
     ChainDB.OpenedLgrDB -> Info
     ChainDB.StartedOpeningDB -> Info
     ChainDB.StartedOpeningImmutableDB -> Info
@@ -225,6 +220,7 @@ instance HasSeverityAnnotation (ChainDB.TraceEvent blk) where
     VolDb.BlockAlreadyHere{}    -> Debug
     VolDb.Truncate{}            -> Error
     VolDb.InvalidFileNames{}    -> Warning
+    VolDb.DBClosed{}            -> Info
 
 instance HasSeverityAnnotation (LedgerEvent blk) where
   getSeverityAnnotation (LedgerUpdate _)  = Notice
@@ -490,14 +486,6 @@ instance ( ConvertRawHash blk
       => Transformable Text IO (ChainDB.TraceEvent blk) where
   trTransformer = trStructuredText
 
-instance Transformable Text IO LedgerDB.BackingStoreTraceByBackend where
-  trTransformer = trStructuredText
-
-instance HasTextFormatter LedgerDB.BackingStoreTraceByBackend where
-    formatText ev _obj = case ev of
-      LedgerDB.LMDBTrace ev' -> "LMDB: " <> showT ev'
-      LedgerDB.InMemoryTrace ev' -> "InMemory: " <> showT ev'
-
 instance ( ConvertRawHash blk
          , LedgerSupportsProtocol blk
          , InspectLedger blk)
@@ -540,7 +528,7 @@ instance ( ConvertRawHash blk
           ChainDB.InvalidBlock err pt ->
             "Invalid block " <> renderRealPointAsPhrase pt <> ": " <> showT err
           ChainDB.ValidCandidate c ->
-            "Valid candidate " <> renderPointAsPhrase (AF.headPoint c)
+            "Valid candidate spanning from " <> renderPointAsPhrase (AF.lastPoint c) <> " to " <> renderPointAsPhrase (AF.headPoint c)
           ChainDB.CandidateContainsFutureBlocks c hdrs ->
             "Candidate contains blocks from near future:  " <>
             renderPointAsPhrase (AF.headPoint c) <> ", slots " <>
@@ -570,26 +558,6 @@ instance ( ConvertRawHash blk
           ChainDB.TrapTentativeHeader hdr -> "Discovered trap tentative header " <> renderPointAsPhrase (blockPoint hdr)
           ChainDB.OutdatedTentativeHeader hdr -> "Tentative header is now outdated" <> renderPointAsPhrase (blockPoint hdr)
 
-      ChainDB.TraceLedgerReplayEvent ev -> case ev of
-        LedgerDB.ReplayFromGenesis _replayTo ->
-          "Replaying ledger from genesis"
-        LedgerDB.ReplayFromSnapshot _ tip' _ _ ->
-          "Replaying ledger from snapshot at " <>
-            renderRealPointAsPhrase tip'
-        LedgerDB.ReplayedBlock pt _ledgerEvents (LedgerDB.ReplayStart replayFrom) (LedgerDB.ReplayGoal replayTo) ->
-          let fromSlot = withOrigin 0 Prelude.id $ unSlotNo <$> pointSlot replayFrom
-              atSlot   = unSlotNo $ realPointSlot pt
-              atDiff   = atSlot - fromSlot
-              toSlot   = withOrigin 0 Prelude.id $ unSlotNo <$> pointSlot replayTo
-              toDiff   = toSlot - fromSlot
-          in
-             "Replayed block: slot "
-          <> showT atSlot
-          <> " out of "
-          <> showT toSlot
-          <> ". Progress: "
-          <> showProgressT (fromIntegral atDiff) (fromIntegral toDiff)
-          <> "%"
       ChainDB.TraceLedgerDBEvent ev -> case ev of
         LedgerDB.LedgerDBSnapshotEvent ev' -> case ev' of
           LedgerDB.InvalidSnapshot snap failure ->
@@ -599,11 +567,31 @@ instance ( ConvertRawHash blk
             " at " <> renderRealPointAsPhrase pt
           LedgerDB.DeletedSnapshot snap ->
             "Deleted old snapshot " <> showT snap
-        LedgerDB.BackingStoreInitEvent ev' -> case ev' of
-          LedgerDB.BackingStoreInitialisedInMemory ->
-            "Using In-Memory backing store"
-          LedgerDB.BackingStoreInitialisedLMDB limits ->
-            "Using LMDB backing store " <> showT limits
+        LedgerDB.LedgerReplayEvent ev' -> case ev' of
+          LedgerDB.TraceReplayStartEvent ev'' -> case ev'' of
+            LedgerDB.ReplayFromGenesis ->
+              "Replaying ledger from genesis"
+            LedgerDB.ReplayFromSnapshot _ (LedgerDB.ReplayStart tip') ->
+              "Replaying ledger from snapshot at " <>
+                renderPointAsPhrase tip'
+          LedgerDB.TraceReplayProgressEvent
+            (LedgerDB.ReplayedBlock pt _ledgerEvents (LedgerDB.ReplayStart replayFrom) (LedgerDB.ReplayGoal replayTo)) ->
+            let fromSlot = withOrigin 0 Prelude.id $ unSlotNo <$> pointSlot replayFrom
+                atSlot   = unSlotNo $ realPointSlot pt
+                atDiff   = atSlot - fromSlot
+                toSlot   = withOrigin 0 Prelude.id $ unSlotNo <$> pointSlot replayTo
+                toDiff   = toSlot - fromSlot
+            in
+               "Replayed block: slot "
+            <> showT atSlot
+            <> " out of "
+            <> showT toSlot
+            <> ". Progress: "
+            <> showProgressT (fromIntegral atDiff) (fromIntegral toDiff)
+            <> "%"
+        LedgerDB.LedgerDBForkerEvent ev' -> showT ev'
+        LedgerDB.LedgerDBFlavorImplEvent ev' -> showT ev'
+
       ChainDB.TraceCopyToImmutableDBEvent ev -> case ev of
         ChainDB.CopiedBlockToImmutableDB pt ->
           "Copied block " <> renderPointAsPhrase pt <> " to the ImmutableDB"
@@ -628,7 +616,9 @@ instance ( ConvertRawHash blk
         ChainDB.OpenedImmutableDB immTip chunk ->
           "Opened imm db with immutable tip at " <> renderPointAsPhrase immTip <>
           " and chunk " <> showT chunk
-        ChainDB.OpenedVolatileDB ->  "Opened vol db"
+        ChainDB.OpenedVolatileDB mx ->  "Opened " <> case mx of
+          NoMaxSlotNo -> "empty Volatile DB"
+          MaxSlotNo mxx -> "Volatile DB with max slot seen " <> showT mxx
         ChainDB.OpenedLgrDB ->  "Opened lgr db"
       ChainDB.TraceFollowerEvent ev -> case ev of
         ChainDB.NewFollower ->  "New follower was created"
@@ -640,7 +630,7 @@ instance ( ConvertRawHash blk
         ChainDB.InitalChainSelected -> "Initial chain selected"
         ChainDB.InitChainSelValidation e -> case e of
           ChainDB.InvalidBlock _err _pt -> "Invalid block found during Initial chain selection, truncating the candidate and retrying to select a best candidate."
-          ChainDB.ValidCandidate af     -> "Valid candidate at tip " <> renderPointAsPhrase (AF.lastPoint af)
+          ChainDB.ValidCandidate af     -> "Valid candidate spanning from " <> renderPointAsPhrase (AF.lastPoint af) <> " to " <> renderPointAsPhrase (AF.headPoint af)
           ChainDB.CandidateContainsFutureBlocks {} -> "Found a candidate containing future blocks during Initial chain selection, truncating the candidate and retrying to select a best candidate."
           ChainDB.CandidateContainsFutureBlocksExceedingClockSkew {} -> "Found a candidate containing future blocks exceeding clock skew during Initial chain selection, truncating the candidate and retrying to select a best candidate."
           ChainDB.UpdateLedgerDbTraceEvent (StartedPushingBlockToTheLedgerDb (PushStart start) (PushGoal goal) (Pushing curr)) ->
@@ -741,6 +731,7 @@ instance ( ConvertRawHash blk
         VolDb.BlockAlreadyHere bh   -> "Block " <> showT bh <> " was already in the Volatile DB."
         VolDb.Truncate e pth offs   -> "Truncating the file at " <> showT pth <> " at offset " <> showT offs <> ": " <> showT e
         VolDb.InvalidFileNames fs   -> "Invalid Volatile DB files: " <> showT fs
+        VolDb.DBClosed{}            -> "Closed Volatile DB."
      where showProgressT :: Int -> Int -> Text
            showProgressT chunkNo outOf =
              pack (showFFloat (Just 2) (100 * fromIntegral chunkNo / fromIntegral outOf :: Float) mempty)
@@ -1007,19 +998,6 @@ instance ( ConvertRawHash blk
      chainLengthΔ :: AF.AnchoredFragment (Header blk) -> AF.AnchoredFragment (Header blk) -> Int
      chainLengthΔ = on (-) (fromWithOrigin (-1) . fmap (fromIntegral . unBlockNo) . AF.headBlockNo)
 
-  toObject MinimalVerbosity (ChainDB.TraceLedgerReplayEvent _ev) = mempty -- no output
-  toObject verb (ChainDB.TraceLedgerReplayEvent ev) = case ev of
-    LedgerDB.ReplayFromGenesis _replayTo ->
-      mconcat [ "kind" .= String "TraceLedgerReplayEvent.ReplayFromGenesis" ]
-    LedgerDB.ReplayFromSnapshot snap tip' _replayFrom _replayTo ->
-      mconcat [ "kind" .= String "TraceLedgerReplayEvent.ReplayFromSnapshot"
-               , "snapshot" .= toObject verb snap
-               , "tip" .= show tip' ]
-    LedgerDB.ReplayedBlock pt _ledgerEvents _ (LedgerDB.ReplayGoal replayTo)  ->
-      mconcat [ "kind" .= String "TraceLedgerReplayEvent.ReplayedBlock"
-               , "slot" .= unSlotNo (realPointSlot pt)
-               , "tip"  .= withOrigin 0 unSlotNo (pointSlot replayTo) ]
-
   toObject MinimalVerbosity (ChainDB.TraceLedgerDBEvent _ev) = mempty -- no output
   toObject verb (ChainDB.TraceLedgerDBEvent ev) = case ev of
     LedgerDB.LedgerDBSnapshotEvent ev' -> case ev' of
@@ -1034,14 +1012,25 @@ instance ( ConvertRawHash blk
         mconcat [ "kind" .= String "TraceLedgerDBEvent.LedgerDBSnapshotEvent.InvalidSnapshot"
                  , "snapshot" .= toObject verb snap
                  , "failure" .= show failure ]
-    LedgerDB.BackingStoreInitEvent ev' -> case ev' of
-      LedgerDB.BackingStoreInitialisedLMDB limits ->
-        mconcat [ "kind" .= String "TraceLedgerDBEvent.BackingStoreInitialisedLMDB"
-                , "limits" .= String (showT limits)
-                ]
-      LedgerDB.BackingStoreInitialisedInMemory ->
-        mconcat [ "kind" .= String "TraceLedgerDBEvent.BackingStoreInitialisedInMemory" ]
-
+    LedgerDB.LedgerReplayEvent ev' -> case ev' of
+      LedgerDB.TraceReplayStartEvent ev'' -> case ev'' of
+        LedgerDB.ReplayFromGenesis ->
+          mconcat [ "kind" .= String "TraceLedgerReplayEvent.ReplayFromGenesis" ]
+        LedgerDB.ReplayFromSnapshot snap tip' ->
+          mconcat [ "kind" .= String "TraceLedgerReplayEvent.ReplayFromSnapshot"
+                  , "snapshot" .= toObject verb snap
+                  , "tip" .= show tip' ]
+      LedgerDB.TraceReplayProgressEvent (LedgerDB.ReplayedBlock pt _ledgerEvents _ (LedgerDB.ReplayGoal replayTo)) ->
+        mconcat [ "kind" .= String "TraceLedgerReplayEvent.ReplayedBlock"
+                , "slot" .= unSlotNo (realPointSlot pt)
+                , "tip"  .= withOrigin 0 unSlotNo (pointSlot replayTo) ]
+    LedgerDB.LedgerDBForkerEvent (LedgerDB.TraceForkerEventWithKey k ev') ->
+      mconcat [ "kind" .= String "LedgerDBForkerEvent"
+              , "key" .= show k
+              , "event" .= show ev' ]
+    LedgerDB.LedgerDBFlavorImplEvent ev' ->
+      mconcat [ "kind" .= String "LedgerDBFlavorImplEvent"
+              , "event" .= show ev' ]
   toObject verb (ChainDB.TraceCopyToImmutableDBEvent ev) = case ev of
     ChainDB.CopiedBlockToImmutableDB pt ->
       mconcat [ "kind" .= String "TraceCopyToImmutableDBEvent.CopiedBlockToImmutableDB"
@@ -1079,7 +1068,7 @@ instance ( ConvertRawHash blk
       mconcat [ "kind" .= String "TraceOpenEvent.OpenedImmutableDB"
                , "immtip" .= toObject verb immTip
                , "epoch" .= String ((pack . show) epoch) ]
-    ChainDB.OpenedVolatileDB ->
+    ChainDB.OpenedVolatileDB {} ->
       mconcat [ "kind" .= String "TraceOpenEvent.OpenedVolatileDB" ]
     ChainDB.OpenedLgrDB ->
       mconcat [ "kind" .= String "TraceOpenEvent.OpenedLgrDB" ]
@@ -1228,6 +1217,7 @@ instance ( ConvertRawHash blk
       mconcat [ "kind" .= String "TraceVolatileDBEvent.InvalidFileNames"
                , "files" .= String (Text.pack . show $ map show fsPaths)
                ]
+    VolDb.DBClosed -> mconcat [ "kind" .= String "TraceVolatileDBEvent.DBClosed" ]
 
 instance ConvertRawHash blk => ToObject (ImmDB.TraceChunkValidation blk ChunkNo) where
   toObject verb ev = case ev of
@@ -1627,12 +1617,3 @@ instance ToObject BS.BackingStoreValueHandleTrace where
   toObject _verb BS.BSVHRead          = mconcat [ "kind" .= String "BSVHRead" ]
   toObject _verb BS.BSVHStatting      = mconcat [ "kind" .= String "BSVHStatting" ]
   toObject _verb BS.BSVHStatted       = mconcat [ "kind" .= String "BSVHStatted" ]
-
-instance ToObject LedgerDB.BackingStoreTraceByBackend where
-  toObject verb ev = case ev of
-    LedgerDB.LMDBTrace ev' -> mconcat [ "backend" .= String "LMDB"
-                                      , "event" .= toObject verb ev'
-                                      ]
-    LedgerDB.InMemoryTrace ev' -> mconcat [ "backend" .= String "InMemory"
-                                          , "event" .= toObject verb ev'
-                                          ]

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -595,7 +595,7 @@ instance (applyTxErr ~ ApplyTxErr blk, ToObject localPeer)
      => Transformable Text IO (TraceLabelPeer localPeer (NtN.TraceSendRecv (LocalTxSubmission (GenTx blk) applyTxErr))) where
   trTransformer = trStructured
 
-instance (LocalStateQuery.ShowQuery (BlockQuery blk), ToObject localPeer)
+instance (forall fp. LocalStateQuery.ShowQuery (BlockQuery blk fp), ToObject localPeer)
      => Transformable Text IO (TraceLabelPeer localPeer (NtN.TraceSendRecv (LocalStateQuery blk (Point blk) (Query blk)))) where
   trTransformer = trStructured
 

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -109,7 +109,8 @@ import           Ouroboros.Network.NodeToClient (LocalAddress)
 import           Ouroboros.Network.NodeToNode (RemoteAddress)
 
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
-import qualified Ouroboros.Consensus.Storage.LedgerDB as LedgerDB
+import qualified Ouroboros.Consensus.Storage.LedgerDB.DbChangelog.Update as LedgerDB
+import qualified Ouroboros.Consensus.Storage.LedgerDB.Impl as LedgerDB
 
 import           Cardano.Tracing.Config
 import           Cardano.Tracing.HasIssuer (BlockIssuerVerificationKeyHash (..), HasIssuer (..))
@@ -238,7 +239,6 @@ instance ElidingTracer (WithSeverity (ChainDB.TraceEvent blk)) where
   doelide (WithSeverity _ (ChainDB.TraceGCEvent _)) = True
   doelide (WithSeverity _ (ChainDB.TraceAddBlockEvent (ChainDB.IgnoreBlockOlderThanK _))) = False
   doelide (WithSeverity _ (ChainDB.TraceAddBlockEvent (ChainDB.IgnoreInvalidBlock _ _))) = False
-  doelide (WithSeverity _ (ChainDB.TraceAddBlockEvent (ChainDB.BlockInTheFuture _ _))) = False
   doelide (WithSeverity _ (ChainDB.TraceAddBlockEvent (ChainDB.StoreButDontChange _))) = False
   doelide (WithSeverity _ (ChainDB.TraceAddBlockEvent (ChainDB.TrySwitchToAFork _ _))) = False
   doelide (WithSeverity _ (ChainDB.TraceAddBlockEvent (ChainDB.SwitchedToAFork{}))) = False
@@ -1189,24 +1189,31 @@ notifyTxsProcessed fStats tr = Tracer $ \case
 mempoolMetricsTraceTransformer :: Trace IO a -> Tracer IO (TraceEventMempool blk)
 mempoolMetricsTraceTransformer tr = Tracer $ \mempoolEvent -> do
   let tr' = appendName "metrics" tr
-      (_n, tot) = case mempoolEvent of
-                    TraceMempoolAddedTx     _tx0 _ tot0 -> (1, tot0)
-                    TraceMempoolRejectedTx  _tx0 _ tot0 -> (1, tot0)
-                    TraceMempoolRemoveTxs   txs0   tot0 -> (length txs0, tot0)
-                    TraceMempoolManuallyRemovedTxs txs0 txs1 tot0 -> ( length txs0 + length txs1, tot0)
-      logValue1 :: LOContent a
-      logValue1 = LogValue "txsInMempool" $ PureI $ fromIntegral (msNumTxs tot)
-      logValue2 :: LOContent a
-      logValue2 = LogValue "mempoolBytes" $ PureI $ fromIntegral (msNumBytes tot)
-  meta <- mkLOMeta Critical Confidential
-  traceNamedObject tr' (meta, logValue1)
-  traceNamedObject tr' (meta, logValue2)
+      mNTot = case mempoolEvent of
+                    TraceMempoolAddedTx     _tx0 _ tot0 -> Just (1, tot0)
+                    TraceMempoolRejectedTx  _tx0 _ tot0 -> Just (1, tot0)
+                    TraceMempoolRemoveTxs   txs0   tot0 -> Just (length txs0, tot0)
+                    TraceMempoolManuallyRemovedTxs txs0 txs1 tot0 -> Just ( length txs0 + length txs1, tot0)
+                    _ -> Nothing
+  maybe
+    (pure ())
+    (\(_n, tot) -> do
+      let logValue1 :: LOContent a
+          logValue1 = LogValue "txsInMempool" $ PureI $ fromIntegral (msNumTxs tot)
+          logValue2 :: LOContent a
+          logValue2 = LogValue "mempoolBytes" $ PureI $ fromIntegral (msNumBytes tot)
+      meta <- mkLOMeta Critical Confidential
+      traceNamedObject tr' (meta, logValue1)
+      traceNamedObject tr' (meta, logValue2)
+    )
+    mNTot
 
 mempoolTracer
   :: ( ToJSON (GenTxId blk)
      , ToObject (ApplyTxErr blk)
      , ToObject (GenTx blk)
      , LedgerSupportsMempool blk
+     , ConvertRawHash blk
      )
   => TraceSelection
   -> Trace IO Text
@@ -1221,6 +1228,7 @@ mempoolTracer tc tracer fStats = Tracer $ \ev -> do
 mpTracer :: ( ToJSON (GenTxId blk)
             , ToObject (ApplyTxErr blk)
             , ToObject (GenTx blk)
+            , ConvertRawHash blk
             , LedgerSupportsMempool blk
             )
          => TraceSelection -> Trace IO Text -> Tracer IO (TraceEventMempool blk)

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -109,8 +109,9 @@ import           Ouroboros.Network.NodeToClient (LocalAddress)
 import           Ouroboros.Network.NodeToNode (RemoteAddress)
 
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
-import qualified Ouroboros.Consensus.Storage.LedgerDB.DbChangelog.Update as LedgerDB
-import qualified Ouroboros.Consensus.Storage.LedgerDB.Impl as LedgerDB
+import qualified Ouroboros.Consensus.Storage.LedgerDB as LedgerDB
+import           Ouroboros.Consensus.Storage.LedgerDB.BackingStore (BackingStoreTraceByBackend)
+import qualified Ouroboros.Consensus.Storage.LedgerDB.DbChangelog as LedgerDB
 
 import           Cardano.Tracing.Config
 import           Cardano.Tracing.HasIssuer (BlockIssuerVerificationKeyHash (..), HasIssuer (..))
@@ -136,7 +137,6 @@ import qualified Control.Concurrent.STM as STM
 
 import           Cardano.Protocol.TPraos.OCert (KESPeriod (..))
 import qualified Data.Aeson.KeyMap as KeyMap
-import Ouroboros.Consensus.Storage.LedgerDB.BackingStore.Init (BackingStoreTraceByBackend)
 
 {- HLINT ignore "Redundant bracket" -}
 {- HLINT ignore "Use record patterns" -}

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -1340,7 +1340,7 @@ forgeStateInfoTracer p _ts tracer = Tracer $ \ev -> do
 
 nodeToClientTracers'
   :: ( ToObject localPeer
-     , ShowQuery (BlockQuery blk)
+     , forall fp. ShowQuery (BlockQuery blk fp)
      )
   => TraceSelection
   -> TracingVerbosity

--- a/cardano-node/test/Test/Cardano/Node/POM.hs
+++ b/cardano-node/test/Test/Cardano/Node/POM.hs
@@ -9,6 +9,7 @@ import           Data.Monoid (Last (..))
 import           Data.Text (Text)
 import           Data.Time.Clock (secondsToDiffTime)
 
+import           Cardano.Node.Configuration.LedgerDB
 import           Cardano.Node.Configuration.POM
 import           Cardano.Node.Configuration.Socket
 import           Cardano.Node.Handlers.Shutdown
@@ -16,7 +17,9 @@ import           Cardano.Node.Types
 import           Cardano.Tracing.Config (PartialTraceOptions (..), defaultPartialTraceConfiguration,
                    partialTraceSelectionToEither)
 import qualified Ouroboros.Consensus.Node as Consensus (NetworkP2PMode (..))
-import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy (SnapshotInterval (..))
+import           Ouroboros.Consensus.Storage.LedgerDB.Config
+                   (FlushFrequency (DefaultFlushFrequency), QueryBatchSize (DefaultQueryBatchSize),
+                   SnapshotInterval (..))
 import           Ouroboros.Network.Block (SlotNo (..))
 import           Ouroboros.Network.NodeToNode (AcceptedConnectionsLimit (..),
                    DiffusionMode (InitiatorAndResponderDiffusionMode))
@@ -80,6 +83,9 @@ testPartialYamlConfig =
     , pncTargetNumberOfActivePeers = mempty
     , pncEnableP2P = Last (Just DisabledP2PMode)
     , pncPeerSharing = Last (Just NoPeerSharing)
+    , pncLedgerDBBackend = Last (Just InMemory)
+    , pncFlushFrequency = Last (Just DefaultFlushFrequency)
+    , pncQueryBatchSize = Last (Just DefaultQueryBatchSize)
     }
 
 -- | Example partial configuration theoretically created
@@ -115,6 +121,9 @@ testPartialCliConfig =
     , pncTargetNumberOfActivePeers = mempty
     , pncEnableP2P = Last (Just DisabledP2PMode)
     , pncPeerSharing = Last (Just NoPeerSharing)
+    , pncLedgerDBBackend = Last (Just InMemory)
+    , pncFlushFrequency = Last (Just DefaultFlushFrequency)
+    , pncQueryBatchSize = Last (Just DefaultQueryBatchSize)
     }
 
 -- | Expected final NodeConfiguration
@@ -158,6 +167,9 @@ eExpectedConfig = do
     , ncTargetNumberOfActivePeers = 20
     , ncEnableP2P = SomeNetworkP2PMode Consensus.DisabledP2PMode
     , ncPeerSharing = NoPeerSharing
+    , ncLedgerDBBackend = InMemory
+    , ncFlushFrequency = DefaultFlushFrequency
+    , ncQueryBatchSize = DefaultQueryBatchSize
     }
 
 -- -----------------------------------------------------------------------------

--- a/cardano-node/test/Test/Cardano/Node/POM.hs
+++ b/cardano-node/test/Test/Cardano/Node/POM.hs
@@ -17,7 +17,7 @@ import           Cardano.Node.Types
 import           Cardano.Tracing.Config (PartialTraceOptions (..), defaultPartialTraceConfiguration,
                    partialTraceSelectionToEither)
 import qualified Ouroboros.Consensus.Node as Consensus (NetworkP2PMode (..))
-import           Ouroboros.Consensus.Storage.LedgerDB.Config
+import           Ouroboros.Consensus.Storage.LedgerDB
                    (FlushFrequency (DefaultFlushFrequency), QueryBatchSize (DefaultQueryBatchSize),
                    SnapshotInterval (..))
 import           Ouroboros.Network.Block (SlotNo (..))

--- a/configuration/cardano/mainnet-config-new-tracing.yaml
+++ b/configuration/cardano/mainnet-config-new-tracing.yaml
@@ -9,6 +9,8 @@ ByronGenesisFile: mainnet-byron-genesis.json
 ByronGenesisHash: 5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb
 ShelleyGenesisFile: mainnet-shelley-genesis.json
 ShelleyGenesisHash: 1a3be38bcbb7911969283716ad7aa550250226b76a61fc51cc9a9a35d9276d81
+ConwayGenesisFile: mainnet-conway-genesis.json
+ConwayGenesisHash: f28f1c1280ea0d32f8cd3143e268650d6c1a8e221522ce4a7d20d62fc09783e1
 
 ##### Core protocol parameters #####
 

--- a/configuration/cardano/mainnet-config.json
+++ b/configuration/cardano/mainnet-config.json
@@ -42,6 +42,7 @@
   "TraceLocalTxSubmissionProtocol": false,
   "TraceLocalTxSubmissionServer": false,
   "TraceMempool": true,
+  "TraceBackingStore": false,
   "TraceMux": false,
   "TracePeerSelection": true,
   "TracePeerSelectionActions": true,

--- a/configuration/cardano/mainnet-config.yaml
+++ b/configuration/cardano/mainnet-config.yaml
@@ -218,6 +218,9 @@ TraceLocalTxSubmissionServer: False
 # Trace mempool.
 TraceMempool: True
 
+# Trace the backing store operations.
+TraceBackingStore: False
+
 # Trace Mux Events.
 TraceMux: False
 

--- a/trace-dispatcher/src/Cardano/Logging/Tracer/Standard.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Tracer/Standard.hs
@@ -7,13 +7,13 @@ module Cardano.Logging.Tracer.Standard (
 
 import           Control.Concurrent.Async
 import           Control.Concurrent.Chan.Unagi.Bounded
-import           Control.Exception (BlockedIndefinitelyOnMVar, catch)
 import           Control.Monad (forever, when)
 import           Control.Monad.IO.Class
 import           Data.IORef (IORef, modifyIORef', newIORef, readIORef)
 import           Data.Maybe (isNothing)
 import           Data.Text (Text)
 import qualified Data.Text.IO as TIO
+import           GHC.Conc (labelThread, myThreadId)
 import           System.IO (hFlush, stdout)
 
 import           Cardano.Logging.DocuGenerator
@@ -66,9 +66,8 @@ standardTracer = do
 startStdoutThread :: IORef StandardTracerState -> IO ()
 startStdoutThread stateRef = do
     (inChan, outChan) <- newChan 2048
-    as <- async (catch
-      (stdoutThread outChan)
-      (\(_ :: BlockedIndefinitelyOnMVar) -> pure ()))
+    as <- async (myThreadId >>= flip labelThread "TraceStdoutWriter"
+                            >> stdoutThread outChan)
     link as
     modifyIORef' stateRef (\ st ->
       st {stRunning = Just (inChan, outChan, as)})


### PR DESCRIPTION
# Description

This PR is only intended to keep the historical branch for UTxO-HD used in the node 8.2.1-pre release while testing and benchmarking is taking place.

Makes use of input-output-hk/ouroboros-consensus#315 and input-output-hk/cardano-api#203

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
