### PR TITLE
bench | improvements Nomad backend

### DIFF
--- a/nix/workbench/backend/nomad.sh
+++ b/nix/workbench/backend/nomad.sh
@@ -3487,7 +3487,9 @@ client {
   servers = [ ${servers_addresses} ]
   # Sets the search path that is used for CNI plugin discovery. Multiple paths can
   # be searched using colon delimited paths
-  cni_path = "${cni_plugins_path}"
+# TODO: needed to allow having more than one Nomad profile running locally
+# Nomad 1.7.X fails somewhat silently when reading this configuration option.
+#  cni_path = "${cni_plugins_path}"
   # Specifies the maximum amount of time a job is allowed to wait to exit.
   # Individual jobs may customize their own kill timeout, but it may not exceed
   # this value.

--- a/nix/workbench/backend/nomad.sh
+++ b/nix/workbench/backend/nomad.sh
@@ -1415,17 +1415,17 @@ backend_nomad() {
         then
           if ! wait_kill_em_all "${jobs_array[@]}"
           then
-            # Don't use fatal here, let `start` decide!
             msg "$(red "Failed to start tracer(s)")"
-            return 1
+            backend_nomad stop-nomad-job "${dir}" || msg "$(red "Failed to stop Nomad Job")"
+            fatal "scenario.sh start-tracers failed!"
           else
             for node in ${nodes[*]}
             do
               if ! test -f "${dir}"/tracer/"${node}"/started
               then
-                # Don't use fatal here, let `start` decide!
                 msg "$(red "Tracer for \"${node}\" failed to start!")"
-                return 1
+                backend_nomad stop-nomad-job "${dir}" || msg "$(red "Failed to stop Nomad Job")"
+                fatal "scenario.sh start-tracers failed!"
               fi
             done
           fi

--- a/nix/workbench/backend/nomad/exec.nix
+++ b/nix/workbench/backend/nomad/exec.nix
@@ -20,22 +20,8 @@ let
   extraShellPkgs = let
     # If we are going to use the `exec` driver we use the SRE patched version of
     # Nomad that allows to use `nix_installables` as artifacts.
-    nomad-sre = (pkgs.buildGo119Module rec {
-      pname = "nomad";
-      version = "1.4.3";
-      subPackages = [ "." ];
-      doCheck = true;
-      src = pkgs.fetchFromGitHub { # "github:input-output-hk/nomad/release/1.4.3"
-        owner = "input-output-hk";
-        repo = pname;
-        rev = "2b8a93390"; # Use to be "release/${version}" but it changes.
-        # nix-prefetch-url --unpack https://github.com/input-output-hk/nomad/archive/2b8a93390/1.4.3.tar.gz
-        sha256 = "0l2sfhpg0p5mjdbipib7q63wlsrczr2fkq9xi641vhgxsjmprvwm";
-      };
-      # error: either `vendorHash` or `vendorSha256` is required
-      # https://discourse.nixos.org/t/buildgomodule-how-to-get-vendorsha256/9317
-      vendorSha256 = "sha256-JQRpsQhq5r/QcgFwtnptmvnjBEhdCFrXFrTKkJioL3A=";
-    });
+    commit = "8f3b74796a8f56f38a812813c64dba995956a66e"; # Patched 1.6.3
+    nomad-sre = (__getFlake "github:input-output-hk/cardano-perf/${commit}").packages.x86_64-linux.nomad;
   in
     [ nomad-sre
       # The HTTP server to upload/download the genesis tar file in a local env.

--- a/nix/workbench/backend/nomad/exec.sh
+++ b/nix/workbench/backend/nomad/exec.sh
@@ -186,8 +186,6 @@ deploy-genesis-nomadexec() {
   local usage="USAGE: wb backend $op RUN-DIR"
   local dir=${1:?$usage}; shift
   local nomad_job_name=$(jq -r ". [\"job\"] | keys[0]" "${dir}"/nomad/nomad-job.json)
-  local server_name=$(envjqr 'nomad_server_name')
-  local client_name=$(envjqr 'nomad_client_name')
 
   # Add genesis to HTTP cache server
   local nomad_agents_were_already_running=$(envjqr 'nomad_agents_were_already_running')

--- a/nix/workbench/backend/nomad/exec.sh
+++ b/nix/workbench/backend/nomad/exec.sh
@@ -199,8 +199,8 @@ deploy-genesis-nomadexec() {
       if test "${nomad_agents_were_already_running}" = "false"
       then
         msg "$(red "Startup of webfs failed, cleaning up ...")"
+        # `stop-nomad-job` takes care of stopping the Nomad agents.
         backend_nomad stop-nomad-job "${dir}" || msg "$(red "Failed to stop Nomad Job")"
-        wb_nomad agents stop "${server_name}" "${client_name}" "exec"
       fi
       fatal "Failed to start a local HTTP server"
     fi
@@ -213,8 +213,8 @@ deploy-genesis-nomadexec() {
     if test "${nomad_agents_were_already_running}" = "false"
     then
       msg "$(red "Startup of webfs failed, cleaning up ...")"
+      # `stop-nomad-job` takes care of stopping the Nomad agents.
       backend_nomad stop-nomad-job "${dir}" || msg "$(red "Failed to stop Nomad Job")"
-      wb_nomad agents stop "${server_name}" "${client_name}" "exec"
     fi
     fatal "Failed to add genesis file to local HTTP server"
   else
@@ -225,8 +225,8 @@ deploy-genesis-nomadexec() {
   if ! backend_nomad deploy-genesis-wget "${dir}" "${uri}"
   then
     msg "$(red "Deploy of genesis failed, cleaning up ...")"
+    # `stop-nomad-job` takes care of stopping the Nomad agents.
     backend_nomad stop-nomad-job "${dir}" || msg "$(red "Failed to stop Nomad Job")"
-    wb_nomad agents stop "${server_name}" "${client_name}" "exec"
     fatal "Deploy of genesis \"${uri}\" failed"
   else
     msg "$(green "Genesis \"${uri}\" deployed successfully")"

--- a/nix/workbench/nomad.sh
+++ b/nix/workbench/nomad.sh
@@ -83,6 +83,7 @@ usage_nomad() {
     $(helpcmd job monitor-alloc-id)
     $(helpcmd job monitor-alloc-id-task-name)
     $(helpcmd job task-name-allocation-id)
+    $(helpcmd job task-name-node-name)
 EOF
 }
 
@@ -2153,6 +2154,13 @@ EOF
           local job_file=${1:?$usage};  shift
           local task_name=${1:?$usage}; shift
           jq -r '.ID' "${job_file}".run/task.${task_name}.final.json
+        ;;
+####### job -> task-name-node-name )############################################
+        task-name-node-name )
+          local usage="USAGE:wb nomad ${op} ${subop} JOB-FILE TASK-NAME"
+          local job_file=${1:?$usage};  shift
+          local task_name=${1:?$usage}; shift
+          jq -r '.NodeName' "${job_file}".run/task.${task_name}.final.json
         ;;
 ####### job -> stop )###########################################################
         stop )

--- a/nix/workbench/scenario.sh
+++ b/nix/workbench/scenario.sh
@@ -31,7 +31,16 @@ fi
 case "$op" in
     idle )
         backend start-tracers        "$dir"
+
+        scenario_setup_exit_trap              "$dir"
+        # Trap start
+        ############
         backend start-nodes          "$dir"
+        # Trap end
+        ##########
+        scenario_cleanup_termination
+
+        backend stop-all             "$dir"
         ;;
 
     tracer-only )


### PR DESCRIPTION
- Reuse nix flake Nomad output from cardano-perf
- Prevent allocations from being restarted after temporary heartbeats interrumptions
- Correctly handle Nomad process life-cycle when it unexpectedly exits
- Fixes to correctly handle deployment errors when Nomad fails
- Function to translate from node name to Nomad client host

On the Nomad cluster, we've experienced undesired system behaviour when the heartbeat between the Nomad server and a client is interrupted temporarily. A Nomad upgrade to the latest version (1.7.X), that adds options specific to this problem, can fix that but comes with other issues. We're currently working on adapting our automation and deployment around those known issues, before we can eventually apply the upgrade.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
