### PR TITLE
Use environment variable for network magic instead of CLI arg in testnet tests

### DIFF
--- a/cardano-testnet/src/Testnet/Process/Run.hs
+++ b/cardano-testnet/src/Testnet/Process/Run.hs
@@ -146,13 +146,15 @@ mkExecConfig :: ()
   => MonadIO m
   => FilePath
   -> IO.Sprocket
+  -> Int -- ^ Network id
   -> m ExecConfig
-mkExecConfig tempBaseAbsPath sprocket = do
+mkExecConfig tempBaseAbsPath sprocket networkId = do
   env' <- H.evalIO IO.getEnvironment
 
   noteShow H.ExecConfig
     { H.execConfigEnv = Last $ Just $
       [ ("CARDANO_NODE_SOCKET_PATH", IO.sprocketArgumentName sprocket)
+      , ("CARDANO_NODE_NETWORK_ID", show networkId)
       ]
       -- The environment must be passed onto child process on Windows in order to
       -- successfully start that process.
@@ -184,9 +186,6 @@ resourceAndIOExceptionHandlers :: [Handler (ResourceT IO) ProcessError]
 resourceAndIOExceptionHandlers = [ Handler $ return . ProcessIOException
                                  , Handler $ return . ResourceException
                                  ]
-
-
-
 
 
 procFlexNew

--- a/cardano-testnet/src/Testnet/Property/Checks.hs
+++ b/cardano-testnet/src/Testnet/Property/Checks.hs
@@ -39,12 +39,10 @@ prop_spos_in_ledger_state
   -> m ()
 prop_spos_in_ledger_state output tNetOptions execConfig =
   GHC.withFrozenCallStack $ do
-    let testnetMag = cardanoTestnetMagic tNetOptions
-        numExpectedPools = length $ cardanoNodes tNetOptions
+    let numExpectedPools = length $ cardanoNodes tNetOptions
 
     void $ execCli' execConfig
         [ "query", "stake-pools"
-        , "--testnet-magic", show @Int testnetMag
         , "--out-file", output
         ]
 

--- a/cardano-testnet/src/Testnet/Property/Utils.hs
+++ b/cardano-testnet/src/Testnet/Property/Utils.hs
@@ -103,7 +103,6 @@ waitUntilEpoch fp testnetMagic execConfig desiredEpoch = do
 
   void $ H.execCli' execConfig
     [ "query",  "tip"
-    , "--testnet-magic", show @Int testnetMagic
     , "--out-file", fp
     ]
 
@@ -123,17 +122,14 @@ queryTip
   :: (MonadCatch m, MonadIO m, MonadTest m, HasCallStack)
   => QueryTipOutput
   -- ^ Output file
-  -> Int
-  -- ^ Testnet magic
   -> ExecConfig
   -> m QueryTipLocalStateOutput
-queryTip (QueryTipOutput fp) testnetMag execConfig = do
+queryTip (QueryTipOutput fp) execConfig = do
   exists <- H.evalIO $ doesFileExist fp
   when exists $ H.evalIO $ removeFile fp
 
   void $ H.execCli' execConfig
     [ "query",  "tip"
-    , "--testnet-magic", show @Int testnetMag
     , "--out-file", fp
     ]
 

--- a/cardano-testnet/src/Testnet/Start/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Start/Cardano.hs
@@ -346,7 +346,8 @@ cardanoTestnet testnetOptions Conf {tempAbsPath=TmpAbsolutePath tmpAbsPath} = do
 
       let tempBaseAbsPath = makeTmpBaseAbsPath $ TmpAbsolutePath tmpAbsPath
 
-      execConfig <- H.headM (poolSprockets runtime) >>= H.mkExecConfig tempBaseAbsPath
+      node1sprocket <- H.headM $ poolSprockets runtime
+      execConfig <- H.mkExecConfig tempBaseAbsPath node1sprocket testnetMagic
 
       forM_ wallets $ \wallet -> do
         H.cat $ paymentSKey $ paymentKeyInfoPair wallet
@@ -356,7 +357,6 @@ cardanoTestnet testnetOptions Conf {tempAbsPath=TmpAbsolutePath tmpAbsPath} = do
           [ "query", "utxo"
           , "--address", Text.unpack $ paymentKeyInfoAddr wallet
           , "--cardano-mode"
-          , "--testnet-magic", show @Int testnetMagic
           ]
 
         H.note_ utxos

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/LeadershipSchedule.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/LeadershipSchedule.hs
@@ -79,7 +79,8 @@ hprop_leadershipSchedule = H.integrationRetryWorkspace 2 "babbage-leadership-sch
     , configurationFile
     } <- cardanoTestnet cTestnetOptions conf
 
