### PR TITLE
Use handshake for connection checking when starting `cardano-testnet`

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -31,7 +31,7 @@ jobs:
 
     env:
       # Modify this value to "invalidate" the cabal cache.
-      CABAL_CACHE_VERSION: "2023-11-20-3"
+      CABAL_CACHE_VERSION: "2023-12-15"
 
     concurrency:
       group: >

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2023-11-20T23:52:53Z
-  , cardano-haskell-packages 2023-12-06T19:40:56Z
+  , cardano-haskell-packages 2023-12-15T14:50:31Z
 
 packages:
   cardano-git-rev

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -46,21 +46,28 @@ library
                       , cardano-ledger-byron
                       , cardano-ledger-shelley
                       , cardano-node
+                      , cardano-ping ^>= 0.2.0.10
+                      , contra-tracer
                       , containers
                       , data-default-class
+                      , cborg
                       , directory
                       , exceptions
                       , filepath
                       , hedgehog
                       , hedgehog-extras ^>= 0.4.7.0
                       , mtl
+                      , network
+                      , network-mux
                       , optparse-applicative-fork
                       , ouroboros-network ^>= 0.10
                       , ouroboros-network-api
+                      , prettyprinter
                       , process
                       , resourcet
                       , safe-exceptions
                       , scientific
+                      , si-timers
                       , stm
                       , tasty
                       , tasty-expected-failure
@@ -89,6 +96,7 @@ library
                         Testnet.Process.Run
                         Testnet.Runtime
                         Testnet.SubmitApi
+                        Testnet.Ping
 
   other-modules:        Parsers.Cardano
                         Parsers.Help
@@ -170,7 +178,7 @@ test-suite cardano-testnet-test
 
                         Cardano.Testnet.Test.LedgerEvents.Gov.ProposeNewConstitution
                         Cardano.Testnet.Test.LedgerEvents.SanityCheck
-                        
+
                         Cardano.Testnet.Test.Node.Shutdown
                         Cardano.Testnet.Test.SubmitApi.Babbage.Transaction
 

