### PR TITLE
Bubble up exceptions in runNode

### DIFF
--- a/cardano-node/src/Cardano/Node/Protocol.hs
+++ b/cardano-node/src/Cardano/Node/Protocol.hs
@@ -4,10 +4,12 @@ module Cardano.Node.Protocol
   , ProtocolInstantiationError(..)
   ) where
 
+import           Control.Exception
 import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT)
 
 import           Cardano.Api
+import           Cardano.Api.Pretty
 
 import           Cardano.Node.Types
 
@@ -53,6 +55,8 @@ data ProtocolInstantiationError =
   | CardanoProtocolInstantiationError CardanoProtocolInstantiationError
   deriving Show
 
+instance Exception ProtocolInstantiationError where
+  displayException = docToString . prettyError
 
 instance Error ProtocolInstantiationError where
   prettyError (ByronProtocolInstantiationError   err) = prettyError err

--- a/cardano-node/src/Cardano/Node/Types.hs
+++ b/cardano-node/src/Cardano/Node/Types.hs
@@ -31,6 +31,7 @@ module Cardano.Node.Types
   , renderVRFPrivateKeyFilePermissionError
   ) where
 
+import           Control.Exception
 import           Data.Aeson
 import           Data.ByteString (ByteString)
 import           Data.Monoid (Last)
@@ -42,6 +43,7 @@ import           Data.Word (Word16, Word8)
 import           Control.Monad (MonadPlus (..))
 
 import           Cardano.Api
+import           Cardano.Api.Pretty
 import           Cardano.Crypto (RequiresNetworkMagic (..))
 import qualified Cardano.Crypto.Hash as Crypto
 import           Cardano.Node.Configuration.Socket (SocketConfig (..))
@@ -56,6 +58,14 @@ data ConfigError =
     ConfigErrorFileNotFound FilePath
   | ConfigErrorNoEKG
     deriving Show
+
+instance Exception ConfigError where
+  displayException = docToString . prettyError
+
+instance Error ConfigError where
+  prettyError ConfigErrorNoEKG = "ConfigErrorNoEKG"
+  prettyError (ConfigErrorFileNotFound fp) =
+    mconcat ["ConfigErrorFileNotFound: ", pretty fp]
 
 -- | Filepath of the configuration yaml file. This file determines
 -- all the configuration settings required for the cardano node
@@ -351,6 +361,12 @@ data VRFPrivateKeyFilePermissionError
   | GroupPermissionsExist FilePath
   | GenericPermissionsExist FilePath
   deriving Show
+
+instance Exception VRFPrivateKeyFilePermissionError where
+  displayException = Text.unpack . renderVRFPrivateKeyFilePermissionError
+
+instance Error VRFPrivateKeyFilePermissionError where
+  prettyError = pretty . renderVRFPrivateKeyFilePermissionError
 
 renderVRFPrivateKeyFilePermissionError :: VRFPrivateKeyFilePermissionError -> Text
 renderVRFPrivateKeyFilePermissionError err =


### PR DESCRIPTION
# Description

Previously we were printing some errors to `stdout` in `runNode`. This made debugging challenging in cardano-testnet as some errors got reported via `stderr` and others via `stdout`.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