-  execConfig <- H.headM (poolSprockets tr) >>= H.mkExecConfig tempBaseAbsPath
+  node1sprocket <- H.headM $ poolSprockets tr
+  execConfig <- H.mkExecConfig tempBaseAbsPath node1sprocket testnetMagic
 
   let sbe = shelleyBasedEra @BabbageEra
 
@@ -90,7 +91,6 @@ hprop_leadershipSchedule = H.integrationRetryWorkspace 2 "babbage-leadership-sch
     [ "conway", "query", "utxo"
     , "--address", utxoAddr
     , "--cardano-mode"
-    , "--testnet-magic", show @Int testnetMagic
     , "--out-file", work </> "utxo-1.json"
     ]
 
@@ -157,7 +157,6 @@ hprop_leadershipSchedule = H.integrationRetryWorkspace 2 "babbage-leadership-sch
       [ "query", "utxo"
       , "--address", utxoAddr
       , "--cardano-mode"
-      , "--testnet-magic", show @Int testnetMagic
       , "--out-file", work </> "utxo-2.json"
       ]
 
@@ -173,7 +172,6 @@ hprop_leadershipSchedule = H.integrationRetryWorkspace 2 "babbage-leadership-sch
   void $ execCli' execConfig
     [ "transaction", "build"
     , eraFlag
-    , "--testnet-magic", show @Int testnetMagic
     , "--change-address", testDelegatorPaymentAddr -- NB: A large balance ends up at our test delegator's address
     , "--tx-in", Text.unpack $ renderTxIn txin2
     , "--tx-out", utxoAddr <> "+" <> show @Int 5_000_000
@@ -198,7 +196,6 @@ hprop_leadershipSchedule = H.integrationRetryWorkspace 2 "babbage-leadership-sch
   void $ execCli' execConfig
            [ "transaction", "submit"
            , "--tx-file", delegRegTestDelegatorTxFp
-           , "--testnet-magic", show @Int testnetMagic
            ]
 
   threadDelay 15_000000
@@ -209,7 +206,6 @@ hprop_leadershipSchedule = H.integrationRetryWorkspace 2 "babbage-leadership-sch
   void $ checkStakeKeyRegistered
            tempAbsPath
            execConfig
-           cTestnetOptions
            testDelegatorStakeAddress
            testDelegatorStakeAddressInfoOutFp
 
@@ -287,7 +283,6 @@ hprop_leadershipSchedule = H.integrationRetryWorkspace 2 "babbage-leadership-sch
   H.byDeadlineM 10 tipDeadline "Wait for two epochs" $ do
     void $ execCli' execConfig
       [ "query", "tip"
-      , "--testnet-magic", show @Int testnetMagic
       , "--out-file", work </> "current-tip.json"
       ]
 
@@ -309,7 +304,6 @@ hprop_leadershipSchedule = H.integrationRetryWorkspace 2 "babbage-leadership-sch
     H.byDeadlineM 5 leadershipScheduleDeadline "Failed to query for leadership schedule" $ do
       void $ execCli' execConfig
         [ "query", "leadership-schedule"
-        , "--testnet-magic", show @Int testnetMagic
         , "--genesis", shelleyGenesisFile tr
         , "--stake-pool-id", stakePoolIdNewSpo
         , "--vrf-signing-key-file", vrfSkey
@@ -361,7 +355,6 @@ hprop_leadershipSchedule = H.integrationRetryWorkspace 2 "babbage-leadership-sch
     H.byDeadlineM 5 leadershipScheduleDeadline "Failed to query for leadership schedule" $ do
       void $ execCli' execConfig
         [ "query", "leadership-schedule"
-        , "--testnet-magic", show @Int testnetMagic
         , "--genesis", shelleyGenesisFile tr
         , "--stake-pool-id", stakePoolIdNewSpo
         , "--vrf-signing-key-file", vrfSkey

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/StakeSnapshot.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/StakeSnapshot.hs
@@ -65,17 +65,13 @@ hprop_stakeSnapshot = H.integrationRetryWorkspace 2 "babbage-stake-snapshot" $ \
     } <- cardanoTestnet options conf
 
   poolNode1 <- H.headM poolNodes
-
   poolSprocket1 <- H.noteShow $ nodeSprocket $ poolRuntime poolNode1
-
-  execConfig <- H.mkExecConfig tempBaseAbsPath poolSprocket1
-
+  execConfig <- H.mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
   tipDeadline <- H.noteShowM $ DTC.addUTCTime 210 <$> H.noteShowIO DTC.getCurrentTime
 
   H.byDeadlineM 10 tipDeadline "Wait for two epochs" $ do
     void $ execCli' execConfig
       [ "query", "tip"
-      , "--testnet-magic", show @Int testnetMagic
       , "--out-file", work </> "current-tip.json"
       ]
 
@@ -91,7 +87,6 @@ hprop_stakeSnapshot = H.integrationRetryWorkspace 2 "babbage-stake-snapshot" $ \
 
   result <- execCli' execConfig
     [ "query", "stake-snapshot"
-    , "--testnet-magic", show @Int testnetMagic
     , "--all-stake-pools"
     ]
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/Transaction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/Transaction.hs
@@ -69,10 +69,8 @@ hprop_transaction = H.integrationRetryWorkspace 0 "babbage-transaction" $ \tempA
     } <- cardanoTestnet options conf
 
   poolNode1 <- H.headM poolNodes
-
   poolSprocket1 <- H.noteShow $ nodeSprocket $ poolRuntime poolNode1
-
-  execConfig <- H.mkExecConfig tempBaseAbsPath poolSprocket1
+  execConfig <- H.mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
 
 
   txbodyFp <- H.note $ work </> "tx.body"
@@ -82,7 +80,6 @@ hprop_transaction = H.integrationRetryWorkspace 0 "babbage-transaction" $ \tempA
     [ "babbage", "query", "utxo"
     , "--address", Text.unpack $ paymentKeyInfoAddr $ head wallets
     , "--cardano-mode"
-    , "--testnet-magic", show @Int testnetMagic
     , "--out-file", work </> "utxo-1.json"
     ]
 
@@ -92,7 +89,6 @@ hprop_transaction = H.integrationRetryWorkspace 0 "babbage-transaction" $ \tempA
 
   void $ execCli' execConfig
     [ "babbage", "transaction", "build"
-    , "--testnet-magic", show @Int testnetMagic
     , "--change-address", Text.unpack $ paymentKeyInfoAddr $ head wallets
     , "--tx-in", Text.unpack $ renderTxIn txin1
     , "--tx-out", Text.unpack (paymentKeyInfoAddr (head wallets)) <> "+" <> show @Int 5_000_001
@@ -101,7 +97,6 @@ hprop_transaction = H.integrationRetryWorkspace 0 "babbage-transaction" $ \tempA
 
   void $ execCli' execConfig
     [ "babbage", "transaction", "sign"
-    , "--testnet-magic", show @Int testnetMagic
     , "--tx-body-file", txbodyFp
     , "--signing-key-file", paymentSKey $ paymentKeyInfoPair $ wallets !! 0
     , "--out-file", txbodySignedFp
@@ -109,7 +104,6 @@ hprop_transaction = H.integrationRetryWorkspace 0 "babbage-transaction" $ \tempA
 
   void $ execCli' execConfig
     [ "babbage", "transaction", "submit"
-    , "--testnet-magic", show @Int testnetMagic
     , "--tx-file", txbodySignedFp
     ]
 
@@ -118,7 +112,6 @@ hprop_transaction = H.integrationRetryWorkspace 0 "babbage-transaction" $ \tempA
       [ "babbage", "query", "utxo"
       , "--address", Text.unpack $ paymentKeyInfoAddr $ head wallets
       , "--cardano-mode"
-      , "--testnet-magic", show @Int testnetMagic
       , "--out-file", work </> "utxo-2.json"
       ]
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/StakeSnapshot.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/StakeSnapshot.hs
@@ -65,17 +65,14 @@ hprop_stakeSnapshot = H.integrationRetryWorkspace 2 "conway-stake-snapshot" $ \t
     } <- cardanoTestnet options conf
 
   poolNode1 <- H.headM poolNodes
-
   poolSprocket1 <- H.noteShow $ nodeSprocket $ poolRuntime poolNode1
-
-  execConfig <- H.mkExecConfig tempBaseAbsPath poolSprocket1
+  execConfig <- H.mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
 
   tipDeadline <- H.noteShowM $ DTC.addUTCTime 210 <$> H.noteShowIO DTC.getCurrentTime
 
   H.byDeadlineM 10 tipDeadline "Wait for two epochs" $ do
     void $ execCli' execConfig
       [ "query", "tip"
-      , "--testnet-magic", show @Int testnetMagic
       , "--out-file", work </> "current-tip.json"
       ]
 
@@ -91,7 +88,6 @@ hprop_stakeSnapshot = H.integrationRetryWorkspace 2 "conway-stake-snapshot" $ \t
 
   result <- execCli' execConfig
     [ "query", "stake-snapshot"
-    , "--testnet-magic", show @Int testnetMagic
     , "--all-stake-pools"
     ]
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/KesPeriodInfo.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/KesPeriodInfo.hs
@@ -66,7 +66,8 @@ hprop_kes_period_info = H.integrationRetryWorkspace 2 "kes-period-info" $ \tempA
                           }
 
   runTime@TestnetRuntime { configurationFile, testnetMagic, wallets } <- cardanoTestnet cTestnetOptions conf
-  execConfig <- H.headM (poolSprockets runTime) >>= H.mkExecConfig tempBaseAbsPath
+  node1sprocket <- H.headM $ poolSprockets runTime
+  execConfig <- H.mkExecConfig tempBaseAbsPath node1sprocket testnetMagic
 
   -- We get our UTxOs from here
   let utxoAddr = Text.unpack $ paymentKeyInfoAddr $ head wallets
@@ -75,7 +76,6 @@ hprop_kes_period_info = H.integrationRetryWorkspace 2 "kes-period-info" $ \tempA
     [ convertToEraString anyEra, "query", "utxo"
     , "--address", utxoAddr
     , "--cardano-mode"
-    , "--testnet-magic", show @Int testnetMagic
     , "--out-file", work </> "utxo-1.json"
     ]
 
@@ -142,7 +142,6 @@ hprop_kes_period_info = H.integrationRetryWorkspace 2 "kes-period-info" $ \tempA
     [ convertToEraString anyEra, "query", "utxo"
     , "--address", utxoAddr
     , "--cardano-mode"
-    , "--testnet-magic", show @Int testnetMagic
     , "--out-file", work </> "utxo-2.json"
     ]
 
@@ -158,7 +157,6 @@ hprop_kes_period_info = H.integrationRetryWorkspace 2 "kes-period-info" $ \tempA
   void $ execCli' execConfig
     [ "transaction", "build"
     , eraFlag
-    , "--testnet-magic", show @Int testnetMagic
     , "--change-address", testDelegatorPaymentAddr -- NB: A large balance ends up at our test delegator's address
     , "--tx-in", Text.unpack $ renderTxIn txin2
     , "--tx-out", utxoAddr <> "+" <> show @Int 5_000_000
@@ -183,7 +181,6 @@ hprop_kes_period_info = H.integrationRetryWorkspace 2 "kes-period-info" $ \tempA
   void $ execCli' execConfig
            [ "transaction", "submit"
            , "--tx-file", delegRegTestDelegatorTxFp
-           , "--testnet-magic", show @Int testnetMagic
            ]
 
   threadDelay 20_000_000
@@ -192,7 +189,6 @@ hprop_kes_period_info = H.integrationRetryWorkspace 2 "kes-period-info" $ \tempA
   void $ checkStakeKeyRegistered
            tempAbsPath
            execConfig
-           cTestnetOptions
            testDelegatorStakeAddress
            testDelegatorStakeAddressInfoOutFp
 
@@ -268,7 +264,6 @@ hprop_kes_period_info = H.integrationRetryWorkspace 2 "kes-period-info" $ \tempA
 
   stakeSnapshot1 <- execCli' execConfig
      [ "query", "stake-snapshot"
-     , "--testnet-magic", show @Int testnetMagic
      , "--all-stake-pools"
      ]
   H.writeFile (work </> "stake-snapshot-1.json") stakeSnapshot1
@@ -276,14 +271,12 @@ hprop_kes_period_info = H.integrationRetryWorkspace 2 "kes-period-info" $ \tempA
   ledgerStateJson <- execCli' execConfig
     [ "query", "ledger-state"
     , "--cardano-mode"
-    , "--testnet-magic", show @Int testnetMagic
     ]
   H.writeFile (work </> "ledger-state-1.json") ledgerStateJson
 
   let kesPeriodInfoOutput = testSpoDir </> "kes-period-info-expected-success.json"
   void $ execCli' execConfig
     [ "query", "kes-period-info"
-    , "--testnet-magic", show @Int testnetMagic
     , "--op-cert-file", testSpoOperationalCertFp
     , "--out-file", kesPeriodInfoOutput
     ]
@@ -300,7 +293,6 @@ hprop_kes_period_info = H.integrationRetryWorkspace 2 "kes-period-info" $ \tempA
 
   void $ execCli' execConfig
     [ "query",  "tip"
-    , "--testnet-magic", show @Int testnetMagic
     , "--out-file", work </> "current-tip.json"
     ]
 
@@ -330,7 +322,6 @@ hprop_kes_period_info = H.integrationRetryWorkspace 2 "kes-period-info" $ \tempA
 
   void $ execCli' execConfig
     [ "query",  "tip"
-    , "--testnet-magic", show @Int testnetMagic
     , "--out-file", work </> "current-tip-2.json"
     ]
 
@@ -351,7 +342,6 @@ hprop_kes_period_info = H.integrationRetryWorkspace 2 "kes-period-info" $ \tempA
     ]
   stakeSnapshot2 <- execCli' execConfig
      [ "query", "stake-snapshot"
-     , "--testnet-magic", show @Int testnetMagic
      , "--all-stake-pools"
      ]
   H.writeFile (work </> "stake-snapshot-2.json") stakeSnapshot2
@@ -359,7 +349,6 @@ hprop_kes_period_info = H.integrationRetryWorkspace 2 "kes-period-info" $ \tempA
   ledgerStateJson2 <- execCli' execConfig
     [ "query", "ledger-state"
     , "--cardano-mode"
-    , "--testnet-magic", show @Int testnetMagic
     ]
   H.writeFile (work </> "ledger-state-2.json") ledgerStateJson2
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/QuerySlotNumber.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/QuerySlotNumber.hs
@@ -13,26 +13,19 @@ module Cardano.Testnet.Test.Cli.QuerySlotNumber
   ) where
 
 import           Cardano.Api
