### PR TITLE
Add configs to binary release archives

### DIFF
--- a/nix/binary-release.nix
+++ b/nix/binary-release.nix
@@ -15,26 +15,69 @@
 let
   inherit (pkgs) lib;
   name = "cardano-node-${version}-${platform}";
+  environments = lib.getAttrs
+    [ "mainnet" "preprod" "preview" "sanchonet" ]
+    pkgs.cardanoLib.environments;
+  writeConfig = name: env:
+    let
+      nodeConfig = pkgs.writeText
+        "config.json"
+        (builtins.toJSON
+          (env.nodeConfig // {
+            # File references point to the nix store, so we need to rewrite them
+            # as relative paths
+            ByronGenesisFile =  "byron-genesis.json";
+            ShelleyGenesisFile = "shelley-genesis.json";
+            AlonzoGenesisFile = "alonzo-genesis.json";
+            ConwayGenesisFile = "conway-genesis.json";
+          }));
+      topologyConfig = pkgs.cardanoLib.mkTopology env;
+
+      inherit (env.nodeConfig)
+        ByronGenesisFile ShelleyGenesisFile AlonzoGenesisFile ConwayGenesisFile;
+    in
+      # Format the node config file and copy the genesis files
+      ''
+        mkdir -p "share/${name}"
+        jq . < "${nodeConfig}" > share/${name}/config.json
+        jq . < "${topologyConfig}" > share/${name}/topology.json
+        cp -n --remove-destination -v \
+          "${ByronGenesisFile}" \
+           share/${name}/byron-genesis.json
+        cp -n --remove-destination -v \
+          "${ShelleyGenesisFile}"  \
+           share/${name}/shelley-genesis.json
+        cp -n --remove-destination -v \
+          "${AlonzoGenesisFile}" \
+           share/${name}/alonzo-genesis.json
+        cp -n --remove-destination -v \
+          "${ConwayGenesisFile}" \
+           share/${name}/conway-genesis.json
+      '';
 
 in pkgs.runCommand name {
     nativeBuildInputs = with pkgs.pkgsBuildBuild; [
-      haskellBuildUtils bintools nix zip
+      haskellBuildUtils bintools jq nix zip
     ];
   } ''
-  mkdir -p $out release
+  mkdir -p $out release/{bin,share}
   cd release
 
   # note: on windows, we have all the .dlls in the same /bin folder. Thus we will
   #       get the same dlls for each executable multiple times. So we cannot really
   #       use `-n` here, which would warn that we "skipped" some duplicates; and
   #       exit with 1. `-u` on the otherhand will just update as needed.
-  cp -u --remove-destination -v ${pkgs.lib.concatMapStringsSep " " (exe: "${exe}/bin/*") exes} ./
-  mkdir -p configuration
-  cp -Rv ${../configuration}/* ./configuration/
+  cp -u --remove-destination -v ${pkgs.lib.concatMapStringsSep " " (exe: "${exe}/bin/*") exes} ./bin
   chmod -R +w .
 
+  ${lib.pipe environments [
+    (lib.mapAttrs writeConfig)
+    (lib.mapAttrsToList (_: val: val))
+    (lib.concatStringsSep "\n")
+  ]}
+
   ${lib.optionalString (platform == "macos") (lib.concatMapStrings (exe: ''
-    rewrite-libs . ${exe}/bin/*
+    rewrite-libs bin ${exe}/bin/*
   '') exes)}
 
   ${if (platform == "win64")


### PR DESCRIPTION
# Description

Fixes #5507. Create subdirectories `bin` and `share` in the binary release archives, where the binaries go into `bin` and the configs go into `share`. 

Note that we only add mainnet, preprod, preview and sanchonet, omitting environments not listed in the Cardano Operations Book.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
