### PR TITLE
Add governance treasury withdrawal test case

### DIFF
--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -46,8 +46,7 @@ library
                       , cardano-ledger-conway
                       , cardano-ledger-api
                       , cardano-ledger-conway
-                      , cardano-ledger-core
-                      , cardano-ledger-core:testlib
+                      , cardano-ledger-core:{cardano-ledger-core, testlib}
                       , cardano-ledger-shelley
                       , cardano-node
                       , cardano-ping ^>= 0.2.0.13
@@ -55,13 +54,16 @@ library
                       , containers
                       , data-default-class
                       , cborg
+                      , containers
+                      , contra-tracer
+                      , data-default-class
                       , directory
                       , exceptions
                       , filepath
                       , hedgehog
                       , hedgehog-extras < 0.6.2
-                      , microlens
                       , lens-aeson
+                      , microlens
                       , mtl
                       , network
                       , network-mux
@@ -185,10 +187,11 @@ test-suite cardano-testnet-test
                         Cardano.Testnet.Test.FoldBlocks
                         Cardano.Testnet.Test.Misc
 
-                        Cardano.Testnet.Test.LedgerEvents.Gov.ProposeNewConstitution
-                        Cardano.Testnet.Test.LedgerEvents.Gov.InfoAction
-                        Cardano.Testnet.Test.LedgerEvents.Gov.ProposeNewConstitutionSPO
                         Cardano.Testnet.Test.LedgerEvents.Gov.DRepDeposits
+                        Cardano.Testnet.Test.LedgerEvents.Gov.InfoAction
+                        Cardano.Testnet.Test.LedgerEvents.Gov.ProposeNewConstitution
+                        Cardano.Testnet.Test.LedgerEvents.Gov.ProposeNewConstitutionSPO
+                        Cardano.Testnet.Test.LedgerEvents.Gov.TreasuryWithdrawal
                         Cardano.Testnet.Test.LedgerEvents.SanityCheck
                         Cardano.Testnet.Test.LedgerEvents.TreasuryGrowth
 