-
 import           Cardano.Testnet
 
-import           Prelude
-
 import           Data.Either
-import           Data.Monoid (Last (..))
 import qualified Data.Time.Clock as DT
 import qualified Data.Time.Format as DT
-import           System.Environment (getEnvironment)
+import           Prelude
 import qualified System.Info as SYS
 
 import           Hedgehog (Property)
-import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Stock as H
-import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
 import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.Process as H
 import qualified Hedgehog.Internal.Property as H
-
+import qualified Testnet.Process.Run as H
 import           Testnet.Process.Run
 import qualified Testnet.Property.Utils as H
 import           Testnet.Runtime
@@ -66,23 +59,13 @@ hprop_querySlotNumber = H.integrationRetryWorkspace 2 "query-slot-number" $ \tem
 
   poolNode1 <- H.headM poolNodes
   poolSprocket1 <- H.noteShow $ nodeSprocket $ poolRuntime poolNode1
-  env <- H.evalIO getEnvironment
-  execConfig <- H.noteShow H.ExecConfig
-    { H.execConfigEnv = Last $ Just $
-      [ ("CARDANO_NODE_SOCKET_PATH", IO.sprocketArgumentName poolSprocket1)
-      ]
-      -- The environment must be passed onto child process on Windows in order to
-      -- successfully start that process.
-      <> env
-    , H.execConfigCwd = Last $ Just tempBaseAbsPath'
-    }
+  execConfig <- H.mkExecConfig tempBaseAbsPath' poolSprocket1 testnetMagic
 
   id do
     H.note_ "Try to retrieve slot 5s before genesis"
     testTime <- H.note . formatTime $ (-5) `DT.addUTCTime` startTime
     (result, _) <- H.runTestT $ execCli' execConfig
       [ "query", "slot-number"
-      , "--testnet-magic", show @Int testnetMagic
       , testTime
       ]
     H.assertWith result isLeft