--- a/cardano-testnet/src/Testnet/Ping.hs
+++ b/cardano-testnet/src/Testnet/Ping.hs
@@ -1,0 +1,191 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Testnet.Ping
+  ( pingNode
+  , checkSprocket
+  , waitForSprocket
+  , TestnetMagic
+  , PingClientError(..)
+  ) where
+
+import           Control.Exception.Safe
+import           Control.Monad (when)
+import           Control.Monad.Class.MonadTime.SI (Time)
+import           Control.Tracer (nullTracer)
+import           Data.Word (Word32)
+import           Network.Mux.Bearer (MakeBearer (..), makeSocketBearer)
+import           Network.Mux.Timeout (TimeoutFn, withTimeoutSerial)
+import           Network.Mux.Types (MiniProtocolDir (InitiatorDir), MiniProtocolNum (..),
+                   MuxBearer (read, write), MuxSDU (..), MuxSDUHeader (..),
+                   RemoteClockModel (RemoteClockModel))
+import           Network.Socket (AddrInfo (..), StructLinger (..))
+
+import           Cardano.Api (Error (..))
+import           Cardano.Api.Pretty
+import           Cardano.Network.Ping (HandshakeFailure, NodeVersion (..), handshakeDec,
+                   handshakeReq, isSameVersionAndMagic, supportedNodeToClientVersions)
+import qualified Codec.CBOR.Read as CBOR
+import qualified Control.Monad.Class.MonadTimer.SI as MT
+import           Control.Monad.IO.Class
+import qualified Data.ByteString.Lazy as LBS
+import           Data.Either (isLeft)
+import           Data.IORef
+import qualified Data.List as L
+import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
+import qualified Network.Socket as Socket
+import           Prettyprinter
+
+type TestnetMagic = Word32
+
+-- | Mini protocol number. We're only sending ping, so 0.
+handshakeNum ::  MiniProtocolNum
+handshakeNum = MiniProtocolNum 0
+
+-- | Timeout for reading a multiplexer service data unit, in seconds.
+sduTimeout :: MT.DiffTime
+sduTimeout = 30
+
+-- | Perform handshake query to obtain supported version numbers by node.
+doHandshakeQuery :: Bool
+doHandshakeQuery = True
+
+-- | Ping the node once
+pingNode :: MonadIO m
+         => TestnetMagic -- ^ testnet magic
+         -> IO.Sprocket  -- ^ node sprocket
+         -> m (Either PingClientError ()) -- ^ '()' means success
+pingNode networkMagic sprocket = liftIO $ bracket
+  (Socket.socket (Socket.addrFamily peer) Socket.Stream Socket.defaultProtocol)
+  Socket.close
+  (\sd -> withTimeoutSerial $ \timeoutfn -> do
+    when (Socket.addrFamily peer /= Socket.AF_UNIX) $ do
+      Socket.setSocketOption sd Socket.NoDelay 1
+      Socket.setSockOpt sd Socket.Linger
+        StructLinger
+          { sl_onoff  = 1
+          , sl_linger = 0
+          }
+
+    Socket.connect sd (Socket.addrAddress peer)
+    peerStr <- peerString
+
+    bearer <- getBearer makeSocketBearer sduTimeout nullTracer sd
+
+    let versions = supportedNodeToClientVersions networkMagic
+    !_ <- write bearer timeoutfn $ wrap handshakeNum InitiatorDir (handshakeReq versions doHandshakeQuery)
+    (msg, !_) <- nextMsg bearer timeoutfn handshakeNum
+
+    pure $ case CBOR.deserialiseFromBytes handshakeDec msg of
+      Left err -> Left $ PceDecodingError peerStr err
+      Right (_, Left err) -> Left $ PceProtocolError peerStr err
+      Right (_, Right recVersions)
+        | areVersionsAccepted versions recVersions -> pure ()
+        | otherwise -> Left $ PceVersionNegotiationError peerStr versions recVersions
+  )
+  where
+    peer = sprocketToAddrInfo sprocket :: AddrInfo
+
+    -- | Wrap a message in a mux service data unit.
+    wrap :: MiniProtocolNum -> MiniProtocolDir -> LBS.ByteString -> MuxSDU
+    wrap mhNum mhDir msBlob = MuxSDU
+      { msHeader = MuxSDUHeader
+        { mhTimestamp = RemoteClockModel 0
+        , mhNum
+        , mhDir
+        , mhLength    = fromIntegral $ LBS.length msBlob
+        }
+      , msBlob
+      }
+
+    areVersionsAccepted :: [NodeVersion] -> [NodeVersion] -> Bool
+    areVersionsAccepted accVersions recVersions =
+      let intersects = L.intersectBy isSameVersionAndMagic recVersions accVersions in
+      not $ null intersects
+
+    peerString :: IO String
+    peerString =
+      case Socket.addrFamily peer of
+        Socket.AF_UNIX -> pure . show $ Socket.addrAddress peer
+        _ -> do
+          (Just host, Just port) <-
+            Socket.getNameInfo
+              [Socket.NI_NUMERICHOST, Socket.NI_NUMERICSERV]
+              True True (Socket.addrAddress peer)
+          pure $ host <> ":" <> port
+
+    -- | Fetch next message from mux bearer. Ignores messages not matching handshake protocol number.
+    nextMsg :: MuxBearer IO -- ^ a mux bearer
+            -> TimeoutFn IO -- ^ timeout function, for reading messages
+            -> MiniProtocolNum -- ^ handshake protocol number
+            -> IO (LBS.ByteString, Time) -- ^ raw message and timestamp
+    nextMsg bearer timeoutfn ptclNum = do
+      (sdu, t_e) <- Network.Mux.Types.read bearer timeoutfn
+      if mhNum (msHeader sdu) == ptclNum
+        then pure (msBlob sdu, t_e)
+        else nextMsg bearer timeoutfn ptclNum
+
+-- | Wait for 'sprocket' to become ready. Periodically tries to connect to 'sprocket', with the provided interval.
+-- If there was no success within 'timeout' period, return the last exception thrown during a connection
+-- attempt.
+waitForSprocket :: MonadIO m
+                => MT.DiffTime -- ^ timeout
+                -> MT.DiffTime -- ^ interval
+                -> IO.Sprocket
+                -> m (Either IOException ())
+waitForSprocket timeout interval sprocket = liftIO $ do
+  lastResult <- newIORef (Right ())
+  _ <- MT.timeout timeout $ loop lastResult
+  readIORef lastResult
+  where
+    loop lastResult = do
+      r <- checkSprocket sprocket
+      writeIORef lastResult r
+      when (isLeft r) $ do
+        -- repeat on error
+        MT.threadDelay interval
+        loop lastResult
+
+-- | Check if the sprocket can be connected to. Returns an exception thrown during the connection attempt.
+checkSprocket :: MonadIO m => IO.Sprocket -> m (Either IOException ())
+checkSprocket sprocket = liftIO $ do
+  let AddrInfo{addrFamily, addrSocketType, addrProtocol, addrAddress} = sprocketToAddrInfo sprocket
+  bracket (Socket.socket addrFamily addrSocketType addrProtocol) Socket.close $ \sock -> do
+    -- Capture only synchronous exceptions from the connection attempt.
+    catch (Socket.connect sock addrAddress >> pure (pure ())) $ \e ->
+      pure (Left e)
+
+sprocketToAddrInfo :: IO.Sprocket -> AddrInfo
+sprocketToAddrInfo sprocket = do
+  let socketAbsPath = IO.sprocketSystemName sprocket
+  Socket.AddrInfo
+    [] Socket.AF_UNIX Socket.Stream
+    Socket.defaultProtocol (Socket.SockAddrUnix socketAbsPath) Nothing
+
+
+data PingClientError
+  = PceDecodingError
+      !String -- ^ peer string
+      !CBOR.DeserialiseFailure -- ^ deserialization exception
+  | PceProtocolError
+      !String -- ^ peer string
+      !HandshakeFailure -- ^ handshake exception
+  | PceVersionNegotiationError
+      !String -- ^ peer string
+      ![NodeVersion] -- ^ requested versions
+      ![NodeVersion] -- ^ received node versions
+
+instance Error PingClientError where
+  prettyError = \case
+    PceDecodingError peerStr exception -> pretty peerStr <+> "Decoding error:" <+> pretty (displayException exception)
+    PceProtocolError peerStr exception -> pretty peerStr <+> "Protocol error:" <+> viaShow exception
+    PceVersionNegotiationError peerStr requestedVersions receivedVersions -> vsep
+      [ pretty peerStr <+> "Version negotiation error: No overlapping versions with" <+> viaShow requestedVersions
+      , "Received versions:" <+> viaShow receivedVersions
+      ]
+
+

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/LeadershipSchedule.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/LeadershipSchedule.hs
@@ -281,7 +281,7 @@ hprop_leadershipSchedule = H.integrationRetryWorkspace 2 "babbage-leadership-sch
 
   yamlBs <- createConfigYaml tempAbsPath (cardanoNodeEra cTestnetOptions)
   H.lbsWriteFile (work </> "configuration.yaml") yamlBs
