### PR TITLE
Add `startLedgerStateLogging`. Cleanup test cases.

### DIFF
--- a/cardano-testnet/src/Testnet/Components/Configuration.hs
+++ b/cardano-testnet/src/Testnet/Components/Configuration.hs
@@ -10,12 +10,11 @@ module Testnet.Components.Configuration
   , numSeededUTxOKeys
   ) where
 
+import           Cardano.Api.Pretty
 import           Cardano.Api.Shelley hiding (cardanoEra)
-
 import qualified Cardano.Node.Configuration.Topology as NonP2P
 import qualified Cardano.Node.Configuration.TopologyP2P as P2P
 import           Cardano.Node.Types
-import           Data.Bifunctor
 import           Ouroboros.Network.PeerSelection.LedgerPeers
 import           Ouroboros.Network.PeerSelection.RelayAccessPoint
 import           Ouroboros.Network.PeerSelection.State.LocalRootPeers
@@ -25,12 +24,16 @@ import           Control.Monad.Catch (MonadCatch)
 import           Control.Monad.IO.Class (MonadIO)
 import           Data.Aeson
 import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Lens as L
+import           Data.Bifunctor
 import qualified Data.ByteString.Lazy as LBS
+import           Data.Char (toLower)
 import qualified Data.List as List
 import           Data.String
 import           Data.Time
 import           GHC.Stack (HasCallStack)
 import qualified GHC.Stack as GHC
+import           Lens.Micro
 import           System.FilePath.Posix (takeDirectory, (</>))
 
 import           Hedgehog
@@ -38,9 +41,6 @@ import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Stock.Time as DTC
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
-
-import qualified Data.Aeson.Lens as L
-import           Lens.Micro
 
 import           Testnet.Defaults
 import           Testnet.Filepath
@@ -208,12 +208,4 @@ mkTopologyConfig numNodes allPorts port True = Aeson.encode topologyP2P
 
 
 convertToEraString :: AnyCardanoEra -> String
-convertToEraString (AnyCardanoEra e) =
-  case e of
-    ConwayEra -> "conway"
-    BabbageEra -> "babbage"
-    AlonzoEra -> "alonzo"
-    MaryEra -> "mary"
-    AllegraEra -> "allegra"
-    ShelleyEra -> "shelley"
-    ByronEra -> "byron"
+convertToEraString = map toLower . docToString . pretty

--- a/cardano-testnet/src/Testnet/Filepath.hs
+++ b/cardano-testnet/src/Testnet/Filepath.hs
@@ -4,7 +4,6 @@
 
 module Testnet.Filepath
   ( TmpAbsolutePath(..)
-  , makeDbDir
   , makeLogDir
   , makeSocketDir
   , makeSprocket
@@ -17,8 +16,6 @@ import           Data.String (IsString (..))
 import           System.FilePath
 
 import           Hedgehog.Extras.Stock.IO.Network.Sprocket (Sprocket (..))
-
-
 
 
 makeSprocket
@@ -40,10 +37,7 @@ makeSocketDir :: TmpAbsolutePath -> FilePath
 makeSocketDir fp = makeTmpRelPath fp </> "socket"
 
 makeTmpBaseAbsPath :: TmpAbsolutePath -> FilePath
-makeTmpBaseAbsPath (TmpAbsolutePath fp) = takeDirectory fp
+makeTmpBaseAbsPath (TmpAbsolutePath fp) = addTrailingPathSeparator $ takeDirectory fp
 
 makeLogDir :: TmpAbsolutePath -> FilePath
-makeLogDir (TmpAbsolutePath fp) = fp </> "logs"
-
-makeDbDir :: Int -> TmpAbsolutePath -> FilePath
-makeDbDir nodeNumber (TmpAbsolutePath fp) = fp </> "db/node-" </> show nodeNumber
+makeLogDir (TmpAbsolutePath fp) = addTrailingPathSeparator $ fp </> "logs"

--- a/cardano-testnet/src/Testnet/Property/Utils.hs
+++ b/cardano-testnet/src/Testnet/Property/Utils.hs
@@ -21,7 +21,6 @@ module Testnet.Property.Utils
   ) where
 
 import           Cardano.Api
-
 import           Cardano.Chain.Genesis (GenesisHash (unGenesisHash), readGenesisData)
 import           Cardano.CLI.Types.Output
 import qualified Cardano.Crypto.Hash.Blake2b as Crypto

--- a/cardano-testnet/src/Testnet/Start/Types.hs
+++ b/cardano-testnet/src/Testnet/Start/Types.hs
@@ -16,13 +16,12 @@ module Testnet.Start.Types
   ) where
 
 import           Cardano.Api hiding (cardanoEra)
-
-import           Prelude
-
 import           Data.Word
-
-import           Hedgehog.Extras.Test.Base (Integration)
-
+import           GHC.Stack
+import           Hedgehog (MonadTest)
+import qualified Hedgehog.Extras as H
+import           Prelude
+import           System.FilePath (addTrailingPathSeparator)
 import           Testnet.Filepath
 
 
@@ -86,10 +85,12 @@ newtype Conf = Conf
   { tempAbsPath :: TmpAbsolutePath
   } deriving (Eq, Show)
 