@@ -93,7 +76,6 @@ hprop_querySlotNumber = H.integrationRetryWorkspace 2 "query-slot-number" $ \tem
     let expectedSlot = 0
     slot <- H.readNoteM =<< execCli' execConfig
       [ "query", "slot-number"
-      , "--testnet-magic", show @Int testnetMagic
       , testTime
       ]
     H.assertWithinTolerance slot expectedSlot slotPrecision
@@ -105,7 +87,6 @@ hprop_querySlotNumber = H.integrationRetryWorkspace 2 "query-slot-number" $ \tem
     testTime <- H.note . formatTime $ passedTime `DT.addUTCTime` startTime
     slot <- H.readNoteM @Int =<< execCli' execConfig
       [ "query", "slot-number"
-      , "--testnet-magic", show @Int testnetMagic
       , testTime
       ]
     H.assertWithinTolerance slot expectedSlot slotPrecision
@@ -120,7 +101,6 @@ hprop_querySlotNumber = H.integrationRetryWorkspace 2 "query-slot-number" $ \tem
     testTime <- H.note . formatTime $ passedTime `DT.addUTCTime` startTime
     slot <- H.readNoteM @Int =<< execCli' execConfig
       [ "query", "slot-number"
-      , "--testnet-magic", show @Int testnetMagic
       , testTime
       ]
     H.assertWithinTolerance slot expectedSlot slotPrecision
