### PR TITLE
fix stylish-haskell makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,9 @@ host-hlint: ## Run the system (not Nix) version of hlint
 	hlint bench cardano-{api,cli,node,node-capi,node-chairman,submit-api,testnet,tracer}
 
 stylish-haskell: ## Apply stylish-haskell on all *.hs files
-	@find . -type f -name "*.hs" -not -path '.git' -print0 | xargs -0 stylish-haskell -i
+	@# The top-level directory for the project.
+	@export REPO_TOP_DIR=$(shell git rev-parse --show-toplevel);	\
+	$${REPO_TOP_DIR}/scripts/stylish-haskell.sh
 
 cabal-hashes:
 	nix run .#checkCabalProject

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Diffusion.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Diffusion.hs
@@ -316,9 +316,9 @@ instance LogFormatting MuxTrace where
             { tcpi_snd_mss, tcpi_rcv_mss, tcpi_lost, tcpi_retrans
             , tcpi_rtt, tcpi_rttvar, tcpi_snd_cwnd }
             len) =
-      sformat ("TCPInfo rtt % int % " rttvar " % ínt % " cwnd " % int %
-               " smss " % int % " rmss " % int % " lost " % int %
-               " retrans " % int % " len " %int)
+      sformat ("TCPInfo rtt" %+ int %+ "rttvar" %+ int %+ "cwnd" %+ int %+
+               "smss" %+ int %+ "rmss" %+ int %+ "lost" %+ int %+
+               "retrans" %+ int %+ "len" %+ int)
               (fromIntegral tcpi_rtt :: Word) (fromIntegral tcpi_rttvar :: Word)
               (fromIntegral tcpi_snd_cwnd :: Word) (fromIntegral tcpi_snd_mss :: Word)
               (fromIntegral tcpi_rcv_mss :: Word) (fromIntegral tcpi_lost :: Word)

--- a/scripts/stylish-haskell.sh
+++ b/scripts/stylish-haskell.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# The top-level directory for the project.
+REPO_TOP_DIR=${REPO_TOP_DIR:=$(git rev-parse --show-toplevel)}
+
+# The YAML configuration file for stylish-haskell.
+SH_YAML=${REPO_TOP_DIR}/.stylish-haskell.yaml
+
+# Starting from all the cabal files in the project, found via git, this
+# descends into the directory containing the cabal file so that
+# stylish-haskell can find it. Its search strategy is to ascend from its
+# current directory at the time of invocation, not to scrutinise the
+# path of the file given. So this strategy is required to accommodate
+# it. And it needs the cabal files for language extensions affecting
+# parsing for code reformatting.
+for cabal_file in $(git ls-files '*.cabal')
+do
+	# REPO_TOP_DIR makes the path absolute, so there are no issues
+	# with having to cd back to a starting point at a loop end etc.
+	cd ${REPO_TOP_DIR}/$(dirname ${cabal_file});			\
+	stylish-haskell -c ${SH_YAML}					\
+			-i $(git ls-files '*.hs' '*.lhs')		\
+		|| exit ${?}
+done

--- a/scripts/stylish-haskell.sh
+++ b/scripts/stylish-haskell.sh
@@ -6,6 +6,16 @@ REPO_TOP_DIR=${REPO_TOP_DIR:=$(git rev-parse --show-toplevel)}
 # The YAML configuration file for stylish-haskell.
 SH_YAML=${REPO_TOP_DIR}/.stylish-haskell.yaml
 
+# Set the return code variable to a default of success. The global scope
+# doesn't actually help the two groups communicate because the pipe
+# demands subshells. So it has to be communicated over file descriptors.
+rc=0
+
+# Get free file descriptors to pass the exit code between
+# subshells and a temporary fd to swap stdout and stderr.
+eval "exec {rcfd}<> <(:)"
+eval "exec {swpfd}<> <(:)"
+
 # Starting from all the cabal files in the project, found via git, this
 # descends into the directory containing the cabal file so that
 # stylish-haskell can find it. Its search strategy is to ascend from its
@@ -13,12 +23,60 @@ SH_YAML=${REPO_TOP_DIR}/.stylish-haskell.yaml
 # path of the file given. So this strategy is required to accommodate
 # it. And it needs the cabal files for language extensions affecting
 # parsing for code reformatting.
