### PR TITLE
wb | nomad: adjust GH API query to IntersectMBO

### DIFF
--- a/nix/workbench/backend/nomad/cloud.sh
+++ b/nix/workbench/backend/nomad/cloud.sh
@@ -366,7 +366,7 @@ allocate-run-nomadcloud() {
     local curl_response
     # Makes `curl` return two objects, one with the body the other with
     # the headers, separated by a newline (`jq -s`).
-    if curl_response=$(curl --silent --show-error --write-out '%{json}' https://api.github.com/repos/input-output-hk/cardano-node/commits/"${gitrev}")
+    if curl_response=$(curl --silent --show-error --write-out '%{json}' https://api.github.com/repos/IntersectMBO/cardano-node/commits/"${gitrev}")
     then
       # Check HTTP status code for existance
       # https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#get-a-commit


### PR DESCRIPTION
# Description

Adjusts GH API query to new repo owner `IntersectMBO`, unblocking Nomad cloud deployment.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [X] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [X] Self-reviewed the diff