--- a/cardano-testnet/src/Cardano/Testnet.hs
+++ b/cardano-testnet/src/Cardano/Testnet.hs
@@ -35,6 +35,7 @@ module Cardano.Testnet (
   -- * Utils
   integration,
   waitUntilEpoch,
+  waitForEpochs,
 
   -- * Runtime
   NodeRuntime(..),

--- a/cardano-testnet/src/Testnet/Components/Configuration.hs
+++ b/cardano-testnet/src/Testnet/Components/Configuration.hs
@@ -32,10 +32,9 @@ import           Ouroboros.Network.PeerSelection.State.LocalRootPeers
 
 import           Control.Monad
 import           Control.Monad.Catch (MonadCatch)
-import           Data.Aeson
-import qualified Data.Aeson as Aeson
-import qualified Data.Aeson.Encode.Pretty as Aeson
-import qualified Data.Aeson.KeyMap as Aeson
+import           Data.Aeson (Value (..))
+import qualified Data.Aeson.Encode.Pretty as A
+import           Data.Aeson.KeyMap (KeyMap)
 import qualified Data.Aeson.Lens as L
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.List as List
@@ -71,7 +70,7 @@ createConfigJson (TmpAbsolutePath tempAbsPath) era = GHC.withFrozenCallStack $ d
   alonzoGenesisHash  <- getHash AlonzoEra  "AlonzoGenesisHash"
   conwayGenesisHash  <- getHash ConwayEra  "ConwayGenesisHash"
 
-  return . Aeson.encodePretty . Aeson.Object
+  pure . A.encodePretty . Object
     $ mconcat [ byronGenesisHash
               , shelleyGenesisHash
               , alonzoGenesisHash
@@ -79,7 +78,7 @@ createConfigJson (TmpAbsolutePath tempAbsPath) era = GHC.withFrozenCallStack $ d
               , defaultYamlHardforkViaConfig era
               ]
    where
-    getHash :: (MonadTest m, MonadIO m) => CardanoEra a -> Text.Text -> m (Aeson.KeyMap Aeson.Value)
+    getHash :: (MonadTest m, MonadIO m) => CardanoEra a -> Text.Text -> m (KeyMap Value)
     getHash e = getShelleyGenesisHash (tempAbsPath </> defaultGenesisFilepath e)
 
 numSeededUTxOKeys :: Int
@@ -115,9 +114,9 @@ createSPOGenesisAndFiles (NumPools numPoolNodes) (NumDReps numDelReps) era shell
   -- Then, create-testnet-data will output (possibly augmented/modified) versions
   -- and we remove those input files (see below), to avoid confusion.
   H.evalIO $ do
-    LBS.writeFile inputGenesisShelleyFp $ Aeson.encodePretty shelleyGenesis
-    LBS.writeFile inputGenesisAlonzoFp  $ Aeson.encodePretty alonzoGenesis
-    LBS.writeFile inputGenesisConwayFp  $ Aeson.encodePretty conwayGenesis
+    LBS.writeFile inputGenesisShelleyFp $ A.encodePretty shelleyGenesis
+    LBS.writeFile inputGenesisAlonzoFp  $ A.encodePretty alonzoGenesis
+    LBS.writeFile inputGenesisConwayFp  $ A.encodePretty conwayGenesis
 
   let genesisShelleyDirAbs = takeDirectory inputGenesisShelleyFp
   genesisShelleyDir <- H.createDirectoryIfMissing genesisShelleyDirAbs
@@ -176,7 +175,7 @@ ifaceAddress = "127.0.0.1"
 -- TODO: Reconcile all other mkTopologyConfig functions. NB: We only intend
 -- to support current era on mainnet and the upcoming era.
 mkTopologyConfig :: Int -> [Int] -> Int -> Bool -> LBS.ByteString
-mkTopologyConfig numNodes allPorts port False = Aeson.encodePretty topologyNonP2P
+mkTopologyConfig numNodes allPorts port False = A.encodePretty topologyNonP2P
   where
     topologyNonP2P :: NonP2P.NetworkTopology
     topologyNonP2P =
@@ -186,7 +185,7 @@ mkTopologyConfig numNodes allPorts port False = Aeson.encodePretty topologyNonP2
                                (numNodes - 1)
         | peerPort <- allPorts List.\\ [port]
         ]
-mkTopologyConfig numNodes allPorts port True = Aeson.encodePretty topologyP2P
+mkTopologyConfig numNodes allPorts port True = A.encodePretty topologyP2P
   where
     rootConfig :: P2P.RootConfig
     rootConfig =

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/DRepDeposits.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/DRepDeposits.hs
@@ -4,8 +4,7 @@ module Cardano.Testnet.Test.LedgerEvents.Gov.DRepDeposits
   ( hprop_ledger_events_drep_deposits
   ) where
 
-import           Cardano.Api (AnyCardanoEra (..), File (..), ShelleyBasedEra (..),
-                   ToCardanoEra (..))
+import           Cardano.Api
 import qualified Cardano.Api.Ledger as L
 
 import           Cardano.Testnet
@@ -45,7 +44,8 @@ hprop_ledger_events_drep_deposits = H.integrationWorkspace "drep-deposits" $ \te
 
   work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
 
-  let sbe = ShelleyBasedEraConway
+  let ceo = ConwayEraOnwardsConway
+      sbe = conwayEraOnwardsToShelleyBasedEra ceo
       era = toCardanoEra sbe
       cEra = AnyCardanoEra era
       fastTestnetOptions = cardanoDefaultTestnetOptions
@@ -79,7 +79,7 @@ hprop_ledger_events_drep_deposits = H.integrationWorkspace "drep-deposits" $ \te
 
   gov <- H.createDirectoryIfMissing $ work </> "governance"
 
-  minDRepDeposit <- getMinDRepDeposit execConfig
+  minDRepDeposit <- getMinDRepDeposit execConfig ceo
 
   -- DRep 1 (not enough deposit)
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/InfoAction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/InfoAction.hs
@@ -59,7 +59,6 @@ hprop_ledger_events_info_action = H.integrationRetryWorkspace 0 "info-hash" $ \t
       era = toCardanoEra sbe
       fastTestnetOptions = cardanoDefaultTestnetOptions
         { cardanoEpochLength = 100
-        , cardanoSlotLength = 0.1
         , cardanoNodeEra = AnyCardanoEra era
         }
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/TreasuryWithdrawal.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/TreasuryWithdrawal.hs
@@ -1,0 +1,319 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Cardano.Testnet.Test.LedgerEvents.Gov.TreasuryWithdrawal
+  ( hprop_ledger_events_treasury_withdrawal
+  ) where
+
+import           Cardano.Api
+import           Cardano.Api.Ledger (EpochInterval (EpochInterval), KeyRole (Staking),
+                   StandardCrypto)
+import           Cardano.Api.ReexposeLedger (Coin, Credential)
+
+import           Cardano.CLI.Types.Output (QueryTipLocalStateOutput (..))
+import qualified Cardano.Ledger.BaseTypes as L
+import qualified Cardano.Ledger.Coin as L
+import qualified Cardano.Ledger.Conway.Governance as L
+import qualified Cardano.Ledger.Shelley.LedgerState as L
+import           Cardano.Testnet
+
+import           Prelude
+
+import           Control.Monad
+import           Control.Monad.State.Class
+import           Data.Bifunctor (Bifunctor (..))
+import           Data.Map (Map)
+import qualified Data.Map.Strict as M
+import qualified Data.Text as Text
+import           GHC.Stack
+import           Lens.Micro
+import           System.FilePath ((</>))
+
+import           Testnet.Components.Query
+import           Testnet.Components.TestWatchdog
+import           Testnet.Defaults
+import qualified Testnet.Process.Cli as P
+import qualified Testnet.Process.Run as H
+import qualified Testnet.Property.Utils as H
+import           Testnet.Runtime
+import           Testnet.Start.Types (eraToString)
+
+import           Hedgehog
+import qualified Hedgehog.Extras as H
+import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
+
+hprop_ledger_events_treasury_withdrawal:: Property
+hprop_ledger_events_treasury_withdrawal = H.integrationRetryWorkspace 1  "treasury-withdrawal" $ \tempAbsBasePath' -> runWithDefaultWatchdog_ $ do
+  conf@Conf { tempAbsPath } <- H.noteShowM $ mkConf tempAbsBasePath'
+  let tempAbsPath' = unTmpAbsPath tempAbsPath
+      tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
+
+  work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
+
+  let ceo = ConwayEraOnwardsConway
+      sbe = conwayEraOnwardsToShelleyBasedEra ceo
+      era = toCardanoEra sbe
+      eraName = eraToString era
+      cEra = AnyCardanoEra era
+
+      fastTestnetOptions = cardanoDefaultTestnetOptions
+        { cardanoEpochLength = 100
+        , cardanoNodeEra = cEra
+        , cardanoActiveSlotsCoeff = 0.3
+        }
+
+  testnetRuntime@TestnetRuntime
+    { testnetMagic
+    , poolNodes
+    , wallets=wallet0:wallet1:_
+    , configurationFile
+    }
+    <- cardanoTestnetDefault fastTestnetOptions conf
+
+  poolNode1 <- H.headM poolNodes
+  poolSprocket1 <- H.noteShow $ nodeSprocket $ poolRuntime poolNode1
+  execConfig <- H.mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
+
+  let socketName' = IO.sprocketName poolSprocket1
+      socketBase = IO.sprocketBase poolSprocket1 -- /tmp
+      socketPath = socketBase </> socketName'
+
+  epochStateView <- getEpochStateView (File configurationFile) (File socketPath)
+
+  H.note_ $ "Sprocket: " <> show poolSprocket1
+  H.note_ $ "Abs path: " <> tempAbsBasePath'
+  H.note_ $ "Socketpath: " <> socketPath
+  H.note_ $ "Foldblocks config file: " <> configurationFile
+
+  startLedgerNewEpochStateLogging testnetRuntime tempAbsPath'
+
+  gov <- H.createDirectoryIfMissing $ work </> "governance"
+  proposalAnchorFile <- H.note $ work </> gov </> "sample-proposal-anchor"
+  treasuryWithdrawalActionFp <- H.note $ work </> gov </> "treasury-withdrawal.action"
+
+  H.writeFile proposalAnchorFile "dummy anchor data"
+
+  proposalAnchorDataHash <- H.execCli' execConfig
+    [ eraName, "governance"
+    , "hash", "anchor-data", "--file-text", proposalAnchorFile
+    ]
+
+  txin2 <- findLargestUtxoForPaymentKey epochStateView sbe wallet1
+
+  -- {{{ Register stake address
+  let stakeVkeyFp = gov </> "stake.vkey"
+      stakeSKeyFp = gov </> "stake.skey"
+      stakeCertFp = gov </> "stake.regcert"
+
+  _ <- P.cliStakeAddressKeyGen tempAbsPath'
+         $ P.KeyNames { P.verificationKeyFile = stakeVkeyFp
+                      , P.signingKeyFile = stakeSKeyFp
+                      }
+
+  void $ H.execCli' execConfig
+    [ eraName, "stake-address", "registration-certificate"
+    , "--stake-verification-key-file", stakeVkeyFp
+    , "--key-reg-deposit-amt", show @Int 0 -- TODO: why this needs to be 0????
+    , "--out-file", stakeCertFp
+    ]
+
+  stakeCertTxBodyFp <- H.note $ work </> "stake.registration.txbody"
+  stakeCertTxSignedFp <- H.note $ work </> "stake.registration.tx"
+
+  void $ H.execCli' execConfig
+    [ eraName, "transaction", "build"
+    , "--change-address", Text.unpack $ paymentKeyInfoAddr wallet1
+    , "--tx-in", Text.unpack $ renderTxIn txin2
+    , "--tx-out", Text.unpack (paymentKeyInfoAddr wallet0) <> "+" <> show @Int 10_000_000
+    , "--certificate-file", stakeCertFp
+    , "--witness-override", show @Int 2
+    , "--out-file", stakeCertTxBodyFp
+    ]
+
+  void $ H.execCli' execConfig
+    [ eraName, "transaction", "sign"
+    , "--tx-body-file", stakeCertTxBodyFp
+    , "--signing-key-file", paymentSKey $ paymentKeyInfoPair wallet1
+    , "--signing-key-file", stakeSKeyFp
+    , "--out-file", stakeCertTxSignedFp
+    ]
+
+  void $ H.execCli' execConfig
+    [ eraName, "transaction", "submit"
+    , "--tx-file", stakeCertTxSignedFp
+    ]
+  -- }}}
+
+  -- {{{ Create treasury withdrawal
+  let withdrawalAmount = 3_300_777 :: Integer
+  govActionDeposit <- getMinDRepDeposit execConfig ceo
+  void $ H.execCli' execConfig
+    [ eraName, "governance", "action", "create-treasury-withdrawal"
+    , "--testnet"
+    , "--anchor-url", "https://tinyurl.com/3wrwb2as"
+    , "--anchor-data-hash", proposalAnchorDataHash
+    , "--governance-action-deposit", show govActionDeposit
+    , "--deposit-return-stake-verification-key-file", stakeVkeyFp
+    , "--transfer", show withdrawalAmount
+    , "--funds-receiving-stake-verification-key-file", stakeVkeyFp
+    , "--out-file", treasuryWithdrawalActionFp
+    ]
+
+
+  txbodyFp <- H.note $ work </> "tx.body"
+  txbodySignedFp <- H.note $ work </> "tx.body.signed"
+
+  -- wait for an epoch before using wallet0 again
+  void $ waitForEpochs execConfig (File configurationFile) (File socketPath) (EpochInterval 1)
+
+  txin3 <- findLargestUtxoForPaymentKey epochStateView sbe wallet0
+
+  void $ H.execCli' execConfig
+    [ eraName, "transaction", "build"
+    , "--change-address", Text.unpack $ paymentKeyInfoAddr wallet0
+    , "--tx-in", Text.unpack $ renderTxIn txin3
+    , "--tx-out", Text.unpack (paymentKeyInfoAddr wallet1) <> "+" <> show @Int 5_000_000
+    , "--proposal-file", treasuryWithdrawalActionFp
+    , "--out-file", txbodyFp
+    ]
+
+  void $ H.execCli' execConfig
+    [ eraName, "transaction", "sign"
+    , "--tx-body-file", txbodyFp
+    , "--signing-key-file", paymentSKey $ paymentKeyInfoPair wallet0
+    , "--out-file", txbodySignedFp
+    ]
+
+  void $ H.execCli' execConfig
+    [ eraName, "transaction", "submit"
+    , "--tx-file", txbodySignedFp
+    ]
+  -- }}}
+
+  txidString <- mconcat . lines <$> H.execCli' execConfig
+    [ "transaction", "txid"
+    , "--tx-file", txbodySignedFp
+    ]
+
+  currentEpoch <- H.nothingFailM $ mEpoch <$> queryTip execConfig
+  let terminationEpoch = succ . succ $ currentEpoch
+  L.GovActionIx governanceActionIndex <- fmap L.gaidGovActionIx . H.nothingFailM $
+    getTreasuryWithdrawalProposal (File configurationFile) (File socketPath) terminationEpoch
+
+  let voteFp :: Int -> FilePath
+      voteFp n = work </> gov </> "vote-" <> show n
+
+  -- Proposal was successfully submitted, now we vote on the proposal and confirm it was ratified
+  H.forConcurrently_ [1..3] $ \n -> do
+    H.execCli' execConfig
+      [ eraName, "governance", "vote", "create"
+      , "--yes"
+      , "--governance-action-tx-id", txidString
+      , "--governance-action-index", show governanceActionIndex
+      , "--drep-verification-key-file", defaultDRepVkeyFp n
+      , "--out-file", voteFp n
+      ]
+
+  txin4 <- findLargestUtxoForPaymentKey epochStateView sbe wallet1
+
+  voteTxFp <- H.note $ work </> gov </> "vote.tx"
+  voteTxBodyFp <- H.note $ work </> gov </> "vote.txbody"
+  -- {{{ Submit votes
+  void $ H.execCli' execConfig
+    [ eraName, "transaction", "build"
+    , "--change-address", Text.unpack $ paymentKeyInfoAddr wallet1
+    , "--tx-in", Text.unpack $ renderTxIn txin4
+    , "--tx-out", Text.unpack (paymentKeyInfoAddr wallet0) <> "+" <> show @Int 3_000_000
+    , "--vote-file", voteFp 1
+    , "--vote-file", voteFp 2
+    , "--vote-file", voteFp 3
+    , "--witness-override", show @Int 4
+    , "--out-file", voteTxBodyFp
+    ]
+
+  void $ H.execCli' execConfig
+    [ eraName, "transaction", "sign"
+    , "--tx-body-file", voteTxBodyFp
+    , "--signing-key-file", paymentSKey $ paymentKeyInfoPair wallet1
+    , "--signing-key-file", defaultDRepSkeyFp 1
+    , "--signing-key-file", defaultDRepSkeyFp 2
+    , "--signing-key-file", defaultDRepSkeyFp 3
+    , "--out-file", voteTxFp
+    ]
+
+  void $ H.execCli' execConfig
+    [ eraName, "transaction", "submit"
+    , "--tx-file", voteTxFp
+    ]
+  -- }}}
+
+  withdrawals <- H.nothingFailM $
+    H.nothingFailM (mEpoch <$> queryTip execConfig) >>=
+      getAnyWithdrawals (File configurationFile) (File socketPath) . (`L.addEpochInterval` EpochInterval 5)
+
+  H.noteShow_ withdrawals
+  (L.unCoin . snd <$> M.toList withdrawals) === [withdrawalAmount]
+
+
+getAnyWithdrawals
+  :: HasCallStack
+  => MonadIO m
+  => MonadTest m
+  => NodeConfigFile In
+  -> SocketPath
+  -> EpochNo
+  -> m (Maybe (Map (Credential Staking StandardCrypto) Coin))
+getAnyWithdrawals nodeConfigFile socketPath maxEpoch = withFrozenCallStack $ do
+  fmap snd . H.leftFailM . evalIO . runExceptT $ foldEpochState nodeConfigFile socketPath FullValidation maxEpoch Nothing
+    $ \(AnyNewEpochState actualEra newEpochState) ->
+      caseShelleyToBabbageOrConwayEraOnwards
+        (error $ "Expected Conway era onwards, got state in " <> docToString (pretty actualEra))
+        (\cEra _ _ -> conwayEraOnwardsConstraints cEra $ do
+          let withdrawals = newEpochState
+                ^. L.newEpochStateGovStateL
+                . L.drepPulsingStateGovStateL
+                . to L.extractDRepPulsingState
+                . L.rsEnactStateL
+                . L.ensWithdrawalsL
+          if M.null withdrawals
+            then pure ConditionNotMet
+            else do
+              put $ Just withdrawals
+              pure ConditionMet
+        ) actualEra
+
+
+getTreasuryWithdrawalProposal
+  :: HasCallStack
+  => MonadIO m
+  => MonadTest m
+  => NodeConfigFile In
+  -> SocketPath
+  -> EpochNo -- ^ The termination epoch: the withdrawal proposal must be found *before* this epoch
+  -> m (Maybe (L.GovActionId StandardCrypto))
+getTreasuryWithdrawalProposal nodeConfigFile socketPath maxEpoch = withFrozenCallStack $ do
+  fmap snd . H.leftFailM . evalIO . runExceptT $ foldEpochState nodeConfigFile socketPath QuickValidation maxEpoch Nothing
+      $ \(AnyNewEpochState actualEra newEpochState) ->
+        caseShelleyToBabbageOrConwayEraOnwards
+          (error $ "Expected Conway era onwards, got state in " <> docToString (pretty actualEra))
+          (\cEra _ _ -> conwayEraOnwardsConstraints cEra $ do
+            let proposals = newEpochState
+                      ^. L.newEpochStateGovStateL
+                      . L.cgsProposalsL
+                govActions = M.toList $ L.proposalsActionsMap proposals
+            case map (second L.gasAction) govActions of
+              (govActionId, L.TreasuryWithdrawals _ _): _ -> do
+                put $ Just govActionId
+                pure ConditionMet
+              _ ->
+                pure ConditionNotMet
+          ) actualEra
+

--- a/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
+++ b/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
@@ -17,6 +17,7 @@ import qualified Cardano.Testnet.Test.FoldBlocks
 import qualified Cardano.Testnet.Test.LedgerEvents.Gov.DRepDeposits
 import qualified Cardano.Testnet.Test.LedgerEvents.Gov.ProposeNewConstitution
 import qualified Cardano.Testnet.Test.LedgerEvents.Gov.ProposeNewConstitutionSPO as LedgerEvents
+import qualified Cardano.Testnet.Test.LedgerEvents.Gov.TreasuryWithdrawal as LedgerEvents
 import qualified Cardano.Testnet.Test.LedgerEvents.SanityCheck as LedgerEvents
 import qualified Cardano.Testnet.Test.LedgerEvents.TreasuryGrowth as LedgerEvents
 import qualified Cardano.Testnet.Test.Node.Shutdown
@@ -51,6 +52,7 @@ tests = do
                   -- FIXME Those tests are flaky
                   -- , H.ignoreOnWindows "InfoAction" LedgerEvents.hprop_ledger_events_info_action
                 , H.ignoreOnWindows "ProposeNewConstitutionSPO" LedgerEvents.hprop_ledger_events_propose_new_constitution_spo
+                , H.ignoreOnWindows "TreasuryWithdrawal" LedgerEvents.hprop_ledger_events_treasury_withdrawal
                 , H.ignoreOnWindows "DRepRetirement" DRepRetirement.hprop_drep_retirement
                 ]
             , T.testGroup "Plutus"


### PR DESCRIPTION
# Description

Adds treasury withdrawal test case.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