-for cabal_file in $(git ls-files '*.cabal')
-do
-	# REPO_TOP_DIR makes the path absolute, so there are no issues
-	# with having to cd back to a starting point at a loop end etc.
-	cd ${REPO_TOP_DIR}/$(dirname ${cabal_file});			\
-	stylish-haskell -c ${SH_YAML}					\
-			-i $(git ls-files '*.hs' '*.lhs')		\
-		|| exit ${?}
-done
+{
+	for cabal_file in $(git ls-files '*.cabal')
+	do
+		# REPO_TOP_DIR makes the path absolute, so there are no
+		# issues with having to cd back to a starting point at a
+		# loop end etc.
+		cd ${REPO_TOP_DIR}/$(dirname ${cabal_file});		\
+		stylish-haskell						\
+			-c ${SH_YAML}					\
+			-i $(git ls-files '*.hs' '*.lhs')
+		shrc=${?}
+		if [ ${shrc} -ne 0 ]
+		then
+			rc=${shrc}
+			break
+		fi
+	done
+
+	# Pass the exit code through one anonymous fd.
+	echo "${rc}" 1>&${rcfd}
+
+# Swap stdout and stderr to post-process stderr via the other.
+} {swpfd}>&1 1>&2 2>&${swpfd}						\
+| {
+
+	# read tokenises according to IFS, so that changing IFS to
+	# be stylish-haskell's delimiter for the file name at the
+	# beginning of error report lines will yield the file name to
+	# be re-relativised to be relative to the top directory of
+	# the project.
+	OLDIFS=${IFS}
+	IFS=":"
+	while read fpath rest
+	do
+		# git happily has utility functions for both carrying
+		# out a search to check whether a string is a path to
+		# a git-controlled file and re-relativising file path
+		# names relative to the project root. If we discover
+		# that it is under git's control, the rewritten path
+		# gets put into the reassembled stderr line.
+		if git ls-files --error-unmatch				\
+				  "*/${fpath}"				\
+					> /dev/null 2>&1
+		then
+			fpath=$(git ls-files				\
+				    --full-name				\
+				    "*/${fpath}")
+		fi
+		IFS="${OLDIFS}"
+		echo "${fpath}:${rest}"
+		IFS=":"
+		done
+
+  # Swap stdout and stderr back to normal.
+  } {swpfd}>&1 1>&2 2>&${swpfd}
+read -u ${rcfd} rc
+exit ${rc}


### PR DESCRIPTION
# Description
    1. Ensure .stylish-haskell.yaml is picked up properly.
    2. Avoid descending into inappropriate subdirectories.
    3. Pick up language extensions from the sub-projects' cabal files.
    
    Failures to parse source files occurred by dint of not having language
    extensions enabled according to the sub-projects' cabal files and the
    global .yaml file. The global .yaml file's path is passed in as an
    argument to the -c option at each invocation. It also descends into
    sub-projects' directories to launch stylish-haskell invocations in order
    to accommodate the limitations on stylish-haskell's search procedure
    for cabal files. Furthermore, it propagates the precise failure exit codes
    upstream to make while using iterative constructs that typically obscure
    them, where the prior invocation via xargs returned a different exit code
    from the one reported by the failing program (stylish-haskell). It also
    post-processes messages on stderr to report the paths to filenames
    referenced in error messages relative to the project root, where that
    behaviour would have been disturbed by the usual format of reporting
    during invocations from sub-directories of the project root.

    Co-authored-by: Nadia Chambers <nadia.chambers@iohk.io>
    
    Though he's not reviewed any changes afterwards, for the first commit in the sequence, also:
    Co-authored-by: Clément Hurlin <clement.hurlin@iohk.io>

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
        This is in itself a sort of test and build system utility.
- [X] Any changes are noted in the `CHANGELOG.md` for affected package
        This falls beneath the threshold of notability for changelogging.
- [X] The version bounds in `.cabal` files are updated
        None are affected.
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
          This is largely a build system patch, so hlint is of minimal relevance.
  - [X] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
          This is an update to the invocation of stylish-haskell in a .PHONY makefile target, so it's of minimal relevance.
  - [x] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [X] Self-reviewed the diff
        There was a moderate amount of local testing. 