### PR TITLE
cardano-testnet: read JSON from the CLI more easily

### DIFF
--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/StakeSnapshot.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/StakeSnapshot.hs
@@ -2,14 +2,8 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
-
-{- HLINT ignore "Redundant id" -}
-{- HLINT ignore "Redundant return" -}
-{- HLINT ignore "Use head" -}
-{- HLINT ignore "Use let" -}
 
 module Cardano.Testnet.Test.Cli.Babbage.StakeSnapshot
   ( hprop_stakeSnapshot
@@ -22,24 +16,18 @@ import           Cardano.Testnet
 
 import           Prelude
 
-import           Control.Monad (void)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KM
-import qualified Data.ByteString.Lazy as LBS
-import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
 import qualified Data.Time.Clock as DTC
 import           GHC.Stack (callStack)
-import           System.FilePath ((</>))
 import qualified System.Info as SYS
 
 import           Hedgehog (Property, (===))
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
 
+import           Testnet.Process.Cli (execCliStdoutToJson)
 import qualified Testnet.Process.Run as H
-import           Testnet.Process.Run
 import qualified Testnet.Property.Utils as H
 import           Testnet.Runtime
 
@@ -48,7 +36,6 @@ hprop_stakeSnapshot = H.integrationRetryWorkspace 2 "babbage-stake-snapshot" $ \
   H.note_ SYS.os
   conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
-  work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
 
   let
     tempBaseAbsPath = makeTmpBaseAbsPath $ TmpAbsolutePath tempAbsPath'
@@ -70,13 +57,7 @@ hprop_stakeSnapshot = H.integrationRetryWorkspace 2 "babbage-stake-snapshot" $ \
   tipDeadline <- H.noteShowM $ DTC.addUTCTime 210 <$> H.noteShowIO DTC.getCurrentTime
 
   H.byDeadlineM 10 tipDeadline "Wait for two epochs" $ do
-    void $ execCli' execConfig
-      [ "query", "tip"
-      , "--out-file", work </> "current-tip.json"
-      ]
-
-    tipJson <- H.leftFailM . H.readJsonFile $ work </> "current-tip.json"
-    tip <- H.noteShowM $ H.jsonErrorFail $ Aeson.fromJSON @QueryTipLocalStateOutput tipJson
+    tip <- execCliStdoutToJson execConfig [ "query", "tip" ]
 
     currEpoch <- case mEpoch tip of
       Nothing -> H.failMessage callStack "cardano-cli query tip returned Nothing for EpochNo"
@@ -85,12 +66,7 @@ hprop_stakeSnapshot = H.integrationRetryWorkspace 2 "babbage-stake-snapshot" $ \
     H.note_ $ "Current Epoch: " <> show currEpoch
     H.assert $ currEpoch > 2
 
-  result <- execCli' execConfig
-    [ "query", "stake-snapshot"
-    , "--all-stake-pools"
-    ]
-
-  json <- H.leftFail $ Aeson.eitherDecode @Aeson.Value (LBS.fromStrict (Text.encodeUtf8 (Text.pack result)))
+  json <- execCliStdoutToJson execConfig [ "query", "stake-snapshot", "--all-stake-pools" ]
 
   -- There are three stake pools so check that "pools" has three entries
   case json of

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/StakeSnapshot.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/StakeSnapshot.hs
@@ -2,14 +2,8 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
-
-{- HLINT ignore "Redundant id" -}
-{- HLINT ignore "Redundant return" -}
-{- HLINT ignore "Use head" -}
-{- HLINT ignore "Use let" -}
 
 module Cardano.Testnet.Test.Cli.Conway.StakeSnapshot
   ( hprop_stakeSnapshot
@@ -22,24 +16,18 @@ import           Cardano.Testnet
 
 import           Prelude
 
-import           Control.Monad (void)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KM
-import qualified Data.ByteString.Lazy as LBS
-import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
 import qualified Data.Time.Clock as DTC
 import           GHC.Stack (callStack)
-import           System.FilePath ((</>))
 import qualified System.Info as SYS
 
 import           Hedgehog (Property, (===))
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
 
+import           Testnet.Process.Cli (execCliStdoutToJson)
 import qualified Testnet.Process.Run as H
-import           Testnet.Process.Run
 import qualified Testnet.Property.Utils as H
 import           Testnet.Runtime
 
@@ -48,7 +36,6 @@ hprop_stakeSnapshot = H.integrationRetryWorkspace 2 "conway-stake-snapshot" $ \t
   H.note_ SYS.os
   conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
-  work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
 
   let
     tempBaseAbsPath = makeTmpBaseAbsPath $ TmpAbsolutePath tempAbsPath'
@@ -71,13 +58,7 @@ hprop_stakeSnapshot = H.integrationRetryWorkspace 2 "conway-stake-snapshot" $ \t
   tipDeadline <- H.noteShowM $ DTC.addUTCTime 210 <$> H.noteShowIO DTC.getCurrentTime
 
   H.byDeadlineM 10 tipDeadline "Wait for two epochs" $ do
-    void $ execCli' execConfig
-      [ "query", "tip"
-      , "--out-file", work </> "current-tip.json"
-      ]
-
-    tipJson <- H.leftFailM . H.readJsonFile $ work </> "current-tip.json"
-    tip <- H.noteShowM $ H.jsonErrorFail $ Aeson.fromJSON @QueryTipLocalStateOutput tipJson
+    tip <- execCliStdoutToJson execConfig [ "query", "tip" ]
 
     currEpoch <- case mEpoch tip of
       Nothing -> H.failMessage callStack "cardano-cli query tip returned Nothing for EpochNo"
@@ -86,12 +67,7 @@ hprop_stakeSnapshot = H.integrationRetryWorkspace 2 "conway-stake-snapshot" $ \t
     H.note_ $ "Current Epoch: " <> show currEpoch
     H.assert $ currEpoch > 2
 
-  result <- execCli' execConfig
-    [ "query", "stake-snapshot"
-    , "--all-stake-pools"
-    ]
-
-  json <- H.leftFail $ Aeson.eitherDecode @Aeson.Value (LBS.fromStrict (Text.encodeUtf8 (Text.pack result)))
+  json <- execCliStdoutToJson execConfig [ "query", "stake-snapshot", "--all-stake-pools" ]
 
   -- There are three stake pools so check that "pools" has three entries
   case json of

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/InfoAction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/InfoAction.hs
@@ -44,7 +44,7 @@ import           Testnet.Runtime
 -- | Execute me with:
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/InfoAction/'@
 hprop_ledger_events_info_action :: Property
-hprop_ledger_events_info_action = H.integrationRetryWorkspace 0 "info-hash" $ \tempAbsBasePath' -> do
+hprop_ledger_events_info_action = H.integrationRetryWorkspace 2 "info-hash" $ \tempAbsBasePath' -> do
 
   -- Start a local test net
   conf@Conf { tempAbsPath } <- H.noteShowM $ mkConf tempAbsBasePath'


### PR DESCRIPTION
# Description

Introduce a new function to read the CLI's JSON output. This function is useful right now, because there are existing callers; but for what it's worth, this is a spinoff of https://github.com/IntersectMBO/cardano-node/pull/5634.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [ ] CI passes.
- [X] Self-reviewed the diff