-mkConf :: FilePath -> Integration Conf
-mkConf tempAbsPath' =
-  return $ Conf
-    { tempAbsPath = TmpAbsolutePath tempAbsPath'
+-- | Create a 'Conf' from a temporary absolute path. Logs the argument in the test.
+mkConf :: (HasCallStack, MonadTest m) => FilePath -> m Conf
+mkConf tempAbsPath' = withFrozenCallStack $ do
+  H.note_ tempAbsPath'
+  pure $ Conf
+    { tempAbsPath = TmpAbsolutePath (addTrailingPathSeparator tempAbsPath')
     }
 
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/StakeSnapshot.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/StakeSnapshot.hs
@@ -46,7 +46,7 @@ import           Testnet.Runtime
 hprop_stakeSnapshot :: Property
 hprop_stakeSnapshot = H.integrationRetryWorkspace 2 "babbage-stake-snapshot" $ \tempAbsBasePath' -> do
   H.note_ SYS.os
-  conf@Conf { tempAbsPath } <- H.noteShowM $ mkConf tempAbsBasePath'
+  conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
   work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/Transaction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/Transaction.hs
@@ -48,7 +48,7 @@ import           Lens.Micro
 hprop_transaction :: Property
 hprop_transaction = H.integrationRetryWorkspace 0 "babbage-transaction" $ \tempAbsBasePath' -> do
   H.note_ SYS.os
-  conf@Conf { tempAbsPath } <- H.noteShowM $ mkConf tempAbsBasePath'
+  conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
   work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/StakeSnapshot.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/StakeSnapshot.hs
@@ -46,7 +46,7 @@ import           Testnet.Runtime
 hprop_stakeSnapshot :: Property
 hprop_stakeSnapshot = H.integrationRetryWorkspace 2 "conway-stake-snapshot" $ \tempAbsBasePath' -> do
   H.note_ SYS.os
-  conf@Conf { tempAbsPath } <- H.noteShowM $ mkConf tempAbsBasePath'
+  conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
   work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/QuerySlotNumber.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/QuerySlotNumber.hs
@@ -41,7 +41,7 @@ import           Testnet.Runtime
 hprop_querySlotNumber :: Property
 hprop_querySlotNumber = H.integrationRetryWorkspace 2 "query-slot-number" $ \tempAbsBasePath' -> do
   H.note_ SYS.os
-  conf <- H.noteShowM $ mkConf tempAbsBasePath'
+  conf <- mkConf tempAbsBasePath'
 
   let tempBaseAbsPath' = makeTmpBaseAbsPath $ tempAbsPath conf
       era = BabbageEra

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/ProposeNewConstitution.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/ProposeNewConstitution.hs
@@ -48,7 +48,7 @@ newtype AdditionalCatcher
 hprop_ledger_events_propose_new_constitution :: Property
 hprop_ledger_events_propose_new_constitution = H.integrationWorkspace "propose-new-constitution" $ \tempAbsBasePath' -> do
   -- Start a local test net
-  conf@Conf { tempAbsPath } <- H.noteShowM $ mkConf tempAbsBasePath'
+  conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
       tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/SanityCheck.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/SanityCheck.hs
@@ -45,7 +45,7 @@ newtype AdditionalCatcher
 hprop_ledger_events_sanity_check :: Property
 hprop_ledger_events_sanity_check = H.integrationWorkspace "ledger-events-sanity-check" $ \tempAbsBasePath' -> do
   -- Start a local test net
-  conf <- H.noteShowM $  mkConf tempAbsBasePath'
+  conf <- mkConf tempAbsBasePath'
 
   let fastTestnetOptions = cardanoDefaultTestnetOptions
         { cardanoEpochLength = 100

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Node/Shutdown.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Node/Shutdown.hs
@@ -59,7 +59,7 @@ import           Testnet.Start.Byron
 -- TODO: Use cardanoTestnet in hprop_shutdown
 hprop_shutdown :: Property
 hprop_shutdown = H.integrationRetryWorkspace 2 "shutdown" $ \tempAbsBasePath' -> do
-  conf <- H.noteShowM $ mkConf tempAbsBasePath'
+  conf <- mkConf tempAbsBasePath'
   let tempBaseAbsPath' = makeTmpBaseAbsPath $ tempAbsPath conf
       tempAbsPath' = unTmpAbsPath $ tempAbsPath conf
       logDir' = makeLogDir $ tempAbsPath conf
@@ -183,7 +183,7 @@ hprop_shutdownOnSlotSynced :: Property
 hprop_shutdownOnSlotSynced = H.integrationRetryWorkspace 2 "shutdown-on-slot-synced" $ \tempAbsBasePath' -> do
   -- Start a local test net
   -- TODO: Move yaml filepath specification into individual node options
-  conf <- H.noteShowM $  mkConf tempAbsBasePath'
+  conf <- mkConf tempAbsBasePath'
 
   let maxSlot = 150
       slotLen = 0.01
@@ -231,7 +231,7 @@ hprop_shutdownOnSigint :: Property
 hprop_shutdownOnSigint = H.integrationRetryWorkspace 2 "shutdown-on-sigint" $ \tempAbsBasePath' -> do
   -- Start a local test net
   -- TODO: Move yaml filepath specification into individual node options
-  conf <- H.noteShowM $  mkConf tempAbsBasePath'
+  conf <- mkConf tempAbsBasePath'
 
   let fastTestnetOptions = cardanoDefaultTestnetOptions
         { cardanoEpochLength = 300

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SubmitApi/Babbage/Transaction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SubmitApi/Babbage/Transaction.hs
@@ -58,7 +58,7 @@ import           Text.Regex (mkRegex, subRegex)
 hprop_transaction :: Property
 hprop_transaction = H.integrationRetryWorkspace 0 "submit-api-babbage-transaction" $ \tempAbsBasePath' -> do
   H.note_ SYS.os
-  conf@Conf { tempAbsPath } <- H.noteShowM $ mkConf tempAbsBasePath'
+  conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
   work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
 


### PR DESCRIPTION
# Description

Adds `enableLedgerStateLogging` which dumps ledger state on every block to the `logs/ledger-state.log` file. Just put
```haskell
startLedgerStateLogging runtime workspaceDirectory
```
in your test case and it will spawn a logging thread in the background.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