@@ -131,7 +111,6 @@ hprop_querySlotNumber = H.integrationRetryWorkspace 2 "query-slot-number" $ \tem
     testTime <- H.note . formatTime $ timeOffset `DT.addUTCTime` startTime
     (result, _) <- H.runTestT $ execCli' execConfig
       [ "query", "slot-number"
-      , "--testnet-magic", show @Int testnetMagic
       , testTime
       ]
     H.assertWith result isLeft

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/ProposeNewConstitution.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/ProposeNewConstitution.hs
@@ -71,10 +71,8 @@ hprop_ledger_events_propose_new_constitution = H.integrationWorkspace "propose-n
     <- cardanoTestnet fastTestnetOptions conf
 
   poolNode1 <- H.headM poolNodes
-
   poolSprocket1 <- H.noteShow $ nodeSprocket $ poolRuntime poolNode1
-
-  execConfig <- H.mkExecConfig tempBaseAbsPath poolSprocket1
+  execConfig <- H.mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
 
   let socketName' = IO.sprocketName poolSprocket1
       socketBase = IO.sprocketBase poolSprocket1 -- /tmp
@@ -142,7 +140,6 @@ hprop_ledger_events_propose_new_constitution = H.integrationWorkspace "propose-n
     [ "conway", "query", "utxo"
     , "--address", Text.unpack $ paymentKeyInfoAddr $ head wallets
     , "--cardano-mode"
-    , "--testnet-magic", show @Int testnetMagic
     , "--out-file", work </> "utxo-1.json"
     ]
 
