### PR TITLE
cardano-testnet-test: allow to rewrite Conway configuration

### DIFF
--- a/cardano-testnet/src/Testnet/Start/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Start/Cardano.hs
@@ -127,7 +127,7 @@ startTimeOffsetSeconds = if OS.isWin32 then 90 else 15
 -- > └── utxo-keys
 -- >     └── utxo{1,2,3}.{addr,skey,vkey}
 cardanoTestnet :: CardanoTestnetOptions -> Conf -> H.Integration TestnetRuntime
-cardanoTestnet testnetOptions Conf {tempAbsPath} = do
+cardanoTestnet testnetOptions Conf {tempAbsPath, rewriteConway} = do
   testnetMinimumConfigurationRequirements testnetOptions
   void $ H.note OS.os
   currentTime <- H.noteShowIO DTC.getCurrentTime
@@ -167,7 +167,8 @@ cardanoTestnet testnetOptions Conf {tempAbsPath} = do
     H.evalIO $ LBS.writeFile alonzoConwayTestGenesisJsonTargetFile $ Aeson.encode gen
 
     conwayConwayTestGenesisJsonTargetFile <- H.noteShow $ tempAbsPath' </> "genesis.conway.spec.json"
-    H.evalIO $ LBS.writeFile conwayConwayTestGenesisJsonTargetFile $ Aeson.encode defaultConwayGenesis
+    let conwayGenesis = rewriteConway defaultConwayGenesis
+    H.evalIO $ LBS.writeFile conwayConwayTestGenesisJsonTargetFile $ Aeson.encode conwayGenesis
 
     configurationFile <- H.noteShow $ tempAbsPath' </> "configuration.yaml"
 

--- a/cardano-testnet/src/Testnet/Start/Types.hs
+++ b/cardano-testnet/src/Testnet/Start/Types.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Testnet.Start.Types
@@ -23,6 +24,8 @@ import           Data.Word
 
 import           Hedgehog.Extras.Test.Base (Integration)
 
+import           Cardano.Api.Ledger (StandardCrypto)
+import qualified Cardano.Ledger.Conway.Genesis as Ledger
 import           Testnet.Filepath
 
 
@@ -82,14 +85,27 @@ newtype NodeConfigurationYaml = NodeConfigurationYaml
   { unYamlFilePath :: FilePath
   } deriving (Eq, Show)
 
-newtype Conf = Conf
+data Conf = Conf
   { tempAbsPath :: TmpAbsolutePath
-  } deriving (Eq, Show)
+  , -- | Function to rewrite the Conway genesis file before creating the testnet
+    rewriteConway :: Ledger.ConwayGenesis StandardCrypto -> Ledger.ConwayGenesis StandardCrypto
+  }
+
+instance Show Conf where
+  -- We ignore rewriteConway
+  show Conf { tempAbsPath } =
+    unlines
+      ["Conf{"
+       , "  tempAbsPath=" ++ show tempAbsPath
+       , "  rewriteConway=unshowable"
+       , "}"
+      ]
 
 mkConf :: FilePath -> Integration Conf
 mkConf tempAbsPath' =
   return $ Conf
     { tempAbsPath = TmpAbsolutePath tempAbsPath'
+    , rewriteConway = id -- By default, don't change anything
     }
 
 


### PR DESCRIPTION
# Description

This PR makes it possible to rewrite the Conway genesis file before calling `create-testnet-data` in integration tests. I have been using it to tweak parameters in not-yet-PRed work, but this will be useful to others.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- NA New tests are added if needed and existing tests are updated.
- NA Any changes are noted in the `CHANGELOG.md` for affected package
- NA The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
- [X] Self-reviewed the diff