### PR TITLE
Test DRep retirement in an integration test

### DIFF
--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -170,6 +170,7 @@ test-suite cardano-testnet-test
   other-modules:        Cardano.Testnet.Test.Cli.Babbage.LeadershipSchedule
                         Cardano.Testnet.Test.Cli.Babbage.StakeSnapshot
                         Cardano.Testnet.Test.Cli.Babbage.Transaction
+                        Cardano.Testnet.Test.Cli.Conway.DRepRetirement
                         Cardano.Testnet.Test.Cli.Conway.StakeSnapshot
                         Cardano.Testnet.Test.Cli.KesPeriodInfo
                         Cardano.Testnet.Test.Cli.QuerySlotNumber
@@ -199,6 +200,7 @@ test-suite cardano-testnet-test
                       , cardano-testnet
                       , containers
                       , directory
+                      , exceptions
                       , filepath
                       , hedgehog
                       , hedgehog-extras

--- a/cardano-testnet/src/Parsers/Cardano.hs
+++ b/cardano-testnet/src/Parsers/Cardano.hs
@@ -26,8 +26,8 @@ optsTestnet envCli = CardanoTestnetOptions
   <*> pLegacyCardanoEra envCli
   <*> OA.option auto
       (   OA.long "epoch-length"
-      <>  OA.help "Epoch length"
-      <>  OA.metavar "MILLISECONDS"
+      <>  OA.help "Epoch length, in number of slots"
+      <>  OA.metavar "SLOTS"
       <>  OA.showDefault
       <>  OA.value (cardanoEpochLength cardanoDefaultTestnetOptions)
       )

--- a/cardano-testnet/src/Testnet/Start/Types.hs
+++ b/cardano-testnet/src/Testnet/Start/Types.hs
@@ -37,9 +37,9 @@ data CardanoTestnetOptions = CardanoTestnetOptions
   { -- | List of node options. Each option will result in a single node being
     -- created.
     cardanoNodes :: [TestnetNodeOptions]
-  , cardanoNodeEra :: AnyCardanoEra
-  , cardanoEpochLength :: Int
-  , cardanoSlotLength :: Double
+  , cardanoNodeEra :: AnyCardanoEra -- ^ The era to start at
+  , cardanoEpochLength :: Int -- ^ An epoch's duration, in number of slots
+  , cardanoSlotLength :: Double -- ^ Slot length, in seconds
   , cardanoTestnetMagic :: Int
   , cardanoActiveSlotsCoeff :: Double
   , cardanoMaxSupply :: Word64 -- ^ The amount of ADA you are starting your testnet with

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
@@ -8,7 +8,7 @@ Usage: cardano-testnet cardano [--num-pool-nodes COUNT]
   | --alonzo-era
   | --babbage-era
   ]
-  [--epoch-length MILLISECONDS]
+  [--epoch-length SLOTS]
   [--slot-length SECONDS]
   --testnet-magic INT
   [--active-slots-coeff DOUBLE]

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/cardano.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/cardano.cli
@@ -6,7 +6,7 @@ Usage: cardano-testnet cardano [--num-pool-nodes COUNT]
   | --alonzo-era
   | --babbage-era
   ]
-  [--epoch-length MILLISECONDS]
+  [--epoch-length SLOTS]
   [--slot-length SECONDS]
   --testnet-magic INT
   [--active-slots-coeff DOUBLE]
@@ -26,8 +26,7 @@ Available options:
   --mary-era               Specify the Mary era
   --alonzo-era             Specify the Alonzo era
   --babbage-era            Specify the Babbage era (default)
