### PR TITLE
Expose numOfDiskSnapshots as flag

### DIFF
--- a/cardano-node/src/Cardano/Node/Parsers.hs
+++ b/cardano-node/src/Cardano/Node/Parsers.hs
@@ -27,7 +27,8 @@ import           Text.Read (readMaybe)
 
 import           Ouroboros.Consensus.Mempool (MempoolCapacityBytes (..),
                    MempoolCapacityBytesOverride (..))
-import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy (SnapshotInterval (..))
+import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy (NumOfDiskSnapshots (..),
+                   SnapshotInterval (..))
 
 import           Cardano.Logging.Types
 import           Cardano.Node.Configuration.NodeAddress (File (..),
@@ -71,7 +72,8 @@ nodeRunParser = do
 
   -- NodeConfiguration filepath
   nodeConfigFp <- lastOption parseConfigFile
-  snapshotInterval <- lastOption parseSnapshotInterval
+  numOfDiskSnapshots <- lastOption parseNumOfDiskSnapshots
+  snapshotInterval   <- lastOption parseSnapshotInterval
 
   validate <- lastOption parseValidateDB
   shutdownIPC <- lastOption parseShutdownIPC
@@ -90,6 +92,7 @@ nodeRunParser = do
            , pncTopologyFile = TopologyFile <$> topFp
            , pncDatabaseFile = DbFile <$> dbFp
            , pncDiffusionMode = mempty
+           , pncNumOfDiskSnapshots = numOfDiskSnapshots
            , pncSnapshotInterval = snapshotInterval
            , pncExperimentalProtocolsEnabled = mempty
            , pncProtocolFiles = Last $ Just ProtocolFilepaths
@@ -329,6 +332,15 @@ parseStartAsNonProducingNode =
         ]
     ]
 
+parseNumOfDiskSnapshots :: Parser NumOfDiskSnapshots
+parseNumOfDiskSnapshots = fmap RequestedNumOfDiskSnapshots parseNum
+  where
+  parseNum = Opt.option auto
+    ( long "num-of-disk-snapshots"
+        <> metavar "NUMOFDISKSNAPSHOTS"
+        <> help "Number of ledger snapshots stored on disk."
+    )
+
 -- TODO revisit because it sucks
 parseSnapshotInterval :: Parser SnapshotInterval
 parseSnapshotInterval = fmap (RequestedSnapshotInterval . secondsToDiffTime) parseDifftime
@@ -336,7 +348,7 @@ parseSnapshotInterval = fmap (RequestedSnapshotInterval . secondsToDiffTime) par
   parseDifftime = Opt.option auto
     ( long "snapshot-interval"
         <> metavar "SNAPSHOTINTERVAL"
-        <> help "Snapshot Interval (in second)"
+        <> help "Snapshot Interval (in seconds)"
     )
 
 -- | Produce just the brief help header for a given CLI option parser,

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -89,8 +89,8 @@ import           Cardano.Tracing.Config (TraceOptions (..), TraceSelection (..))
 
 import qualified Ouroboros.Consensus.Config as Consensus
 import           Ouroboros.Consensus.Config.SupportsNode (ConfigSupportsNode (..))
-import           Ouroboros.Consensus.Node (NetworkP2PMode (..), RunNodeArgs (..),
-                   StdRunNodeArgs (..), stdChainSyncTimeout)
+import           Ouroboros.Consensus.Node (DiskPolicyArgs (..), NetworkP2PMode (..),
+                   RunNodeArgs (..), StdRunNodeArgs (..), stdChainSyncTimeout)
 import qualified Ouroboros.Consensus.Node as Node (getChainDB, run)
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.ProtocolInfo
@@ -476,7 +476,7 @@ handleSimpleNode blockType runP p2pMode tracers nc onKernel = do
               { srnBfcMaxConcurrencyBulkSync    = unMaxConcurrencyBulkSync <$> ncMaxConcurrencyBulkSync nc
               , srnBfcMaxConcurrencyDeadline    = unMaxConcurrencyDeadline <$> ncMaxConcurrencyDeadline nc
               , srnChainDbValidateOverride      = ncValidateDB nc
-              , srnSnapshotInterval             = ncSnapshotInterval nc
+              , srnDiskPolicyArgs               = diskPolicyArgs
               , srnDatabasePath                 = dbPath
               , srnDiffusionArguments           = diffusionArguments
               , srnDiffusionArgumentsExtra      = diffusionArgumentsExtra
@@ -526,7 +526,7 @@ handleSimpleNode blockType runP p2pMode tracers nc onKernel = do
               { srnBfcMaxConcurrencyBulkSync   = unMaxConcurrencyBulkSync <$> ncMaxConcurrencyBulkSync nc
               , srnBfcMaxConcurrencyDeadline   = unMaxConcurrencyDeadline <$> ncMaxConcurrencyDeadline nc
               , srnChainDbValidateOverride     = ncValidateDB nc
-              , srnSnapshotInterval            = ncSnapshotInterval nc
+              , srnDiskPolicyArgs              = diskPolicyArgs
               , srnDatabasePath                = dbPath
               , srnDiffusionArguments          = diffusionArguments
               , srnDiffusionArgumentsExtra     = mkNonP2PArguments ipProducers dnsProducers
@@ -594,6 +594,12 @@ handleSimpleNode blockType runP p2pMode tracers nc onKernel = do
       case prj $ latestReleasedNodeVersion (Proxy @blk) of
         Nothing       -> id
         Just version_ -> Map.takeWhileAntitone (<= version_)
+
+  diskPolicyArgs :: DiskPolicyArgs
+  diskPolicyArgs =
+    DiskPolicyArgs
+      (ncSnapshotInterval nc)
+      (ncNumOfDiskSnapshots nc)
 
 --------------------------------------------------------------------------------
 -- SIGHUP Handlers


### PR DESCRIPTION
# Description
Fixes [issue 533](https://github.com/IntersectMBO/ouroboros-consensus/issues/533) in ouroboros-consensus. Note that this PR relies on the [accompanying PR](https://github.com/IntersectMBO/ouroboros-consensus/pull/943) in ourboros-consensus to be merged.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff
