### PR TITLE
Update hedgehog-extras to 0.5.0.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -59,4 +59,11 @@ package plutus-scripts-bench
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
 
+source-repository-package
+    type: git
+    location: https://github.com/IntersectMBO/cardano-cli.git
+    tag: 35a5a31170be02695f2b0a8d0bbfb78119bcd8f9
+    subdir: cardano-cli
+    --sha256: 02dgj99d113d8h9aam82lggwlf1vp4rdfq8km8sqcwmrfgbp1igy
+
 -- `smtp-mail` should depend on `crypton-connection` rather than `connection`!

--- a/cabal.project
+++ b/cabal.project
@@ -13,7 +13,7 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state:
-  , hackage.haskell.org 2023-11-20T23:52:53Z
+  , hackage.haskell.org 2023-12-16T11:21:56Z
   , cardano-haskell-packages 2023-12-15T14:50:31Z
 
 packages:

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -55,7 +55,7 @@ library
                       , exceptions
                       , filepath
                       , hedgehog
-                      , hedgehog-extras ^>= 0.4.7.0
+                      , hedgehog-extras ^>= 0.5.0.0
                       , mtl
                       , network
                       , network-mux


### PR DESCRIPTION
# Description

Prepare for newer version of cardano-api, that requires hedgehog-extras 0.5.0.0

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- NA New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- NA Any changes are noted in the `CHANGELOG.md` for affected package
- NA The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [X] Self-reviewed the diff