-  --epoch-length MILLISECONDS
-                           Epoch length (default: 500)
+  --epoch-length SLOTS     Epoch length, in number of slots (default: 500)
   --slot-length SECONDS    Slot length (default: 0.1)
   --testnet-magic INT      Specify a testnet magic id.
   --active-slots-coeff DOUBLE

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/DRepRetirement.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/DRepRetirement.hs
@@ -1,0 +1,272 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Cardano.Testnet.Test.Cli.Conway.DRepRetirement
+  ( hprop_drep_retirement
+  ) where
+
+import           Cardano.Api
+import qualified Cardano.Api as Api
+import           Cardano.Api.Ledger
+import qualified Cardano.Api.Ledger as L
+import           Cardano.Api.Pretty (docToString)
+
+import           Cardano.CLI.Types.Output (QueryTipLocalStateOutput (..))
+import qualified Cardano.Ledger.Shelley.LedgerState as L
+import           Cardano.Testnet
+
+import           Prelude
+
+import           Control.Monad (void)
+import           Control.Monad.Catch (MonadCatch)
+import           Control.Monad.IO.Class
+import           Control.Monad.Trans.Except (runExceptT)
+import           Control.Monad.Trans.State.Strict (put)
+import           Data.Data
+import qualified Data.Map.Strict as Map
+import qualified Data.Text as Text
+import           Data.Type.Equality (testEquality)
+import           GHC.IORef (newIORef)
+import           GHC.Stack (HasCallStack, withFrozenCallStack)
+import           Lens.Micro ((^.))
+import           System.FilePath ((</>))
+
+import qualified Testnet.Process.Cli as P
+import qualified Testnet.Process.Run as H
+import qualified Testnet.Property.Utils as H
+import           Testnet.Property.Utils (queryUtxos)
+import           Testnet.Runtime
+
+import           Hedgehog
+import qualified Hedgehog as H
+import           Hedgehog.Extras (Integration)
+import qualified Hedgehog.Extras as H
+import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
+
+-- | The era in which this test runs
+sbe :: ShelleyBasedEra ConwayEra
+sbe = ShelleyBasedEraConway
+
+-- Execute this test with:
+-- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/DRepRetirement/"'@
+hprop_drep_retirement :: Property
+hprop_drep_retirement = H.integrationRetryWorkspace 2 "drep-retirement" $ \tempAbsBasePath' -> do
+  -- Start a local test net
+  conf@Conf { tempAbsPath } <- H.noteShowM $ mkConf tempAbsBasePath'
+  let tempAbsPath' = unTmpAbsPath tempAbsPath
+      tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
+
+  work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
+
+  utxoFileCounter <- liftIO $ newIORef 1
+
+  let era = toCardanoEra sbe
+      cardanoNodeEra = AnyCardanoEra era
+      fastTestnetOptions = cardanoDefaultTestnetOptions
+        { cardanoEpochLength = 50 -- 50 * (1/10s) length, i.e. 5 seconds
+        , cardanoSlotLength = 0.1  -- 1/10s slot (100ms)
+        , cardanoNodeEra
+        }
+
+  TestnetRuntime
+    { testnetMagic
+    , poolNodes
+    , wallets
+    , configurationFile
+    }
+    <- cardanoTestnetDefault fastTestnetOptions conf
+
+  poolNode1 <- H.headM poolNodes
+  poolSprocket1 <- H.noteShow $ nodeSprocket $ poolRuntime poolNode1
+  execConfig <- H.mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
+
+  let queryAnyUtxo :: Text.Text -> Integration TxIn
+      queryAnyUtxo address = withFrozenCallStack $ do
+        utxos <- queryUtxos execConfig work utxoFileCounter sbe address
+        H.noteShow =<< H.headM (Map.keys utxos)
+      socketName' = IO.sprocketName poolSprocket1
+      socketBase = IO.sprocketBase poolSprocket1 -- /tmp
+      socketPath = socketBase </> socketName'
+
+  H.note_ $ "Sprocket: " <> show poolSprocket1
+  H.note_ $ "Abs path: " <> tempAbsBasePath'
+  H.note_ $ "Socketpath: " <> socketPath
+
+  -- Create Conway constitution
+  gov <- H.createDirectoryIfMissing $ work </> "governance"
+
+  let stakeVkeyFp = gov </> "stake.vkey"
+      stakeSKeyFp = gov </> "stake.skey"
+
+  _ <- P.cliStakeAddressKeyGen tempAbsPath'
+         $ P.KeyNames { P.verificationKeyFile = stakeVkeyFp
+                      , P.signingKeyFile = stakeSKeyFp
+                      }
+
+  let drepVkeyFp :: Int -> FilePath
+      drepVkeyFp n = tempAbsPath' </> "drep-keys" </> ("drep" <> show n) </> "drep.vkey"
+
+      drepSKeyFp :: Int -> FilePath
+      drepSKeyFp n = tempAbsPath' </> "drep-keys" </> ("drep" <> show n) </> "drep.skey"
+
+  -- Create Drep registration certificates
+  let drepCertFile :: Int -> FilePath
+      drepCertFile n = gov </> "drep-keys" <>"drep" <> show n <> ".regcert"
+  H.forConcurrently_ [1..3] $ \n -> do
+    H.noteM_ $ H.execCli' execConfig
+       [ "conway", "governance", "drep", "registration-certificate"
+       , "--drep-verification-key-file", drepVkeyFp n
+       , "--key-reg-deposit-amt", show @Int 0
+       , "--out-file", drepCertFile n
+       ]
+
+  txin1 <- queryAnyUtxo . paymentKeyInfoAddr $ head wallets
+
+  -- Submit registration certificates
+  drepRegTxbodyFp <- H.note $ work </> "drep.registration.txbody"
+  drepRegTxSignedFp <- H.note $ work </> "drep.registration.tx"
+
+  H.noteM_ $ H.execCli' execConfig
+    [ "conway", "transaction", "build"
+    , "--tx-in", Text.unpack $ renderTxIn txin1
+    , "--change-address", Text.unpack $ paymentKeyInfoAddr $ head wallets
+    , "--certificate-file", drepCertFile 1
+    , "--certificate-file", drepCertFile 2
+    , "--certificate-file", drepCertFile 3
+    , "--witness-override", show @Int 4
+    , "--out-file", drepRegTxbodyFp
+    ]
+
+  H.noteM_ $ H.execCli' execConfig
+    [ "conway", "transaction", "sign"
+    , "--tx-body-file", drepRegTxbodyFp
+    , "--signing-key-file", paymentSKey $ paymentKeyInfoPair $ head wallets
+    , "--signing-key-file", drepSKeyFp 1
+    , "--signing-key-file", drepSKeyFp 2
+    , "--signing-key-file", drepSKeyFp 3
+    , "--out-file", drepRegTxSignedFp
+    ]
+
+  H.noteM_ $ H.execCli' execConfig
+    [ "conway", "transaction", "submit"
+    , "--tx-file", drepRegTxSignedFp
+    ]
+
+  let sizeBefore = 3
+      configFile' = Api.File configurationFile
+      socketPath' = Api.File socketPath
+
+  waitDRepsNumber configFile' socketPath' execConfig sizeBefore
+
+  -- Deregister first DRep
+  let dreprRetirementCertFile = gov </> "drep-keys" <> "drep1.retirementcert"
+
+  H.noteM_ $ H.execCli' execConfig
+     [ "conway", "governance", "drep", "retirement-certificate"
+     , "--drep-verification-key-file", drepVkeyFp 1
+     , "--deposit-amt", show @Int 0
+     , "--out-file", dreprRetirementCertFile
+     ]
+
+  H.noteM_ $ H.execCli' execConfig
+    [ "conway", "query", "utxo"
+    , "--address", Text.unpack $ paymentKeyInfoAddr $ head wallets
+    , "--cardano-mode"
+    , "--out-file", work </> "utxo-11.json"
+    ]
+
+  txin2 <- queryAnyUtxo . paymentKeyInfoAddr $ head wallets
+
+  drepRetirementRegTxbodyFp <- H.note $ work </> "drep.retirement.txbody"
+  drepRetirementRegTxSignedFp <- H.note $ work </> "drep.retirement.tx"
+
+  H.noteM_ $ H.execCli' execConfig
+    [ "conway", "transaction", "build"
+    , "--tx-in", Text.unpack $ renderTxIn txin2
+    , "--change-address", Text.unpack $ paymentKeyInfoAddr $ head wallets
+    , "--certificate-file", dreprRetirementCertFile
+    , "--witness-override", "2"
+    , "--out-file", drepRetirementRegTxbodyFp
+    ]
+
+  H.noteM_ $ H.execCli' execConfig
+    [ "conway", "transaction", "sign"
+    , "--tx-body-file", drepRetirementRegTxbodyFp
+    , "--signing-key-file", paymentSKey $ paymentKeyInfoPair $ head wallets
+    , "--signing-key-file", drepSKeyFp 1
+    , "--out-file", drepRetirementRegTxSignedFp
+    ]
+
+  H.noteM_ $ H.execCli' execConfig
+    [ "conway", "transaction", "submit"
+    , "--tx-file", drepRetirementRegTxSignedFp
+    ]
+
+  -- The important bit is that we pass (sizeBefore - 1) as the last argument,
+  -- to witness that the number of dreps indeed decreased.
+  waitDRepsNumber configFile' socketPath' execConfig (sizeBefore - 1)
+  H.success
+
+-- | @waitDRepsNumber config socket execConfig n@
+-- wait for the number of DReps being @n@ for two epochs. If
+-- this number is not attained before two epochs, the test is failed.
+waitDRepsNumber ::
+  (HasCallStack, MonadIO m, MonadCatch m, MonadTest m)
+  => NodeConfigFile 'In
+  -> SocketPath
+  -> H.ExecConfig
+  -> Int
+  -> m ()
+waitDRepsNumber configurationFile socketPath execConfig expectedDRepsNb = do
+  QueryTipLocalStateOutput{mEpoch} <- P.execCliStdoutToJson execConfig [ "query", "tip" ]
+  currentEpoch <- H.evalMaybe mEpoch
+  let terminationEpoch = succ . succ $ currentEpoch
+  void $ H.evalMaybeM $ waitDRepsNumber' configurationFile socketPath terminationEpoch expectedDRepsNb
+
+-- | @waitDRepsNumber' config socket terminationEpoch n@
+-- wait until @terminationEpoch@ for the number of DReps being @n@. If
+-- this number is not attained before @terminationEpoch@, the test is failed.
+-- So if you call this function, you are expecting the number of DReps to already
+-- be @n@, or to be @n@ before @terminationEpoch@
+waitDRepsNumber' ::
+  (HasCallStack, MonadIO m, MonadTest m)
+  => NodeConfigFile In
+  -> SocketPath
+  -> EpochNo -- ^ The termination epoch: the constitution proposal must be found *before* this epoch
+  -> Int -- ^ The expected numbers of DReps. If this number is not reached until the termination epoch, this function fails the test.
+  -> m (Maybe [L.DRepState StandardCrypto]) -- ^ The DReps when the expected number of DReps was attained.
+waitDRepsNumber' nodeConfigFile socketPath maxEpoch expectedDRepsNb = do
+  result <- runExceptT $ checkLedgerStateCondition nodeConfigFile socketPath QuickValidation maxEpoch Nothing
+      $ \(AnyNewEpochState actualEra newEpochState) -> do
+        case testEquality sbe actualEra of
+          Just Refl -> do
+            let dreps = Map.elems $ shelleyBasedEraConstraints sbe newEpochState
+                      ^. L.nesEsL
+                      . L.esLStateL
+                      . L.lsCertStateL
+                      . L.certVStateL
+                      . L.vsDRepsL
+            if length dreps == expectedDRepsNb then do
+                put $ Just dreps
+                pure ConditionMet
+            else
+                pure ConditionNotMet
+          Nothing -> do
+            error $ "Eras mismatch! expected: " <> show sbe <> ", actual: " <> show actualEra
+  case result of
+    Left (FoldBlocksApplyBlockError (TerminationEpochReached epochNo)) -> do
+      H.note_ $ unlines
+                  [ "waitDRepsNumber: drep number did not become " <> show expectedDRepsNb <> " before termination epoch: " <> show epochNo
+                  , "This is likely an error of this test." ]
+      H.failure
+    Left err -> do
+      H.note_ $ unlines
+                  [ "waitDRepsNumber: could not reach termination epoch: " <> docToString (prettyError err)
+                  , "This is probably an error unrelated to this test." ]
+      H.failure
+    Right (_, val) ->
+      return val

