### PR TITLE
CI: Fix ghcr.io upload

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: true
 contact_links:
   - name: Cardano CLI Issues
-    url: https://github.com/input-output-hk/cardano-cli/issues
+    url: https://github.com/IntersectMBO/cardano-cli/issues
     about: Report CLI related issues here
   - name: Cardano API Issues
-    url: https://github.com/input-output-hk/cardano-api/issues
+    url: https://github.com/IntersectMBO/cardano-api/issues
     about: Report API related issues here

--- a/.github/workflows/release-ghcr.yaml
+++ b/.github/workflows/release-ghcr.yaml
@@ -71,15 +71,15 @@ jobs:
         echo "::endgroup::"
 
         echo "::group::Uploading to registry"
-        skopeo copy docker-archive:./result docker://ghcr.io/input-output-hk/cardano-node:$GITHUB_REF_NAME
+        skopeo copy docker-archive:./result docker://ghcr.io/intersectmbo/cardano-node:$GITHUB_REF_NAME
         echo "::endgroup::"
 
-    - name: Uploading input-output-hk/cardano-submit-api
+    - name: Uploading intersectmbo/cardano-submit-api
       run: |
         echo "::group::Downloading from cache"
         nix build --accept-flake-config --print-out-paths --builders "" --max-jobs 0 ${{ steps.flake-metadata.outputs.LOCKED_URL }}#dockerImage/submit-api
         echo "::endgroup::"
 
         echo "::group::Uploading to registry"
-        skopeo copy docker-archive:./result docker://ghcr.io/input-output-hk/cardano-submit-api:$GITHUB_REF_NAME
+        skopeo copy docker-archive:./result docker://ghcr.io/intersectmbo/cardano-submit-api:$GITHUB_REF_NAME
         echo "::endgroup::"


### PR DESCRIPTION
# Description

This change fixes old references to input-output-hk. An example of a successful GH workflow run can be found here: https://github.com/IntersectMBO/cardano-node/actions/runs/7834800510

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