@@ -155,7 +152,6 @@ hprop_ledger_events_propose_new_constitution = H.integrationWorkspace "propose-n
 
   void $ H.execCli' execConfig
     [ "conway", "transaction", "build"
-    , "--testnet-magic", show @Int testnetMagic
     , "--change-address", Text.unpack $ paymentKeyInfoAddr $ head wallets
     , "--tx-in", Text.unpack $ renderTxIn txin1
     , "--tx-out", Text.unpack (paymentKeyInfoAddr (wallets !! 1)) <> "+" <> show @Int 5_000_000
@@ -168,7 +164,6 @@ hprop_ledger_events_propose_new_constitution = H.integrationWorkspace "propose-n
 
   void $ H.execCli' execConfig
     [ "conway", "transaction", "sign"
-    , "--testnet-magic", show @Int testnetMagic
     , "--tx-body-file", drepRegTxbodyFp
     , "--signing-key-file", paymentSKey $ paymentKeyInfoPair $ head wallets
     , "--signing-key-file", drepSKeyFp 1
@@ -179,7 +174,6 @@ hprop_ledger_events_propose_new_constitution = H.integrationWorkspace "propose-n
 
   void $ H.execCli' execConfig
     [ "conway", "transaction", "submit"
-    , "--testnet-magic", show @Int testnetMagic
     , "--tx-file", drepRegTxSignedFp
     ]
 
@@ -204,7 +198,6 @@ hprop_ledger_events_propose_new_constitution = H.integrationWorkspace "propose-n
     [ "conway", "query", "utxo"
     , "--address", Text.unpack $ paymentKeyInfoAddr $ wallets !! 1
     , "--cardano-mode"
-    , "--testnet-magic", show @Int testnetMagic
     , "--out-file", work </> "utxo-2.json"
     ]
 
@@ -214,7 +207,6 @@ hprop_ledger_events_propose_new_constitution = H.integrationWorkspace "propose-n
 
   void $ H.execCli' execConfig
     [ "conway", "transaction", "build"
-    , "--testnet-magic", show @Int testnetMagic
     , "--change-address", Text.unpack $ paymentKeyInfoAddr $ wallets !! 1
     , "--tx-in", Text.unpack $ renderTxIn txin2
     , "--tx-out", Text.unpack (paymentKeyInfoAddr (head wallets)) <> "+" <> show @Int 5_000_000
@@ -224,7 +216,6 @@ hprop_ledger_events_propose_new_constitution = H.integrationWorkspace "propose-n
 
   void $ H.execCli' execConfig
     [ "conway", "transaction", "sign"
-    , "--testnet-magic", show @Int testnetMagic
     , "--tx-body-file", txbodyFp
     , "--signing-key-file", paymentSKey $ paymentKeyInfoPair $ wallets !! 1
     , "--out-file", txbodySignedFp
@@ -232,7 +223,6 @@ hprop_ledger_events_propose_new_constitution = H.integrationWorkspace "propose-n
 
   void $ H.execCli' execConfig
     [ "conway", "transaction", "submit"
-    , "--testnet-magic", show @Int testnetMagic
     , "--tx-file", txbodySignedFp
     ]
 
@@ -280,7 +270,6 @@ hprop_ledger_events_propose_new_constitution = H.integrationWorkspace "propose-n
    [ "conway", "query", "utxo"
    , "--address", Text.unpack $ paymentKeyInfoAddr $ head wallets
    , "--cardano-mode"
-   , "--testnet-magic", show @Int testnetMagic
    , "--out-file", work </> "utxo-3.json"
    ]
 
@@ -294,7 +283,6 @@ hprop_ledger_events_propose_new_constitution = H.integrationWorkspace "propose-n
   -- Submit votes
   void $ H.execCli' execConfig
     [ "conway", "transaction", "build"
-    , "--testnet-magic", show @Int testnetMagic
     , "--change-address", Text.unpack $ paymentKeyInfoAddr $ head wallets
     , "--tx-in", Text.unpack $ renderTxIn txin3
     , "--tx-out", Text.unpack (paymentKeyInfoAddr (wallets !! 1)) <> "+" <> show @Int 3_000_000
@@ -308,7 +296,6 @@ hprop_ledger_events_propose_new_constitution = H.integrationWorkspace "propose-n
 
   void $ H.execCli' execConfig
     [ "conway", "transaction", "sign"
-    , "--testnet-magic", show @Int testnetMagic
     , "--tx-body-file", voteTxBodyFp
     , "--signing-key-file", paymentSKey $ paymentKeyInfoPair $ head wallets
     , "--signing-key-file", drepSKeyFp 1
@@ -319,7 +306,6 @@ hprop_ledger_events_propose_new_constitution = H.integrationWorkspace "propose-n
 
   void $ H.execCli' execConfig
     [ "conway", "transaction", "submit"
-    , "--testnet-magic", show @Int testnetMagic
     , "--tx-file", voteTxFp
     ]
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SubmitApi/Babbage/Transaction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SubmitApi/Babbage/Transaction.hs
@@ -83,7 +83,7 @@ hprop_transaction = H.integrationRetryWorkspace 0 "submit-api-babbage-transactio
 
   poolSprocket1 <- H.noteShow $ nodeSprocket $ poolRuntime poolNode1
 
-  execConfig <- H.mkExecConfig tempBaseAbsPath poolSprocket1
+  execConfig <- H.mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
 
   void $ procSubmitApi
     [ "--config", configurationFile
@@ -102,7 +102,6 @@ hprop_transaction = H.integrationRetryWorkspace 0 "submit-api-babbage-transactio
     [ "babbage", "query", "utxo"
     , "--address", Text.unpack $ paymentKeyInfoAddr $ head wallets
     , "--cardano-mode"
-    , "--testnet-magic", show @Int testnetMagic
     , "--out-file", work </> "utxo-1.json"
     ]
 
@@ -112,7 +111,6 @@ hprop_transaction = H.integrationRetryWorkspace 0 "submit-api-babbage-transactio
 
   void $ execCli' execConfig
     [ "babbage", "transaction", "build"
-    , "--testnet-magic", show @Int testnetMagic
     , "--change-address", Text.unpack $ paymentKeyInfoAddr $ head wallets
     , "--tx-in", Text.unpack $ renderTxIn txin1
     , "--tx-out", Text.unpack (paymentKeyInfoAddr (head wallets)) <> "+" <> show @Int 5_000_001
@@ -121,7 +119,6 @@ hprop_transaction = H.integrationRetryWorkspace 0 "submit-api-babbage-transactio
 
   void $ execCli' execConfig
     [ "babbage", "transaction", "sign"
-    , "--testnet-magic", show @Int testnetMagic
     , "--tx-body-file", txbodyFp
     , "--signing-key-file", paymentSKey $ paymentKeyInfoPair $ wallets !! 0
     , "--out-file", txbodySignedFp
@@ -161,7 +158,6 @@ hprop_transaction = H.integrationRetryWorkspace 0 "submit-api-babbage-transactio
         [ "babbage", "query", "utxo"
         , "--address", Text.unpack $ paymentKeyInfoAddr $ head wallets
         , "--cardano-mode"
-        , "--testnet-magic", show @Int testnetMagic
         , "--out-file", work </> "utxo-2.json"
         ]
 


### PR DESCRIPTION
# Description

This PR adds network magic environment variable to `ExecConfig` used to invoke `cardano-cli` in testnet. This reduces boilerplate required to call online commands of `cardano-cli`.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
