### PR TITLE
Remove GHC 9.2 from GHA

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         # If you edit these versions, make sure the version in the lonely macos-latest job below is updated accordingly
-        ghc: ["9.2.8", "9.6.3"]
+        ghc: ["9.6.4"]
         cabal: ["3.10.2.1"]
         os: [windows-latest, ubuntu-latest]
         include:
@@ -34,11 +34,11 @@ jobs:
           # We want a single job, because macOS runners are scarce.
           - os: macos-latest
             cabal: "3.10.2.1"
-            ghc: "9.6.3"
+            ghc: "9.6.4"
 
     env:
       # Modify this value to "invalidate" the cabal cache.
-      CABAL_CACHE_VERSION: "2024-01-19"
+      CABAL_CACHE_VERSION: "2024-01-24"
 
     concurrency:
       group: >


### PR DESCRIPTION
# Description

Removing GHC 9.2 from CI as there is a regression in this compiler version which won't be supported.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