--- a/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
+++ b/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
@@ -8,6 +8,7 @@ import qualified Cardano.Crypto.Init as Crypto
 import qualified Cardano.Testnet.Test.Cli.Babbage.LeadershipSchedule
 import qualified Cardano.Testnet.Test.Cli.Babbage.StakeSnapshot
 import qualified Cardano.Testnet.Test.Cli.Babbage.Transaction
+import qualified Cardano.Testnet.Test.Cli.Conway.DRepRetirement as DRepRetirement
 import qualified Cardano.Testnet.Test.Cli.KesPeriodInfo
 import qualified Cardano.Testnet.Test.Cli.QuerySlotNumber
 import qualified Cardano.Testnet.Test.FoldBlocks
@@ -39,6 +40,7 @@ tests = pure $ T.testGroup "test/Spec.hs"
             -- [ H.ignoreOnMacAndWindows "ProposeAndRatifyNewConstitution" LedgerEvents.hprop_ledger_events_propose_new_constitution
             [ H.ignoreOnWindows "InfoAction" LedgerEvents.hprop_ledger_events_info_action
             , H.ignoreOnWindows "ProposeNewConstitutionSPO" LedgerEvents.hprop_ledger_events_propose_new_constitution_spo
+            , H.ignoreOnWindows "DRepRetirement" DRepRetirement.hprop_drep_retirement
             ]
           ]
       , T.testGroup "CLI"


### PR DESCRIPTION
# Description

This PR adds an integration test that deregistering a DRep has the desired effect on the ledger state.

This new tests runs approximately in 55 seconds and does not use `foldBlocks`, but uses `checkLedgerStateCondition` instead :muscle: 

# Context

Fixes https://github.com/IntersectMBO/cardano-node/issues/5596

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] New tests are added
- NA Any changes are noted in the `CHANGELOG.md` for affected package
- NA The version bounds in `.cabal` files are updated
- [X] CI passes. See note on CI.  The following CI checks are required:
- [X] Self-reviewed the diff