-  eRuntime <- lift . lift . runExceptT $ startNode (TmpAbsolutePath tempAbsPath') "test-spo" 3005
+  eRuntime <- lift . lift . runExceptT $ startNode (TmpAbsolutePath tempAbsPath') "test-spo" 3005 testnetMagic
         [ "run"
         , "--config", work </> "configuration.yaml"
         , "--topology", topologyFile

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/Transaction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/Transaction.hs
@@ -113,7 +113,7 @@ hprop_transaction = H.integrationRetryWorkspace 0 "babbage-transaction" $ \tempA
     , "--tx-file", txbodySignedFp
     ]
 
-  H.byDurationM 1 10 "Expected UTxO found" $ do
+  H.byDurationM 1 15 "Expected UTxO found" $ do
     void $ execCli' execConfig
       [ "babbage", "query", "utxo"
       , "--address", Text.unpack $ paymentKeyInfoAddr $ head wallets

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/KesPeriodInfo.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/KesPeriodInfo.hs
@@ -201,7 +201,7 @@ hprop_kes_period_info = H.integrationRetryWorkspace 2 "kes-period-info" $ \tempA
            , "--testnet-magic", show @Int testnetMagic
            ]
 
-  threadDelay 15_000000
+  threadDelay 20_000_000
   let testDelegatorStakeAddressInfoOutFp = work </> "test-delegator-stake-address-info.json"
   void $ checkStakeKeyRegistered
            tempAbsPath
@@ -267,7 +267,7 @@ hprop_kes_period_info = H.integrationRetryWorkspace 2 "kes-period-info" $ \tempA
 
   yamlBs <- createConfigYaml tempAbsPath (cardanoNodeEra cTestnetOptions)
   H.lbsWriteFile (work </> "configuration.yaml") yamlBs
-  eRuntime <- lift . lift . runExceptT $ startNode (TmpAbsolutePath tempAbsPath') "test-spo" 3005
+  eRuntime <- lift . lift . runExceptT $ startNode (TmpAbsolutePath tempAbsPath') "test-spo" 3005 testnetMagic
         [ "run"
         , "--config", work </> "configuration.yaml"
         , "--topology", topologyFile

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SubmitApi/Babbage/Transaction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SubmitApi/Babbage/Transaction.hs
@@ -152,7 +152,7 @@ hprop_transaction = H.integrationRetryWorkspace 0 "submit-api-babbage-transactio
 
       getResponseStatusCode response === 202
 
-    H.byDurationM 5 30 "Expected UTxO found" $ do
+    H.byDurationM 5 45 "Expected UTxO found" $ do
       void $ execCli' execConfig
         [ "babbage", "query", "utxo"
         , "--address", Text.unpack $ paymentKeyInfoAddr $ head wallets


### PR DESCRIPTION
# Description

This PR changes how `cardano-testnet` executable checks for node start:
* Remove blind wait for 5s
* Add wait for socket with 20s timeout
* After ping socket appears, ping the and node fail on any ping error - use `NodeToClientVersion` configuration from `cardano-ping`.

This PR depends on:
* https://github.com/input-output-hk/ouroboros-network/pull/4743

To be merged after new cardano-ping release and without SRP.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
