### PR TITLE
Add CARDANO_NODE_RTS_OPTIONS env to docker image

### DIFF
--- a/nix/docker/context/bin/run-node
+++ b/nix/docker/context/bin/run-node
@@ -73,6 +73,10 @@ printRunEnv () {
     echo "CARDANO_SHELLEY_VRF_KEY=$CARDANO_SHELLEY_VRF_KEY"
     echo "CARDANO_SHELLEY_OPERATIONAL_CERTIFICATE=$CARDANO_SHELLEY_OPERATIONAL_CERTIFICATE"
   fi
+
+  if [ "${CARDANO_NODE_RTS_OPTIONS}" != "" ]; then
+    echo "CARDANO_NODE_RTS_OPTIONS=${CARDANO_NODE_RTS_OPTIONS}"
+  fi
 }
 
 #####################################################################
@@ -123,6 +127,10 @@ runRelayNode () {
 
   effopts+=(${options[@]})
 
+  if [ "${CARDANO_NODE_RTS_OPTIONS}" != "" ]; then
+    effopts+=(+RTS ${CARDANO_NODE_RTS_OPTIONS} -RTS)
+  fi
+
   echo "cardano-node run ${effopts[@]}"
   exec /usr/local/bin/cardano-node run ${effopts[@]}
 }
@@ -144,6 +152,10 @@ runBlockProducerNode () {
     --shelley-operational-certificate $CARDANO_SHELLEY_OPERATIONAL_CERTIFICATE)
 
   effopts+=(${options[@]})
+
+  if [ "${CARDANO_NODE_RTS_OPTIONS}" != "" ]; then
+    effopts+=(+RTS ${CARDANO_NODE_RTS_OPTIONS} -RTS)
+  fi
 
   echo "cardano-node run ${effopts[@]}"
   exec /usr/local/bin/cardano-node run ${effopts[@]}


### PR DESCRIPTION
This allows to set Haskell RTS options through the docker image by providing an environment variable on a docker run command.

For example:

```
docker run --rm -it -e CARDANO_NODE_RTS_OPTIONS="-N" cardano-node run
```

will start the node with RTS option -N (utilizing all cores):

```
Running the cardano node ...
CARDANO_BIND_ADDR=0.0.0.0
CARDANO_BLOCK_PRODUCER=false
CARDANO_CONFIG=/opt/cardano/config/mainnet-config.json
CARDANO_DATABASE_PATH=/opt/cardano/data
CARDANO_LOG_DIR=/opt/cardano/logs
CARDANO_PORT=3001
CARDANO_SOCKET_PATH=/opt/cardano/ipc/socket
CARDANO_TOPOLOGY=/opt/cardano/config/mainnet-topology.json
CARDANO_NODE_RTS_OPTIONS=-N
cardano-node run --config /opt/cardano/config/mainnet-config.json --topology /opt/cardano/config/mainnet-topology.json --database-path /opt/cardano/data --socket-path /opt/cardano/ipc/socket --host-addr 0.0.0.0 --port 3001 +RTS -N -RTS
```

Related issues (asking for more or less cpu usage, although unclear whether the docker image is used): #5330 and #5500

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.
  - No tests about docker image found
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
  - The `cadano-node/changelog.md` seems VERY outdated on `master`?
- [x] The version bounds in `.cabal` files are updated
  - Not needed
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - N/A
- [ ] Self-reviewed the diff
