### PR TITLE
Delete unused function `renderApplyMempoolPayloadErr`

### DIFF
--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -43,7 +43,6 @@ library
                       , cardano-binary
                       , cardano-cli ^>= 8.18.0.0
                       , cardano-crypto-class ^>= 2.1.2
-                      , cardano-ledger-byron ^>= 1.0
                       , formatting
                       , http-media
                       , iohk-monitoring

--- a/cardano-submit-api/src/Cardano/TxSubmit/ErrorRender.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/ErrorRender.hs
@@ -2,8 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Cardano.TxSubmit.ErrorRender
-  ( renderApplyMempoolPayloadErr
-  , renderEraMismatch
+  ( renderEraMismatch
   ) where
 
 -- This file contains error renders. They should have been defined at a lower level, with the error
@@ -11,59 +10,8 @@ module Cardano.TxSubmit.ErrorRender
 -- They will be defined here for now and then moved where they are supposed to be once they
 -- are working.
 
-import           Cardano.Api
-
-import           Cardano.Chain.Byron.API (ApplyMempoolPayloadErr (..))
-import           Cardano.Chain.UTxO.UTxO (UTxOError (..))
-import           Cardano.Chain.UTxO.Validation (TxValidationError (..), UTxOValidationError (..))
 import           Data.Text (Text)
-import           Formatting (build, sformat, stext, (%))
 import           Ouroboros.Consensus.Cardano.Block (EraMismatch (..))
-
-renderApplyMempoolPayloadErr :: ApplyMempoolPayloadErr -> Text
-renderApplyMempoolPayloadErr err =
-    case err of
-      MempoolTxErr ve -> renderValidationError ve
-      MempoolDlgErr {} -> "Delegation error"
-      MempoolUpdateProposalErr {} -> "Update proposal error"
-      MempoolUpdateVoteErr {} -> "Update vote error"
-
-renderValidationError :: UTxOValidationError -> Text
-renderValidationError ve =
-  case ve of
-    UTxOValidationTxValidationError tve -> renderTxValidationError tve
-    UTxOValidationUTxOError ue -> renderUTxOError ue
-
-renderTxValidationError :: TxValidationError -> Text
-renderTxValidationError tve =
-  "Tx Validation: " <>
-    case tve of
-      TxValidationLovelaceError txt e ->
-        sformat ("Lovelace error " % stext % ": " % build) txt e
-      TxValidationFeeTooSmall tx expected actual ->
-        sformat ("Tx " % build % " fee " % build % "too low, expected " % build) tx actual expected
-      TxValidationWitnessWrongSignature wit pmid sig ->
-        sformat ("Bad witness " % build % " for signature " % stext % " protocol magic id " % stext) wit (textShow sig) (textShow pmid)
-      TxValidationWitnessWrongKey wit addr ->
-        sformat ("Bad witness " % build % " for address " % build) wit addr
-      TxValidationMissingInput tx ->
-        sformat ("Validation cannot find input tx " % build) tx
-      -- Fields are <expected> <actual>
-      TxValidationNetworkMagicMismatch expected actual ->
-        mconcat [ "Bad network magic  ", textShow actual, ", expected ", textShow expected ]
-      TxValidationTxTooLarge expected actual ->
-        mconcat [ "Tx is ", textShow actual, " bytes, but expected < ", textShow expected, " bytes" ]
-      TxValidationUnknownAddressAttributes ->
-        "Unknown address attributes"
-      TxValidationUnknownAttributes ->
-        "Unknown attributes"
-
-renderUTxOError :: UTxOError -> Text
-renderUTxOError ue =
-  "UTxOError: " <>
-    case ue of
-      UTxOMissingInput tx -> sformat ("Lookup of tx " % build % " failed") tx
-      UTxOOverlappingUnion -> "Union or two overlapping UTxO sets"
 
 renderEraMismatch :: EraMismatch -> Text
 renderEraMismatch EraMismatch{ledgerEraName, otherEraName} =


### PR DESCRIPTION
# Description

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
