### PR TITLE
Add stylish-haskell import rules, reformat haskell codebase

### DIFF
--- a/.github/workflows/stylish-haskell.yml
+++ b/.github/workflows/stylish-haskell.yml
@@ -26,22 +26,19 @@ jobs:
       fail-fast: false
 
     env:
-      # Modify this value to "invalidate" the cabal cache.
-      CABAL_CACHE_VERSION: "2023-11-20-3"
-
-      STYLISH_HASKELL_VERSION: "0.14.4.0"
+      STYLISH_HASKELL_VERSION: "0.14.6.0"
 
       STYLISH_HASKELL_PATHS: >
-        cardano-testnet
         cardano-git-rev
         cardano-node
-        cardano-node-chairman
-        cardano-tracer
-        trace-resources
         cardano-node-capi
+        cardano-node-chairman
+        cardano-submit-api
+        cardano-testnet
+        cardano-tracer
         trace-dispatcher
         trace-forward
-        cardano-submit-api
+        trace-resources
 
     steps:
     - name: Download stylish-haskell

--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -41,6 +41,18 @@ steps:
 
       space_surround: false
 
+      # Principle 10
+      group_imports: true
+
+      group_rules:
+        - match: ^Cardano.Api\>
+        - match: ^(Cardano|Ouroboros|PlutusCore|PlutusLedgerApi)\>
+        - match: ^Prelude\>
+        - match: ^(Control|Codec|Data|Formatting|GHC|Lens|Network|Numeric|Options|Prettyprinter|System|Text)\>
+        - match: ^(Test.Gen.Cardano.Api)\>
+        - match: ^(Test.Cardano|Test.Gen.Cardano|Testnet)\>
+        - match: ^(Hedgehog|HaskellWorks.Hspec|Test)\>
+
   - language_pragmas:
       style: vertical
 

--- a/cardano-git-rev/src/Cardano/Git/RevFromGit.hs
+++ b/cardano-git-rev/src/Cardano/Git/RevFromGit.hs
@@ -3,11 +3,12 @@ module Cardano.Git.RevFromGit
   ) where
 
 import           Control.Exception (catch)
-import qualified Language.Haskell.TH as TH
 import           System.Exit (ExitCode (..))
 import qualified System.IO as IO
 import           System.IO.Error (isDoesNotExistError)
 import           System.Process (readProcessWithExitCode)
+
+import qualified Language.Haskell.TH as TH
 
 -- | Git revision found by running git rev-parse. If git could not be
 -- executed, then this will be an empty string.

--- a/cardano-node-capi/src/Node.hs
+++ b/cardano-node-capi/src/Node.hs
@@ -1,16 +1,16 @@
 module Node where
 
+import           Cardano.Node.Parsers (nodeCLIParser, parserHelpHeader, parserHelpOptions,
+                   renderHelpDoc)
 import           Cardano.Node.Run (runNode)
-import           Data.Aeson (eitherDecodeStrict)
 
+import           Data.Aeson (eitherDecodeStrict)
 import           Data.ByteString.Char8 (pack)
+import           Options.Applicative
+
 import           Foreign.C (CString, peekCString)
 import           Foreign.Marshal.Array (peekArray)
 import           Foreign.Ptr (Ptr)
-
-import           Cardano.Node.Parsers (nodeCLIParser, parserHelpHeader, parserHelpOptions,
-                   renderHelpDoc)
-import           Options.Applicative
 
 -- | @crunNode@ is an exported C entry point to start a node.
 -- We parese the same arguments as the node CLI, but allow to

--- a/cardano-node-chairman/app/Cardano/Chairman.hs
+++ b/cardano-node-chairman/app/Cardano/Chairman.hs
@@ -11,6 +11,17 @@
 
 module Cardano.Chairman (chairmanTest) where
 
+import           Cardano.Api
+import           Cardano.Api.Shelley
+
+import           Ouroboros.Consensus.Block.Abstract
+import           Ouroboros.Consensus.Cardano.Block
+import           Ouroboros.Consensus.Config.SecurityParam
+import           Ouroboros.Network.AnchoredFragment (Anchor, AnchoredFragment)
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import qualified Ouroboros.Network.Block as Block
+import           Ouroboros.Network.Protocol.ChainSync.Client
+
 import           Control.Concurrent.Class.MonadSTM.Strict
 import           Control.Monad (void)
 import           Control.Monad.Class.MonadAsync
@@ -23,18 +34,6 @@ import qualified Data.Map.Strict as Map
 import           Data.Ord (comparing)
 import           Data.Proxy (Proxy (..))
 import           Data.Word (Word64)
-
-import           Ouroboros.Consensus.Block.Abstract
-import           Ouroboros.Consensus.Cardano.Block
-import           Ouroboros.Consensus.Config.SecurityParam
-
-import           Ouroboros.Network.AnchoredFragment (Anchor, AnchoredFragment)
-import qualified Ouroboros.Network.AnchoredFragment as AF
-import qualified Ouroboros.Network.Block as Block
-import           Ouroboros.Network.Protocol.ChainSync.Client
-
-import           Cardano.Api
-import           Cardano.Api.Shelley
 
 -- | The chairman checks for consensus and progress.
 --

--- a/cardano-node-chairman/app/Cardano/Chairman/Commands.hs
+++ b/cardano-node-chairman/app/Cardano/Chairman/Commands.hs
@@ -2,6 +2,7 @@ module Cardano.Chairman.Commands where
 
 import           Cardano.Chairman.Commands.Run
 import           Cardano.Chairman.Commands.Version
+
 import           Options.Applicative
 
 {- HLINT ignore "Monoid law, left identity" -}

--- a/cardano-node-chairman/app/Cardano/Chairman/Commands/Run.hs
+++ b/cardano-node-chairman/app/Cardano/Chairman/Commands/Run.hs
@@ -8,10 +8,20 @@ module Cardano.Chairman.Commands.Run
   ( cmdRun
   ) where
 
-import           Cardano.Prelude (ConvertText (..))
-
+import           Cardano.Api
 import qualified Cardano.Api as Api
 import           Cardano.Api.Pretty
+
+import           Cardano.Chairman (chairmanTest)
+import           Cardano.Node.Configuration.POM (PartialNodeConfiguration (..),
+                   parseNodeConfigurationFP)
+import           Cardano.Node.Protocol
+import           Cardano.Node.Types
+import           Cardano.Prelude (ConvertText (..))
+import qualified Ouroboros.Consensus.Config as Consensus
+import           Ouroboros.Consensus.Config.SecurityParam (SecurityParam (..))
+import           Ouroboros.Consensus.Config.SupportsNode
+import           Ouroboros.Consensus.Node.ProtocolInfo
 
 import           Control.Monad.Class.MonadTime.SI (DiffTime)
 import           Control.Monad.IO.Class (MonadIO (..))
@@ -24,20 +34,6 @@ import           Options.Applicative
 import qualified Options.Applicative as Opt
 import           System.Exit (exitFailure)
 import qualified System.IO as IO
-
-import           Cardano.Node.Configuration.NodeAddress
-import           Cardano.Node.Configuration.POM (PartialNodeConfiguration (..),
-                   parseNodeConfigurationFP)
-import           Cardano.Node.Protocol
-import           Cardano.Node.Types
-import qualified Ouroboros.Consensus.Config as Consensus
-import           Ouroboros.Consensus.Config.SecurityParam (SecurityParam (..))
-import           Ouroboros.Consensus.Config.SupportsNode
-import           Ouroboros.Consensus.Node.ProtocolInfo
-
-
-import           Cardano.Api
-import           Cardano.Chairman (chairmanTest)
 
 data RunOpts = RunOpts
   { -- | Stop the test after given number of seconds. The chairman will

--- a/cardano-node-chairman/app/Cardano/Chairman/Commands/Version.hs
+++ b/cardano-node-chairman/app/Cardano/Chairman/Commands/Version.hs
@@ -5,13 +5,14 @@ module Cardano.Chairman.Commands.Version
   ) where
 
 import           Cardano.Git.Rev (gitRev)
-import           Data.Version (showVersion)
-import           Options.Applicative
-import           Paths_cardano_node_chairman (version)
-import           System.Info (arch, compilerName, compilerVersion, os)
 
 import qualified Data.Text as T
+import           Data.Version (showVersion)
+import           Options.Applicative
+import           System.Info (arch, compilerName, compilerVersion, os)
 import qualified System.IO as IO
+
+import           Paths_cardano_node_chairman (version)
 
 data VersionOptions = VersionOptions deriving (Eq, Show)
 

--- a/cardano-node-chairman/app/cardano-node-chairman.hs
+++ b/cardano-node-chairman/app/cardano-node-chairman.hs
@@ -1,10 +1,10 @@
 module Main where
 
 import           Cardano.Chairman.Commands
+import qualified Cardano.Crypto.Init as Crypto
+
 import           Control.Monad
 import           Options.Applicative
-
-import qualified Cardano.Crypto.Init as Crypto
 
 main :: IO ()
 main = do

--- a/cardano-node-chairman/test/Main.hs
+++ b/cardano-node-chairman/test/Main.hs
@@ -4,19 +4,19 @@ module Main
   ( main
   ) where
 
-import           Data.String (IsString (..))
+import qualified Cardano.Crypto.Init as Crypto
+
 import           Prelude
 
+import           Data.String (IsString (..))
 import qualified System.Environment as E
 import           System.IO (BufferMode (LineBuffering), hSetBuffering, hSetEncoding, stdout, utf8)
+
 import qualified Test.Tasty as T
 import qualified Test.Tasty.Hedgehog as H
 import qualified Test.Tasty.Ingredients as T
 
--- import qualified Spec.Chairman.Cardano
 import qualified Spec.Network
-
-import qualified Cardano.Crypto.Init as Crypto
 
 tests :: IO T.TestTree
 tests = do

--- a/cardano-node-chairman/test/Spec/Chairman/Cardano.hs
+++ b/cardano-node-chairman/test/Spec/Chairman/Cardano.hs
@@ -6,10 +6,11 @@ module Spec.Chairman.Cardano where
 
 import qualified Cardano.Testnet as H
 
+import qualified Testnet.Property.Utils as H
+
 import qualified Hedgehog as H
 
 import           Spec.Chairman.Chairman (chairmanOver)
-import qualified Testnet.Property.Utils as H
 
 -- TODO: Conway broken in conway
 hprop_chairman :: H.Property

--- a/cardano-node-chairman/test/Spec/Chairman/Chairman.hs
+++ b/cardano-node-chairman/test/Spec/Chairman/Chairman.hs
@@ -6,24 +6,24 @@ module Spec.Chairman.Chairman
   ( chairmanOver
   ) where
 
+import           Cardano.Testnet (TmpAbsolutePath (TmpAbsolutePath), makeLogDir)
+import qualified Cardano.Testnet as H
+
 import           Control.Monad (when)
 import           Data.Functor ((<&>))
-import           Hedgehog.Extras.Stock.IO.Network.Sprocket (Sprocket (..))
-import           Hedgehog.Extras.Test.Base (Integration)
+import qualified System.Environment as IO
 import           System.Exit (ExitCode (..))
 import           System.FilePath.Posix ((</>))
-
-import qualified Hedgehog as H
-import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
-import qualified Hedgehog.Extras.Test.Process as H
-import qualified System.Environment as IO
 import qualified System.IO as IO
 import qualified System.Process as IO
 
-import           Cardano.Testnet (TmpAbsolutePath (TmpAbsolutePath), makeLogDir)
-import qualified Cardano.Testnet as H
+import qualified Hedgehog as H
+import           Hedgehog.Extras.Stock.IO.Network.Sprocket (Sprocket (..))
+import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
+import           Hedgehog.Extras.Test.Base (Integration)
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+import qualified Hedgehog.Extras.Test.Process as H
 
 {- HLINT ignore "Reduce duplication" -}
 {- HLINT ignore "Redundant <&>" -}

--- a/cardano-node-chairman/test/Spec/Network.hs
+++ b/cardano-node-chairman/test/Spec/Network.hs
@@ -10,25 +10,27 @@ module Spec.Network
   , hprop_isPortOpen_True
   ) where
 
+import           Prelude (error)
+
 import           Control.Exception (IOException)
 import           Control.Monad
+import qualified Control.Monad.Trans.Resource as IO
 import           Data.Bool
 import           Data.Either
 import           Data.Function
 import           Data.Int
-import           Hedgehog (Property, (===))
-import           Network.Socket (Socket)
-import           Prelude (error)
-import           System.IO (IO)
-
-import qualified Control.Monad.Trans.Resource as IO
 import qualified Data.List as L
+import           Network.Socket (Socket)
+import qualified Network.Socket as IO
+import           System.IO (IO)
+import qualified System.Random as IO
+
+import           Hedgehog (Property, (===))
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Stock.IO.Network.Socket as IO
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.Network as H
-import qualified Network.Socket as IO
-import qualified System.Random as IO
+
 import qualified UnliftIO.Exception as IO
 
 hprop_isPortOpen_False :: Property

--- a/cardano-node-chairman/testnet/Main.hs
+++ b/cardano-node-chairman/testnet/Main.hs
@@ -5,6 +5,7 @@ import           Data.Function
 import           Data.Semigroup
 import           Options.Applicative
 import           System.IO (IO)
+
 import           Testnet.Commands
 
 main :: IO ()

--- a/cardano-node-chairman/testnet/Testnet/Commands/Version.hs
+++ b/cardano-node-chairman/testnet/Testnet/Commands/Version.hs
@@ -5,18 +5,19 @@ module Testnet.Commands.Version
   ) where
 
 import           Cardano.Git.Rev (gitRev)
+
 import           Data.Eq
 import           Data.Function
 import           Data.Monoid
+import qualified Data.Text as T
 import           Data.Version (showVersion)
 import           Options.Applicative
-import           Paths_cardano_node_chairman (version)
 import           System.Info (arch, compilerName, compilerVersion, os)
+import qualified System.IO as IO
 import           System.IO (IO)
 import           Text.Show
 
-import qualified Data.Text as T
-import qualified System.IO as IO
+import           Paths_cardano_node_chairman (version)
 
 data VersionOptions = VersionOptions deriving (Eq, Show)
 

--- a/cardano-node-chairman/testnet/Testnet/Run.hs
+++ b/cardano-node-chairman/testnet/Testnet/Run.hs
@@ -2,6 +2,8 @@ module Testnet.Run
   ( runTestnet
   ) where
 
+import qualified Control.Concurrent as IO
+import qualified Control.Concurrent.STM as STM
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Resource
@@ -9,19 +11,18 @@ import           Data.Bool
 import           Data.Function
 import           Data.Int
 import           Data.Maybe
+import qualified System.Console.ANSI as ANSI
 import           System.Console.ANSI (Color (..), ColorIntensity (..), ConsoleLayer (..), SGR (..))
+import qualified System.Exit as IO
+import qualified System.IO as IO
 import           System.IO (IO)
 
-import qualified Control.Concurrent as IO
-import qualified Control.Concurrent.STM as STM
+import qualified Testnet.Conf as H
+
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.Process as H
-import qualified System.Console.ANSI as ANSI
-import qualified System.Exit as IO
-import qualified System.IO as IO
 import qualified Test.Base as H
-import qualified Testnet.Conf as H
 
 testnetProperty :: (H.Conf -> H.Integration ()) -> H.Property
 testnetProperty tn = H.integrationRetryWorkspace 2 "testnet-chairman" $ \tempAbsPath' -> do

--- a/cardano-node/app/cardano-node.hs
+++ b/cardano-node/app/cardano-node.hs
@@ -1,17 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 
-import           Options.Applicative
-import qualified Options.Applicative as Opt
-import           Options.Applicative.Help ((<$$>))
-
+import qualified Cardano.Crypto.Init as Crypto
 import           Cardano.Git.Rev (gitRev)
-import qualified Data.Text as Text
-import qualified Data.Text.IO as Text
-import           Data.Version (showVersion)
-import           Paths_cardano_node (version)
-import           System.Info (arch, compilerName, compilerVersion, os)
-
 import           Cardano.Node.Configuration.POM (PartialNodeConfiguration)
 import           Cardano.Node.Handlers.TopLevel
 import           Cardano.Node.Parsers (nodeCLIParser, parserHelpHeader, parserHelpOptions,
@@ -20,7 +11,15 @@ import           Cardano.Node.Run (runNode)
 import           Cardano.Node.Tracing.Documentation (TraceDocumentationCmd (..),
                    parseTraceDocumentationCmd, runTraceDocumentationCmd)
 
-import qualified Cardano.Crypto.Init as Crypto
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
+import           Data.Version (showVersion)
+import           Options.Applicative
+import qualified Options.Applicative as Opt
+import           Options.Applicative.Help ((<$$>))
+import           System.Info (arch, compilerName, compilerVersion, os)
+
+import           Paths_cardano_node (version)
 
 main :: IO ()
 main = do

--- a/cardano-node/src/Cardano/Node/Configuration/NodeAddress.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/NodeAddress.hs
@@ -32,6 +32,8 @@ module Cardano.Node.Configuration.NodeAddress
 
 import           Cardano.Api
 
+import           Ouroboros.Network.PeerSelection.RelayAccessPoint (DomainAccessPoint (..))
+
 import           Data.Aeson (FromJSON (..), ToJSON (..), Value (..), object, withObject, (.:), (.=))
 import           Data.IP (IP (..), IPv4, IPv6)
 import qualified Data.IP as IP
@@ -41,8 +43,6 @@ import qualified Data.Text.Encoding as Text
 import qualified Network.DNS as DNS (Domain)
 import           Network.Socket (PortNumber, SockAddr (..))
 import           Text.Read (readMaybe)
-
-import           Ouroboros.Network.PeerSelection.RelayAccessPoint (DomainAccessPoint (..))
 
 
 -- | IPv4 or IPv6 address with a port number.

--- a/cardano-node/src/Cardano/Node/Configuration/POM.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/POM.hs
@@ -22,22 +22,6 @@ module Cardano.Node.Configuration.POM
   )
 where
 
-import           Control.Monad (when)
-import           Data.Aeson
-import qualified Data.Aeson.Types as Aeson
-import           Data.Bifunctor (Bifunctor (..))
-import           Data.Maybe
-import           Data.Monoid (Last (..))
-import           Data.Text (Text)
-import qualified Data.Text as Text
-import           Data.Time.Clock (DiffTime)
-import           Data.Yaml (decodeFileThrow)
-import           Generic.Data (gmappend)
-import           Generic.Data.Orphans ()
-import           GHC.Generics (Generic)
-import           Options.Applicative
-import           System.FilePath (takeDirectory, (</>))
-
 import           Cardano.Crypto (RequiresNetworkMagic (..))
 import           Cardano.Logging.Types
 import           Cardano.Node.Configuration.NodeAddress (SocketPath)
@@ -53,6 +37,23 @@ import qualified Ouroboros.Consensus.Node as Consensus (NetworkP2PMode (..))
 import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy (SnapshotInterval (..))
 import           Ouroboros.Network.NodeToNode (AcceptedConnectionsLimit (..), DiffusionMode (..))
 import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
+
+import           Control.Monad (when)
+import           Data.Aeson
+import qualified Data.Aeson.Types as Aeson
+import           Data.Bifunctor (Bifunctor (..))
+import           Data.Maybe
+import           Data.Monoid (Last (..))
+import           Data.Text (Text)
+import qualified Data.Text as Text
+import           Data.Time.Clock (DiffTime)
+import           Data.Yaml (decodeFileThrow)
+import           GHC.Generics (Generic)
+import           Options.Applicative
+import           System.FilePath (takeDirectory, (</>))
+
+import           Generic.Data (gmappend)
+import           Generic.Data.Orphans ()
 
 data NetworkP2PMode = EnabledP2PMode | DisabledP2PMode
   deriving (Eq, Show, Generic)

--- a/cardano-node/src/Cardano/Node/Configuration/Topology.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/Topology.hs
@@ -15,6 +15,11 @@ module Cardano.Node.Configuration.Topology
   )
 where
 
+import           Cardano.Node.Configuration.NodeAddress
+import           Cardano.Node.Configuration.POM (NodeConfiguration (..))
+import           Cardano.Node.Types
+import           Ouroboros.Consensus.Util.Condense (Condense (..))
+
 import           Control.Exception (Exception (..), IOException)
 import qualified Control.Exception as Exception
 import           Data.Aeson
@@ -26,12 +31,6 @@ import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Word (Word64)
 import           Text.Read (readMaybe)
-
-import           Cardano.Node.Configuration.NodeAddress
-import           Cardano.Node.Configuration.POM (NodeConfiguration (..))
-import           Cardano.Node.Types
-
-import           Ouroboros.Consensus.Util.Condense (Condense (..))
 
 
 newtype TopologyError

--- a/cardano-node/src/Cardano/Node/Configuration/TopologyP2P.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/TopologyP2P.hs
@@ -23,9 +23,23 @@ module Cardano.Node.Configuration.TopologyP2P
   )
 where
 
+import           Cardano.Node.Configuration.NodeAddress
+import           Cardano.Node.Configuration.POM (NodeConfiguration (..))
+import           Cardano.Node.Configuration.Topology (TopologyError (..))
+import           Cardano.Node.Startup (StartupTrace (..))
+import           Cardano.Node.Types
+import           Cardano.Tracing.OrphanInstances.Network ()
+import           Ouroboros.Network.NodeToNode (PeerAdvertise (..))
+import           Ouroboros.Network.PeerSelection.LedgerPeers (UseLedgerAfter (..))
+import           Ouroboros.Network.PeerSelection.RelayAccessPoint (RelayAccessPoint (..))
+import           Ouroboros.Network.PeerSelection.State.LocalRootPeers (HotValency (..),
+                   WarmValency (..))
+
+import           Control.Applicative (Alternative (..))
 import           Control.Exception (IOException)
 import qualified Control.Exception as Exception
 import           Control.Exception.Base (Exception (..))
+import           "contra-tracer" Control.Tracer (Tracer, traceWith)
 import           Data.Aeson
 import           Data.Bifunctor (Bifunctor (..))
 import qualified Data.ByteString as BS
@@ -33,23 +47,6 @@ import qualified Data.ByteString.Lazy.Char8 as LBS
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Word (Word64)
-
-import           "contra-tracer" Control.Tracer (Tracer, traceWith)
-
-import           Cardano.Node.Configuration.POM (NodeConfiguration (..))
-
-import           Cardano.Node.Configuration.NodeAddress
-import           Cardano.Node.Configuration.Topology (TopologyError (..))
-import           Cardano.Node.Startup (StartupTrace (..))
-import           Cardano.Node.Types
-
-import           Cardano.Tracing.OrphanInstances.Network ()
-import           Control.Applicative (Alternative (..))
-import           Ouroboros.Network.NodeToNode (PeerAdvertise (..))
-import           Ouroboros.Network.PeerSelection.LedgerPeers (UseLedgerAfter (..))
-import           Ouroboros.Network.PeerSelection.RelayAccessPoint (RelayAccessPoint (..))
-import           Ouroboros.Network.PeerSelection.State.LocalRootPeers (HotValency (..),
-                   WarmValency (..))
 
 data NodeSetup = NodeSetup
   { nodeId          :: !Word64

--- a/cardano-node/src/Cardano/Node/Handlers/Shutdown.hs
+++ b/cardano-node/src/Cardano/Node/Handlers/Shutdown.hs
@@ -26,15 +26,24 @@ module Cardano.Node.Handlers.Shutdown
   )
 where
 
+import           Cardano.Api (bounded)
+
+import           Cardano.Slotting.Slot (WithOrigin (..))
+import           Ouroboros.Consensus.Block (Header)
+import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
+import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
+import           Ouroboros.Consensus.Util.STM (Watcher (..), forkLinkedWatcher)
+import           Ouroboros.Network.Block (BlockNo (..), HasHeader, SlotNo (..), pointSlot)
+
 import           Control.Concurrent.Async (race_)
 import           Control.DeepSeq (NFData)
 import           Control.Exception (try)
 import           Control.Exception.Base (throwIO)
 import           Control.Monad (void, when)
+import           "contra-tracer" Control.Tracer
 import           Data.Aeson (FromJSON, ToJSON)
 import           Data.Foldable (asum)
 import           Data.Text (Text, pack)
-import           Generic.Data.Orphans ()
 import           GHC.Generics (Generic)
 import qualified GHC.IO.Handle.FD as IO (fdToHandle)
 import qualified Options.Applicative as Opt
@@ -43,14 +52,7 @@ import qualified System.IO as IO
 import qualified System.IO.Error as IO
 import           System.Posix.Types (Fd (Fd))
 
-import           Cardano.Api (bounded)
-import           Cardano.Slotting.Slot (WithOrigin (..))
-import           "contra-tracer" Control.Tracer
-import           Ouroboros.Consensus.Block (Header)
-import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
-import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
-import           Ouroboros.Consensus.Util.STM (Watcher (..), forkLinkedWatcher)
-import           Ouroboros.Network.Block (BlockNo (..), HasHeader, SlotNo (..), pointSlot)
+import           Generic.Data.Orphans ()
 
 data ShutdownOn
   = ASlot  !SlotNo

--- a/cardano-node/src/Cardano/Node/Handlers/TopLevel.hs
+++ b/cardano-node/src/Cardano/Node/Handlers/TopLevel.hs
@@ -46,16 +46,15 @@ module Cardano.Node.Handlers.TopLevel
 -- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 -- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import qualified Ouroboros.Network.Diffusion as Network
+
 import           Prelude
 
 import           Control.Exception
-
 import           Control.Monad.Class.MonadAsync (ExceptionInLinkedThread (..))
 import           System.Environment
 import           System.Exit
 import           System.IO
-
-import qualified Ouroboros.Network.Diffusion as Network
 
 -- | An exception handler to use for a program top level, as an alternative to
 -- the default top level handler provided by GHC.

--- a/cardano-node/src/Cardano/Node/Orphans.hs
+++ b/cardano-node/src/Cardano/Node/Orphans.hs
@@ -7,11 +7,10 @@ module Cardano.Node.Orphans () where
 
 import           Cardano.Api ()
 
-import           Data.Aeson.Types
-
 import           Ouroboros.Network.NodeToNode (AcceptedConnectionsLimit (..))
 import           Ouroboros.Network.SizeInBytes (SizeInBytes (..))
 
+import           Data.Aeson.Types
 import           Text.Printf (PrintfArg (..))
 
 instance PrintfArg SizeInBytes where

--- a/cardano-node/src/Cardano/Node/Parsers.hs
+++ b/cardano-node/src/Cardano/Node/Parsers.hs
@@ -11,7 +11,18 @@ module Cardano.Node.Parsers
   , renderHelpDoc
   ) where
 
+import           Cardano.Logging.Types
+import           Cardano.Node.Configuration.NodeAddress (File (..),
+                   NodeHostIPv4Address (NodeHostIPv4Address),
+                   NodeHostIPv6Address (NodeHostIPv6Address), PortNumber, SocketPath)
+import           Cardano.Node.Configuration.POM (PartialNodeConfiguration (..), lastOption)
+import           Cardano.Node.Configuration.Socket
+import           Cardano.Node.Handlers.Shutdown
+import           Cardano.Node.Types
 import           Cardano.Prelude (ConvertText (..))
+import           Ouroboros.Consensus.Mempool (MempoolCapacityBytes (..),
+                   MempoolCapacityBytesOverride (..))
+import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy (SnapshotInterval (..))
 
 import           Data.Foldable
 import           Data.Maybe (fromMaybe)
@@ -24,19 +35,6 @@ import qualified Options.Applicative as Opt
 import qualified Options.Applicative.Help as OptI
 import           System.Posix.Types (Fd (..))
 import           Text.Read (readMaybe)
-
-import           Ouroboros.Consensus.Mempool (MempoolCapacityBytes (..),
-                   MempoolCapacityBytesOverride (..))
-import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy (SnapshotInterval (..))
-
-import           Cardano.Logging.Types
-import           Cardano.Node.Configuration.NodeAddress (File (..),
-                   NodeHostIPv4Address (NodeHostIPv4Address),
-                   NodeHostIPv6Address (NodeHostIPv6Address), PortNumber, SocketPath)
-import           Cardano.Node.Configuration.POM (PartialNodeConfiguration (..), lastOption)
-import           Cardano.Node.Configuration.Socket
-import           Cardano.Node.Handlers.Shutdown
-import           Cardano.Node.Types
 
 nodeCLIParser  :: Parser PartialNodeConfiguration
 nodeCLIParser = subparser

--- a/cardano-node/src/Cardano/Node/Pretty.hs
+++ b/cardano-node/src/Cardano/Node/Pretty.hs
@@ -15,14 +15,13 @@ module Cardano.Node.Pretty
     white,
   ) where
 
+import qualified Control.Concurrent.QSem as IO
 import           Control.Exception (bracket_)
 import           Control.Monad.IO.Class (MonadIO, liftIO)
-import           Prettyprinter
-import           Prettyprinter.Render.Terminal
-
-import qualified Control.Concurrent.QSem as IO
 import qualified Data.Text.Lazy as TextLazy
 import qualified Data.Text.Lazy.IO as TextLazy
+import           Prettyprinter
+import           Prettyprinter.Render.Terminal
 import qualified System.IO as IO
 import qualified System.IO.Unsafe as IO
 

--- a/cardano-node/src/Cardano/Node/Protocol.hs
+++ b/cardano-node/src/Cardano/Node/Protocol.hs
@@ -4,20 +4,19 @@ module Cardano.Node.Protocol
   , ProtocolInstantiationError(..)
   ) where
 
-import           Control.Exception
-import           Control.Monad.Trans.Except (ExceptT)
-import           Control.Monad.Trans.Except.Extra (firstExceptT)
-
 import           Cardano.Api
 import           Cardano.Api.Pretty
-
-import           Cardano.Node.Types
 
 import           Cardano.Node.Orphans ()
 import           Cardano.Node.Protocol.Byron
 import           Cardano.Node.Protocol.Cardano
 import           Cardano.Node.Protocol.Shelley
 import           Cardano.Node.Protocol.Types (SomeConsensusProtocol (..))
+import           Cardano.Node.Types
+
+import           Control.Exception
+import           Control.Monad.Trans.Except (ExceptT)
+import           Control.Monad.Trans.Except.Extra (firstExceptT)
 
 
 ------------------------------------------------------------------------------

--- a/cardano-node/src/Cardano/Node/Protocol/Alonzo.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Alonzo.hs
@@ -12,14 +12,11 @@ import           Cardano.Api
 import           Cardano.Api.Pretty
 
 import qualified Cardano.Ledger.Alonzo.Genesis as Alonzo
-
 import           Cardano.Node.Orphans ()
+import           Cardano.Node.Protocol.Shelley (GenesisReadError, readGenesisAny)
 import           Cardano.Node.Types
-
 import           Cardano.Tracing.OrphanInstances.HardFork ()
 import           Cardano.Tracing.OrphanInstances.Shelley ()
-
-import           Cardano.Node.Protocol.Shelley (GenesisReadError, readGenesisAny)
 
 import           Control.Monad.Except (ExceptT)
 

--- a/cardano-node/src/Cardano/Node/Protocol/Byron.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Byron.hs
@@ -12,18 +12,9 @@ module Cardano.Node.Protocol.Byron
   , readLeaderCredentials
   ) where
 
-import           Cardano.Prelude (canonicalDecodePretty)
-
-import           Control.Monad.Except (throwError)
-import           Control.Monad.IO.Class (MonadIO (..))
-import           Control.Monad.Trans.Except (ExceptT)
-import           Control.Monad.Trans.Except.Extra (bimapExceptT, firstExceptT, hoistEither, left)
-import qualified Data.ByteString.Lazy as LB
-import           Data.Maybe (fromMaybe)
-import           Data.Text (Text)
-
 import           Cardano.Api.Byron
 import           Cardano.Api.Pretty
+
 import qualified Cardano.Chain.Genesis as Genesis
 import qualified Cardano.Chain.Update as Update
 import qualified Cardano.Chain.UTxO as UTxO
@@ -35,13 +26,21 @@ import           Cardano.Node.Tracing.Era.Byron ()
 import           Cardano.Node.Tracing.Era.HardFork ()
 import           Cardano.Node.Tracing.Tracers.ChainDB ()
 import           Cardano.Node.Types
+import           Cardano.Prelude (canonicalDecodePretty)
 import           Cardano.Tracing.OrphanInstances.Byron ()
 import           Cardano.Tracing.OrphanInstances.HardFork ()
 import           Cardano.Tracing.OrphanInstances.Shelley ()
-
 import           Ouroboros.Consensus.Cardano
 import qualified Ouroboros.Consensus.Cardano as Consensus
 import qualified Ouroboros.Consensus.Mempool.Capacity as TxLimits
+
+import           Control.Monad.Except (throwError)
+import           Control.Monad.IO.Class (MonadIO (..))
+import           Control.Monad.Trans.Except (ExceptT)
+import           Control.Monad.Trans.Except.Extra (bimapExceptT, firstExceptT, hoistEither, left)
+import qualified Data.ByteString.Lazy as LB
+import           Data.Maybe (fromMaybe)
+import           Data.Text (Text)
 
 
 ------------------------------------------------------------------------------

--- a/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
@@ -15,23 +15,10 @@ module Cardano.Node.Protocol.Cardano
   , CardanoProtocolInstantiationError(..)
   ) where
 
-import           Prelude
-
-import           Control.Monad.Trans.Except (ExceptT)
-import           Control.Monad.Trans.Except.Extra (firstExceptT)
-
-import           Ouroboros.Consensus.Cardano
-import qualified Ouroboros.Consensus.Cardano as Consensus
-import qualified Ouroboros.Consensus.Cardano.CanHardFork as Consensus
-import           Ouroboros.Consensus.Cardano.Condense ()
-import           Ouroboros.Consensus.HardFork.Combinator.Condense ()
-import qualified Ouroboros.Consensus.Mempool.Capacity as TxLimits
-import qualified Ouroboros.Consensus.Shelley.Node.Praos as Praos
-
 import           Cardano.Api
 import           Cardano.Api.Byron as Byron
-import qualified Cardano.Chain.Update as Update
 
+import qualified Cardano.Chain.Update as Update
 import qualified Cardano.Ledger.Api.Transition as Ledger
 import           Cardano.Ledger.BaseTypes (natVersion)
 import qualified Cardano.Node.Protocol.Alonzo as Alonzo
@@ -42,6 +29,18 @@ import           Cardano.Node.Protocol.Types
 import           Cardano.Node.Types
 import           Cardano.Tracing.OrphanInstances.Byron ()
 import           Cardano.Tracing.OrphanInstances.Shelley ()
+import           Ouroboros.Consensus.Cardano
+import qualified Ouroboros.Consensus.Cardano as Consensus
+import qualified Ouroboros.Consensus.Cardano.CanHardFork as Consensus
+import           Ouroboros.Consensus.Cardano.Condense ()
+import           Ouroboros.Consensus.HardFork.Combinator.Condense ()
+import qualified Ouroboros.Consensus.Mempool.Capacity as TxLimits
+import qualified Ouroboros.Consensus.Shelley.Node.Praos as Praos
+
+import           Prelude
+
+import           Control.Monad.Trans.Except (ExceptT)
+import           Control.Monad.Trans.Except.Extra (firstExceptT)
 
 ------------------------------------------------------------------------------
 -- Real Cardano protocol

--- a/cardano-node/src/Cardano/Node/Protocol/Conway.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Conway.hs
@@ -11,17 +11,13 @@ module Cardano.Node.Protocol.Conway
 import           Cardano.Api
 import           Cardano.Api.Pretty
 
-import           Ouroboros.Consensus.Shelley.Eras (StandardCrypto)
-
 import qualified Cardano.Ledger.Conway.Genesis as Conway
-
 import           Cardano.Node.Orphans ()
+import           Cardano.Node.Protocol.Shelley (GenesisReadError, readGenesisAny)
 import           Cardano.Node.Types
-
 import           Cardano.Tracing.OrphanInstances.HardFork ()
 import           Cardano.Tracing.OrphanInstances.Shelley ()
-
-import           Cardano.Node.Protocol.Shelley (GenesisReadError, readGenesisAny)
+import           Ouroboros.Consensus.Shelley.Eras (StandardCrypto)
 
 import           Control.Monad.Except (ExceptT)
 

--- a/cardano-node/src/Cardano/Node/Protocol/Shelley.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Shelley.hs
@@ -21,45 +21,36 @@ module Cardano.Node.Protocol.Shelley
   , validateGenesis
   ) where
 
-import           Control.Exception (IOException)
-import           Control.Monad.Except (ExceptT, MonadError (..))
-
 import qualified Cardano.Api as Api
 import           Cardano.Api.Pretty
 import           Cardano.Api.Shelley hiding (FileError)
 
-import qualified Data.Aeson as Aeson
-import qualified Data.ByteString as BS
-import qualified Data.Text as T
-
-import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT, hoistEither, left,
-                   newExceptT)
-
 import qualified Cardano.Crypto.Hash.Class as Crypto
+import           Cardano.Ledger.BaseTypes (ProtVer (..), natVersion)
 import           Cardano.Ledger.Crypto (StandardCrypto)
 import           Cardano.Ledger.Keys (coerceKeyRole)
-
+import qualified Cardano.Ledger.Shelley.Genesis as Shelley
+import           Cardano.Node.Protocol.Types
+import           Cardano.Node.Tracing.Era.HardFork ()
+import           Cardano.Node.Tracing.Era.Shelley ()
+import           Cardano.Node.Tracing.Formatting ()
+import           Cardano.Node.Tracing.Tracers.ChainDB ()
+import           Cardano.Node.Types
+import           Cardano.Tracing.OrphanInstances.HardFork ()
+import           Cardano.Tracing.OrphanInstances.Shelley ()
 import qualified Ouroboros.Consensus.Cardano as Consensus
 import qualified Ouroboros.Consensus.Mempool.Capacity as TxLimits
 import           Ouroboros.Consensus.Protocol.Praos.Common (PraosCanBeLeader (..))
 import           Ouroboros.Consensus.Shelley.Node (Nonce (..), ProtocolParams (..),
                    ProtocolParamsShelleyBased (..), ShelleyLeaderCredentials (..))
 
-import           Cardano.Ledger.BaseTypes (ProtVer (..), natVersion)
-import qualified Cardano.Ledger.Shelley.Genesis as Shelley
-
-
-import           Cardano.Node.Types
-
-import           Cardano.Tracing.OrphanInstances.HardFork ()
-import           Cardano.Tracing.OrphanInstances.Shelley ()
-
-import           Cardano.Node.Tracing.Era.HardFork ()
-import           Cardano.Node.Tracing.Era.Shelley ()
-import           Cardano.Node.Tracing.Formatting ()
-import           Cardano.Node.Tracing.Tracers.ChainDB ()
-
-import           Cardano.Node.Protocol.Types
+import           Control.Exception (IOException)
+import           Control.Monad.Except (ExceptT, MonadError (..))
+import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT, hoistEither, left,
+                   newExceptT)
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
+import qualified Data.Text as T
 
 ------------------------------------------------------------------------------
 -- Shelley protocol

--- a/cardano-node/src/Cardano/Node/Queries.hs
+++ b/cardano-node/src/Cardano/Node/Queries.hs
@@ -36,27 +36,18 @@ module Cardano.Node.Queries
   , fromSMaybe
   ) where
 
-import           Control.Monad.STM (atomically)
-import           Data.ByteString (ByteString)
-import           Data.IORef (IORef, newIORef, readIORef, writeIORef)
-import qualified Data.Map.Strict as Map
-import           Data.SOP
-import           Data.Word (Word64)
-
 import qualified Cardano.Chain.Block as Byron
 import qualified Cardano.Chain.UTxO as Byron
 import qualified Cardano.Crypto.Hash as Crypto
 import qualified Cardano.Crypto.Hashing as Byron.Crypto
 import           Cardano.Crypto.KES.Class (Period)
-import           Cardano.Protocol.TPraos.OCert (KESPeriod (..))
-
 import           Cardano.Ledger.BaseTypes (StrictMaybe (..), fromSMaybe)
 import qualified Cardano.Ledger.SafeHash as Ledger
 import qualified Cardano.Ledger.Shelley.LedgerState as Shelley
 import qualified Cardano.Ledger.Shelley.UTxO as Shelley
 import qualified Cardano.Ledger.TxIn as Ledger
 import qualified Cardano.Ledger.UMap as UM
-
+import           Cardano.Protocol.TPraos.OCert (KESPeriod (..))
 import           Ouroboros.Consensus.Block (ForgeStateInfo, ForgeStateUpdateError)
 import           Ouroboros.Consensus.Byron.Ledger.Block (ByronBlock)
 import qualified Ouroboros.Consensus.Byron.Ledger.Block as Byron
@@ -79,10 +70,16 @@ import           Ouroboros.Consensus.Shelley.Node ()
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util.Orphans ()
-
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.NodeToClient (LocalConnectionId)
 import           Ouroboros.Network.NodeToNode (RemoteAddress, RemoteConnectionId)
+
+import           Control.Monad.STM (atomically)
+import           Data.ByteString (ByteString)
+import           Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import qualified Data.Map.Strict as Map
+import           Data.SOP
+import           Data.Word (Word64)
 
 --
 -- * TxId -> ByteString projection

--- a/cardano-node/src/Cardano/Node/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Startup.hs
@@ -10,23 +10,14 @@
 module Cardano.Node.Startup where
 
 import qualified Cardano.Api as Api
-import           Control.DeepSeq (NFData)
-import           Prelude
 
-import           Data.Aeson (FromJSON, ToJSON)
-import           Data.Map.Strict (Map)
-import           Data.Monoid (Last (..), getLast)
-import           Data.Text (Text, pack)
-import           Data.Time.Clock (NominalDiffTime, UTCTime)
-import           Data.Version (showVersion)
-import           Data.Word (Word64)
-import           GHC.Generics (Generic)
-
-import           Network.HostName (getHostName)
-import qualified Network.Socket as Socket
-
+import           Cardano.Git.Rev (gitRev)
 import           Cardano.Ledger.Shelley.Genesis (sgSystemStart)
-
+import           Cardano.Logging
+import           Cardano.Node.Configuration.POM (NodeConfiguration (..), ncProtocol)
+import           Cardano.Node.Configuration.Socket
+import           Cardano.Node.Protocol (ProtocolInstantiationError)
+import           Cardano.Node.Protocol.Types (SomeConsensusProtocol (..))
 import qualified Ouroboros.Consensus.BlockchainTime.WallClock.Types as WCT
 import           Ouroboros.Consensus.Cardano.Block
 import           Ouroboros.Consensus.Cardano.CanHardFork (shelleyLedgerConfig)
@@ -37,24 +28,30 @@ import           Ouroboros.Consensus.Node (pInfoConfig)
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion (BlockNodeToClientVersion,
                    BlockNodeToNodeVersion)
 import           Ouroboros.Consensus.Shelley.Ledger.Ledger (shelleyLedgerGenesis)
-
 import           Ouroboros.Network.Magic (NetworkMagic (..))
 import           Ouroboros.Network.NodeToClient (LocalAddress (..), LocalSocket,
                    NodeToClientVersion)
 import           Ouroboros.Network.NodeToNode (DiffusionMode (..), NodeToNodeVersion, PeerAdvertise)
 import           Ouroboros.Network.PeerSelection.LedgerPeers (UseLedgerAfter (..))
 import           Ouroboros.Network.PeerSelection.RelayAccessPoint (RelayAccessPoint)
+import           Ouroboros.Network.PeerSelection.State.LocalRootPeers (HotValency, WarmValency)
 import           Ouroboros.Network.Subscription.Dns (DnsSubscriptionTarget (..))
 import           Ouroboros.Network.Subscription.Ip (IPSubscriptionTarget (..))
 
-import           Cardano.Logging
-import           Cardano.Node.Configuration.POM (NodeConfiguration (..), ncProtocol)
-import           Cardano.Node.Configuration.Socket
-import           Cardano.Node.Protocol (ProtocolInstantiationError)
-import           Cardano.Node.Protocol.Types (SomeConsensusProtocol (..))
+import           Prelude
 
-import           Cardano.Git.Rev (gitRev)
-import           Ouroboros.Network.PeerSelection.State.LocalRootPeers (HotValency, WarmValency)
+import           Control.DeepSeq (NFData)
+import           Data.Aeson (FromJSON, ToJSON)
+import           Data.Map.Strict (Map)
+import           Data.Monoid (Last (..), getLast)
+import           Data.Text (Text, pack)
+import           Data.Time.Clock (NominalDiffTime, UTCTime)
+import           Data.Version (showVersion)
+import           Data.Word (Word64)
+import           GHC.Generics (Generic)
+import           Network.HostName (getHostName)
+import qualified Network.Socket as Socket
+
 import           Paths_cardano_node (version)
 
 data StartupTrace blk =

--- a/cardano-node/src/Cardano/Node/TraceConstraints.hs
+++ b/cardano-node/src/Cardano/Node/TraceConstraints.hs
@@ -15,7 +15,6 @@ import           Cardano.Logging (LogFormatting)
 import           Cardano.Node.Queries (ConvertTxId, GetKESInfo (..), HasKESInfo (..),
                    HasKESMetricsData (..), LedgerQueries)
 import           Cardano.Tracing.HasIssuer (HasIssuer)
-
 import           Ouroboros.Consensus.Block (BlockProtocol, CannotForge, ForgeStateUpdateError,
                    GetHeader, HasHeader, Header)
 import           Ouroboros.Consensus.HeaderValidation (OtherHeaderEnvelopeError)
@@ -27,7 +26,6 @@ import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.Run (RunNode, SerialiseNodeToNodeConstraints)
 import           Ouroboros.Consensus.Protocol.Abstract (SelectView, ValidationErr)
 import           Ouroboros.Consensus.Shelley.Ledger.Mempool (GenTx, TxId)
-
 import           Ouroboros.Network.Block (Serialised)
 
 import           Data.Aeson

--- a/cardano-node/src/Cardano/Node/Tracing.hs
+++ b/cardano-node/src/Cardano/Node/Tracing.hs
@@ -9,28 +9,25 @@ module Cardano.Node.Tracing
   , ConsensusStartupException (..)
   ) where
 
-import           Prelude (IO)
-
-import           Codec.CBOR.Read (DeserialiseFailure)
-import           "contra-tracer" Control.Tracer (Tracer (..))
-
+import           Cardano.Logging.Resources
+import           Cardano.Node.Handlers.Shutdown (ShutdownTrace)
+import           Cardano.Node.Startup (NodeInfo, NodeStartupInfo, StartupTrace (..))
+import           Cardano.Node.Tracing.StateRep (NodeState)
+import           Cardano.Node.Tracing.Tracers.ConsensusStartupException
+                   (ConsensusStartupException (..))
+import           Cardano.Node.Tracing.Tracers.Peer (PeerT)
 import qualified Ouroboros.Consensus.Network.NodeToClient as NodeToClient
 import qualified Ouroboros.Consensus.Network.NodeToNode as NodeToNode
 import qualified Ouroboros.Consensus.Node.Tracers as Consensus
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import qualified Ouroboros.Network.Diffusion as Diffusion
-
 import           Ouroboros.Network.NodeToClient (LocalAddress, NodeToClientVersion)
 import           Ouroboros.Network.NodeToNode (NodeToNodeVersion, RemoteAddress)
 
-import           Cardano.Node.Handlers.Shutdown (ShutdownTrace)
-import           Cardano.Node.Startup (NodeInfo, NodeStartupInfo, StartupTrace (..))
+import           Prelude (IO)
 
-import           Cardano.Logging.Resources
-import           Cardano.Node.Tracing.StateRep (NodeState)
-import           Cardano.Node.Tracing.Tracers.ConsensusStartupException
-                   (ConsensusStartupException (..))
-import           Cardano.Node.Tracing.Tracers.Peer (PeerT)
+import           Codec.CBOR.Read (DeserialiseFailure)
+import           "contra-tracer" Control.Tracer (Tracer (..))
 
 data Tracers peer localPeer blk p2p = Tracers
   { -- | Trace the ChainDB

--- a/cardano-node/src/Cardano/Node/Tracing/API.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/API.hs
@@ -7,20 +7,20 @@ module Cardano.Node.Tracing.API
   ( initTraceDispatcher
   ) where
 
-import           Data.Bifunctor (first)
-import           Prelude
-
-import           "contra-tracer" Control.Tracer (traceWith)
-import           "trace-dispatcher" Control.Tracer (nullTracer)
-import qualified Data.Map.Strict as Map
-import           Data.Maybe (fromMaybe)
-import           Data.Time.Clock (getCurrentTime)
-
-
-import           System.Metrics as EKG
-
-import           Network.Mux.Trace (TraceLabelPeer (..))
-
+import           Cardano.Logging hiding (traceWith)
+import           Cardano.Node.Configuration.NodeAddress (File (..))
+import           Cardano.Node.Configuration.POM (NodeConfiguration (..))
+import           Cardano.Node.Protocol.Types
+import           Cardano.Node.Queries
+import           Cardano.Node.Startup
+import           Cardano.Node.TraceConstraints
+import           Cardano.Node.Tracing
+import           Cardano.Node.Tracing.DefaultTraceConfig (defaultCardanoConfig)
+import           Cardano.Node.Tracing.StateRep (NodeState (..))
+import           Cardano.Node.Tracing.Tracers
+import           Cardano.Node.Tracing.Tracers.Peer (startPeerTracer)
+import           Cardano.Node.Tracing.Tracers.Resources (startResourceTracer)
+import           Cardano.Node.Types
 import           Ouroboros.Consensus.Ledger.Inspect (LedgerEvent)
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client (TraceChainSyncClientEvent)
 import           Ouroboros.Consensus.Node (NetworkP2PMode)
@@ -29,21 +29,16 @@ import           Ouroboros.Network.Magic (NetworkMagic)
 import           Ouroboros.Network.NodeToClient (withIOManager)
 import           Ouroboros.Network.NodeToNode (RemoteAddress)
 
-import           Cardano.Node.Configuration.NodeAddress (File (..))
-import           Cardano.Node.Configuration.POM (NodeConfiguration (..))
-import           Cardano.Node.Protocol.Types
-import           Cardano.Node.Queries
-import           Cardano.Node.Startup
-import           Cardano.Node.TraceConstraints
-import           Cardano.Node.Tracing
-import           Cardano.Node.Types
+import           Prelude
 
-import           Cardano.Logging hiding (traceWith)
-import           Cardano.Node.Tracing.DefaultTraceConfig (defaultCardanoConfig)
-import           Cardano.Node.Tracing.StateRep (NodeState (..))
-import           Cardano.Node.Tracing.Tracers
-import           Cardano.Node.Tracing.Tracers.Peer (startPeerTracer)
-import           Cardano.Node.Tracing.Tracers.Resources (startResourceTracer)
+import           "contra-tracer" Control.Tracer (traceWith)
+import           "trace-dispatcher" Control.Tracer (nullTracer)
+import           Data.Bifunctor (first)
+import qualified Data.Map.Strict as Map
+import           Data.Maybe (fromMaybe)
+import           Data.Time.Clock (getCurrentTime)
+import           Network.Mux.Trace (TraceLabelPeer (..))
+import           System.Metrics as EKG
 
 initTraceDispatcher ::
   forall blk p2p.

--- a/cardano-node/src/Cardano/Node/Tracing/Consistency.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Consistency.hs
@@ -12,23 +12,18 @@ module Cardano.Node.Tracing.Consistency
   , checkNodeTraceConfiguration'
   ) where
 
-import           Control.Exception (SomeException)
-import qualified Data.Text as T
-import           Network.Mux (MuxTrace (..), WithMuxBearer (..))
-import qualified Network.Socket as Socket
-
 import           Cardano.Logging
 import           Cardano.Logging.Resources
 import           Cardano.Logging.Resources.Types ()
+import           Cardano.Node.Handlers.Shutdown (ShutdownTrace)
+import           Cardano.Node.Startup
 import           Cardano.Node.Tracing.DefaultTraceConfig (defaultCardanoConfig)
+import           Cardano.Node.Tracing.Documentation (docTracersFirstPhase)
 import           Cardano.Node.Tracing.Formatting ()
 import qualified Cardano.Node.Tracing.StateRep as SR
 import           Cardano.Node.Tracing.Tracers.BlockReplayProgress
 import           Cardano.Node.Tracing.Tracers.Consensus
 import           Cardano.Node.Tracing.Tracers.Diffusion ()
-
-import           Cardano.Node.Handlers.Shutdown (ShutdownTrace)
-import           Cardano.Node.Startup
 import           Cardano.Node.Tracing.Tracers.KESInfo ()
 import           Cardano.Node.Tracing.Tracers.NodeToClient ()
 import           Cardano.Node.Tracing.Tracers.NodeToNode ()
@@ -37,7 +32,6 @@ import           Cardano.Node.Tracing.Tracers.P2P ()
 import           Cardano.Node.Tracing.Tracers.Peer
 import           Cardano.Node.Tracing.Tracers.Shutdown ()
 import           Cardano.Node.Tracing.Tracers.Startup ()
-
 import           Ouroboros.Consensus.BlockchainTime.WallClock.Types (RelativeTime)
 import           Ouroboros.Consensus.BlockchainTime.WallClock.Util (TraceBlockchainTimeEvent (..))
 import           Ouroboros.Consensus.Cardano.Block
@@ -52,9 +46,6 @@ import           Ouroboros.Consensus.MiniProtocol.LocalTxSubmission.Server
                    (TraceLocalTxSubmissionServerEvent (..))
 import qualified Ouroboros.Consensus.Protocol.Ledger.HotKey as HotKey
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
-
-
-import           Cardano.Node.Tracing.Documentation (docTracersFirstPhase)
 import           Ouroboros.Network.Block (Point (..), SlotNo, Tip)
 import qualified Ouroboros.Network.BlockFetch.ClientState as BlockFetch
 import           Ouroboros.Network.BlockFetch.Decision
@@ -92,6 +83,11 @@ import           Ouroboros.Network.Subscription.Dns (DnsTrace (..), WithDomainNa
 import           Ouroboros.Network.Subscription.Worker (SubscriptionTrace (..))
 import           Ouroboros.Network.TxSubmission.Inbound (TraceTxSubmissionInbound)
 import           Ouroboros.Network.TxSubmission.Outbound (TraceTxSubmissionOutbound)
+
+import           Control.Exception (SomeException)
+import qualified Data.Text as T
+import           Network.Mux (MuxTrace (..), WithMuxBearer (..))
+import qualified Network.Socket as Socket
 
 
 -- | Check the configuration in the given file.

--- a/cardano-node/src/Cardano/Node/Tracing/DefaultTraceConfig.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/DefaultTraceConfig.hs
@@ -2,10 +2,11 @@ module Cardano.Node.Tracing.DefaultTraceConfig
   ( defaultCardanoConfig
   ) where
 
-import qualified Data.Map.Strict as Map
+import           Cardano.Logging
+
 import           Prelude
 
-import           Cardano.Logging
+import qualified Data.Map.Strict as Map
 
 
 defaultCardanoConfig :: TraceConfig

--- a/cardano-node/src/Cardano/Node/Tracing/Documentation.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Documentation.hs
@@ -18,19 +18,12 @@ module Cardano.Node.Tracing.Documentation
   , docTracersFirstPhase
   ) where
 
-import           Control.Exception (SomeException)
-import           Data.Aeson.Types (ToJSON)
-import           Data.Proxy (Proxy (..))
-import qualified Data.Text.IO as T
-import           GHC.Generics (Generic)
-import           Network.Mux (MuxTrace (..), WithMuxBearer (..))
-import qualified Network.Socket as Socket
-import qualified Options.Applicative as Opt
-
 import           Cardano.Logging
 import           Cardano.Logging.Resources
 import           Cardano.Logging.Resources.Types ()
-
+import           Cardano.Node.Handlers.Shutdown (ShutdownTrace)
+import           Cardano.Node.Startup
+import           Cardano.Node.TraceConstraints
 import           Cardano.Node.Tracing.DefaultTraceConfig (defaultCardanoConfig)
 import           Cardano.Node.Tracing.Formatting ()
 import qualified Cardano.Node.Tracing.StateRep as SR
@@ -47,11 +40,6 @@ import           Cardano.Node.Tracing.Tracers.P2P ()
 import           Cardano.Node.Tracing.Tracers.Peer
 import           Cardano.Node.Tracing.Tracers.Shutdown ()
 import           Cardano.Node.Tracing.Tracers.Startup ()
-
-import           Cardano.Node.Handlers.Shutdown (ShutdownTrace)
-import           Cardano.Node.Startup
-import           Cardano.Node.TraceConstraints
-
 import           Ouroboros.Consensus.BlockchainTime.WallClock.Types (RelativeTime)
 import           Ouroboros.Consensus.BlockchainTime.WallClock.Util (TraceBlockchainTimeEvent (..))
 import           Ouroboros.Consensus.Cardano.Block
@@ -67,8 +55,6 @@ import           Ouroboros.Consensus.MiniProtocol.LocalTxSubmission.Server
 import qualified Ouroboros.Consensus.Node.Tracers as Consensus
 import qualified Ouroboros.Consensus.Protocol.Ledger.HotKey as HotKey
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
-
-
 import           Ouroboros.Network.Block (Point (..), Serialised, SlotNo, Tip)
 import qualified Ouroboros.Network.BlockFetch.ClientState as BlockFetch
 import           Ouroboros.Network.BlockFetch.Decision
@@ -107,6 +93,15 @@ import           Ouroboros.Network.Subscription.Ip (WithIPList (..))
 import           Ouroboros.Network.Subscription.Worker (SubscriptionTrace (..))
 import           Ouroboros.Network.TxSubmission.Inbound (TraceTxSubmissionInbound)
 import           Ouroboros.Network.TxSubmission.Outbound (TraceTxSubmissionOutbound)
+
+import           Control.Exception (SomeException)
+import           Data.Aeson.Types (ToJSON)
+import           Data.Proxy (Proxy (..))
+import qualified Data.Text.IO as T
+import           GHC.Generics (Generic)
+import           Network.Mux (MuxTrace (..), WithMuxBearer (..))
+import qualified Network.Socket as Socket
+import qualified Options.Applicative as Opt
 
 data TraceDocumentationCmd
   = TraceDocumentationCmd

--- a/cardano-node/src/Cardano/Node/Tracing/Era/Byron.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Era/Byron.hs
@@ -13,18 +13,16 @@ module Cardano.Node.Tracing.Era.Byron () where
 
 -- TODO: Temporary hack for toJSON instances
 -- Will be moved when old tracing will be removed
-import           Cardano.Tracing.OrphanInstances.Byron ()
+import           Cardano.Api (textShow)
 
+import           Cardano.Chain.Block (ABlockOrBoundaryHdr (..), AHeader (..),
+                   ChainValidationError (..), delegationCertificate)
+import           Cardano.Chain.Byron.API (ApplyMempoolPayloadErr (..))
+import           Cardano.Chain.Delegation (delegateVK)
+import           Cardano.Crypto.Signing (VerificationKey)
 import           Cardano.Logging
-
-import           Data.Aeson (Value (String), (.=))
-import           Data.ByteString (ByteString)
-import qualified Data.Set as Set
-import qualified Data.Text as Text
-
+import           Cardano.Tracing.OrphanInstances.Byron ()
 import           Ouroboros.Consensus.Block (Header)
-import           Ouroboros.Network.Block (blockHash, blockNo, blockSlot)
-
 import           Ouroboros.Consensus.Block.EBB (fromIsEBB)
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock (..),
                    ByronOtherHeaderEnvelopeError (..), TxId (..), byronHeaderRaw)
@@ -33,13 +31,12 @@ import           Ouroboros.Consensus.Byron.Ledger.Inspect (ByronLedgerUpdate (..
 import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTx, txId)
 import           Ouroboros.Consensus.Protocol.PBFT (PBftSelectView (..))
 import           Ouroboros.Consensus.Util.Condense (condense)
+import           Ouroboros.Network.Block (blockHash, blockNo, blockSlot)
 
-import           Cardano.Api (textShow)
-import           Cardano.Chain.Block (ABlockOrBoundaryHdr (..), AHeader (..),
-                   ChainValidationError (..), delegationCertificate)
-import           Cardano.Chain.Byron.API (ApplyMempoolPayloadErr (..))
-import           Cardano.Chain.Delegation (delegateVK)
-import           Cardano.Crypto.Signing (VerificationKey)
+import           Data.Aeson (Value (String), (.=))
+import           Data.ByteString (ByteString)
+import qualified Data.Set as Set
+import qualified Data.Text as Text
 
 {- HLINT ignore "Use :" -}
 

--- a/cardano-node/src/Cardano/Node/Tracing/Era/HardFork.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Era/HardFork.hs
@@ -15,16 +15,9 @@
 module Cardano.Node.Tracing.Era.HardFork ()
   where
 
-import           Cardano.Tracing.OrphanInstances.HardFork ()
-
-import           Data.Aeson
-import           Data.Proxy (Proxy (..))
-import           Data.SOP (All, Compose, K (K))
-import           Data.SOP.Strict
-
 import           Cardano.Logging
-
 import           Cardano.Slotting.Slot (EpochSize (..))
+import           Cardano.Tracing.OrphanInstances.HardFork ()
 import           Ouroboros.Consensus.Block (BlockProtocol, CannotForge, ForgeStateInfo,
                    ForgeStateUpdateError)
 import           Ouroboros.Consensus.BlockchainTime (getSlotLength)
@@ -46,6 +39,11 @@ import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr)
 import           Ouroboros.Consensus.Protocol.Abstract (SelectView, ValidationErr)
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
+
+import           Data.Aeson
+import           Data.Proxy (Proxy (..))
+import           Data.SOP (All, Compose, K (K))
+import           Data.SOP.Strict
 
 
 --

--- a/cardano-node/src/Cardano/Node/Tracing/Formatting.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Formatting.hs
@@ -7,17 +7,15 @@ module Cardano.Node.Tracing.Formatting
   (
   ) where
 
-import           Data.Aeson (Value (String), toJSON, (.=))
-import           Data.Proxy (Proxy (..))
-import           Data.Void (Void)
-
 import           Cardano.Logging (LogFormatting (..))
-
 import           Cardano.Node.Tracing.Render (renderHeaderHashForDetails)
-
 import           Ouroboros.Consensus.Block (ConvertRawHash (..), RealPoint, realPointHash,
                    realPointSlot)
 import           Ouroboros.Network.Block
+
+import           Data.Aeson (Value (String), toJSON, (.=))
+import           Data.Proxy (Proxy (..))
+import           Data.Void (Void)
 
 -- | A bit of a weird one, but needed because some of the very general
 -- consensus interfaces are sometimes instantiated to 'Void', when there are

--- a/cardano-node/src/Cardano/Node/Tracing/Peers.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Peers.hs
@@ -7,14 +7,13 @@ module Cardano.Node.Tracing.Peers
   , traceNodePeers
   ) where
 
+import           Cardano.Logging
+import           Cardano.Node.Tracing.Tracers.Peer (PeerT, ppPeer)
+
 import           Control.DeepSeq (NFData)
 import           Data.Aeson (FromJSON, ToJSON)
 import           Data.Text (Text)
 import           GHC.Generics (Generic)
-
-import           Cardano.Logging
-
-import           Cardano.Node.Tracing.Tracers.Peer (PeerT, ppPeer)
 
 type PeerInfoPP = Text -- The result of 'ppPeer' function.
 

--- a/cardano-node/src/Cardano/Node/Tracing/Render.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Render.hs
@@ -32,13 +32,8 @@ module Cardano.Node.Tracing.Render
   ) where
 
 import qualified Cardano.Api.Shelley as Api
-import qualified Cardano.Crypto.Hash.Class as Crypto
-import qualified Data.ByteString.Base16 as B16
-import           Data.Proxy (Proxy (..))
-import           Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
 
+import qualified Cardano.Crypto.Hash.Class as Crypto
 import           Cardano.Ledger.Alonzo.Scripts (AlonzoPlutusPurpose (..), AsItem (..),
                    PlutusPurpose)
 import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
@@ -49,10 +44,6 @@ import qualified Cardano.Ledger.SafeHash as SafeHash
 import           Cardano.Logging
 import           Cardano.Node.Queries (ConvertTxId (..))
 import           Cardano.Slotting.Slot (SlotNo (..), WithOrigin (..))
-import           Data.Aeson ((.=))
-import qualified Data.Aeson as Aeson
-import qualified Data.Aeson.Key as Aeson
-import qualified Data.Aeson.Types as Aeson
 import           Ouroboros.Consensus.Block (BlockNo (..), ConvertRawHash (..), RealPoint (..))
 import           Ouroboros.Consensus.Block.Abstract (Point (..))
 import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTx, TxId)
@@ -61,6 +52,16 @@ import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal (ChunkN
 import           Ouroboros.Consensus.Util.Condense (Condense, condense)
 import           Ouroboros.Network.Block (ChainHash (..), HeaderHash, StandardHash, Tip,
                    getTipPoint)
+
+import           Data.Aeson ((.=))
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Aeson
+import qualified Data.Aeson.Types as Aeson
+import qualified Data.ByteString.Base16 as B16
+import           Data.Proxy (Proxy (..))
+import           Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
 
 condenseT :: Condense a => a -> Text
 condenseT = Text.pack . condense

--- a/cardano-node/src/Cardano/Node/Tracing/StateRep.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/StateRep.hs
@@ -22,15 +22,11 @@ module Cardano.Node.Tracing.StateRep
 import           Cardano.Api (textShow)
 
 import           Cardano.Logging
-
-import           Control.DeepSeq (NFData)
-import           Data.Aeson
-import           Data.Text (Text)
-import           Data.Time.Clock
-import           Data.Time.Clock.POSIX
-import           GHC.Generics (Generic)
-
+import           Cardano.Node.Handlers.Shutdown (ShutdownTrace)
 import           Cardano.Node.Protocol.Types (SomeConsensusProtocol (..))
+import qualified Cardano.Node.Startup as Startup
+import           Cardano.Slotting.Slot (EpochNo, SlotNo (..), WithOrigin)
+import           Cardano.Tracing.OrphanInstances.Network ()
 import qualified Ouroboros.Consensus.Block.RealPoint as RP
 import qualified Ouroboros.Consensus.Node.NetworkProtocolVersion as NPV
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
@@ -38,10 +34,12 @@ import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal
 import qualified Ouroboros.Consensus.Storage.LedgerDB as LgrDb
 import           Ouroboros.Network.Block (pointSlot)
 
-import           Cardano.Node.Handlers.Shutdown (ShutdownTrace)
-import qualified Cardano.Node.Startup as Startup
-import           Cardano.Slotting.Slot (EpochNo, SlotNo (..), WithOrigin)
-import           Cardano.Tracing.OrphanInstances.Network ()
+import           Control.DeepSeq (NFData)
+import           Data.Aeson
+import           Data.Text (Text)
+import           Data.Time.Clock
+import           Data.Time.Clock.POSIX
+import           GHC.Generics (Generic)
 
 deriving instance FromJSON ChunkNo
 

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
@@ -16,17 +16,18 @@ module Cardano.Node.Tracing.Tracers
   ( mkDispatchTracers
   ) where
 
-import           Codec.CBOR.Read (DeserialiseFailure)
-import           Control.Monad (unless)
-import           Data.Proxy (Proxy (..))
-
 import           Cardano.Logging
+import           Cardano.Node.Protocol.Types (SomeConsensusProtocol)
+import           Cardano.Node.Queries (NodeKernelData)
+import           Cardano.Node.TraceConstraints
+import           Cardano.Node.Tracing
 import           Cardano.Node.Tracing.Consistency (checkNodeTraceConfiguration')
 import           Cardano.Node.Tracing.Formatting ()
+import           Cardano.Node.Tracing.Peers
+import qualified Cardano.Node.Tracing.StateRep as SR
 import           Cardano.Node.Tracing.Tracers.BlockReplayProgress
 import           Cardano.Node.Tracing.Tracers.ChainDB
 import           Cardano.Node.Tracing.Tracers.Consensus
-import           Cardano.Node.Tracing.Tracers.ConsensusStartupException
 import           Cardano.Node.Tracing.Tracers.Diffusion ()
 import           Cardano.Node.Tracing.Tracers.ForgingThreadStats (forgeThreadStats)
 import           Cardano.Node.Tracing.Tracers.KESInfo
@@ -37,17 +38,6 @@ import           Cardano.Node.Tracing.Tracers.P2P ()
 import           Cardano.Node.Tracing.Tracers.Peer ()
 import           Cardano.Node.Tracing.Tracers.Shutdown ()
 import           Cardano.Node.Tracing.Tracers.Startup ()
-
-import           Cardano.Node.Protocol.Types (SomeConsensusProtocol)
-import           Cardano.Node.Queries (NodeKernelData)
-import           Cardano.Node.TraceConstraints
-import           Cardano.Node.Tracing
-import           Cardano.Node.Tracing.Peers
-import qualified Cardano.Node.Tracing.StateRep as SR
-import           "contra-tracer" Control.Tracer (Tracer (..))
-
-import           Network.Mux.Trace (TraceLabelPeer (..))
-
 import           Ouroboros.Consensus.Ledger.Inspect (LedgerEvent)
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client (TraceChainSyncClientEvent)
 import qualified Ouroboros.Consensus.Network.NodeToClient as NodeToClient
@@ -60,7 +50,6 @@ import qualified Ouroboros.Consensus.Node.Run as Consensus
 import qualified Ouroboros.Consensus.Node.Tracers as Consensus
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import qualified Ouroboros.Consensus.Storage.LedgerDB as LedgerDB
-
 import qualified Ouroboros.Network.BlockFetch.ClientState as BlockFetch
 import           Ouroboros.Network.ConnectionId (ConnectionId)
 import qualified Ouroboros.Network.Diffusion as Diffusion
@@ -68,6 +57,12 @@ import qualified Ouroboros.Network.Diffusion.NonP2P as NonP2P
 import qualified Ouroboros.Network.Diffusion.P2P as P2P
 import           Ouroboros.Network.NodeToClient (LocalAddress)
 import           Ouroboros.Network.NodeToNode (RemoteAddress)
+
+import           Codec.CBOR.Read (DeserialiseFailure)
+import           Control.Monad (unless)
+import           "contra-tracer" Control.Tracer (Tracer (..))
+import           Data.Proxy (Proxy (..))
+import           Network.Mux.Trace (TraceLabelPeer (..))
 
 import           Trace.Forward.Utils.DataPoint (DataPoint)
 

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/BlockReplayProgress.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/BlockReplayProgress.hs
@@ -5,20 +5,18 @@ module Cardano.Node.Tracing.Tracers.BlockReplayProgress
    , ReplayBlockStats(..)
   ) where
 
-import           Control.Monad.IO.Class (MonadIO)
-import           Data.Aeson (Value (String), (.=))
-import           Data.Text (pack)
-
 import           Cardano.Api (textShow)
 
 import           Cardano.Logging
-
 import           Ouroboros.Consensus.Block (realPointSlot)
+import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
+import qualified Ouroboros.Consensus.Storage.LedgerDB as LedgerDB
 import           Ouroboros.Network.Block (pointSlot, unSlotNo)
 import           Ouroboros.Network.Point (withOrigin)
 
-import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
-import qualified Ouroboros.Consensus.Storage.LedgerDB as LedgerDB
+import           Control.Monad.IO.Class (MonadIO)
+import           Data.Aeson (Value (String), (.=))
+import           Data.Text (pack)
 
 data ReplayBlockStats = ReplayBlockStats
   { rpsDisplay      :: Bool

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
@@ -13,22 +13,12 @@ module Cardano.Node.Tracing.Tracers.ChainDB
    ( withAddedToCurrentChainEmptyLimited
    ) where
 
-import           Cardano.Prelude (maximumDef)
-
-import           Data.Aeson (Value (String), toJSON, (.=))
-import           Data.Int (Int64)
-import           Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
-import           Data.Word (Word64)
-import           Numeric (showFFloat)
-
 import           Cardano.Logging
 import           Cardano.Node.Tracing.Era.Byron ()
 import           Cardano.Node.Tracing.Era.Shelley ()
 import           Cardano.Node.Tracing.Formatting ()
 import           Cardano.Node.Tracing.Render
-
+import           Cardano.Prelude (maximumDef)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation (HeaderEnvelopeError (..), HeaderError (..),
                    OtherHeaderEnvelopeError)
@@ -47,8 +37,15 @@ import qualified Ouroboros.Consensus.Storage.LedgerDB as LedgerDB
 import qualified Ouroboros.Consensus.Storage.VolatileDB as VolDB
 import           Ouroboros.Consensus.Util.Condense (condense)
 import           Ouroboros.Consensus.Util.Enclose
-
 import qualified Ouroboros.Network.AnchoredFragment as AF
+
+import           Data.Aeson (Value (String), toJSON, (.=))
+import           Data.Int (Int64)
+import           Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import           Data.Word (Word64)
+import           Numeric (showFFloat)
 
 -- {-# ANN module ("HLint: ignore Redundant bracket" :: Text) #-}
 

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
@@ -22,19 +22,6 @@ module Cardano.Node.Tracing.Tracers.Consensus
   ) where
 
 
-import           Control.Monad.Class.MonadTime.SI (Time (..))
-import           Data.Aeson (ToJSON, Value (Number, String), toJSON, (.=))
-import qualified Data.Aeson as Aeson
-import           Data.Foldable (Foldable (..))
-import           Data.Int (Int64)
-import           Data.IntPSQ (IntPSQ)
-import qualified Data.IntPSQ as Pq
-import qualified Data.Text as Text
-import           Data.Time (DiffTime, NominalDiffTime)
-import           Data.Word (Word32, Word64)
-
-import           Cardano.Slotting.Slot (WithOrigin (..))
-
 import           Cardano.Logging
 import           Cardano.Node.Queries (HasKESInfo (..))
 import           Cardano.Node.Tracing.Era.Byron ()
@@ -43,22 +30,8 @@ import           Cardano.Node.Tracing.Formatting ()
 import           Cardano.Node.Tracing.Render
 import           Cardano.Node.Tracing.Tracers.ConsensusStartupException ()
 import           Cardano.Node.Tracing.Tracers.StartLeadershipCheck
-
 import           Cardano.Protocol.TPraos.OCert (KESPeriod (..))
-
-import qualified Ouroboros.Network.AnchoredFragment as AF
-import qualified Ouroboros.Network.AnchoredSeq as AS
-import           Ouroboros.Network.Block hiding (blockPrevHash)
-import           Ouroboros.Network.BlockFetch.ClientState (TraceLabelPeer (..))
-import qualified Ouroboros.Network.BlockFetch.ClientState as BlockFetch
-import           Ouroboros.Network.BlockFetch.Decision
-import           Ouroboros.Network.ConnectionId (ConnectionId (..))
-import           Ouroboros.Network.DeltaQ (GSV (..), PeerGSV (..))
-import           Ouroboros.Network.KeepAlive (TraceKeepAliveClient (..))
-import           Ouroboros.Network.SizeInBytes (SizeInBytes (..))
-import           Ouroboros.Network.TxSubmission.Inbound hiding (txId)
-import           Ouroboros.Network.TxSubmission.Outbound
-
+import           Cardano.Slotting.Slot (WithOrigin (..))
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime (SystemStart (..))
 import           Ouroboros.Consensus.BlockchainTime.WallClock.Util (TraceBlockchainTimeEvent (..))
@@ -78,6 +51,29 @@ import           Ouroboros.Consensus.Node.Run (SerialiseNodeToNodeConstraints, e
 import           Ouroboros.Consensus.Node.Tracers
 import qualified Ouroboros.Consensus.Protocol.Ledger.HotKey as HotKey
 import           Ouroboros.Consensus.Util.Enclose
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import qualified Ouroboros.Network.AnchoredSeq as AS
+import           Ouroboros.Network.Block hiding (blockPrevHash)
+import           Ouroboros.Network.BlockFetch.ClientState (TraceLabelPeer (..))
+import qualified Ouroboros.Network.BlockFetch.ClientState as BlockFetch
+import           Ouroboros.Network.BlockFetch.Decision
+import           Ouroboros.Network.ConnectionId (ConnectionId (..))
+import           Ouroboros.Network.DeltaQ (GSV (..), PeerGSV (..))
+import           Ouroboros.Network.KeepAlive (TraceKeepAliveClient (..))
+import           Ouroboros.Network.SizeInBytes (SizeInBytes (..))
+import           Ouroboros.Network.TxSubmission.Inbound hiding (txId)
+import           Ouroboros.Network.TxSubmission.Outbound
+
+import           Control.Monad.Class.MonadTime.SI (Time (..))
+import           Data.Aeson (ToJSON, Value (Number, String), toJSON, (.=))
+import qualified Data.Aeson as Aeson
+import           Data.Foldable (Foldable (..))
+import           Data.Int (Int64)
+import           Data.IntPSQ (IntPSQ)
+import qualified Data.IntPSQ as Pq
+import qualified Data.Text as Text
+import           Data.Time (DiffTime, NominalDiffTime)
+import           Data.Word (Word32, Word64)
 
 
 instance (LogFormatting adr, Show adr) => LogFormatting (ConnectionId adr) where

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ConsensusStartupException.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ConsensusStartupException.hs
@@ -6,11 +6,11 @@ module Cardano.Node.Tracing.Tracers.ConsensusStartupException
   ( ConsensusStartupException (..)
   ) where
 
+import           Cardano.Logging.Types
+
+import           Control.Exception (SomeException)
 import           Data.Aeson (Value (String), (.=))
 import qualified Data.Text as Text
-
-import           Cardano.Logging.Types
-import           Control.Exception (SomeException)
 
 -- | Exceptions logged when the consensus is initialising.
 --

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ForgingThreadStats.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ForgingThreadStats.hs
@@ -10,6 +10,11 @@ module Cardano.Node.Tracing.Tracers.ForgingThreadStats
   ) where
 
 import           Cardano.Logging
+import           Cardano.Node.Tracing.Tracers.StartLeadershipCheck (ForgeTracerType)
+import           Cardano.Slotting.Slot (SlotNo (..))
+import           Ouroboros.Consensus.Node.Tracers
+import qualified Ouroboros.Consensus.Node.Tracers as Consensus
+import           Ouroboros.Consensus.Shelley.Node ()
 
 import           Control.Concurrent (ThreadId, myThreadId)
 import           Control.Monad.IO.Class (MonadIO (..))
@@ -17,12 +22,6 @@ import           Data.Aeson (Value (..), (.=))
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe)
-
-import           Cardano.Node.Tracing.Tracers.StartLeadershipCheck (ForgeTracerType)
-import           Cardano.Slotting.Slot (SlotNo (..))
-import           Ouroboros.Consensus.Node.Tracers
-import qualified Ouroboros.Consensus.Node.Tracers as Consensus
-import           Ouroboros.Consensus.Shelley.Node ()
 
 --------------------------------------------------------------------------------
 -- ForgeThreadStats Tracer

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/KESInfo.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/KESInfo.hs
@@ -16,18 +16,17 @@ module Cardano.Node.Tracing.Tracers.KESInfo
       traceAsKESInfo
    ) where
 
+import           Cardano.Logging
+import           Cardano.Node.Queries (GetKESInfo (..))
+import           Cardano.Protocol.TPraos.OCert (KESPeriod (KESPeriod))
+import           Ouroboros.Consensus.Block.Forging
+import           Ouroboros.Consensus.Node.Tracers (TraceLabelCreds (..))
+import qualified Ouroboros.Consensus.Protocol.Ledger.HotKey as HotKey
+
 import           Control.Monad.IO.Class (MonadIO)
 import           Data.Aeson (ToJSON (..), Value (..), (.=))
 import           Data.Proxy (Proxy)
 import qualified Data.Text as Text
-
-import           Cardano.Logging
-import           Cardano.Node.Queries (GetKESInfo (..))
-import           Cardano.Protocol.TPraos.OCert (KESPeriod (KESPeriod))
-
-import           Ouroboros.Consensus.Block.Forging
-import           Ouroboros.Consensus.Node.Tracers (TraceLabelCreds (..))
-import qualified Ouroboros.Consensus.Protocol.Ledger.HotKey as HotKey
 
 traceAsKESInfo
   :: forall m blk . (GetKESInfo blk, MonadIO m)

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/NodeToClient.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/NodeToClient.hs
@@ -11,17 +11,16 @@
 module Cardano.Node.Tracing.Tracers.NodeToClient () where
 
 import           Cardano.Logging
-import           Data.Aeson (Value (String), (.=))
-import           Data.Text (Text, pack)
-
-import           Network.TypedProtocol.Codec (AnyMessageAndAgency (..))
-
 import           Ouroboros.Consensus.Ledger.Query (Query)
 import           Ouroboros.Network.Driver.Simple (TraceSendRecv (..))
 import           Ouroboros.Network.Protocol.ChainSync.Type as ChainSync
 import qualified Ouroboros.Network.Protocol.LocalStateQuery.Type as LSQ
 import qualified Ouroboros.Network.Protocol.LocalTxMonitor.Type as LTM
 import qualified Ouroboros.Network.Protocol.LocalTxSubmission.Type as LTS
+
+import           Data.Aeson (Value (String), (.=))
+import           Data.Text (Text, pack)
+import           Network.TypedProtocol.Codec (AnyMessageAndAgency (..))
 
 {-# ANN module ("HLint: ignore Redundant bracket" :: Text) #-}
 

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/NodeToNode.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/NodeToNode.hs
@@ -13,23 +13,21 @@ module Cardano.Node.Tracing.Tracers.NodeToNode
    ) where
 
 import           Cardano.Logging
-import           Data.Aeson (ToJSON (..), Value (String), (.=))
-import           Data.Proxy (Proxy (..))
-import           Data.Text (pack)
-import           Network.TypedProtocol.Codec (AnyMessageAndAgency (..))
-
 import           Cardano.Node.Queries (ConvertTxId)
 import           Cardano.Node.Tracing.Render (renderHeaderHash, renderTxIdForDetails)
-
 import           Ouroboros.Consensus.Block (ConvertRawHash, GetHeader, StandardHash, getHeader)
 import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTx, HasTxId, HasTxs,
                    LedgerSupportsMempool, extractTxs, txId)
 import           Ouroboros.Consensus.Node.Run (SerialiseNodeToNodeConstraints, estimateBlockSize)
-
 import           Ouroboros.Network.Block (Point, Serialised (..), blockHash)
 import           Ouroboros.Network.Protocol.BlockFetch.Type (BlockFetch (..), Message (..))
 import qualified Ouroboros.Network.Protocol.TxSubmission2.Type as STX
 import           Ouroboros.Network.SizeInBytes (SizeInBytes (..))
+
+import           Data.Aeson (ToJSON (..), Value (String), (.=))
+import           Data.Proxy (Proxy (..))
+import           Data.Text (pack)
+import           Network.TypedProtocol.Codec (AnyMessageAndAgency (..))
 
 --------------------------------------------------------------------------------
 -- BlockFetch Tracer

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/NonP2P.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/NonP2P.hs
@@ -10,13 +10,6 @@ module Cardano.Node.Tracing.Tracers.NonP2P
     () where
 
 import           Cardano.Logging
-
-import           Control.Exception (Exception (..), SomeException (..))
-import           Data.Aeson (Value (String), (.=))
-import qualified Data.IP as IP
-import           Data.Text (pack)
-import qualified Network.Socket as Socket
-
 import           Ouroboros.Network.NodeToNode (ErrorPolicyTrace (..))
 import qualified Ouroboros.Network.NodeToNode as NtN
 import           Ouroboros.Network.Snocket (LocalAddress (..))
@@ -24,6 +17,12 @@ import           Ouroboros.Network.Subscription.Dns (DnsTrace (..), WithDomainNa
 import           Ouroboros.Network.Subscription.Ip (SubscriptionTrace, WithIPList (..))
 import           Ouroboros.Network.Subscription.Worker (ConnectResult (..), SubscriberError,
                    SubscriptionTrace (..))
+
+import           Control.Exception (Exception (..), SomeException (..))
+import           Data.Aeson (Value (String), (.=))
+import qualified Data.IP as IP
+import           Data.Text (pack)
+import qualified Network.Socket as Socket
 
 
 --------------------------------------------------------------------------------

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/P2P.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/P2P.hs
@@ -13,22 +13,10 @@ module Cardano.Node.Tracing.Tracers.P2P
   () where
 
 import           Cardano.Logging
-import           Data.Aeson (Object, ToJSON, ToJSONKey, Value (..), object, toJSON, toJSONList,
-                   (.=))
-import           Data.Aeson.Types (listValue)
-import           Data.Bifunctor (Bifunctor (..))
-import           Data.Foldable (Foldable (..))
-import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
-import           Data.Text (pack)
-import           Network.Socket (SockAddr (..))
-
 import           Cardano.Node.Configuration.TopologyP2P ()
-import           Cardano.Tracing.OrphanInstances.Network ()
-
 import           Cardano.Node.Tracing.Tracers.NodeToNode ()
 import           Cardano.Node.Tracing.Tracers.NonP2P ()
-
+import           Cardano.Tracing.OrphanInstances.Network ()
 import           Ouroboros.Network.ConnectionHandler (ConnectionHandlerTrace (..))
 import           Ouroboros.Network.ConnectionId (ConnectionId (..))
 import           Ouroboros.Network.ConnectionManager.Types (ConnectionManagerCounters (..),
@@ -53,6 +41,16 @@ import           Ouroboros.Network.PeerSelection.Types ()
 import           Ouroboros.Network.RethrowPolicy (ErrorCommand (..))
 import           Ouroboros.Network.Server2 (ServerTrace (..))
 import           Ouroboros.Network.Snocket (LocalAddress (..))
+
+import           Data.Aeson (Object, ToJSON, ToJSONKey, Value (..), object, toJSON, toJSONList,
+                   (.=))
+import           Data.Aeson.Types (listValue)
+import           Data.Bifunctor (Bifunctor (..))
+import           Data.Foldable (Foldable (..))
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import           Data.Text (pack)
+import           Network.Socket (SockAddr (..))
 
 
 

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Peer.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Peer.hs
@@ -10,14 +10,26 @@ module Cardano.Node.Tracing.Tracers.Peer
   , ppPeer
   ) where
 
+import           Cardano.Logging hiding (traceWith)
 import           Cardano.Node.Orphans ()
-
-import qualified Control.Concurrent.Class.MonadSTM.Strict as STM
-import           "contra-tracer" Control.Tracer
+import           Cardano.Node.Queries
+import           Ouroboros.Consensus.Block (Header)
+import           Ouroboros.Consensus.Util.NormalForm.StrictTVar (StrictTVar, readTVar)
+import           Ouroboros.Consensus.Util.Orphans ()
+import qualified Ouroboros.Network.AnchoredFragment as Net
+import           Ouroboros.Network.Block (unSlotNo)
+import qualified Ouroboros.Network.Block as Net
+import qualified Ouroboros.Network.BlockFetch.ClientRegistry as Net
+import           Ouroboros.Network.BlockFetch.ClientState (PeerFetchInFlight (..),
+                   PeerFetchStatus (..), readFetchClientState)
+import           Ouroboros.Network.ConnectionId (remoteAddress)
+import           Ouroboros.Network.NodeToNode (RemoteAddress)
 
 import           Control.Concurrent (threadDelay)
 import           Control.Concurrent.Async
+import qualified Control.Concurrent.Class.MonadSTM.Strict as STM
 import           Control.Monad (forever)
+import           "contra-tracer" Control.Tracer
 import           Data.Aeson (ToJSON (..), Value (..), toJSON, (.=))
 import           Data.Functor ((<&>))
 import qualified Data.List as List
@@ -27,22 +39,6 @@ import qualified Data.Set as Set
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Text.Printf (printf)
-
-import           Ouroboros.Consensus.Block (Header)
-import           Ouroboros.Consensus.Util.NormalForm.StrictTVar (StrictTVar, readTVar)
-import           Ouroboros.Consensus.Util.Orphans ()
-import           Ouroboros.Network.ConnectionId (remoteAddress)
-
-import qualified Ouroboros.Network.AnchoredFragment as Net
-import           Ouroboros.Network.Block (unSlotNo)
-import qualified Ouroboros.Network.Block as Net
-import qualified Ouroboros.Network.BlockFetch.ClientRegistry as Net
-import           Ouroboros.Network.BlockFetch.ClientState (PeerFetchInFlight (..),
-                   PeerFetchStatus (..), readFetchClientState)
-import           Ouroboros.Network.NodeToNode (RemoteAddress)
-
-import           Cardano.Logging hiding (traceWith)
-import           Cardano.Node.Queries
 
 {- HLINT ignore "Use =<<" -}
 {- HLINT ignore "Use <=<" -}

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Resources.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Resources.hs
@@ -4,14 +4,13 @@ module Cardano.Node.Tracing.Tracers.Resources
   ( startResourceTracer
   ) where
 
+import           Cardano.Logging.Resources
+
 import           Control.Concurrent (threadDelay)
 import           Control.Concurrent.Async (async)
 import           Control.Monad (forM_, forever)
 import           Control.Monad.Class.MonadAsync (link)
-
 import           "contra-tracer" Control.Tracer
-
-import           Cardano.Logging.Resources
 
 startResourceTracer
   :: Tracer IO ResourceStats

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Shutdown.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Shutdown.hs
@@ -9,13 +9,14 @@ module Cardano.Node.Tracing.Tracers.Shutdown
   ( ppShutdownTrace
   ) where
 
+import           Cardano.Logging
+import           Cardano.Node.Handlers.Shutdown
+
+import           Prelude (Maybe (..), show)
+
 import           Data.Aeson (Value (..), (.=))
 import           Data.Monoid (mconcat, (<>))
 import           Data.Text (Text, pack)
-import           Prelude (Maybe (..), show)
-
-import           Cardano.Logging
-import           Cardano.Node.Handlers.Shutdown
 
 -- --------------------------------------------------------------------------------
 -- -- ShutdownTrace Tracer

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
@@ -16,28 +16,17 @@ module Cardano.Node.Tracing.Tracers.Startup
 
 import           Cardano.Api (NetworkMagic (..), SlotNo (..))
 import qualified Cardano.Api as Api
-import           Prelude
-
-import           Data.Aeson (ToJSON (..), Value (..), (.=))
-import qualified Data.Aeson as Aeson
-import           Data.List (intercalate)
-import qualified Data.Map.Strict as Map
-import           Data.Text (Text, pack)
-import           Data.Time (getCurrentTime)
-import           Data.Time.Clock.POSIX (POSIXTime, utcTimeToPOSIXSeconds)
-import           Data.Version (showVersion)
-import           Network.Socket (SockAddr)
-import           Paths_cardano_node (version)
 
 import qualified Cardano.Chain.Genesis as Gen
-import           Cardano.Slotting.Slot (EpochSize (..))
-
+import           Cardano.Git.Rev (gitRev)
 import           Cardano.Ledger.Shelley.API as SL
-
-import           Ouroboros.Network.NodeToClient (LocalAddress (..), LocalSocket (..))
-import           Ouroboros.Network.NodeToNode (DiffusionMode (..))
-import           Ouroboros.Network.PeerSelection.LedgerPeers (UseLedgerAfter (..))
-
+import           Cardano.Logging
+import           Cardano.Node.Configuration.POM (NodeConfiguration, ncProtocol)
+import           Cardano.Node.Configuration.Socket
+import           Cardano.Node.Protocol (SomeConsensusProtocol (..))
+import           Cardano.Node.Startup
+import           Cardano.Node.Types (UseLedger (..))
+import           Cardano.Slotting.Slot (EpochSize (..))
 import qualified Ouroboros.Consensus.BlockchainTime.WallClock.Types as WCT
 import           Ouroboros.Consensus.Byron.Ledger.Conversions (fromByronEpochSlots,
                    fromByronSlotLength, genesisSlotLength)
@@ -50,16 +39,23 @@ import           Ouroboros.Consensus.HardFork.Combinator.Degenerate (HardForkLed
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.ProtocolInfo (ProtocolInfo (..))
 import           Ouroboros.Consensus.Shelley.Ledger.Ledger (shelleyLedgerGenesis)
+import           Ouroboros.Network.NodeToClient (LocalAddress (..), LocalSocket (..))
+import           Ouroboros.Network.NodeToNode (DiffusionMode (..))
+import           Ouroboros.Network.PeerSelection.LedgerPeers (UseLedgerAfter (..))
 
-import           Cardano.Logging
+import           Prelude
 
-import           Cardano.Git.Rev (gitRev)
+import           Data.Aeson (ToJSON (..), Value (..), (.=))
+import qualified Data.Aeson as Aeson
+import           Data.List (intercalate)
+import qualified Data.Map.Strict as Map
+import           Data.Text (Text, pack)
+import           Data.Time (getCurrentTime)
+import           Data.Time.Clock.POSIX (POSIXTime, utcTimeToPOSIXSeconds)
+import           Data.Version (showVersion)
+import           Network.Socket (SockAddr)
 
-import           Cardano.Node.Configuration.POM (NodeConfiguration, ncProtocol)
-import           Cardano.Node.Configuration.Socket
-import           Cardano.Node.Protocol (SomeConsensusProtocol (..))
-import           Cardano.Node.Startup
-import           Cardano.Node.Types (UseLedger (..))
+import           Paths_cardano_node (version)
 
 
 getStartupInfo

--- a/cardano-node/src/Cardano/Node/Types.hs
+++ b/cardano-node/src/Cardano/Node/Types.hs
@@ -31,7 +31,17 @@ module Cardano.Node.Types
   , renderVRFPrivateKeyFilePermissionError
   ) where
 
+import           Cardano.Api
+import           Cardano.Api.Pretty
+
+import           Cardano.Crypto (RequiresNetworkMagic (..))
+import qualified Cardano.Crypto.Hash as Crypto
+import           Cardano.Node.Configuration.Socket (SocketConfig (..))
+import           Ouroboros.Network.NodeToNode (DiffusionMode (..))
+import           Ouroboros.Network.PeerSelection.LedgerPeers (UseLedgerAfter (..))
+
 import           Control.Exception
+import           Control.Monad (MonadPlus (..))
 import           Data.Aeson
 import           Data.ByteString (ByteString)
 import           Data.Monoid (Last)
@@ -39,19 +49,6 @@ import           Data.String (IsString)
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Word (Word16, Word8)
-
-import           Control.Monad (MonadPlus (..))
-
-import           Cardano.Api
-import           Cardano.Api.Pretty
-import           Cardano.Crypto (RequiresNetworkMagic (..))
-import qualified Cardano.Crypto.Hash as Crypto
-import           Cardano.Node.Configuration.Socket (SocketConfig (..))
-
---TODO: things will probably be clearer if we don't use these newtype wrappers and instead
--- use records with named fields in the CLI code.
-import           Ouroboros.Network.NodeToNode (DiffusionMode (..))
-import           Ouroboros.Network.PeerSelection.LedgerPeers (UseLedgerAfter (..))
 
 -- | Errors for the cardano-config module.
 data ConfigError =

--- a/cardano-node/src/Cardano/Tracing/Config.hs
+++ b/cardano-node/src/Cardano/Tracing/Config.hs
@@ -73,6 +73,9 @@ module Cardano.Tracing.Config
   , proxyName
   ) where
 
+import           Cardano.BM.Tracing (TracingVerbosity (..))
+import           Cardano.Node.Orphans ()
+
 import           Control.Monad (MonadPlus (..))
 import           Data.Aeson
 import qualified Data.Aeson.Key as Aeson
@@ -82,13 +85,10 @@ import           Data.Monoid (Last (..))
 import           Data.Proxy (Proxy (..))
 import           Data.Text (Text)
 import qualified Data.Text as Text
-import           Generic.Data (gmappend)
 import           GHC.Generics (Generic)
 import           GHC.TypeLits (KnownSymbol, Symbol, symbolVal)
 
-
-import           Cardano.BM.Tracing (TracingVerbosity (..))
-import           Cardano.Node.Orphans ()
+import           Generic.Data (gmappend)
 
 {- HLINT ignore "Functor law" -}
 

--- a/cardano-node/src/Cardano/Tracing/HasIssuer.hs
+++ b/cardano-node/src/Cardano/Tracing/HasIssuer.hs
@@ -11,22 +11,21 @@ module Cardano.Tracing.HasIssuer
   , HasIssuer (..)
   ) where
 
-import           Data.ByteString (ByteString)
-import           Data.SOP
-
 import           Cardano.Api (serialiseToRawBytes, verificationKeyHash)
 import           Cardano.Api.Byron (VerificationKey (ByronVerificationKey))
 import           Cardano.Api.Shelley (VerificationKey (StakePoolVerificationKey))
+
 import qualified Cardano.Chain.Block as Byron
 import           Cardano.Ledger.Crypto (StandardCrypto)
 import qualified Cardano.Ledger.Shelley.API as Shelley
-
 import           Ouroboros.Consensus.Byron.Ledger.Block (ByronBlock, Header (..))
 import           Ouroboros.Consensus.HardFork.Combinator (HardForkBlock, Header (..),
                    OneEraHeader (..))
 import           Ouroboros.Consensus.Shelley.Ledger.Block (Header (..), ShelleyBlock)
-
 import           Ouroboros.Consensus.Shelley.Protocol.Abstract
+
+import           Data.ByteString (ByteString)
+import           Data.SOP
 
 -- | Block issuer verification key hash.
 data BlockIssuerVerificationKeyHash

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Byron.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Byron.hs
@@ -12,18 +12,15 @@ module Cardano.Tracing.OrphanInstances.Byron () where
 
 import           Cardano.Api (textShow)
 
-import           Data.Aeson (Value (..))
-import           Data.ByteString (ByteString)
-import qualified Data.Set as Set
-import qualified Data.Text as Text
-
+import           Cardano.Chain.Block (ABlockOrBoundaryHdr (..), AHeader (..),
+                   ChainValidationError (..), delegationCertificate)
+import           Cardano.Chain.Byron.API (ApplyMempoolPayloadErr (..))
+import           Cardano.Chain.Delegation (delegateVK)
+import           Cardano.Crypto.Signing (VerificationKey)
 import           Cardano.Tracing.OrphanInstances.Common
 import           Cardano.Tracing.OrphanInstances.Consensus ()
 import           Cardano.Tracing.Render (renderTxId)
-
 import           Ouroboros.Consensus.Block (Header)
-import           Ouroboros.Network.Block (blockHash, blockNo, blockSlot)
-
 import           Ouroboros.Consensus.Block.EBB (fromIsEBB)
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock (..), ByronNodeToClientVersion (..),
                    ByronNodeToNodeVersion (..), ByronOtherHeaderEnvelopeError (..), TxId (..),
@@ -33,12 +30,12 @@ import           Ouroboros.Consensus.Byron.Ledger.Inspect (ByronLedgerUpdate (..
 import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTx, txId)
 import           Ouroboros.Consensus.Protocol.PBFT (PBftSelectView (..))
 import           Ouroboros.Consensus.Util.Condense (condense)
+import           Ouroboros.Network.Block (blockHash, blockNo, blockSlot)
 
-import           Cardano.Chain.Block (ABlockOrBoundaryHdr (..), AHeader (..),
-                   ChainValidationError (..), delegationCertificate)
-import           Cardano.Chain.Byron.API (ApplyMempoolPayloadErr (..))
-import           Cardano.Chain.Delegation (delegateVK)
-import           Cardano.Crypto.Signing (VerificationKey)
+import           Data.Aeson (Value (..))
+import           Data.ByteString (ByteString)
+import qualified Data.Set as Set
+import qualified Data.Text as Text
 
 {- HLINT ignore "Use :" -}
 

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Common.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Common.hs
@@ -37,13 +37,6 @@ module Cardano.Tracing.OrphanInstances.Common
   , mkLOMeta
   ) where
 
-import           Data.Aeson hiding (Value)
-import           Data.Scientific (coefficient)
-import           Data.Text (Text)
-import           Data.Void (Void)
-import           Network.Socket (PortNumber)
-import           Text.Read (readMaybe)
-
 import           Cardano.BM.Data.LogItem (LOContent (..), LogObject (..), PrivacyAnnotation (..),
                    mkLOMeta)
 import           Cardano.BM.Data.Tracer (HasTextFormatter (..), emptyObject, mkObject, trStructured,
@@ -53,6 +46,13 @@ import           Cardano.BM.Tracing (HasPrivacyAnnotation (..), HasSeverityAnnot
                    Severity (..), ToObject (..), Tracer (..), TracingVerbosity (..),
                    Transformable (..))
 import           Cardano.Node.Handlers.Shutdown ()
+
+import           Data.Aeson hiding (Value)
+import           Data.Scientific (coefficient)
+import           Data.Text (Text)
+import           Data.Void (Void)
+import           Network.Socket (PortNumber)
+import           Text.Read (readMaybe)
 -- | A bit of a weird one, but needed because some of the very general
 -- consensus interfaces are sometimes instantiated to 'Void', when there are
 -- no cases needed.

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
@@ -18,18 +18,9 @@
 
 module Cardano.Tracing.OrphanInstances.Consensus () where
 
+import           Cardano.Node.Tracing.Tracers.ConsensusStartupException
+                   (ConsensusStartupException (..))
 import           Cardano.Prelude (maximumDef)
-import           Data.Aeson (Value (..))
-import qualified Data.Aeson as Aeson
-import           Data.Data (Proxy (..))
-import           Data.Foldable (Foldable (..))
-import           Data.Text (Text, pack)
-import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
-import           Data.Word (Word32)
-import           GHC.Generics (Generic)
-import           Numeric (showFFloat)
-
 import           Cardano.Slotting.Slot (fromWithOrigin)
 import           Cardano.Tracing.OrphanInstances.Common
 import           Cardano.Tracing.OrphanInstances.Network ()
@@ -37,10 +28,6 @@ import           Cardano.Tracing.Render (renderChainHash, renderChunkNo, renderH
                    renderHeaderHashForVerbosity, renderPoint, renderPointAsPhrase,
                    renderPointForVerbosity, renderRealPoint, renderRealPointAsPhrase,
                    renderTipBlockNo, renderTipHash, renderWithOrigin)
-
-import           Cardano.Node.Tracing.Tracers.ConsensusStartupException
-                   (ConsensusStartupException (..))
-
 import           Ouroboros.Consensus.Block (BlockProtocol, BlockSupportsProtocol, CannotForge,
                    ConvertRawHash (..), ForgeStateUpdateError, Header, RealPoint, blockNo,
                    blockPoint, blockPrevHash, getHeader, headerPoint, pointHash, realPointHash,
@@ -67,28 +54,35 @@ import qualified Ouroboros.Consensus.Node.Tracers as Consensus
 import           Ouroboros.Consensus.Protocol.Abstract
 import qualified Ouroboros.Consensus.Protocol.BFT as BFT
 import qualified Ouroboros.Consensus.Protocol.PBFT as PBFT
+import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
+import qualified Ouroboros.Consensus.Storage.ImmutableDB.API as ImmDB
 import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal (ChunkNo (..),
                    chunkNoToInt)
+import qualified Ouroboros.Consensus.Storage.ImmutableDB.Impl.Types as ImmDB
 import           Ouroboros.Consensus.Storage.LedgerDB (PushGoal (..), PushStart (..), Pushing (..))
 import qualified Ouroboros.Consensus.Storage.LedgerDB as LedgerDB
 import qualified Ouroboros.Consensus.Storage.VolatileDB.Impl as VolDb
-import           Ouroboros.Network.BlockFetch.ClientState (TraceLabelPeer (..))
-
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.Enclose
 import           Ouroboros.Consensus.Util.Orphans ()
-
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (BlockNo (..), ChainUpdate (..), SlotNo (..), StandardHash,
                    Tip (..), blockHash, pointSlot, tipFromHeader)
+import           Ouroboros.Network.BlockFetch.ClientState (TraceLabelPeer (..))
 import           Ouroboros.Network.Point (withOrigin)
 import           Ouroboros.Network.SizeInBytes (SizeInBytes (..))
 
-import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
--- TODO: 'TraceCacheEvent' should be exported by the 'Impl' module
+import           Data.Aeson (Value (..))
+import qualified Data.Aeson as Aeson
+import           Data.Data (Proxy (..))
+import           Data.Foldable (Foldable (..))
 import           Data.Function (on)
-import qualified Ouroboros.Consensus.Storage.ImmutableDB.API as ImmDB
-import qualified Ouroboros.Consensus.Storage.ImmutableDB.Impl.Types as ImmDB
+import           Data.Text (Text, pack)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import           Data.Word (Word32)
+import           GHC.Generics (Generic)
+import           Numeric (showFFloat)
 
 
 {- HLINT ignore "Use const" -}

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/HardFork.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/HardFork.hs
@@ -18,17 +18,9 @@
 
 module Cardano.Tracing.OrphanInstances.HardFork () where
 
-import           Data.Aeson
-import qualified Data.ByteString.Base16 as Base16
-import qualified Data.ByteString.Short as SBS
-import           Data.Proxy (Proxy (..))
-import           Data.SOP (All, Compose, K (..))
-import           Data.SOP.Strict
-
+import           Cardano.Slotting.Slot (EpochSize (..))
 import           Cardano.Tracing.OrphanInstances.Common
 import           Cardano.Tracing.OrphanInstances.Consensus ()
-
-import           Cardano.Slotting.Slot (EpochSize (..))
 import           Ouroboros.Consensus.Block (BlockProtocol, CannotForge, ForgeStateInfo,
                    ForgeStateUpdateError)
 import           Ouroboros.Consensus.BlockchainTime (getSlotLength)
@@ -54,6 +46,13 @@ import           Ouroboros.Consensus.Node.NetworkProtocolVersion (BlockNodeToCli
 import           Ouroboros.Consensus.Protocol.Abstract (SelectView, ValidationErr)
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
+
+import           Data.Aeson
+import qualified Data.ByteString.Base16 as Base16
+import qualified Data.ByteString.Short as SBS
+import           Data.Proxy (Proxy (..))
+import           Data.SOP (All, Compose, K (..))
+import           Data.SOP.Strict
 
 
 --

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -16,36 +16,10 @@
 
 module Cardano.Tracing.OrphanInstances.Network () where
 
-import           Control.Exception (Exception (..), SomeException (..))
-import           Control.Monad.Class.MonadTime.SI (DiffTime, Time (..))
-import           Data.Aeson (FromJSON (..), Value (..))
-import qualified Data.Aeson as Aeson
-import           Data.Aeson.Types (listValue)
-import qualified Data.Aeson.Types as Aeson
-import           Data.Bifunctor (Bifunctor (first))
-import           Data.Data (Proxy (..))
-import           Data.Foldable (Foldable (..))
-import           Data.Functor.Identity (Identity (..))
-import qualified Data.IP as IP
-import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
-import           Data.Text (Text, pack)
-import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
-import qualified Text.Read as Text
-
-import           Network.TypedProtocol.Codec (AnyMessageAndAgency (..))
-import           Network.TypedProtocol.Core (PeerHasAgency (..))
-
-
-import           Network.Mux (MiniProtocolNum (..), MuxTrace (..), WithMuxBearer (..))
-import           Network.Socket (SockAddr (..))
-
 import           Cardano.Node.Queries (ConvertTxId)
 import           Cardano.Node.Types (UseLedger (..))
 import           Cardano.Tracing.OrphanInstances.Common
 import           Cardano.Tracing.Render
-
 import           Ouroboros.Consensus.Block (ConvertRawHash (..), Header, getHeader)
 import           Ouroboros.Consensus.Ledger.Query (BlockQuery, Query)
 import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr, GenTx, GenTxId,
@@ -65,6 +39,7 @@ import           Ouroboros.Network.ConnectionManager.Types (AbstractState (..),
                    OperationResult (..))
 import qualified Ouroboros.Network.ConnectionManager.Types as ConnMgr
 import           Ouroboros.Network.DeltaQ (GSV (..), PeerGSV (..))
+import qualified Ouroboros.Network.Diffusion as ND
 import           Ouroboros.Network.Driver.Limits (ProtocolLimitFailure (..))
 import           Ouroboros.Network.ExitPolicy (RepromoteDelay (..))
 import           Ouroboros.Network.InboundGovernor (InboundGovernorTrace (..), RemoteSt (..))
@@ -82,6 +57,7 @@ import           Ouroboros.Network.PeerSelection.Governor (DebugPeerSelection (.
                    PeerSelectionCounters (..), PeerSelectionState (..), PeerSelectionTargets (..),
                    TracePeerSelection (..))
 import           Ouroboros.Network.PeerSelection.LedgerPeers
+import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing)
 import           Ouroboros.Network.PeerSelection.PeerStateActions (PeerSelectionActionsTrace (..))
 import           Ouroboros.Network.PeerSelection.RelayAccessPoint
 import           Ouroboros.Network.PeerSelection.RootPeersDNS.LocalRootPeers
@@ -119,8 +95,27 @@ import           Ouroboros.Network.TxSubmission.Inbound (ProcessedTxCount (..),
                    TraceTxSubmissionInbound (..))
 import           Ouroboros.Network.TxSubmission.Outbound (TraceTxSubmissionOutbound (..))
 
-import qualified Ouroboros.Network.Diffusion as ND
-import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing)
+import           Control.Exception (Exception (..), SomeException (..))
+import           Control.Monad.Class.MonadTime.SI (DiffTime, Time (..))
+import           Data.Aeson (FromJSON (..), Value (..))
+import qualified Data.Aeson as Aeson
+import           Data.Aeson.Types (listValue)
+import qualified Data.Aeson.Types as Aeson
+import           Data.Bifunctor (Bifunctor (first))
+import           Data.Data (Proxy (..))
+import           Data.Foldable (Foldable (..))
+import           Data.Functor.Identity (Identity (..))
+import qualified Data.IP as IP
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import           Data.Text (Text, pack)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import           Network.Mux (MiniProtocolNum (..), MuxTrace (..), WithMuxBearer (..))
+import           Network.Socket (SockAddr (..))
+import           Network.TypedProtocol.Codec (AnyMessageAndAgency (..))
+import           Network.TypedProtocol.Core (PeerHasAgency (..))
+import qualified Text.Read as Text
 
 {- HLINT ignore "Use record patterns" -}
 

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
@@ -49,6 +49,8 @@ import qualified Cardano.Ledger.Crypto as Core
 import qualified Cardano.Ledger.SafeHash as SafeHash
 import           Cardano.Ledger.Shelley.API
 import           Cardano.Ledger.Shelley.Rules
+import           Cardano.Node.Tracing.Render (renderMissingRedeemers, renderScriptHash,
+                   renderScriptIntegrityHash)
 import           Cardano.Node.Tracing.Tracers.KESInfo ()
 import           Cardano.Protocol.TPraos.API (ChainTransitionError (ChainTransitionError))
 import           Cardano.Protocol.TPraos.BHeader (LastAppliedBlock, labBlockNo)
@@ -76,8 +78,6 @@ import           Ouroboros.Consensus.Util.Condense (condense)
 import           Ouroboros.Network.Block (SlotNo (..), blockHash, blockNo, blockSlot)
 import           Ouroboros.Network.Point (WithOrigin, withOriginToMaybe)
 
-import           Cardano.Node.Tracing.Render (renderMissingRedeemers, renderScriptHash,
-                   renderScriptIntegrityHash)
 import           Data.Aeson (Value (..), object)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Base16 as B16

--- a/cardano-node/src/Cardano/Tracing/Peer.hs
+++ b/cardano-node/src/Cardano/Tracing/Peer.hs
@@ -11,7 +11,22 @@ module Cardano.Tracing.Peer
   , tracePeers
   ) where
 
+import           Cardano.BM.Data.LogItem (LOContent (..))
+import           Cardano.BM.Trace (traceNamedObject)
+import           Cardano.BM.Tracing
 import           Cardano.Node.Orphans ()
+import           Cardano.Node.Queries
+import           Ouroboros.Consensus.Block (Header)
+import           Ouroboros.Consensus.Util.NormalForm.StrictTVar (StrictTVar, readTVar)
+import           Ouroboros.Consensus.Util.Orphans ()
+import qualified Ouroboros.Network.AnchoredFragment as Net
+import           Ouroboros.Network.Block (unSlotNo)
+import qualified Ouroboros.Network.Block as Net
+import qualified Ouroboros.Network.BlockFetch.ClientRegistry as Net
+import           Ouroboros.Network.BlockFetch.ClientState (PeerFetchInFlight (..),
+                   PeerFetchStatus (..), readFetchClientState)
+import           Ouroboros.Network.ConnectionId (remoteAddress)
+import           Ouroboros.Network.NodeToNode (RemoteAddress)
 
 import qualified Control.Concurrent.Class.MonadSTM.Strict as STM
 import           Control.DeepSeq (NFData (..))
@@ -24,27 +39,9 @@ import qualified Data.Set as Set
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import           GHC.Generics (Generic)
-import           NoThunks.Class (AllowThunk (..), NoThunks)
 import           Text.Printf (printf)
 
-import           Cardano.BM.Data.LogItem (LOContent (..))
-import           Cardano.BM.Trace (traceNamedObject)
-import           Cardano.BM.Tracing
-
-import           Ouroboros.Consensus.Block (Header)
-import           Ouroboros.Consensus.Util.NormalForm.StrictTVar (StrictTVar, readTVar)
-import           Ouroboros.Consensus.Util.Orphans ()
-import           Ouroboros.Network.ConnectionId (remoteAddress)
-
-import qualified Ouroboros.Network.AnchoredFragment as Net
-import           Ouroboros.Network.Block (unSlotNo)
-import qualified Ouroboros.Network.Block as Net
-import qualified Ouroboros.Network.BlockFetch.ClientRegistry as Net
-import           Ouroboros.Network.BlockFetch.ClientState (PeerFetchInFlight (..),
-                   PeerFetchStatus (..), readFetchClientState)
-import           Ouroboros.Network.NodeToNode (RemoteAddress)
-
-import           Cardano.Node.Queries
+import           NoThunks.Class (AllowThunk (..), NoThunks)
 
 {- HLINT ignore "Use =<<" -}
 {- HLINT ignore "Use <=<" -}

--- a/cardano-node/src/Cardano/Tracing/Render.hs
+++ b/cardano-node/src/Cardano/Tracing/Render.hs
@@ -22,13 +22,8 @@ module Cardano.Tracing.Render
   , renderWithOrigin
   ) where
 
-import qualified Data.ByteString.Base16 as B16
-import           Data.Proxy (Proxy (..))
-import           Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
-
 import           Cardano.BM.Tracing (TracingVerbosity (..))
+import           Cardano.Node.Queries (ConvertTxId (..))
 import           Cardano.Slotting.Slot (EpochNo (..), SlotNo (..), WithOrigin (..))
 import           Ouroboros.Consensus.Block (BlockNo (..), ConvertRawHash (..), RealPoint (..))
 import           Ouroboros.Consensus.Block.Abstract (Point (..))
@@ -39,7 +34,11 @@ import           Ouroboros.Consensus.Storage.ImmutableDB.Impl.Types (BlockOrEBB 
 import           Ouroboros.Network.Block (ChainHash (..), HeaderHash, StandardHash, Tip,
                    getTipPoint)
 
-import           Cardano.Node.Queries (ConvertTxId (..))
+import qualified Data.ByteString.Base16 as B16
+import           Data.Proxy (Proxy (..))
+import           Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
 
 renderBlockOrEBB :: BlockOrEBB -> Text
 renderBlockOrEBB (Block slotNo) = "Block at " <> renderSlotNo slotNo

--- a/cardano-node/src/Cardano/Tracing/Shutdown.hs
+++ b/cardano-node/src/Cardano/Tracing/Shutdown.hs
@@ -4,9 +4,6 @@
 
 module Cardano.Tracing.Shutdown () where
 
-import           Data.Text (Text)
-import           Prelude (IO)
-
 import           Cardano.BM.Data.Tracer (HasTextFormatter (..), trStructuredText)
 import           Cardano.BM.Tracing (HasPrivacyAnnotation (..), HasSeverityAnnotation (..),
                    Severity (..), ToObject (..), Transformable (..))
@@ -14,6 +11,10 @@ import           Cardano.Logging (LogFormatting (..))
 import           Cardano.Node.Handlers.Shutdown
 import           Cardano.Node.Tracing.Compat
 import           Cardano.Node.Tracing.Tracers.Shutdown
+
+import           Prelude (IO)
+
+import           Data.Text (Text)
 
 instance HasPrivacyAnnotation  ShutdownTrace
 instance HasSeverityAnnotation ShutdownTrace where

--- a/cardano-node/src/Cardano/Tracing/Startup.hs
+++ b/cardano-node/src/Cardano/Tracing/Startup.hs
@@ -6,22 +6,21 @@
 
 module Cardano.Tracing.Startup where
 
-import           Data.Aeson (ToJSON)
-import           Data.Text (Text)
-import           Prelude
-
+import           Cardano.BM.Data.Tracer (HasTextFormatter (..), trStructuredText)
+import           Cardano.BM.Tracing (HasPrivacyAnnotation (..), HasSeverityAnnotation (..),
+                   Severity (..), ToObject (..), Transformable (..))
 import           Cardano.Logging (LogFormatting (..))
 import           Cardano.Node.Startup
 import           Cardano.Node.Tracing.Compat
 import           Cardano.Node.Tracing.Tracers.Startup
 import           Cardano.Tracing.OrphanInstances.Network ()
-
-import           Cardano.BM.Data.Tracer (HasTextFormatter (..), trStructuredText)
-import           Cardano.BM.Tracing (HasPrivacyAnnotation (..), HasSeverityAnnotation (..),
-                   Severity (..), ToObject (..), Transformable (..))
-
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion (BlockNodeToClientVersion,
                    BlockNodeToNodeVersion)
+
+import           Prelude
+
+import           Data.Aeson (ToJSON)
+import           Data.Text (Text)
 
 
 instance HasSeverityAnnotation (StartupTrace blk) where

--- a/cardano-node/test/Test/Cardano/Config/Mainnet.hs
+++ b/cardano-node/test/Test/Cardano/Config/Mainnet.hs
@@ -8,17 +8,18 @@ module Test.Cardano.Config.Mainnet
 
 import           Cardano.Api (File (..), initialLedgerState)
 import           Cardano.Api.Error (displayError)
-import           Control.Monad.Trans.Except
-import           Hedgehog (Property, (===))
-import           System.FilePath ((</>))
 
+import           Control.Monad.Trans.Except
 import qualified Data.Aeson as J
 import qualified Data.Yaml as Y
 import qualified GHC.Stack as GHC
+import qualified System.Directory as IO
+import           System.FilePath ((</>))
+
+import           Hedgehog (Property, (===))
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.Process as H
-import qualified System.Directory as IO
 
 hprop_configMainnetHash :: Property
 hprop_configMainnetHash = H.propertyOnce $ do

--- a/cardano-node/test/Test/Cardano/Node/Gen.hs
+++ b/cardano-node/test/Test/Cardano/Node/Gen.hs
@@ -17,10 +17,7 @@ module Test.Cardano.Node.Gen
   , genNodeSetup
   ) where
 
-import qualified Data.Aeson as Aeson
-import qualified Data.Aeson.KeyMap as Aeson.KeyMap
-import qualified Data.ByteString.Lazy as LBS
-import qualified Data.Vector as Vector
+import           Cardano.Api (textShow)
 
 import           Cardano.Node.Configuration.NodeAddress (NodeAddress' (..), NodeHostIPAddress (..),
                    NodeHostIPv4Address (..), NodeHostIPv6Address (..), NodeIPAddress,
@@ -36,12 +33,13 @@ import           Ouroboros.Network.PeerSelection.RelayAccessPoint (DomainAccessP
 import           Ouroboros.Network.PeerSelection.State.LocalRootPeers (HotValency (..),
                    WarmValency (..))
 
-
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as Aeson.KeyMap
+import qualified Data.ByteString.Lazy as LBS
 import qualified Data.IP as IP
-
-import           Cardano.Api (textShow)
-
+import qualified Data.Vector as Vector
 import           Data.Word (Word32)
+
 import           Hedgehog (Gen)
 import           Hedgehog.Corpus (cooking)
 import qualified Hedgehog.Gen as Gen

--- a/cardano-node/test/Test/Cardano/Node/Json.hs
+++ b/cardano-node/test/Test/Cardano/Node/Json.hs
@@ -9,10 +9,10 @@ import           Cardano.Node.Configuration.TopologyP2P (NetworkTopology)
 import           Data.Aeson (decode, encode, fromJSON, toJSON)
 import           Data.Maybe (isJust)
 
+import           Test.Cardano.Node.Gen
+
 import           Hedgehog (Property, discover)
 import qualified Hedgehog
-
-import           Test.Cardano.Node.Gen
 
 prop_roundtrip_NodeIPv4Address_JSON :: Property
 prop_roundtrip_NodeIPv4Address_JSON =

--- a/cardano-node/test/Test/Cardano/Node/POM.hs
+++ b/cardano-node/test/Test/Cardano/Node/POM.hs
@@ -5,10 +5,6 @@ module Test.Cardano.Node.POM
   ( tests
   ) where
 
-import           Data.Monoid (Last (..))
-import           Data.Text (Text)
-import           Data.Time.Clock (secondsToDiffTime)
-
 import           Cardano.Crypto.ProtocolMagic (RequiresNetworkMagic (..))
 import           Cardano.Node.Configuration.POM
 import           Cardano.Node.Configuration.Socket
@@ -22,6 +18,10 @@ import           Ouroboros.Network.Block (SlotNo (..))
 import           Ouroboros.Network.NodeToNode (AcceptedConnectionsLimit (..),
                    DiffusionMode (InitiatorAndResponderDiffusionMode))
 import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
+
+import           Data.Monoid (Last (..))
+import           Data.Text (Text)
+import           Data.Time.Clock (secondsToDiffTime)
 
 import           Hedgehog (Property, discover, withTests, (===))
 import qualified Hedgehog

--- a/cardano-node/test/Test/Cardano/Tracing/NewTracing/Consistency.hs
+++ b/cardano-node/test/Test/Cardano/Tracing/NewTracing/Consistency.hs
@@ -1,6 +1,8 @@
 -- | Check namespace consistencies agains configurations
 module Test.Cardano.Tracing.NewTracing.Consistency (tests) where
 
+import           Cardano.Node.Tracing.Consistency (checkNodeTraceConfiguration)
+
 import           Control.Monad.IO.Class (liftIO)
 import           Data.Text
 
@@ -8,8 +10,6 @@ import           Hedgehog (Property)
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H.Base
 import           Hedgehog.Internal.Property (PropertyName (PropertyName))
-
-import           Cardano.Node.Tracing.Consistency (checkNodeTraceConfiguration)
 
 tests :: IO Bool
 tests = H.checkSequential

--- a/cardano-node/test/Test/Cardano/Tracing/OrphanInstances/HardFork.hs
+++ b/cardano-node/test/Test/Cardano/Tracing/OrphanInstances/HardFork.hs
@@ -11,6 +11,15 @@
 -- The examples can be best viewed using a tool like 'jq'.
 module Test.Cardano.Tracing.OrphanInstances.HardFork (tests) where
 
+import           Cardano.Ledger.Crypto (StandardCrypto)
+import           Cardano.Tracing.OrphanInstances.Byron ()
+import           Cardano.Tracing.OrphanInstances.HardFork ()
+import           Cardano.Tracing.OrphanInstances.Shelley ()
+import           Ouroboros.Consensus.Byron.Ledger.NetworkProtocolVersion as Consensus.Cardano
+import qualified Ouroboros.Consensus.Cardano.Block as Consensus.Cardano
+import qualified Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common as Consensus
+import           Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion as Consensus.Cardano
+
 import qualified Data.Aeson as Aeson
 import           Data.ByteString.Lazy.Char8 (unpack)
 import           Data.SOP.Strict (NP (Nil, (:*)))
@@ -20,17 +29,6 @@ import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H.Base
 import qualified Hedgehog.Extras.Test.Golden as H.Golden
 import           Hedgehog.Internal.Property (PropertyName (PropertyName))
-
-import           Cardano.Ledger.Crypto (StandardCrypto)
-
-import           Ouroboros.Consensus.Byron.Ledger.NetworkProtocolVersion as Consensus.Cardano
-import qualified Ouroboros.Consensus.Cardano.Block as Consensus.Cardano
-import qualified Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common as Consensus
-import           Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion as Consensus.Cardano
-
-import           Cardano.Tracing.OrphanInstances.Byron ()
-import           Cardano.Tracing.OrphanInstances.HardFork ()
-import           Cardano.Tracing.OrphanInstances.Shelley ()
 
 tests :: IO Bool
 tests = H.checkSequential

--- a/cardano-submit-api/src/Cardano/TxSubmit.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit.hs
@@ -6,20 +6,20 @@ module Cardano.TxSubmit
   , opts
   ) where
 
+import qualified Cardano.BM.Setup as Logging
 import           Cardano.BM.Trace (Trace, logInfo)
+import qualified Cardano.BM.Trace as Logging
 import           Cardano.TxSubmit.CLI.Parsers (opts)
 import           Cardano.TxSubmit.CLI.Types (ConfigFile (unConfigFile), TxSubmitNodeParams (..))
 import           Cardano.TxSubmit.Config (GenTxSubmitNodeConfig (..), ToggleLogging (..),
                    TxSubmitNodeConfig, readTxSubmitNodeConfig)
 import           Cardano.TxSubmit.Metrics (registerMetricsServer)
 import           Cardano.TxSubmit.Web (runTxSubmitServer)
+
+import qualified Control.Concurrent.Async as Async
 import           Control.Monad (void)
 import           Control.Monad.IO.Class (MonadIO (liftIO))
 import           Data.Text (Text)
-
-import qualified Cardano.BM.Setup as Logging
-import qualified Cardano.BM.Trace as Logging
-import qualified Control.Concurrent.Async as Async
 
 runTxSubmitWebapi :: TxSubmitNodeParams -> IO ()
 runTxSubmitWebapi tsnp = do

--- a/cardano-submit-api/src/Cardano/TxSubmit/CLI/Parsers.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/CLI/Parsers.hs
@@ -11,13 +11,11 @@ import           Cardano.Api (File (..), SocketPath)
 
 import           Cardano.CLI.Environment (EnvCli (..))
 import           Cardano.CLI.EraBased.Options.Common
-
 import           Cardano.TxSubmit.CLI.Types (ConfigFile (..), TxSubmitNodeParams (..))
 import           Cardano.TxSubmit.Rest.Parsers (pWebserverConfig)
 
 import           Control.Applicative ((<**>))
 import           Options.Applicative (Parser, ParserInfo)
-
 import qualified Options.Applicative as Opt
 
 opts :: EnvCli -> ParserInfo TxSubmitNodeParams

--- a/cardano-submit-api/src/Cardano/TxSubmit/CLI/Types.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/CLI/Types.hs
@@ -5,6 +5,7 @@ module Cardano.TxSubmit.CLI.Types
   ) where
 
 import           Cardano.Api (ConsensusModeParams, NetworkId (..), SocketPath)
+
 import           Cardano.TxSubmit.Rest.Types (WebserverConfig)
 
 -- | The product type of all command line arguments

--- a/cardano-submit-api/src/Cardano/TxSubmit/Config.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Config.hs
@@ -13,16 +13,16 @@ module Cardano.TxSubmit.Config
 
 import           Cardano.Api
 
-import           Control.Exception (IOException, catch)
-import           Data.Aeson (FromJSON (..), Object, Value (..), (.:))
-import           Data.Aeson.Types (Parser)
-import           Data.Bool (bool)
-import           Data.ByteString (ByteString)
-
 import qualified Cardano.BM.Configuration as Logging
 import qualified Cardano.BM.Configuration.Model as Logging
 import qualified Cardano.BM.Data.Configuration as Logging
+
+import           Control.Exception (IOException, catch)
+import           Data.Aeson (FromJSON (..), Object, Value (..), (.:))
 import qualified Data.Aeson as Aeson
+import           Data.Aeson.Types (Parser)
+import           Data.Bool (bool)
+import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Yaml as Yaml
 

--- a/cardano-submit-api/src/Cardano/TxSubmit/Orphans.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Orphans.hs
@@ -9,10 +9,12 @@ module Cardano.TxSubmit.Orphans
   ) where
 
 import           Cardano.Api
+
 import           Cardano.Binary (DecoderError)
+import           Ouroboros.Consensus.Cardano.Block
+
 import           Data.Aeson (ToJSON (..))
 import qualified Data.Aeson as Aeson
-import           Ouroboros.Consensus.Cardano.Block
 
 instance ToJSON DecoderError where
   toJSON = Aeson.String . textShow

--- a/cardano-submit-api/src/Cardano/TxSubmit/Rest/Parsers.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Rest/Parsers.hs
@@ -7,6 +7,7 @@ module Cardano.TxSubmit.Rest.Parsers
   ) where
 
 import           Cardano.TxSubmit.Rest.Types (WebserverConfig (..))
+
 import           Data.String (fromString)
 import           Network.Wai.Handler.Warp (HostPreference, Port)
 import           Options.Applicative (Parser, auto, help, long, metavar, option, showDefault,

--- a/cardano-submit-api/src/Cardano/TxSubmit/Rest/Types.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Rest/Types.hs
@@ -7,7 +7,6 @@ module Cardano.TxSubmit.Rest.Types
   ) where
 
 import           Data.Function ((&))
-
 import qualified Network.Wai.Handler.Warp as Warp
 
 ------------------------------------------------------------

--- a/cardano-submit-api/src/Cardano/TxSubmit/Rest/Web.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Rest/Web.hs
@@ -5,14 +5,15 @@ module Cardano.TxSubmit.Rest.Web
   ) where
 
 import           Cardano.BM.Trace (Trace, logInfo)
+
 import           Control.Exception (bracket)
 import           Data.Streaming.Network (bindPortTCP)
 import           Data.Text (Text)
+import qualified Data.Text as T
 import           Network.Socket (close, getSocketName, withSocketsDo)
 import           Network.Wai.Handler.Warp (Settings, getHost, getPort, runSettingsSocket)
-import           Servant (Application)
 
-import qualified Data.Text as T
+import           Servant (Application)
 
 -- | Like 'Network.Wai.Handler.Warp.runSettings', except with better logging.
 runSettings :: Trace IO Text -> Settings -> Application -> IO ()

--- a/cardano-submit-api/src/Cardano/TxSubmit/Tracing/ToObjectOrphans.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Tracing/ToObjectOrphans.hs
@@ -9,10 +9,10 @@ module Cardano.TxSubmit.Tracing.ToObjectOrphans () where
 import           Cardano.BM.Data.Severity (Severity (Debug, Error, Notice, Warning))
 import           Cardano.BM.Data.Tracer (HasPrivacyAnnotation, HasSeverityAnnotation (..),
                    HasTextFormatter, ToObject (toObject), Transformable (..), trStructured)
-import           Data.Aeson ((.=))
-import           Data.Text (Text)
 import           Ouroboros.Network.NodeToClient (ErrorPolicyTrace (..), WithAddr (..))
 
+import           Data.Aeson ((.=))
+import           Data.Text (Text)
 import qualified Network.Socket as Socket
 
 instance HasPrivacyAnnotation (WithAddr Socket.SockAddr ErrorPolicyTrace)

--- a/cardano-submit-api/src/Cardano/TxSubmit/Types.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Types.hs
@@ -21,20 +21,22 @@ module Cardano.TxSubmit.Types
 
 import           Cardano.Api (Error (..), TxId, TxValidationErrorInCardanoMode (..), textShow)
 import           Cardano.Api.Pretty
+
 import           Cardano.Binary (DecoderError)
 import           Cardano.TxSubmit.Orphans ()
+
 import           Data.Aeson (ToJSON (..), Value (..), (.=))
 import qualified Data.Aeson as Aeson
 import           Data.ByteString.Char8 (ByteString)
+import qualified Data.ByteString.Lazy.Char8 as LBS
 import           Data.Text (Text)
+import qualified Data.Text as T
 import           GHC.Generics (Generic)
 import           Network.HTTP.Media ((//))
+
 import           Servant (Accept (..), JSON, MimeRender (..), MimeUnrender (..), PostAccepted,
                    ReqBody, (:>))
 import           Servant.API.Generic (ToServantApi, (:-))
-
-import qualified Data.ByteString.Lazy.Char8 as LBS
-import qualified Data.Text as T
 
 newtype TxSubmitPort = TxSubmitPort Int
 

--- a/cardano-submit-api/src/Cardano/TxSubmit/Util.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Util.hs
@@ -3,9 +3,11 @@ module Cardano.TxSubmit.Util
   ) where
 
 import           Cardano.Api (textShow)
-import           Prelude
 
 import           Cardano.BM.Trace (Trace, logError)
+
+import           Prelude
+
 import           Control.Exception (SomeException, catch, throwIO)
 import           Data.Text (Text)
 

--- a/cardano-submit-api/src/Cardano/TxSubmit/Web.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Web.hs
@@ -26,14 +26,13 @@ import qualified Cardano.Crypto.Hash.Class as Crypto
 import           Cardano.TxSubmit.Metrics (TxSubmitMetrics (..))
 import           Cardano.TxSubmit.Rest.Types (WebserverConfig (..), toWarpSettings)
 import qualified Cardano.TxSubmit.Rest.Web as Web
-
+import           Cardano.TxSubmit.Types (EnvSocketError (..), RawCborDecodeError (..),
+                   TxCmdError (..), TxSubmitApi, TxSubmitApiRecord (..),
+                   TxSubmitWebApiError (TxSubmitFail), renderTxCmdError)
 import           Cardano.TxSubmit.Util (logException)
 import           Ouroboros.Consensus.Cardano.Block (EraMismatch (..))
 import qualified Ouroboros.Network.Protocol.LocalTxSubmission.Client as Net.Tx
 
-import           Cardano.TxSubmit.Types (EnvSocketError (..), RawCborDecodeError (..),
-                   TxCmdError (..), TxSubmitApi, TxSubmitApiRecord (..),
-                   TxSubmitWebApiError (TxSubmitFail), renderTxCmdError)
 import           Control.Applicative (Applicative (pure), (<$>))
 import           Control.Monad (Functor (fmap), Monad (return), (=<<))
 import           Control.Monad.Except (ExceptT, MonadError (throwError), runExceptT)
@@ -59,15 +58,16 @@ import           Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.IO as T
-import qualified Servant
-import           Servant (Application, Handler, ServerError (..), err400, throwError)
-import           Servant.API.Generic (toServant)
-import           Servant.Server.Generic (AsServerT)
 import           System.Environment (lookupEnv)
 import qualified System.IO as IO
 import           System.IO (IO)
 import qualified System.Metrics.Prometheus.Metric.Gauge as Gauge
 import           Text.Show (Show (show))
+
+import qualified Servant
+import           Servant (Application, Handler, ServerError (..), err400, throwError)
+import           Servant.API.Generic (toServant)
+import           Servant.Server.Generic (AsServerT)
 
 runTxSubmitServer
   :: Trace IO Text

--- a/cardano-submit-api/test/test.hs
+++ b/cardano-submit-api/test/test.hs
@@ -1,6 +1,6 @@
-import qualified System.IO as IO
-
 import qualified Cardano.Crypto.Init as Crypto
+
+import qualified System.IO as IO
 
 main :: IO ()
 main = do

--- a/cardano-testnet/src/Parsers/Help.hs
+++ b/cardano-testnet/src/Parsers/Help.hs
@@ -5,6 +5,8 @@ module Parsers.Help
   , runHelpOptions
   ) where
 
+import           Cardano.CLI.EraBased.Options.Common
+
 import           Control.Monad (forM_)
 import qualified Data.List as List
 import           Options.Applicative
@@ -12,8 +14,6 @@ import           Options.Applicative.Help.Core
 import           Options.Applicative.Help.Types (renderHelp)
 import           Options.Applicative.Types (OptReader (..), Option (..), Parser (..))
 import qualified System.IO as IO
-
-import           Cardano.CLI.EraBased.Options.Common
 
 data HelpOptions = HelpOptions
   deriving (Eq, Show)

--- a/cardano-testnet/src/Parsers/Run.hs
+++ b/cardano-testnet/src/Parsers/Run.hs
@@ -14,11 +14,12 @@ import           Data.Foldable
 import           Options.Applicative
 import qualified Options.Applicative as Opt
 
+import           Testnet.Property.Run
+import           Testnet.Start.Cardano
+
 import           Parsers.Cardano
 import           Parsers.Help
 import           Parsers.Version
-import           Testnet.Property.Run
-import           Testnet.Start.Cardano
 
 pref :: ParserPrefs
 pref = Opt.prefs $ showHelpOnEmpty <> showHelpOnError

--- a/cardano-testnet/src/Parsers/Version.hs
+++ b/cardano-testnet/src/Parsers/Version.hs
@@ -4,15 +4,16 @@ module Parsers.Version
   , runVersionOptions
   ) where
 
+import           Cardano.CLI.EraBased.Options.Common
 import           Cardano.Git.Rev (gitRev)
+
 import qualified Data.Text as T
 import           Data.Version (showVersion)
 import           Options.Applicative
-import           Paths_cardano_testnet (version)
 import           System.Info (arch, compilerName, compilerVersion, os)
 import qualified System.IO as IO
 
-import           Cardano.CLI.EraBased.Options.Common
+import           Paths_cardano_testnet (version)
 
 
 data VersionOptions = VersionOptions

--- a/cardano-testnet/src/Testnet/Components/Configuration.hs
+++ b/cardano-testnet/src/Testnet/Components/Configuration.hs
@@ -14,8 +14,10 @@ module Testnet.Components.Configuration
   , numPools
   ) where
 
+import           Cardano.Api.Ledger (StandardCrypto)
 import           Cardano.Api.Pretty
 import           Cardano.Api.Shelley hiding (cardanoEra)
+
 import qualified Cardano.Node.Configuration.Topology as NonP2P
 import qualified Cardano.Node.Configuration.TopologyP2P as P2P
 import           Cardano.Node.Types
@@ -34,24 +36,23 @@ import qualified Data.ByteString.Lazy as LBS
 import           Data.Char (toLower)
 import qualified Data.List as List
 import           Data.String
+import           Data.Word (Word32)
 import           GHC.Stack (HasCallStack)
 import qualified GHC.Stack as GHC
 import           Lens.Micro
 import           System.FilePath.Posix (takeDirectory, (</>))
+
+import           Testnet.Defaults
+import           Testnet.Filepath
+import           Testnet.Process.Run (execCli_)
+import           Testnet.Property.Utils
+import           Testnet.Start.Types (CardanoTestnetOptions (..))
 
 import           Hedgehog
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Stock.Time as DTC
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
-
-import           Cardano.Api.Ledger (StandardCrypto)
-import           Data.Word (Word32)
-import           Testnet.Defaults
-import           Testnet.Filepath
-import           Testnet.Process.Run (execCli_)
-import           Testnet.Property.Utils
-import           Testnet.Start.Types (CardanoTestnetOptions (..))
 
 
 createConfigYaml

--- a/cardano-testnet/src/Testnet/Components/SPO.hs
+++ b/cardano-testnet/src/Testnet/Components/SPO.hs
@@ -26,15 +26,15 @@ import           GHC.Stack (HasCallStack)
 import qualified GHC.Stack as GHC
 import           System.FilePath.Posix ((</>))
 
-import           Hedgehog
-import           Hedgehog.Extras (ExecConfig, threadDelay)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
-
 import           Testnet.Filepath
 import           Testnet.Process.Cli
 import           Testnet.Process.Run (execCli, execCli', execCli_)
 import           Testnet.Start.Types
+
+import           Hedgehog
+import           Hedgehog.Extras (ExecConfig, threadDelay)
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
 
 checkStakePoolRegistered
   :: (MonadTest m, MonadCatch m, MonadIO m, HasCallStack)

--- a/cardano-testnet/src/Testnet/Ping.hs
+++ b/cardano-testnet/src/Testnet/Ping.hs
@@ -13,10 +13,23 @@ module Testnet.Ping
   , PingClientError(..)
   ) where
 
+import           Cardano.Api (Error (..))
+import           Cardano.Api.Pretty
+
+import           Cardano.Network.Ping (HandshakeFailure, NodeVersion (..), handshakeDec,
+                   handshakeReq, isSameVersionAndMagic, supportedNodeToClientVersions)
+
+import qualified Codec.CBOR.Read as CBOR
 import           Control.Exception.Safe
 import           Control.Monad (when)
 import           Control.Monad.Class.MonadTime.SI (Time)
+import qualified Control.Monad.Class.MonadTimer.SI as MT
+import           Control.Monad.IO.Class
 import           Control.Tracer (nullTracer)
+import qualified Data.ByteString.Lazy as LBS
+import           Data.Either (isLeft)
+import           Data.IORef
+import qualified Data.List as L
 import           Data.Word (Word32)
 import           Network.Mux.Bearer (MakeBearer (..), makeSocketBearer)
 import           Network.Mux.Timeout (TimeoutFn, withTimeoutSerial)
@@ -24,21 +37,10 @@ import           Network.Mux.Types (MiniProtocolDir (InitiatorDir), MiniProtocol
                    MuxBearer (read, write), MuxSDU (..), MuxSDUHeader (..),
                    RemoteClockModel (RemoteClockModel))
 import           Network.Socket (AddrInfo (..), StructLinger (..))
-
-import           Cardano.Api (Error (..))
-import           Cardano.Api.Pretty
-import           Cardano.Network.Ping (HandshakeFailure, NodeVersion (..), handshakeDec,
-                   handshakeReq, isSameVersionAndMagic, supportedNodeToClientVersions)
-import qualified Codec.CBOR.Read as CBOR
-import qualified Control.Monad.Class.MonadTimer.SI as MT
-import           Control.Monad.IO.Class
-import qualified Data.ByteString.Lazy as LBS
-import           Data.Either (isLeft)
-import           Data.IORef
-import qualified Data.List as L
-import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
 import qualified Network.Socket as Socket
 import           Prettyprinter
+
+import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
 
 type TestnetMagic = Word32
 

--- a/cardano-testnet/src/Testnet/Process/Cli.hs
+++ b/cardano-testnet/src/Testnet/Process/Cli.hs
@@ -40,11 +40,12 @@ import           Options.Applicative hiding (command)
 import qualified Options.Applicative as Opt
 import           System.FilePath.Posix
 
+import           Testnet.Process.Run
+
 import           Hedgehog (MonadTest)
 import           Hedgehog.Extras (ExecConfig)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H (writeFile)
-import           Testnet.Process.Run
 
 data KeyNames = KeyNames
   { verificationKeyFile :: FilePath

--- a/cardano-testnet/src/Testnet/Process/Run.hs
+++ b/cardano-testnet/src/Testnet/Process/Run.hs
@@ -36,6 +36,7 @@ import           GHC.Stack (HasCallStack)
 import qualified GHC.Stack as GHC
 import qualified System.Directory as IO
 import qualified System.Environment as IO
+import           System.Exit (ExitCode)
 import           System.FilePath
 import           System.IO
 import qualified System.IO.Unsafe as IO
@@ -50,7 +51,6 @@ import           Hedgehog.Extras.Test.Base
 import           Hedgehog.Extras.Test.Process (ExecConfig)
 import qualified Hedgehog.Extras.Test.Process as H
 import qualified Hedgehog.Internal.Property as H
-import           System.Exit (ExitCode)
 
 -- | Path to the bash executable.  This is used on Windows so that the caller can supply a Windows
 -- path to the bash executable because there is no reliable way to invoke bash without the full

--- a/cardano-testnet/src/Testnet/Property/Assert.hs
+++ b/cardano-testnet/src/Testnet/Property/Assert.hs
@@ -19,24 +19,25 @@ import           Control.Monad.IO.Class (MonadIO)
 import           Control.Monad.Trans.Reader (ReaderT)
 import           Control.Monad.Trans.Resource (ResourceT)
 import           Data.Aeson (FromJSON (..), Value, (.:))
-import           Data.Text (Text)
-import           Data.Word (Word8)
-import           GHC.Stack (HasCallStack)
-import qualified GHC.Stack as GHC
-import           Hedgehog (MonadTest)
-import           Hedgehog.Extras.Internal.Test.Integration (IntegrationState)
-
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Types as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.List as L
 import           Data.Maybe (mapMaybe)
 import qualified Data.Maybe as Maybe
+import           Data.Text (Text)
 import qualified Data.Time.Clock as DTC
+import           Data.Word (Word8)
+import           GHC.Stack (HasCallStack)
+import qualified GHC.Stack as GHC
+
+import           Testnet.Runtime (NodeLoggingFormat (..))
+
+import           Hedgehog (MonadTest)
 import qualified Hedgehog as H
+import           Hedgehog.Extras.Internal.Test.Integration (IntegrationState)
 import qualified Hedgehog.Extras.Stock.IO.File as IO
 import qualified Hedgehog.Extras.Test.Base as H
-import           Testnet.Runtime (NodeLoggingFormat (..))
 
 newlineBytes :: Word8
 newlineBytes = 10

--- a/cardano-testnet/src/Testnet/Property/Checks.hs
+++ b/cardano-testnet/src/Testnet/Property/Checks.hs
@@ -21,14 +21,14 @@ import qualified Data.Set as Set
 import           GHC.Stack (HasCallStack)
 import qualified GHC.Stack as GHC
 
+import           Testnet.Process.Run
+import           Testnet.Start.Types
+
 import           Hedgehog (MonadTest)
 import qualified Hedgehog as H
 import           Hedgehog.Extras.Test.Base (failMessage)
 import qualified Hedgehog.Extras.Test.File as H
 import           Hedgehog.Extras.Test.Process (ExecConfig)
-
-import           Testnet.Process.Run
-import           Testnet.Start.Types
 
 -- | A sanity check that confirms that there are the expected number of SPOs in the ledger state
 prop_spos_in_ledger_state

--- a/cardano-testnet/src/Testnet/Property/Run.hs
+++ b/cardano-testnet/src/Testnet/Property/Run.hs
@@ -23,6 +23,9 @@ import qualified System.Exit as IO
 import qualified System.Info as SYS
 import qualified System.IO as IO
 
+import qualified Testnet.Property.Utils as H
+import           Testnet.Start.Types
+
 import           Hedgehog (Property)
 import qualified Hedgehog as H
 import           Hedgehog.Extras.Stock.OS (isWin32)
@@ -31,9 +34,6 @@ import           Test.Tasty.ExpectedFailure (wrapTest)
 import qualified Test.Tasty.Hedgehog as H
 import           Test.Tasty.Providers (testPassed)
 import           Test.Tasty.Runners (Result (resultShortDescription), TestTree)
-
-import qualified Testnet.Property.Utils as H
-import           Testnet.Start.Types
 
 runTestnet :: (Conf -> H.Integration a) -> IO ()
 runTestnet tn = do

--- a/cardano-testnet/src/Testnet/Property/Utils.hs
+++ b/cardano-testnet/src/Testnet/Property/Utils.hs
@@ -22,6 +22,7 @@ module Testnet.Property.Utils
   ) where
 
 import           Cardano.Api
+
 import           Cardano.Chain.Genesis (GenesisHash (unGenesisHash), readGenesisData)
 import           Cardano.CLI.Types.Output
 import qualified Cardano.Crypto.Hash.Blake2b as Crypto
@@ -50,14 +51,15 @@ import           System.FilePath ((</>))
 import           System.Info (os)
 import qualified System.IO.Unsafe as IO
 
+import           Testnet.Components.SPO (decodeEraUTxO)
+import qualified Testnet.Process.Run as H
+
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.Concurrent as H
 import qualified Hedgehog.Extras.Test.File as H
 import           Hedgehog.Extras.Test.Process (ExecConfig)
 import           Hedgehog.Internal.Property (MonadTest)
-import           Testnet.Components.SPO (decodeEraUTxO)
-import qualified Testnet.Process.Run as H
 
 disableRetries :: Bool
 disableRetries = IO.unsafePerformIO $ do

--- a/cardano-testnet/src/Testnet/Runtime.hs
+++ b/cardano-testnet/src/Testnet/Runtime.hs
@@ -33,6 +33,7 @@ module Testnet.Runtime
 import           Cardano.Api
 import qualified Cardano.Api as Api
 import           Cardano.Api.Pretty
+
 import qualified Cardano.Chain.Genesis as G
 import           Cardano.Crypto.ProtocolMagic (RequiresNetworkMagic (..))
 import           Cardano.Ledger.Crypto (StandardCrypto)
@@ -40,6 +41,8 @@ import           Cardano.Ledger.Shelley.Genesis
 import           Cardano.Node.Configuration.POM
 import qualified Cardano.Node.Protocol.Byron as Byron
 import           Cardano.Node.Types
+
+import           Prelude
 
 import           Control.Exception.Safe
 import           Control.Monad
@@ -58,11 +61,16 @@ import           GHC.Generics (Generic)
 import qualified GHC.IO.Handle as IO
 import           GHC.Stack
 import qualified GHC.Stack as GHC
-import           Prelude
 import qualified System.Directory as IO
+import           System.Directory (doesDirectoryExist)
 import           System.FilePath
 import qualified System.IO as IO
 import qualified System.Process as IO
+
+import           Testnet.Filepath
+import qualified Testnet.Ping as Ping
+import           Testnet.Process.Run
+import           Testnet.Start.Types
 
 import           Hedgehog (MonadTest)
 import qualified Hedgehog as H
@@ -70,12 +78,6 @@ import           Hedgehog.Extras.Stock.IO.Network.Sprocket (Sprocket (..))
 import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.Concurrent as H
-
-import           System.Directory (doesDirectoryExist)
-import           Testnet.Filepath
-import qualified Testnet.Ping as Ping
-import           Testnet.Process.Run
-import           Testnet.Start.Types
 
 data TestnetRuntime = TestnetRuntime
   { configurationFile :: FilePath

--- a/cardano-testnet/src/Testnet/Start/Byron.hs
+++ b/cardano-testnet/src/Testnet/Start/Byron.hs
@@ -16,10 +16,10 @@ import           Control.Monad.IO.Class (MonadIO)
 import           Data.Time.Clock (UTCTime)
 import           GHC.Stack
 
+import           Testnet.Process.Run
+
 import           Hedgehog.Extras.Stock.Time (showUTCTimeSeconds)
 import           Hedgehog.Internal.Property (MonadTest)
-
-import           Testnet.Process.Run
 
 data ByronGenesisOptions = ByronGenesisOptions
   { byronNumBftNodes :: Int

--- a/cardano-testnet/src/Testnet/Start/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Start/Cardano.hs
@@ -20,40 +20,36 @@ module Testnet.Start.Cardano
   ) where
 
 
+import           Cardano.Api
+import           Cardano.Api.Ledger (StandardCrypto)
+
+import           Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis)
+import           Cardano.Ledger.Conway.Genesis (ConwayGenesis)
+
+import           Prelude hiding (lines)
+
 import           Control.Monad
+import qualified Control.Monad.Class.MonadTimer.SI as MT
+import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Class (lift)
 import           Control.Monad.Trans.Except (runExceptT)
 import           Data.Aeson
+import qualified Data.Aeson as Aeson
+import           Data.Bifunctor (first)
 import qualified Data.ByteString.Lazy as LBS
 import           Data.Either
 import qualified Data.List as L
 import           Data.Maybe
 import qualified Data.Text as Text
+import           Data.Time (UTCTime)
 import qualified Data.Time.Clock as DTC
+import           Data.Word (Word32)
 import qualified GHC.Stack as GHC
-import           Prelude hiding (lines)
 import           System.FilePath ((</>))
 import qualified System.Info as OS
 
-import qualified Hedgehog as H
-import           Hedgehog.Extras (failMessage)
-import qualified Hedgehog.Extras.Stock.OS as OS
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
-
-import qualified Testnet.Defaults as Defaults
-
-import           Cardano.Api
-import           Cardano.Api.Ledger (StandardCrypto)
-import           Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis)
-import           Cardano.Ledger.Conway.Genesis (ConwayGenesis)
-import qualified Control.Monad.Class.MonadTimer.SI as MT
-import           Control.Monad.IO.Class
-import qualified Data.Aeson as Aeson
-import           Data.Bifunctor (first)
-import           Data.Time (UTCTime)
-import           Data.Word (Word32)
 import           Testnet.Components.Configuration
+import qualified Testnet.Defaults as Defaults
 import           Testnet.Filepath
 import qualified Testnet.Process.Run as H
 import           Testnet.Process.Run
@@ -62,6 +58,12 @@ import           Testnet.Property.Checks
 import           Testnet.Runtime as TR hiding (shelleyGenesis)
 import qualified Testnet.Start.Byron as Byron
 import           Testnet.Start.Types
+
+import qualified Hedgehog as H
+import           Hedgehog.Extras (failMessage)
+import qualified Hedgehog.Extras.Stock.OS as OS
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
 
 {- HLINT ignore "Redundant flip" -}
 {- HLINT ignore "Redundant id" -}

--- a/cardano-testnet/src/Testnet/Start/Types.hs
+++ b/cardano-testnet/src/Testnet/Start/Types.hs
@@ -16,13 +16,17 @@ module Testnet.Start.Types
   ) where
 
 import           Cardano.Api hiding (cardanoEra)
+
+import           Prelude
+
 import           Data.Word
 import           GHC.Stack
+import           System.FilePath (addTrailingPathSeparator)
+
+import           Testnet.Filepath
+
 import           Hedgehog (MonadTest)
 import qualified Hedgehog.Extras as H
-import           Prelude
-import           System.FilePath (addTrailingPathSeparator)
-import           Testnet.Filepath
 
 
 {- HLINT ignore "Redundant flip" -}

--- a/cardano-testnet/src/Testnet/SubmitApi.hs
+++ b/cardano-testnet/src/Testnet/SubmitApi.hs
@@ -16,23 +16,23 @@ module Testnet.SubmitApi
   ) where
 
 import           Cardano.Testnet
+import qualified Cardano.Testnet as H
 
 import           Prelude
 
-import qualified Hedgehog as H
-import qualified Hedgehog.Extras.Test.Base as H
+import           Data.Functor ((<&>))
+import qualified System.IO as IO
+import qualified System.Process as IO
 
 import qualified Testnet.Process.Run as H
 
-import qualified Cardano.Testnet as H
-import           Data.Functor ((<&>))
+import qualified Hedgehog as H
 import           Hedgehog.Extras (Integration)
 import           Hedgehog.Extras.Stock (Sprocket (..))
 import qualified Hedgehog.Extras.Stock.IO.Network.Socket as IO
 import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
+import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.Process as H
-import qualified System.IO as IO
-import qualified System.Process as IO
 
 data SubmitApiConf = SubmitApiConf
   { tempAbsPath   :: FilePath

--- a/cardano-testnet/test/cardano-testnet-golden/Cardano/Testnet/Test/Golden/Config.hs
+++ b/cardano-testnet/test/cardano-testnet-golden/Cardano/Testnet/Test/Golden/Config.hs
@@ -5,6 +5,8 @@ module Cardano.Testnet.Test.Golden.Config
   ( goldenDefaultConfigYaml
   ) where
 
+import           Cardano.Api
+
 import           Prelude
 
 import           Data.Aeson
@@ -13,8 +15,6 @@ import qualified Data.ByteString.Lazy as LB
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import           System.FilePath ((</>))
-
-import           Cardano.Api
 
 import           Testnet.Defaults
 

--- a/cardano-testnet/test/cardano-testnet-golden/Cardano/Testnet/Test/Golden/Help.hs
+++ b/cardano-testnet/test/cardano-testnet-golden/Cardano/Testnet/Test/Golden/Help.hs
@@ -7,21 +7,22 @@ module Cardano.Testnet.Test.Golden.Help
   , golden_HelpCmds
   ) where
 
+import           Cardano.Testnet.Test.Golden.Util
+
 import           Prelude hiding (lines)
 
-import           Cardano.Testnet.Test.Golden.Util
 import           Control.Monad (forM_, unless, (<=<))
+import qualified Data.Char as Char
+import qualified Data.List as List
 import           Data.Maybe (maybeToList)
 import           Data.Text (Text)
-import           Hedgehog (Property)
-import           Hedgehog.Extras.Stock.OS (isWin32)
+import qualified Data.Text as Text
 import           System.FilePath ((</>))
 import           Text.Regex (Regex, mkRegex, subRegex)
 
-import qualified Data.Char as Char
-import qualified Data.List as List
-import qualified Data.Text as Text
+import           Hedgehog (Property)
 import qualified Hedgehog.Extras as H
+import           Hedgehog.Extras.Stock.OS (isWin32)
 import qualified Hedgehog.Extras.Test.Golden as H
 
 ansiRegex :: Regex

--- a/cardano-testnet/test/cardano-testnet-golden/Cardano/Testnet/Test/Golden/Util.hs
+++ b/cardano-testnet/test/cardano-testnet-golden/Cardano/Testnet/Test/Golden/Util.hs
@@ -18,22 +18,22 @@ import           Control.Monad.IO.Class (MonadIO (..))
 import           Control.Monad.Trans.Class (lift)
 import           Control.Monad.Trans.Except (runExceptT)
 import           Data.Function ((&))
-import           GHC.Stack (CallStack, HasCallStack)
-import           Hedgehog.Extras (ExecConfig)
-import           Hedgehog.Internal.Property (Diff, MonadTest, liftTest, mkTest)
-import           Hedgehog.Internal.Show (ValueDiff (ValueSame), mkValue, showPretty, valueDiff)
-import           Hedgehog.Internal.Source (getCaller)
-
 import qualified Data.List as List
 import           Data.Monoid (Last (..))
+import           GHC.Stack (CallStack, HasCallStack)
 import qualified GHC.Stack as GHC
-import qualified Hedgehog as H
-import qualified Hedgehog.Extras as H
-import           Hedgehog.Extras.Test (ExecConfig (..))
-import qualified Hedgehog.Internal.Property as H
 import qualified System.Exit as IO
 import qualified System.Process as IO
 import           System.Process (CreateProcess)
+
+import qualified Hedgehog as H
+import           Hedgehog.Extras (ExecConfig)
+import qualified Hedgehog.Extras as H
+import           Hedgehog.Extras.Test (ExecConfig (..))
+import           Hedgehog.Internal.Property (Diff, MonadTest, liftTest, mkTest)
+import qualified Hedgehog.Internal.Property as H
+import           Hedgehog.Internal.Show (ValueDiff (ValueSame), mkValue, showPretty, valueDiff)
+import           Hedgehog.Internal.Source (getCaller)
 
 -- | Execute cardano-testnet via the command line.
 --

--- a/cardano-testnet/test/cardano-testnet-golden/cardano-testnet-golden.hs
+++ b/cardano-testnet/test/cardano-testnet-golden/cardano-testnet-golden.hs
@@ -4,20 +4,20 @@ module Main
   ( main
   ) where
 
-import           Data.String
-import           Prelude
-import           System.IO (BufferMode (LineBuffering), hSetBuffering, hSetEncoding, stdout, utf8)
-import           Test.Tasty (TestTree)
-
-import qualified System.Environment as E
-import qualified Test.Tasty as T
-import qualified Test.Tasty.Hedgehog as H
-import qualified Test.Tasty.Ingredients as T
-
+import qualified Cardano.Crypto.Init as Crypto
 import qualified Cardano.Testnet.Test.Golden.Config
 import qualified Cardano.Testnet.Test.Golden.Help
 
-import qualified Cardano.Crypto.Init as Crypto
+import           Prelude
+
+import           Data.String
+import qualified System.Environment as E
+import           System.IO (BufferMode (LineBuffering), hSetBuffering, hSetEncoding, stdout, utf8)
+
+import qualified Test.Tasty as T
+import           Test.Tasty (TestTree)
+import qualified Test.Tasty.Hedgehog as H
+import qualified Test.Tasty.Ingredients as T
 
 tests :: IO TestTree
 tests = pure $ T.testGroup "Golden tests"

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/LeadershipSchedule.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/LeadershipSchedule.hs
@@ -44,12 +44,6 @@ import qualified GHC.Stack as GHC
 import           System.FilePath ((</>))
 import qualified System.Info as SYS
 
-import           Hedgehog (Property, (===))
-import qualified Hedgehog as H
-import           Hedgehog.Extras (threadDelay)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
-
 import           Testnet.Components.Configuration
 import           Testnet.Components.SPO
 import           Testnet.Process.Cli
@@ -58,6 +52,12 @@ import           Testnet.Process.Run
 import           Testnet.Property.Assert
 import qualified Testnet.Property.Utils as H
 import           Testnet.Runtime
+
+import           Hedgehog (Property, (===))
+import qualified Hedgehog as H
+import           Hedgehog.Extras (threadDelay)
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
 
 -- | Execute me with:
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/leadership-schedule/"'@

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/StakeSnapshot.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/StakeSnapshot.hs
@@ -22,14 +22,14 @@ import qualified Data.Time.Clock as DTC
 import           GHC.Stack (callStack)
 import qualified System.Info as SYS
 
-import           Hedgehog (Property, (===))
-import qualified Hedgehog as H
-import qualified Hedgehog.Extras.Test.Base as H
-
 import           Testnet.Process.Cli (execCliStdoutToJson)
 import qualified Testnet.Process.Run as H
 import qualified Testnet.Property.Utils as H
 import           Testnet.Runtime
+
+import           Hedgehog (Property, (===))
+import qualified Hedgehog as H
+import qualified Hedgehog.Extras.Test.Base as H
 
 hprop_stakeSnapshot :: Property
 hprop_stakeSnapshot = H.integrationRetryWorkspace 2 "babbage-stake-snapshot" $ \tempAbsBasePath' -> do

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/Transaction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/Transaction.hs
@@ -18,32 +18,31 @@ module Cardano.Testnet.Test.Cli.Babbage.Transaction
   ) where
 
 import           Cardano.Api
+import qualified Cardano.Api.Ledger as L
+import qualified Cardano.Api.Ledger.Lens as A
 
 import           Cardano.Testnet
 
 import           Prelude
 
 import           Control.Monad (void)
+import qualified Data.List as List
+import qualified Data.Map as Map
 import qualified Data.Text as Text
+import           Lens.Micro
 import           System.FilePath ((</>))
 import qualified System.Info as SYS
 
-import           Hedgehog (Property)
-import qualified Hedgehog as H
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
-
-import qualified Cardano.Api.Ledger.Lens as A
-import qualified Data.Map as Map
 import           Testnet.Components.SPO
 import qualified Testnet.Process.Run as H
 import           Testnet.Process.Run
 import qualified Testnet.Property.Utils as H
 import           Testnet.Runtime
 
-import qualified Cardano.Api.Ledger as L
-import qualified Data.List as List
-import           Lens.Micro
+import           Hedgehog (Property)
+import qualified Hedgehog as H
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
 
 hprop_transaction :: Property
 hprop_transaction = H.integrationRetryWorkspace 0 "babbage-transaction" $ \tempAbsBasePath' -> do

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/StakeSnapshot.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/StakeSnapshot.hs
@@ -22,14 +22,14 @@ import qualified Data.Time.Clock as DTC
 import           GHC.Stack (callStack)
 import qualified System.Info as SYS
 
-import           Hedgehog (Property, (===))
-import qualified Hedgehog as H
-import qualified Hedgehog.Extras.Test.Base as H
-
 import           Testnet.Process.Cli (execCliStdoutToJson)
 import qualified Testnet.Process.Run as H
 import qualified Testnet.Property.Utils as H
 import           Testnet.Runtime
+
+import           Hedgehog (Property, (===))
+import qualified Hedgehog as H
+import qualified Hedgehog.Extras.Test.Base as H
 
 hprop_stakeSnapshot :: Property
 hprop_stakeSnapshot = H.integrationRetryWorkspace 2 "conway-stake-snapshot" $ \tempAbsBasePath' -> do

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/KesPeriodInfo.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/KesPeriodInfo.hs
@@ -31,12 +31,6 @@ import           GHC.Stack (callStack)
 import           System.FilePath ((</>))
 import qualified System.Info as SYS
 
-import           Hedgehog (Property)
-import qualified Hedgehog as H
-import           Hedgehog.Extras (threadDelay)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
-
 import           Testnet.Components.Configuration
 import           Testnet.Components.SPO
 import           Testnet.Process.Cli
@@ -44,6 +38,12 @@ import qualified Testnet.Process.Run as H
 import           Testnet.Process.Run
 import qualified Testnet.Property.Utils as H
 import           Testnet.Runtime
+
+import           Hedgehog (Property)
+import qualified Hedgehog as H
+import           Hedgehog.Extras (threadDelay)
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
 
 {- HLINT ignore "Use underscore" -}
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/QuerySlotNumber.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/QuerySlotNumber.hs
@@ -13,22 +13,25 @@ module Cardano.Testnet.Test.Cli.QuerySlotNumber
   ) where
 
 import           Cardano.Api
+
 import           Cardano.Testnet
+
+import           Prelude
 
 import           Data.Either
 import qualified Data.Time.Clock as DT
 import qualified Data.Time.Format as DT
-import           Prelude
 import qualified System.Info as SYS
+
+import qualified Testnet.Process.Run as H
+import           Testnet.Process.Run
+import qualified Testnet.Property.Utils as H
+import           Testnet.Runtime
 
 import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Stock as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Internal.Property as H
-import qualified Testnet.Process.Run as H
-import           Testnet.Process.Run
-import qualified Testnet.Property.Utils as H
-import           Testnet.Runtime
 
 -- | Tests @query slot-number@ cardano-cli command that it returns correct slot numbers for provided utc time
 hprop_querySlotNumber :: Property

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/FoldBlocks.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/FoldBlocks.hs
@@ -21,13 +21,13 @@ import           Control.Monad.Trans.Except (runExceptT)
 import qualified System.Directory as IO
 import           System.FilePath ((</>))
 
+import qualified Testnet.Property.Utils as H
+import           Testnet.Runtime
+
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as HE
 import qualified Hedgehog.Extras.Test as HE
 import qualified Hedgehog.Extras.Test.Base as H
-
-import qualified Testnet.Property.Utils as H
-import           Testnet.Runtime
 
 newtype FoldBlocksException = FoldBlocksException Api.FoldBlocksError
 instance Exception FoldBlocksException

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/InfoAction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/InfoAction.hs
@@ -14,9 +14,13 @@ module Cardano.Testnet.Test.LedgerEvents.Gov.InfoAction
 import           Cardano.Api
 import           Cardano.Api.Error (displayError)
 import           Cardano.Api.Shelley
+
 import           Cardano.Ledger.Conway.Governance (RatifyState (..))
 import qualified Cardano.Ledger.Conway.Governance as L
 import           Cardano.Testnet
+
+import           Prelude
+
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Except
@@ -29,17 +33,18 @@ import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Word
 import           GHC.Stack
-import           Hedgehog
-import           Hedgehog.Extras (Integration)
-import qualified Hedgehog.Extras as H
-import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
-import           Prelude
 import           System.FilePath ((</>))
+
 import qualified Testnet.Process.Cli as P
 import qualified Testnet.Process.Run as H
 import qualified Testnet.Property.Utils as H
 import           Testnet.Property.Utils (queryUtxos)
 import           Testnet.Runtime
+
+import           Hedgehog
+import           Hedgehog.Extras (Integration)
+import qualified Hedgehog.Extras as H
+import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
 
 -- | Execute me with:
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/InfoAction/'@

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/ProposeNewConstitution.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/ProposeNewConstitution.hs
@@ -14,8 +14,12 @@ module Cardano.Testnet.Test.LedgerEvents.Gov.ProposeNewConstitution
 import           Cardano.Api
 import           Cardano.Api.Error (displayError)
 import           Cardano.Api.Shelley
+
 import qualified Cardano.Ledger.Conway.Governance as Ledger
 import           Cardano.Testnet
+
+import           Prelude
+
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Except
@@ -28,17 +32,18 @@ import qualified Data.Text as Text
 import           Data.Word
 import           GHC.IO.Exception (IOException)
 import           GHC.Stack (HasCallStack, callStack, withFrozenCallStack)
-import           Hedgehog
-import qualified Hedgehog.Extras as H
-import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
 import           Lens.Micro
-import           Prelude
 import           System.FilePath ((</>))
+
 import qualified Testnet.Process.Cli as P
 import qualified Testnet.Process.Run as H
 import qualified Testnet.Property.Utils as H
 import           Testnet.Property.Utils (queryUtxos)
 import           Testnet.Runtime
+
+import           Hedgehog
+import qualified Hedgehog.Extras as H
+import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
 
 
 newtype AdditionalCatcher

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/ProposeNewConstitutionSPO.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/ProposeNewConstitutionSPO.hs
@@ -10,46 +10,45 @@ module Cardano.Testnet.Test.LedgerEvents.Gov.ProposeNewConstitutionSPO
   ) where
 
 import           Cardano.Api
-
-import           Cardano.Testnet
-
-import           Prelude
-
-import           Control.Monad.Trans.Except
-import qualified Data.Map.Strict as Map
-import qualified Data.Text as Text
-import           Data.Word
-import           GHC.Stack (HasCallStack, withFrozenCallStack)
-import           System.FilePath ((</>))
-
-import           Hedgehog
-import qualified Hedgehog.Extras as H
-import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
-import qualified Testnet.Process.Cli as P
-import qualified Testnet.Process.Run as H
-
-import           Control.Monad.IO.Class
-import           Data.Data
-import           Data.List (isInfixOf)
-import           Data.Type.Equality
-import           GHC.IORef (newIORef)
-import qualified Hedgehog as H
-import           Hedgehog.Extras (Integration)
-import           System.Exit (ExitCode (ExitSuccess))
-import           Testnet.Process.Cli (execCliStdoutToJson)
-import qualified Testnet.Property.Utils as H
-import           Testnet.Property.Utils (queryUtxos)
-import           Testnet.Runtime
-
 import qualified Cardano.Api as Api
 import           Cardano.Api.Ledger
+
 import           Cardano.CLI.Types.Output (QueryTipLocalStateOutput (QueryTipLocalStateOutput),
                    mEpoch)
 import qualified Cardano.Ledger.Conway.Governance as L
 import qualified Cardano.Ledger.Shelley.LedgerState as L
+import           Cardano.Testnet
+
+import           Prelude
+
+import           Control.Monad.IO.Class
+import           Control.Monad.Trans.Except
 import           Control.Monad.Trans.State.Strict (put)
 import           Data.Bifunctor (Bifunctor (..))
+import           Data.Data
+import           Data.List (isInfixOf)
+import qualified Data.Map.Strict as Map
+import qualified Data.Text as Text
+import           Data.Type.Equality
+import           Data.Word
+import           GHC.IORef (newIORef)
+import           GHC.Stack (HasCallStack, withFrozenCallStack)
 import           Lens.Micro
+import           System.Exit (ExitCode (ExitSuccess))
+import           System.FilePath ((</>))
+
+import qualified Testnet.Process.Cli as P
+import           Testnet.Process.Cli (execCliStdoutToJson)
+import qualified Testnet.Process.Run as H
+import qualified Testnet.Property.Utils as H
+import           Testnet.Property.Utils (queryUtxos)
+import           Testnet.Runtime
+
+import           Hedgehog
+import qualified Hedgehog as H
+import           Hedgehog.Extras (Integration)
+import qualified Hedgehog.Extras as H
+import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
 
 -- | Test that SPO cannot vote on a new constitution
 -- Execute me with:

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/SanityCheck.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/SanityCheck.hs
@@ -22,12 +22,12 @@ import           GHC.IO.Exception (IOException)
 import           GHC.Stack (callStack)
 import           System.FilePath ((</>))
 
+import qualified Testnet.Property.Utils as H
+import           Testnet.Runtime
+
 import           Hedgehog
 import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
 import qualified Hedgehog.Extras.Test.Base as H
-
-import qualified Testnet.Property.Utils as H
-import           Testnet.Runtime
 
 newtype AdditionalCatcher
   = IOE IOException

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Misc.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Misc.hs
@@ -1,15 +1,16 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Cardano.Testnet.Test.Misc where
 
+import           Cardano.Api.Pretty
+
+import           Cardano.CLI.EraBased.Run.Query (renderOpCertIntervalInformation)
+import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Output
+
 import           Prelude
 
 import           Data.List (isInfixOf)
 import qualified GHC.Stack as GHC
-
-import           Cardano.Api.Pretty
-import           Cardano.CLI.EraBased.Run.Query (renderOpCertIntervalInformation)
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Output
 
 import           Hedgehog (success)
 import qualified Hedgehog as H

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Node/Shutdown.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Node/Shutdown.hs
@@ -38,6 +38,13 @@ import qualified System.IO as IO
 import qualified System.Process as IO
 import           System.Process (interruptProcessGroupOf)
 
+import           Testnet.Defaults
+import           Testnet.Process.Run
+import qualified Testnet.Property.Utils as H
+import           Testnet.Property.Utils
+import           Testnet.Runtime
+import           Testnet.Start.Byron
+
 import           Hedgehog (Property, (===))
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Stock.IO.Network.Socket as IO
@@ -47,13 +54,6 @@ import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.Concurrent as H
 import qualified Hedgehog.Extras.Test.File as H
 import qualified Hedgehog.Extras.Test.Process as H
-
-import           Testnet.Defaults
-import           Testnet.Process.Run
-import qualified Testnet.Property.Utils as H
-import           Testnet.Property.Utils
-import           Testnet.Runtime
-import           Testnet.Start.Byron
 
 {- HLINT ignore "Redundant <&>" -}
 -- TODO: Use cardanoTestnet in hprop_shutdown

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SubmitApi/Babbage/Transaction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SubmitApi/Babbage/Transaction.hs
@@ -17,32 +17,14 @@ module Cardano.Testnet.Test.SubmitApi.Babbage.Transaction
   ) where
 
 import           Cardano.Api
+import qualified Cardano.Api.Ledger as L
+import qualified Cardano.Api.Ledger.Lens as A
 
 import           Cardano.Testnet
 
 import           Prelude
 
 import           Control.Monad (void)
-import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
-import           System.FilePath ((</>))
-import qualified System.Info as SYS
-
-import           Hedgehog (Property, (===))
-import qualified Hedgehog as H
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
-
-import qualified Cardano.Api.Ledger.Lens as A
-import qualified Data.Map as Map
-import           Network.HTTP.Simple
-import           Testnet.Components.SPO
-import qualified Testnet.Process.Run as H
-import           Testnet.Process.Run
-import qualified Testnet.Property.Utils as H
-import           Testnet.Runtime
-
-import qualified Cardano.Api.Ledger as L
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Encode.Pretty as Aeson
 import qualified Data.Aeson.Lens as Aeson
@@ -50,10 +32,27 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.List as List
-import qualified Hedgehog.Extras.Test.Golden as H
+import qualified Data.Map as Map
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
 import           Lens.Micro
-import           Testnet.SubmitApi
+import           Network.HTTP.Simple
+import           System.FilePath ((</>))
+import qualified System.Info as SYS
 import           Text.Regex (mkRegex, subRegex)
+
+import           Testnet.Components.SPO
+import qualified Testnet.Process.Run as H
+import           Testnet.Process.Run
+import qualified Testnet.Property.Utils as H
+import           Testnet.Runtime
+import           Testnet.SubmitApi
+
+import           Hedgehog (Property, (===))
+import qualified Hedgehog as H
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+import qualified Hedgehog.Extras.Test.Golden as H
 
 hprop_transaction :: Property
 hprop_transaction = H.integrationRetryWorkspace 0 "submit-api-babbage-transaction" $ \tempAbsBasePath' -> do

--- a/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
+++ b/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
@@ -16,11 +16,13 @@ import qualified Cardano.Testnet.Test.LedgerEvents.Gov.ProposeNewConstitutionSPO
 import qualified Cardano.Testnet.Test.LedgerEvents.SanityCheck as LedgerEvents
 import qualified Cardano.Testnet.Test.Node.Shutdown
 import qualified Cardano.Testnet.Test.SubmitApi.Babbage.Transaction
-import qualified Testnet.Property.Run as H
 
 import           Prelude
+
 import qualified System.Environment as E
 import           System.IO (BufferMode (LineBuffering), hSetBuffering, hSetEncoding, stdout, utf8)
+
+import qualified Testnet.Property.Run as H
 
 import qualified Test.Tasty as T
 import           Test.Tasty (TestTree)

--- a/cardano-tracer/app/cardano-tracer.hs
+++ b/cardano-tracer/app/cardano-tracer.hs
@@ -1,8 +1,9 @@
+import           Cardano.Tracer.CLI (TracerParams, parseTracerParams)
+import           Cardano.Tracer.Run (runCardanoTracer)
+
 import           Data.Version (showVersion)
 import           Options.Applicative
 
-import           Cardano.Tracer.CLI (TracerParams, parseTracerParams)
-import           Cardano.Tracer.Run (runCardanoTracer)
 import           Paths_cardano_tracer (version)
 
 main :: IO ()

--- a/cardano-tracer/bench/cardano-tracer-bench.hs
+++ b/cardano-tracer/bench/cardano-tracer-bench.hs
@@ -1,25 +1,23 @@
 {-# LANGUAGE OverloadedStrings #-}
 
+import           Cardano.Logging hiding (LocalSocket)
+import           Cardano.Tracer.Configuration
+import           Cardano.Tracer.Environment
+import           Cardano.Tracer.Handlers.Logs.TraceObjects
+import           Cardano.Tracer.Handlers.RTView.Run
+import           Cardano.Tracer.Handlers.RTView.State.Historical
+import           Cardano.Tracer.MetaTrace
+import           Cardano.Tracer.Types
+import           Cardano.Tracer.Utils
+
 import           Control.Concurrent.Extra (newLock)
 import           Control.Concurrent.STM.TVar (newTVarIO)
-import           Criterion.Main
 import qualified Data.List.NonEmpty as NE
 import           Data.Time.Clock (UTCTime, getCurrentTime)
 import           System.Directory (getTemporaryDirectory, removePathForcibly)
 import           System.FilePath ((</>))
 
-import           Cardano.Logging hiding (LocalSocket)
-
-import           Cardano.Tracer.Handlers.RTView.Run
-import           Cardano.Tracer.Handlers.RTView.State.Historical
-import           Cardano.Tracer.Utils
-
-import           Cardano.Tracer.Configuration
-import           Cardano.Tracer.Environment
-import           Cardano.Tracer.Handlers.Logs.TraceObjects
-import           Cardano.Tracer.MetaTrace
-import           Cardano.Tracer.Types
-
+import           Criterion.Main
 import qualified Criterion.Types as Criterion
 
 main :: IO ()

--- a/cardano-tracer/demo/acceptor.hs
+++ b/cardano-tracer/demo/acceptor.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE LambdaCase #-}
 
-import           System.Environment (getArgs)
-
 import           Cardano.Tracer.Test.Acceptor
+
+import           System.Environment (getArgs)
 
 main :: IO ()
 main = getArgs >>= \case

--- a/cardano-tracer/demo/multi/forwarder.hs
+++ b/cardano-tracer/demo/multi/forwarder.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE LambdaCase #-}
 
-import           System.Environment (getArgs)
-
 import           Cardano.Tracer.Test.Forwarder
+
+import           System.Environment (getArgs)
 
 main :: IO ()
 main = getArgs >>= \case

--- a/cardano-tracer/demo/ssh/forwarder.hs
+++ b/cardano-tracer/demo/ssh/forwarder.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE LambdaCase #-}
 
-import           Data.Functor.Identity
-import           System.Environment (getArgs)
-
 import           Cardano.Tracer.Test.Forwarder
 import           Cardano.Tracer.Test.TestSetup
+
+import           Data.Functor.Identity
+import           System.Environment (getArgs)
 
 main :: IO ()
 main = getArgs >>=

--- a/cardano-tracer/src/Cardano/Tracer/Acceptors/Client.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Acceptors/Client.hs
@@ -4,14 +4,16 @@ module Cardano.Tracer.Acceptors.Client
   ( runAcceptorsClient
   ) where
 
-import           Codec.CBOR.Term (Term)
-import qualified Data.ByteString.Lazy as LBS
-import           Data.Void (Void)
-import           Data.Word (Word32)
-
 import           Cardano.Logging (TraceObject)
 import           Cardano.Logging.Version (ForwardingVersion (..), ForwardingVersionData (..),
                    forwardingCodecCBORTerm, forwardingVersionCodec)
+import           Cardano.Tracer.Acceptors.Utils (notifyAboutNodeDisconnected,
+                   prepareDataPointRequestor, prepareMetricsStores, removeDisconnectedNode)
+import qualified Cardano.Tracer.Configuration as TC
+import           Cardano.Tracer.Environment
+import           Cardano.Tracer.Handlers.Logs.TraceObjects (traceObjectsHandler)
+import           Cardano.Tracer.MetaTrace
+import           Cardano.Tracer.Utils (connIdToNodeId)
 import           Ouroboros.Network.Context (MinimalInitiatorContext (..), ResponderContext (..))
 import           Ouroboros.Network.Driver.Limits (ProtocolTimeLimits)
 import           Ouroboros.Network.IOManager (withIOManager)
@@ -28,6 +30,11 @@ import           Ouroboros.Network.Snocket (LocalAddress, LocalSocket, Snocket,
                    localAddressFromPath, localSnocket, makeLocalBearer)
 import           Ouroboros.Network.Socket (ConnectionId (..), HandshakeCallbacks (..),
                    connectToNode, nullNetworkConnectTracers)
+
+import           Codec.CBOR.Term (Term)
+import qualified Data.ByteString.Lazy as LBS
+import           Data.Void (Void)
+import           Data.Word (Word32)
 import qualified System.Metrics.Configuration as EKGF
 import           System.Metrics.Network.Acceptor (acceptEKGMetricsInit)
 
@@ -35,14 +42,6 @@ import qualified Trace.Forward.Configuration.DataPoint as DPF
 import qualified Trace.Forward.Configuration.TraceObject as TF
 import           Trace.Forward.Run.DataPoint.Acceptor (acceptDataPointsInit)
 import           Trace.Forward.Run.TraceObject.Acceptor (acceptTraceObjectsInit)
-
-import           Cardano.Tracer.Acceptors.Utils (notifyAboutNodeDisconnected,
-                   prepareDataPointRequestor, prepareMetricsStores, removeDisconnectedNode)
-import qualified Cardano.Tracer.Configuration as TC
-import           Cardano.Tracer.Environment
-import           Cardano.Tracer.Handlers.Logs.TraceObjects (traceObjectsHandler)
-import           Cardano.Tracer.MetaTrace
-import           Cardano.Tracer.Utils (connIdToNodeId)
 
 runAcceptorsClient
   :: TracerEnv

--- a/cardano-tracer/src/Cardano/Tracer/Acceptors/Run.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Acceptors/Run.hs
@@ -5,25 +5,24 @@ module Cardano.Tracer.Acceptors.Run
   ( runAcceptors
   ) where
 
-import           Control.Concurrent.Async (forConcurrently_)
-import           "contra-tracer" Control.Tracer (Tracer, contramap, nullTracer, stdoutTracer)
-import qualified Data.List.NonEmpty as NE
-import           Data.Maybe (fromMaybe)
-import           Data.Time.Clock (secondsToNominalDiffTime)
-
-import qualified System.Metrics.Configuration as EKGF
-import qualified System.Metrics.ReqResp as EKGF
-
-import qualified Trace.Forward.Configuration.DataPoint as DPF
-import qualified Trace.Forward.Configuration.TraceObject as TOF
-import qualified Trace.Forward.Protocol.TraceObject.Type as TOF
-
 import           Cardano.Tracer.Acceptors.Client
 import           Cardano.Tracer.Acceptors.Server
 import           Cardano.Tracer.Configuration
 import           Cardano.Tracer.Environment
 import           Cardano.Tracer.MetaTrace
 import           Cardano.Tracer.Utils
+
+import           Control.Concurrent.Async (forConcurrently_)
+import           "contra-tracer" Control.Tracer (Tracer, contramap, nullTracer, stdoutTracer)
+import qualified Data.List.NonEmpty as NE
+import           Data.Maybe (fromMaybe)
+import           Data.Time.Clock (secondsToNominalDiffTime)
+import qualified System.Metrics.Configuration as EKGF
+import qualified System.Metrics.ReqResp as EKGF
+
+import qualified Trace.Forward.Configuration.DataPoint as DPF
+import qualified Trace.Forward.Configuration.TraceObject as TOF
+import qualified Trace.Forward.Protocol.TraceObject.Type as TOF
 
 -- | Run acceptors for all supported protocols.
 --

--- a/cardano-tracer/src/Cardano/Tracer/Acceptors/Utils.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Acceptors/Utils.hs
@@ -8,6 +8,15 @@ module Cardano.Tracer.Acceptors.Utils
   , removeDisconnectedNode
   ) where
 
+import           Cardano.Logging (SeverityS (..))
+import           Cardano.Tracer.Environment
+import           Cardano.Tracer.Handlers.RTView.Notifications.Types
+import           Cardano.Tracer.Handlers.RTView.Notifications.Utils
+import           Cardano.Tracer.Types
+import           Cardano.Tracer.Utils
+import           Ouroboros.Network.Snocket (LocalAddress)
+import           Ouroboros.Network.Socket (ConnectionId (..))
+
 import           Control.Concurrent.STM (atomically)
 import           Control.Concurrent.STM.TVar (TVar, modifyTVar', newTVarIO)
 import qualified Data.Bimap as BM
@@ -15,19 +24,9 @@ import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import           Data.Time.Clock.System (getSystemTime, systemToUTCTime)
 import qualified System.Metrics as EKG
-
-import           Ouroboros.Network.Snocket (LocalAddress)
-import           Ouroboros.Network.Socket (ConnectionId (..))
 import           System.Metrics.Store.Acceptor (MetricsLocalStore, emptyMetricsLocalStore)
+
 import           Trace.Forward.Utils.DataPoint (DataPointRequestor, initDataPointRequestor)
-
-import           Cardano.Logging (SeverityS (..))
-
-import           Cardano.Tracer.Environment
-import           Cardano.Tracer.Handlers.RTView.Notifications.Types
-import           Cardano.Tracer.Handlers.RTView.Notifications.Utils
-import           Cardano.Tracer.Types
-import           Cardano.Tracer.Utils
 
 prepareDataPointRequestor
   :: TracerEnv

--- a/cardano-tracer/src/Cardano/Tracer/CLI.hs
+++ b/cardano-tracer/src/Cardano/Tracer/CLI.hs
@@ -3,9 +3,9 @@ module Cardano.Tracer.CLI
   , parseTracerParams
   ) where
 
-import           Options.Applicative
-
 import           Cardano.Logging
+
+import           Options.Applicative
 
 
 -- | CLI parameters required for the tracer.

--- a/cardano-tracer/src/Cardano/Tracer/Configuration.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Configuration.hs
@@ -17,6 +17,8 @@ module Cardano.Tracer.Configuration
   , readTracerConfig
   ) where
 
+import qualified Cardano.Logging.Types as Log
+
 import           Data.Aeson (FromJSON, ToJSON)
 import           Data.Fixed (Pico)
 import           Data.List (intercalate)
@@ -30,8 +32,6 @@ import           Data.Word (Word16, Word32, Word64)
 import           Data.Yaml (decodeFileEither)
 import           GHC.Generics (Generic)
 import           System.Exit (die)
-
-import qualified Cardano.Logging.Types as Log
 
 -- | Only local socket is supported, to avoid unauthorized connections.
 newtype Address = LocalSocket FilePath

--- a/cardano-tracer/src/Cardano/Tracer/Environment.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Environment.hs
@@ -2,8 +2,6 @@ module Cardano.Tracer.Environment
   ( TracerEnv (..)
   ) where
 
-import           Control.Concurrent.Extra (Lock)
-
 import           Cardano.Logging.Types
 import           Cardano.Tracer.Configuration
 import           Cardano.Tracer.Handlers.RTView.Notifications.Types
@@ -12,6 +10,8 @@ import           Cardano.Tracer.Handlers.RTView.State.TraceObjects
 import           Cardano.Tracer.Handlers.RTView.UI.Types
 import           Cardano.Tracer.MetaTrace
 import           Cardano.Tracer.Types
+
+import           Control.Concurrent.Extra (Lock)
 
 -- | Environment for all functions.
 data TracerEnv = TracerEnv

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/Logs/File.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/Logs/File.hs
@@ -5,6 +5,12 @@ module Cardano.Tracer.Handlers.Logs.File
   ( writeTraceObjectsToFile
   ) where
 
+import           Cardano.Logging (TraceObject (..))
+import           Cardano.Tracer.Configuration
+import           Cardano.Tracer.Handlers.Logs.Utils
+import           Cardano.Tracer.Types
+import           Cardano.Tracer.Utils (nl)
+
 import           Control.Concurrent.Extra (Lock, withLock)
 import           Control.Monad (unless)
 import           Control.Monad.Extra (ifM)
@@ -15,13 +21,6 @@ import qualified Data.Text.Encoding as TE
 import           System.Directory (createDirectoryIfMissing, doesDirectoryExist, makeAbsolute)
 import           System.Directory.Extra (listFiles)
 import           System.FilePath ((</>))
-
-import           Cardano.Logging (TraceObject (..))
-
-import           Cardano.Tracer.Configuration
-import           Cardano.Tracer.Handlers.Logs.Utils
-import           Cardano.Tracer.Types
-import           Cardano.Tracer.Utils (nl)
 
 -- | Append the list of 'TraceObject's to the latest log via symbolic link.
 --

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/Logs/Rotator.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/Logs/Rotator.hs
@@ -6,6 +6,13 @@ module Cardano.Tracer.Handlers.Logs.Rotator
   ( runLogsRotator
   ) where
 
+import           Cardano.Tracer.Configuration
+import           Cardano.Tracer.Environment
+import           Cardano.Tracer.Handlers.Logs.Utils (createEmptyLogRotation, getTimeStampFromLog,
+                   isItLog)
+import           Cardano.Tracer.MetaTrace
+import           Cardano.Tracer.Utils (showProblemIfAny)
+
 import           Control.Concurrent.Async (forConcurrently_)
 import           Control.Concurrent.Extra (Lock)
 import           Control.Monad (forM_, forever, unless, when)
@@ -19,13 +26,6 @@ import           System.Directory (doesDirectoryExist, getFileSize, makeAbsolute
 import           System.Directory.Extra (listDirectories, listFiles)
 import           System.FilePath (takeDirectory, (</>))
 import           System.Time.Extra (sleep)
-
-import           Cardano.Tracer.Configuration
-import           Cardano.Tracer.Environment
-import           Cardano.Tracer.Handlers.Logs.Utils (createEmptyLogRotation, getTimeStampFromLog,
-                   isItLog)
-import           Cardano.Tracer.MetaTrace
-import           Cardano.Tracer.Utils (showProblemIfAny)
 
 -- | Runs rotation mechanism for the log files.
 runLogsRotator :: TracerEnv -> IO ()

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/Logs/TraceObjects.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/Logs/TraceObjects.hs
@@ -4,12 +4,7 @@ module Cardano.Tracer.Handlers.Logs.TraceObjects
   ( traceObjectsHandler
   ) where
 
-import           Control.Concurrent.Async (forConcurrently_)
-import           Control.Monad.Extra (whenJust)
-import qualified Data.List.NonEmpty as NE
-
 import           Cardano.Logging (TraceObject)
-
 import           Cardano.Tracer.Configuration
 import           Cardano.Tracer.Environment
 import           Cardano.Tracer.Handlers.Logs.File
@@ -17,6 +12,10 @@ import           Cardano.Tracer.Handlers.Logs.Journal
 import           Cardano.Tracer.Handlers.RTView.Run
 import           Cardano.Tracer.Types
 import           Cardano.Tracer.Utils
+
+import           Control.Concurrent.Async (forConcurrently_)
+import           Control.Monad.Extra (whenJust)
+import qualified Data.List.NonEmpty as NE
 
 -- | This handler is called periodically by 'TraceObjectForward' protocol
 --   from 'trace-forward' library.

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/Logs/Utils.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/Logs/Utils.hs
@@ -7,6 +7,8 @@ module Cardano.Tracer.Handlers.Logs.Utils
   , isItLog
   ) where
 
+import           Cardano.Tracer.Configuration (LogFormat (..))
+
 import           Control.Concurrent.Extra (Lock, withLock)
 import           Control.Monad (void)
 import qualified Data.ByteString as BS
@@ -16,8 +18,6 @@ import           Data.Time.Clock (UTCTime)
 import           Data.Time.Clock.System (getSystemTime, systemToUTCTime)
 import           Data.Time.Format (defaultTimeLocale, formatTime, parseTimeM)
 import           System.FilePath (takeBaseName, takeExtension, takeFileName, (<.>), (</>))
-
-import           Cardano.Tracer.Configuration (LogFormat (..))
 
 logPrefix :: String
 logPrefix = "node-"

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/Metrics/Monitoring.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/Metrics/Monitoring.hs
@@ -7,6 +7,11 @@ module Cardano.Tracer.Handlers.Metrics.Monitoring
   ( runMonitoringServer
   ) where
 
+import           Cardano.Tracer.Configuration
+import           Cardano.Tracer.Environment
+import           Cardano.Tracer.Handlers.RTView.SSL.Certs
+import           Cardano.Tracer.Types
+
 import           Control.Concurrent (ThreadId)
 import           Control.Concurrent.STM (atomically)
 import           Control.Concurrent.STM.TMVar (TMVar, newEmptyTMVarIO, putTMVar, tryReadTMVar)
@@ -17,15 +22,11 @@ import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import qualified Data.Text as T
 import           Data.Text.Encoding (encodeUtf8)
-import qualified Graphics.UI.Threepenny as UI
-import           Graphics.UI.Threepenny.Core (Element, UI, liftIO, set, (#), (#+))
 import           System.Remote.Monitoring (forkServerWith, serverThreadId)
 import           System.Time.Extra (sleep)
 
-import           Cardano.Tracer.Configuration
-import           Cardano.Tracer.Environment
-import           Cardano.Tracer.Handlers.RTView.SSL.Certs
-import           Cardano.Tracer.Types
+import qualified Graphics.UI.Threepenny as UI
+import           Graphics.UI.Threepenny.Core (Element, UI, liftIO, set, (#), (#+))
 
 -- | 'ekg' package allows to run only one EKG server, to display only one web page
 --   for particular EKG.Store. Since 'cardano-tracer' can be connected to any number

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/Metrics/Prometheus.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/Metrics/Prometheus.hs
@@ -7,6 +7,11 @@ module Cardano.Tracer.Handlers.Metrics.Prometheus
   ( runPrometheusServer
   ) where
 
+import           Cardano.Tracer.Configuration
+import           Cardano.Tracer.Environment
+import           Cardano.Tracer.Types
+import           Cardano.Tracer.Utils
+
 import           Prelude hiding (head)
 
 import           Control.Concurrent.STM.TVar (readTVarIO)
@@ -20,19 +25,15 @@ import           Data.String (IsString (..))
 import           Data.Text (Text)
 import qualified Data.Text as T
 import           Data.Text.Encoding (decodeUtf8, encodeUtf8)
-import           Snap.Blaze (blaze)
-import           Snap.Core (Snap, getRequest, route, rqParams, writeText)
-import           Snap.Http.Server (Config, ConfigLog (..), defaultConfig, setAccessLog, setBind,
-                   setErrorLog, setPort, simpleHttpServe)
 import           System.Metrics (Sample, Value (..), sampleAll)
 import           System.Time.Extra (sleep)
 import           Text.Blaze.Html5 hiding (map)
 import           Text.Blaze.Html5.Attributes hiding (title)
 
-import           Cardano.Tracer.Configuration
-import           Cardano.Tracer.Environment
-import           Cardano.Tracer.Types
-import           Cardano.Tracer.Utils
+import           Snap.Blaze (blaze)
+import           Snap.Core (Snap, getRequest, route, rqParams, writeText)
+import           Snap.Http.Server (Config, ConfigLog (..), defaultConfig, setAccessLog, setBind,
+                   setErrorLog, setPort, simpleHttpServe)
 
 -- | Runs simple HTTP server that listens host and port and returns
 --   the list of currently connected nodes in such a format:

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/Metrics/Servers.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/Metrics/Servers.hs
@@ -4,14 +4,14 @@ module Cardano.Tracer.Handlers.Metrics.Servers
   ( runMetricsServers
   ) where
 
-import           Control.Concurrent.Async.Extra (sequenceConcurrently)
-import           Control.Monad (void)
-
 import           Cardano.Tracer.Configuration
 import           Cardano.Tracer.Environment
 import           Cardano.Tracer.Handlers.Metrics.Monitoring
 import           Cardano.Tracer.Handlers.Metrics.Prometheus
 import           Cardano.Tracer.MetaTrace
+
+import           Control.Concurrent.Async.Extra (sequenceConcurrently)
+import           Control.Monad (void)
 
 -- | Runs metrics servers if needed:
 --

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Notifications/Check.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Notifications/Check.hs
@@ -6,7 +6,6 @@ module Cardano.Tracer.Handlers.RTView.Notifications.Check
 --import qualified Data.Text as T
 
 import           Cardano.Logging (SeverityS (..))
-
 import           Cardano.Tracer.Handlers.RTView.Notifications.Types
 import           Cardano.Tracer.Handlers.RTView.Notifications.Utils
 import           Cardano.Tracer.Handlers.RTView.State.TraceObjects

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Notifications/Email.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Notifications/Email.hs
@@ -9,6 +9,8 @@ module Cardano.Tracer.Handlers.RTView.Notifications.Email
   , statusIsOK
   ) where
 
+import           Cardano.Tracer.Handlers.RTView.Notifications.Types
+
 import           Control.Concurrent.Async (race)
 import           Control.Exception.Extra (try_)
 import           Data.Text (Text)
@@ -17,8 +19,6 @@ import qualified Data.Text.Lazy as LT
 import           Network.Mail.Mime (Address (..), Mail (..), simpleMail')
 import qualified Network.Mail.SMTP as SMTP
 import           System.Time.Extra (sleep)
-
-import           Cardano.Tracer.Handlers.RTView.Notifications.Types
 
 type StatusMessage = Text
 

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Notifications/Send.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Notifications/Send.hs
@@ -4,6 +4,12 @@ module Cardano.Tracer.Handlers.RTView.Notifications.Send
   ( makeAndSendNotification
   ) where
 
+import           Cardano.Logging (showT)
+import           Cardano.Tracer.Handlers.RTView.Notifications.Email
+import           Cardano.Tracer.Handlers.RTView.Notifications.Types
+import           Cardano.Tracer.Types
+import           Cardano.Tracer.Utils
+
 import           Control.Concurrent.Extra (Lock)
 import           Control.Concurrent.STM (atomically)
 import           Control.Concurrent.STM.TBQueue (flushTBQueue)
@@ -15,13 +21,6 @@ import           Data.Text (Text)
 import qualified Data.Text as T
 import           Data.Time.Clock (UTCTime)
 import           Data.Time.Format (defaultTimeLocale, formatTime)
-
-import           Cardano.Logging (showT)
-
-import           Cardano.Tracer.Handlers.RTView.Notifications.Email
-import           Cardano.Tracer.Handlers.RTView.Notifications.Types
-import           Cardano.Tracer.Types
-import           Cardano.Tracer.Utils
 
 makeAndSendNotification
   :: EmailSettings

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Notifications/Settings.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Notifications/Settings.hs
@@ -11,21 +11,19 @@ module Cardano.Tracer.Handlers.RTView.Notifications.Settings
   , saveEventsSettingsOnDisk
   ) where
 
+import           Cardano.Tracer.Environment
+import           Cardano.Tracer.Handlers.RTView.Notifications.Types
+import           Cardano.Tracer.Handlers.RTView.System
+
 import           Control.Exception.Extra (ignore, try_)
-import           Crypto.Cipher.AES ()
-import           Crypto.Cipher.Types ()
-import           Crypto.Error ()
--- import           Crypto.Cipher.AES (AES256)
--- import           Crypto.Cipher.Types (BlockCipher (..), cipherInit, ctrCombine, nullIV)
--- import           Crypto.Error (CryptoError, eitherCryptoError)
 import           Data.Aeson (decodeStrict', encode, encodeFile)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Text as T
 
-import           Cardano.Tracer.Environment
-import           Cardano.Tracer.Handlers.RTView.Notifications.Types
-import           Cardano.Tracer.Handlers.RTView.System
+import           Crypto.Cipher.AES ()
+import           Crypto.Cipher.Types ()
+import           Crypto.Error ()
 
 readSavedEmailSettings :: Maybe FilePath -> IO EmailSettings
 readSavedEmailSettings rtvSD = do

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Notifications/Types.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Notifications/Types.hs
@@ -11,6 +11,10 @@ module Cardano.Tracer.Handlers.RTView.Notifications.Types
   , EventsQueues
   ) where
 
+import           Cardano.Logging (SeverityS (..))
+import           Cardano.Tracer.Handlers.RTView.Notifications.Timer
+import           Cardano.Tracer.Types
+
 import           Control.Concurrent.STM.TBQueue (TBQueue)
 import           Control.Concurrent.STM.TVar (TVar)
 import           Data.Aeson (FromJSON, ToJSON)
@@ -18,11 +22,6 @@ import           Data.Map.Strict (Map)
 import           Data.Text (Text)
 import           Data.Time.Clock (UTCTime)
 import           GHC.Generics (Generic)
-
-import           Cardano.Logging (SeverityS (..))
-
-import           Cardano.Tracer.Handlers.RTView.Notifications.Timer
-import           Cardano.Tracer.Types
 
 -- | Email settings for notifications.
 

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Notifications/Utils.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Notifications/Utils.hs
@@ -7,6 +7,13 @@ module Cardano.Tracer.Handlers.RTView.Notifications.Utils
   , updateNotificationsPeriods
   ) where
 
+import           Cardano.Tracer.Handlers.RTView.Notifications.Send
+import           Cardano.Tracer.Handlers.RTView.Notifications.Settings
+import           Cardano.Tracer.Handlers.RTView.Notifications.Timer
+import           Cardano.Tracer.Handlers.RTView.Notifications.Types
+import           Cardano.Tracer.Handlers.RTView.Update.Utils
+import           Cardano.Tracer.Types
+
 import           Control.Concurrent.Extra (Lock)
 import           Control.Concurrent.STM (atomically)
 import           Control.Concurrent.STM.TBQueue (flushTBQueue, isFullTBQueue, newTBQueueIO,
@@ -14,13 +21,6 @@ import           Control.Concurrent.STM.TBQueue (flushTBQueue, isFullTBQueue, ne
 import           Control.Concurrent.STM.TVar (newTVarIO, readTVarIO)
 import           Control.Monad.Extra (unlessM, whenJust)
 import qualified Data.Map.Strict as M
-
-import           Cardano.Tracer.Handlers.RTView.Notifications.Send
-import           Cardano.Tracer.Handlers.RTView.Notifications.Settings
-import           Cardano.Tracer.Handlers.RTView.Notifications.Timer
-import           Cardano.Tracer.Handlers.RTView.Notifications.Types
-import           Cardano.Tracer.Handlers.RTView.Update.Utils
-import           Cardano.Tracer.Types
 
 initEventsQueues
   :: Maybe FilePath

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Run.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Run.hs
@@ -6,14 +6,6 @@ module Cardano.Tracer.Handlers.RTView.Run
   , module Cardano.Tracer.Handlers.RTView.State.TraceObjects
   ) where
 
-import           Control.Concurrent.Async.Extra (sequenceConcurrently)
-import           Control.Monad (void)
-import           Control.Monad.Extra (whenJust)
-import qualified Data.Text as T
-import           Data.Text.Encoding (encodeUtf8)
-import qualified Graphics.UI.Threepenny as UI
-import           System.Time.Extra (sleep)
-
 import           Cardano.Tracer.Configuration
 import           Cardano.Tracer.Environment
 import           Cardano.Tracer.Handlers.RTView.Notifications.Utils
@@ -26,6 +18,15 @@ import           Cardano.Tracer.Handlers.RTView.UI.HTML.Main
 import           Cardano.Tracer.Handlers.RTView.Update.EraSettings
 import           Cardano.Tracer.Handlers.RTView.Update.Historical
 import           Cardano.Tracer.MetaTrace
+
+import           Control.Concurrent.Async.Extra (sequenceConcurrently)
+import           Control.Monad (void)
+import           Control.Monad.Extra (whenJust)
+import qualified Data.Text as T
+import           Data.Text.Encoding (encodeUtf8)
+import           System.Time.Extra (sleep)
+
+import qualified Graphics.UI.Threepenny as UI
 
 -- | RTView is a part of 'cardano-tracer' that provides an ability
 --   to monitor Cardano nodes in a real-time. The core idea is simple:

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/SSL/Certs.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/SSL/Certs.hs
@@ -5,15 +5,15 @@ module Cardano.Tracer.Handlers.RTView.SSL.Certs
   ( placeDefaultSSLFiles
   ) where
 
+import           Cardano.Tracer.Environment
+import           Cardano.Tracer.Handlers.RTView.System
+
 import           Control.Exception.Extra (ignore)
 import           Control.Monad.Extra (unlessM)
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import           Data.String.QQ
 import qualified System.Directory as D
-
-import           Cardano.Tracer.Environment
-import           Cardano.Tracer.Handlers.RTView.System
 
 placeDefaultSSLFiles :: TracerEnv -> IO (FilePath, FilePath)
 placeDefaultSSLFiles tracerEnv = do

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/State/Displayed.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/State/Displayed.hs
@@ -12,6 +12,8 @@ module Cardano.Tracer.Handlers.RTView.State.Displayed
   , updateDisplayedElements
   ) where
 
+import           Cardano.Tracer.Types (NodeId)
+
 import           Control.Concurrent.STM (atomically)
 import           Control.Concurrent.STM.TVar (TVar, modifyTVar', newTVarIO, readTVarIO)
 import           Data.List ((\\))
@@ -20,8 +22,6 @@ import qualified Data.Map.Strict as M
 import           Data.Set (Set)
 import qualified Data.Set as S
 import           Data.Text (Text)
-
-import           Cardano.Tracer.Types (NodeId)
 
 type ElementId    = Text
 type ElementValue = Text

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/State/EraSettings.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/State/EraSettings.hs
@@ -5,13 +5,13 @@ module Cardano.Tracer.Handlers.RTView.State.EraSettings
   , initErasSettings
   ) where
 
+import           Cardano.Tracer.Types (NodeId)
+
 import           Control.Concurrent.STM (atomically)
 import           Control.Concurrent.STM.TVar (TVar, modifyTVar', newTVarIO)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
 import           Data.Text (Text)
-
-import           Cardano.Tracer.Types (NodeId)
 
 data EraSettings = EraSettings
   { esEra             :: !Text

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/State/Historical.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/State/Historical.hs
@@ -22,6 +22,9 @@ module Cardano.Tracer.Handlers.RTView.State.Historical
   , readValueD
   ) where
 
+import           Cardano.Tracer.Handlers.RTView.Update.Utils
+import           Cardano.Tracer.Types (NodeId)
+
 import           Control.Concurrent.STM (atomically)
 import           Control.Concurrent.STM.TVar (TVar, modifyTVar', newTVarIO, readTVarIO)
 import           Control.Monad (mzero)
@@ -37,9 +40,6 @@ import           Data.Text.Read (decimal, double)
 import           Data.Time.Clock (UTCTime)
 import           Data.Word (Word64)
 import           Text.Printf (printf)
-
-import           Cardano.Tracer.Handlers.RTView.Update.Utils
-import           Cardano.Tracer.Types (NodeId)
 
 -- | A lot of information received from the node is useful as historical data.
 --   It means that such an information should be displayed on time charts,

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/State/Last.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/State/Last.hs
@@ -6,13 +6,13 @@ module Cardano.Tracer.Handlers.RTView.State.Last
   , updateLastResources
   ) where
 
+import           Cardano.Tracer.Types (NodeId)
+
 import           Control.Concurrent.STM (atomically)
 import           Control.Concurrent.STM.TVar (TVar, modifyTVar', newTVarIO)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
 import           Data.Word (Word64)
-
-import           Cardano.Tracer.Types (NodeId)
 
 -- | We have to store last received metric to be able to calculate
 --   the value based on next received metric. For example, calculate

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/State/Peers.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/State/Peers.hs
@@ -9,6 +9,8 @@ module Cardano.Tracer.Handlers.RTView.State.Peers
   , removePeer
   ) where
 
+import           Cardano.Tracer.Types (NodeId)
+
 import           Control.Concurrent.STM (atomically)
 import           Control.Concurrent.STM.TVar
 import           Data.Map.Strict (Map)
@@ -16,8 +18,6 @@ import qualified Data.Map.Strict as M
 import           Data.Set (Set)
 import qualified Data.Set as S
 import           Data.Text (Text)
-
-import           Cardano.Tracer.Types (NodeId)
 
 type PeerAddress  = Text
 type PeersForNode = Set PeerAddress

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/State/TraceObjects.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/State/TraceObjects.hs
@@ -14,6 +14,9 @@ module Cardano.Tracer.Handlers.RTView.State.TraceObjects
   , saveTraceObjects
   ) where
 
+import           Cardano.Logging (SeverityS, TraceObject (..))
+import           Cardano.Tracer.Types (NodeId)
+
 import           Control.Concurrent.STM (atomically)
 import           Control.Concurrent.STM.TQueue
 import           Control.Concurrent.STM.TVar (TVar, modifyTVar', newTVarIO, readTVar, readTVarIO)
@@ -23,10 +26,6 @@ import qualified Data.Map.Strict as M
 import           Data.Maybe (mapMaybe)
 import           Data.Text (Text, intercalate)
 import           Data.Time.Clock (UTCTime)
-
-import           Cardano.Logging (SeverityS, TraceObject (..))
-
-import           Cardano.Tracer.Types (NodeId)
 
 type Namespace       = Text
 type TraceObjectInfo = (Text, SeverityS, UTCTime)

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/Charts.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/Charts.hs
@@ -26,6 +26,18 @@ module Cardano.Tracer.Handlers.RTView.UI.Charts
   , restoreLastHistoryOnCharts
   ) where
 
+import           Cardano.Tracer.Environment
+import           Cardano.Tracer.Handlers.RTView.State.Historical
+import           Cardano.Tracer.Handlers.RTView.System
+import           Cardano.Tracer.Handlers.RTView.UI.CSS.Own
+import qualified Cardano.Tracer.Handlers.RTView.UI.JS.Charts as Chart
+import qualified Cardano.Tracer.Handlers.RTView.UI.JS.Utils as JS
+import           Cardano.Tracer.Handlers.RTView.UI.Types
+import           Cardano.Tracer.Handlers.RTView.UI.Utils
+import           Cardano.Tracer.Handlers.RTView.Update.Historical
+import           Cardano.Tracer.Types
+import           Cardano.Tracer.Utils
+
 import           Control.Concurrent.STM (atomically)
 import           Control.Concurrent.STM.TBQueue (newTBQueueIO, tryReadTBQueue, writeTBQueue)
 import           Control.Concurrent.STM.TVar (modifyTVar', newTVarIO, readTVarIO)
@@ -39,22 +51,11 @@ import qualified Data.Map.Strict as M
 import           Data.Maybe (catMaybes)
 import qualified Data.Set as S
 import           Data.Text (pack, unpack)
-import           Graphics.UI.Threepenny.Core
 import           System.Directory.Extra (listFiles)
 import           System.FilePath (takeBaseName, (</>))
 import           Text.Read (readMaybe)
 
-import           Cardano.Tracer.Environment
-import           Cardano.Tracer.Handlers.RTView.State.Historical
-import           Cardano.Tracer.Handlers.RTView.System
-import           Cardano.Tracer.Handlers.RTView.UI.CSS.Own
-import qualified Cardano.Tracer.Handlers.RTView.UI.JS.Charts as Chart
-import qualified Cardano.Tracer.Handlers.RTView.UI.JS.Utils as JS
-import           Cardano.Tracer.Handlers.RTView.UI.Types
-import           Cardano.Tracer.Handlers.RTView.UI.Utils
-import           Cardano.Tracer.Handlers.RTView.Update.Historical
-import           Cardano.Tracer.Types
-import           Cardano.Tracer.Utils
+import           Graphics.UI.Threepenny.Core
 
 chartsIds :: [ChartId]
 chartsIds = [minBound .. maxBound]

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/HTML/About.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/HTML/About.hs
@@ -4,21 +4,21 @@ module Cardano.Tracer.Handlers.RTView.UI.HTML.About
   ( mkAboutInfo
   ) where
 
-import           Data.List.Extra (lower)
-import qualified Data.Text as T
-import           Data.Version (showVersion)
-import qualified Graphics.UI.Threepenny as UI
-import           Graphics.UI.Threepenny.Core
-import           System.Directory (makeAbsolute)
-import           System.Environment (getArgs)
-import           System.Info (os)
-
 import           Cardano.Git.Rev (gitRev)
-
 import           Cardano.Tracer.Handlers.RTView.System
 import           Cardano.Tracer.Handlers.RTView.UI.Img.Icons
 import           Cardano.Tracer.Handlers.RTView.UI.JS.Utils
 import           Cardano.Tracer.Handlers.RTView.UI.Utils
+
+import           Data.List.Extra (lower)
+import qualified Data.Text as T
+import           Data.Version (showVersion)
+import           System.Directory (makeAbsolute)
+import           System.Environment (getArgs)
+import           System.Info (os)
+
+import qualified Graphics.UI.Threepenny as UI
+import           Graphics.UI.Threepenny.Core
 import           Paths_cardano_tracer (version)
 
 mkAboutInfo :: UI Element

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/HTML/Body.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/HTML/Body.hs
@@ -7,14 +7,6 @@ module Cardano.Tracer.Handlers.RTView.UI.HTML.Body
   ( mkPageBody
   ) where
 
-import           Control.Monad (unless, void, when)
-import           Control.Monad.Extra (whenJustM, whenM)
-import           Data.Text (Text)
-import qualified Graphics.UI.Threepenny as UI
-import           Graphics.UI.Threepenny.Core
-import           Graphics.UI.Threepenny.JQuery (Easing (..), fadeIn, fadeOut)
-import           Text.Read (readMaybe)
-
 import           Cardano.Tracer.Configuration
 import           Cardano.Tracer.Environment
 import           Cardano.Tracer.Handlers.RTView.State.Historical
@@ -32,6 +24,15 @@ import           Cardano.Tracer.Handlers.RTView.UI.Theme
 import           Cardano.Tracer.Handlers.RTView.UI.Types
 import           Cardano.Tracer.Handlers.RTView.UI.Utils
 import           Cardano.Tracer.Handlers.RTView.Update.Logs
+
+import           Control.Monad (unless, void, when)
+import           Control.Monad.Extra (whenJustM, whenM)
+import           Data.Text (Text)
+import           Text.Read (readMaybe)
+
+import qualified Graphics.UI.Threepenny as UI
+import           Graphics.UI.Threepenny.Core
+import           Graphics.UI.Threepenny.JQuery (Easing (..), fadeIn, fadeOut)
 
 mkPageBody
   :: TracerEnv

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/HTML/Logs.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/HTML/Logs.hs
@@ -6,14 +6,15 @@ module Cardano.Tracer.Handlers.RTView.UI.HTML.Logs
   ( mkLogsLiveView
   ) where
 
-import           Control.Monad (void)
-import qualified Graphics.UI.Threepenny as UI
-import           Graphics.UI.Threepenny.Core
-
 import           Cardano.Tracer.Environment
 import           Cardano.Tracer.Handlers.RTView.UI.Img.Icons
 import           Cardano.Tracer.Handlers.RTView.UI.Logs
 import           Cardano.Tracer.Handlers.RTView.UI.Utils
+
+import           Control.Monad (void)
+
+import qualified Graphics.UI.Threepenny as UI
+import           Graphics.UI.Threepenny.Core
 
 mkLogsLiveView :: TracerEnv -> UI Element
 mkLogsLiveView tracerEnv = do

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/HTML/Main.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/HTML/Main.hs
@@ -4,15 +4,6 @@ module Cardano.Tracer.Handlers.RTView.UI.HTML.Main
   ( mkMainPage
   ) where
 
-import           Control.Concurrent.STM.TVar (readTVarIO)
-import           Control.Monad (void)
-import           Control.Monad.Extra (whenM)
-import           Data.List.NonEmpty (NonEmpty)
-import           Data.Text (pack)
-import qualified Graphics.UI.Threepenny as UI
-import           Graphics.UI.Threepenny.Core
-import           System.Time.Extra (sleep)
-
 import           Cardano.Tracer.Configuration
 import           Cardano.Tracer.Environment
 import           Cardano.Tracer.Handlers.RTView.State.Displayed
@@ -35,6 +26,16 @@ import           Cardano.Tracer.Handlers.RTView.Update.NodeState
 import           Cardano.Tracer.Handlers.RTView.Update.Peers
 import           Cardano.Tracer.Handlers.RTView.Update.Reload
 import           Cardano.Tracer.Handlers.RTView.Update.Utils
+
+import           Control.Concurrent.STM.TVar (readTVarIO)
+import           Control.Monad (void)
+import           Control.Monad.Extra (whenM)
+import           Data.List.NonEmpty (NonEmpty)
+import           Data.Text (pack)
+import           System.Time.Extra (sleep)
+
+import qualified Graphics.UI.Threepenny as UI
+import           Graphics.UI.Threepenny.Core
 
 mkMainPage
   :: TracerEnv

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/HTML/NoNodes.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/HTML/NoNodes.hs
@@ -8,15 +8,16 @@ module Cardano.Tracer.Handlers.RTView.UI.HTML.NoNodes
   , showNoNodes
   ) where
 
-import           Data.List (intercalate)
-import qualified Data.List.NonEmpty as NE
-import           Data.String.QQ
-import qualified Graphics.UI.Threepenny as UI
-import           Graphics.UI.Threepenny.Core
-
 import           Cardano.Tracer.Configuration
 import           Cardano.Tracer.Handlers.RTView.UI.Img.Icons
 import           Cardano.Tracer.Handlers.RTView.UI.Utils
+
+import           Data.List (intercalate)
+import qualified Data.List.NonEmpty as NE
+import           Data.String.QQ
+
+import qualified Graphics.UI.Threepenny as UI
+import           Graphics.UI.Threepenny.Core
 
 -- | If the user doesn't see connected nodes - possible reason of it is
 --   misconfiguration of 'cardano-tracer' and/or 'cardano-node'.

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/HTML/Node/Column.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/HTML/Node/Column.hs
@@ -5,15 +5,6 @@ module Cardano.Tracer.Handlers.RTView.UI.HTML.Node.Column
   , deleteNodeColumn
   ) where
 
-import           Control.Monad (forM, void)
-import           Control.Monad.Extra (whenJustM)
-import           Data.List.NonEmpty (NonEmpty)
-import qualified Data.List.NonEmpty as NE
-import           Data.Text (unpack)
-import qualified Graphics.UI.Threepenny as UI
-import           Graphics.UI.Threepenny.Core
-import           System.FilePath ((</>))
-
 import           Cardano.Tracer.Configuration
 import           Cardano.Tracer.Environment
 import           Cardano.Tracer.Handlers.RTView.UI.HTML.Node.EKG
@@ -23,6 +14,16 @@ import           Cardano.Tracer.Handlers.RTView.UI.JS.Utils
 import           Cardano.Tracer.Handlers.RTView.UI.Utils
 import           Cardano.Tracer.Types
 import           Cardano.Tracer.Utils
+
+import           Control.Monad (forM, void)
+import           Control.Monad.Extra (whenJustM)
+import           Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NE
+import           Data.Text (unpack)
+import           System.FilePath ((</>))
+
+import qualified Graphics.UI.Threepenny as UI
+import           Graphics.UI.Threepenny.Core
 
 -- | For every connected node the new column should be added.
 addNodeColumn

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/HTML/Node/EKG.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/HTML/Node/EKG.hs
@@ -5,10 +5,10 @@ module Cardano.Tracer.Handlers.RTView.UI.HTML.Node.EKG
   ( mkEKGMetricsWindow
   ) where
 
+import           Cardano.Tracer.Handlers.RTView.UI.Utils
+
 import qualified Graphics.UI.Threepenny as UI
 import           Graphics.UI.Threepenny.Core
-
-import           Cardano.Tracer.Handlers.RTView.UI.Utils
 
 mkEKGMetricsWindow :: String -> UI Element
 mkEKGMetricsWindow anId = do

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/HTML/Node/Peers.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/HTML/Node/Peers.hs
@@ -6,12 +6,12 @@ module Cardano.Tracer.Handlers.RTView.UI.HTML.Node.Peers
   , deletePeerRow
   ) where
 
-import qualified Graphics.UI.Threepenny as UI
-import           Graphics.UI.Threepenny.Core
-
 import           Cardano.Tracer.Handlers.RTView.State.Peers
 import           Cardano.Tracer.Handlers.RTView.UI.Utils
 import           Cardano.Tracer.Types
+
+import qualified Graphics.UI.Threepenny as UI
+import           Graphics.UI.Threepenny.Core
 
 mkPeersTable :: String -> UI Element
 mkPeersTable anId = do

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/HTML/Notifications.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/HTML/Notifications.hs
@@ -6,13 +6,6 @@ module Cardano.Tracer.Handlers.RTView.UI.HTML.Notifications
   , mkNotificationsSettings
   ) where
 
-import           Control.Monad (void)
-import           Control.Monad.Extra (whenJustM)
-import qualified Data.Text as T
-import qualified Graphics.UI.Threepenny as UI
-import           Graphics.UI.Threepenny.Core
-import           Text.Read (readMaybe)
-
 import           Cardano.Tracer.Environment
 import           Cardano.Tracer.Handlers.RTView.Notifications.Email
 import           Cardano.Tracer.Handlers.RTView.Notifications.Timer
@@ -21,6 +14,14 @@ import           Cardano.Tracer.Handlers.RTView.Notifications.Utils
 import           Cardano.Tracer.Handlers.RTView.UI.Img.Icons
 import           Cardano.Tracer.Handlers.RTView.UI.Notifications
 import           Cardano.Tracer.Handlers.RTView.UI.Utils
+
+import           Control.Monad (void)
+import           Control.Monad.Extra (whenJustM)
+import qualified Data.Text as T
+import           Text.Read (readMaybe)
+
+import qualified Graphics.UI.Threepenny as UI
+import           Graphics.UI.Threepenny.Core
 
 mkNotificationsEvents :: TracerEnv -> EventsQueues -> UI Element
 mkNotificationsEvents tracerEnv eventsQueues = do

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/JS/Charts.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/JS/Charts.hs
@@ -15,17 +15,18 @@ module Cardano.Tracer.Handlers.RTView.UI.JS.Charts
   , setTimeRange
   ) where
 
+import           Cardano.Tracer.Handlers.RTView.State.Historical
+import           Cardano.Tracer.Handlers.RTView.UI.Types
+import           Cardano.Tracer.Handlers.RTView.Update.Utils
+
 import           Data.List (intercalate)
 import           Data.String.QQ
 import           Data.Text (Text)
 import           Data.Time.Clock.System (getSystemTime, systemToUTCTime)
 import           Data.Word (Word16)
+
 import qualified Graphics.UI.Threepenny as UI
 import           Graphics.UI.Threepenny.Core
-
-import           Cardano.Tracer.Handlers.RTView.State.Historical
-import           Cardano.Tracer.Handlers.RTView.UI.Types
-import           Cardano.Tracer.Handlers.RTView.Update.Utils
 
 prepareChartsJS :: UI ()
 prepareChartsJS =

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/JS/Utils.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/JS/Utils.hs
@@ -9,6 +9,7 @@ module Cardano.Tracer.Handlers.RTView.UI.JS.Utils
 
 import           Data.String.QQ
 import           Data.Text (Text)
+
 import qualified Graphics.UI.Threepenny as UI
 import           Graphics.UI.Threepenny.Core
 

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/Logs.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/Logs.hs
@@ -6,14 +6,15 @@ module Cardano.Tracer.Handlers.RTView.UI.Logs
   , saveLogsLiveViewFont
   ) where
 
-import           Control.Exception.Extra (ignore, try_)
-import qualified Data.Text as T
-import qualified Data.Text.IO as TIO
-import           Graphics.UI.Threepenny.Core
-
 import           Cardano.Tracer.Environment
 import           Cardano.Tracer.Handlers.RTView.System
 import           Cardano.Tracer.Handlers.RTView.UI.Utils
+
+import           Control.Exception.Extra (ignore, try_)
+import qualified Data.Text as T
+import qualified Data.Text.IO as TIO
+
+import           Graphics.UI.Threepenny.Core
 
 -- | When the user opened the logs live view window,
 --   the previous font's size should be restored from the disk.

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/Notifications.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/Notifications.hs
@@ -13,14 +13,6 @@ module Cardano.Tracer.Handlers.RTView.UI.Notifications
   , setStatusTestEmailButton
   ) where
 
-import           Control.Monad (unless, when)
-import           Data.Maybe (fromMaybe)
-import           Data.Text (pack, unpack)
-import qualified Data.Text as T
-import           Data.Text.Read (decimal)
-import qualified Graphics.UI.Threepenny as UI
-import           Graphics.UI.Threepenny.Core
-
 import           Cardano.Tracer.Environment
 import           Cardano.Tracer.Handlers.RTView.Notifications.Settings
 import           Cardano.Tracer.Handlers.RTView.Notifications.Timer
@@ -29,6 +21,15 @@ import           Cardano.Tracer.Handlers.RTView.UI.Img.Icons
 import           Cardano.Tracer.Handlers.RTView.UI.JS.Utils
 import           Cardano.Tracer.Handlers.RTView.UI.Utils
 import           Cardano.Tracer.Handlers.RTView.Update.Utils
+
+import           Control.Monad (unless, when)
+import           Data.Maybe (fromMaybe)
+import           Data.Text (pack, unpack)
+import qualified Data.Text as T
+import           Data.Text.Read (decimal)
+
+import qualified Graphics.UI.Threepenny as UI
+import           Graphics.UI.Threepenny.Core
 
 restoreEmailSettings :: TracerEnv -> UI ()
 restoreEmailSettings TracerEnv{teRTViewStateDir} = do

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/Theme.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/Theme.hs
@@ -9,18 +9,19 @@ module Cardano.Tracer.Handlers.RTView.UI.Theme
   , isCurrentThemeDark
   ) where
 
-import           Control.Exception.Extra (ignore, try_)
-import           Control.Monad (void)
-import qualified Data.Text as T
-import qualified Data.Text.IO as TIO
-import qualified Graphics.UI.Threepenny as UI
-import           Graphics.UI.Threepenny.Core
-
 import           Cardano.Tracer.Environment
 import           Cardano.Tracer.Handlers.RTView.System
 import           Cardano.Tracer.Handlers.RTView.UI.Charts
 import           Cardano.Tracer.Handlers.RTView.UI.Img.Icons
 import           Cardano.Tracer.Handlers.RTView.UI.Utils
+
+import           Control.Exception.Extra (ignore, try_)
+import           Control.Monad (void)
+import qualified Data.Text as T
+import qualified Data.Text.IO as TIO
+
+import qualified Graphics.UI.Threepenny as UI
+import           Graphics.UI.Threepenny.Core
 
 restoreTheme, switchTheme :: TracerEnv -> UI ()
 restoreTheme tracerEnv = readSavedTheme tracerEnv >>= setThemeAndSave tracerEnv

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/Types.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/Types.hs
@@ -13,14 +13,14 @@ module Cardano.Tracer.Handlers.RTView.UI.Types
   , WebPageStatus
   ) where
 
+import           Cardano.Tracer.Types
+
 import           Control.Concurrent.STM.TBQueue (TBQueue)
 import           Control.Concurrent.STM.TVar (TVar)
 import           Data.Aeson (FromJSON, ToJSON)
 import           Data.Map.Strict (Map)
 import           Data.Word (Word16)
 import           GHC.Generics (Generic)
-
-import           Cardano.Tracer.Types
 
 data ChartId
   = CPUChart

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/Utils.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/UI/Utils.hs
@@ -50,6 +50,10 @@ module Cardano.Tracer.Handlers.RTView.UI.Utils
   , webPageIsClosed
   ) where
 
+import           Cardano.Tracer.Environment
+import           Cardano.Tracer.Handlers.RTView.State.Displayed
+import           Cardano.Tracer.Types
+
 import           Control.Concurrent.STM (atomically)
 import           Control.Concurrent.STM.TVar (TVar, modifyTVar')
 import           Control.Monad (unless, void)
@@ -57,15 +61,12 @@ import           Control.Monad.Extra (whenJustM)
 import           Data.String.QQ
 import           Data.Text (Text, unpack)
 import qualified Data.Text as T
+
 import qualified Foreign.JavaScript as JS
 import qualified Foreign.RemotePtr as Foreign
 import qualified Graphics.UI.Threepenny as UI
 import           Graphics.UI.Threepenny.Core
 import           Graphics.UI.Threepenny.JQuery (Easing (..), fadeIn, fadeOut)
-
-import           Cardano.Tracer.Environment
-import           Cardano.Tracer.Handlers.RTView.State.Displayed
-import           Cardano.Tracer.Types
 
 (##) :: UI Element -> String -> UI Element
 (##) el anId = el # set UI.id_ anId

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/Chain.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/Chain.hs
@@ -6,12 +6,12 @@ module Cardano.Tracer.Handlers.RTView.Update.Chain
   ( updateBlockchainHistory
   ) where
 
-import           Data.Text.Read (double)
-import           Data.Time.Clock (UTCTime)
-
 import           Cardano.Tracer.Handlers.Metrics.Utils
 import           Cardano.Tracer.Handlers.RTView.State.Historical
 import           Cardano.Tracer.Types
+
+import           Data.Text.Read (double)
+import           Data.Time.Clock (UTCTime)
 
 updateBlockchainHistory
   :: NodeId

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/EKG.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/EKG.hs
@@ -5,19 +5,19 @@ module Cardano.Tracer.Handlers.RTView.Update.EKG
   ( updateEKGMetrics
   ) where
 
+import           Cardano.Logging (showT)
+import           Cardano.Tracer.Environment
+import           Cardano.Tracer.Handlers.Metrics.Utils
+import           Cardano.Tracer.Handlers.RTView.UI.Utils
+import           Cardano.Tracer.Types
+
 import           Control.Concurrent.STM.TVar (readTVarIO)
 import           Control.Monad (forM_, unless)
 import           Data.List (partition, sort)
 import qualified Data.Map.Strict as M
 import           Data.Text (intercalate, isPrefixOf)
+
 import           Graphics.UI.Threepenny.Core (UI, liftIO)
-
-import           Cardano.Logging (showT)
-
-import           Cardano.Tracer.Environment
-import           Cardano.Tracer.Handlers.Metrics.Utils
-import           Cardano.Tracer.Handlers.RTView.UI.Utils
-import           Cardano.Tracer.Types
 
 updateEKGMetrics :: TracerEnv -> UI ()
 updateEKGMetrics TracerEnv{teAcceptedMetrics} = do

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/EraSettings.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/EraSettings.hs
@@ -6,17 +6,16 @@ module Cardano.Tracer.Handlers.RTView.Update.EraSettings
   ( runEraSettingsUpdater
   ) where
 
-import           Control.Monad (forever)
-import           Control.Monad.Extra (whenJustM)
-import           Data.Time.Clock (nominalDiffTimeToSeconds)
-import           System.Time.Extra (sleep)
-
 import           Cardano.Node.Startup (NodeStartupInfo (..))
-
 import           Cardano.Tracer.Environment
 import           Cardano.Tracer.Handlers.RTView.State.EraSettings
 import           Cardano.Tracer.Handlers.RTView.Update.Utils
 import           Cardano.Tracer.Handlers.RTView.Utils
+
+import           Control.Monad (forever)
+import           Control.Monad.Extra (whenJustM)
+import           Data.Time.Clock (nominalDiffTimeToSeconds)
+import           System.Time.Extra (sleep)
 
 runEraSettingsUpdater
   :: TracerEnv

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/Historical.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/Historical.hs
@@ -13,6 +13,20 @@ module Cardano.Tracer.Handlers.RTView.Update.Historical
   , runHistoricalUpdater
   ) where
 
+import           Cardano.Tracer.Environment
+import           Cardano.Tracer.Handlers.Metrics.Utils
+import           Cardano.Tracer.Handlers.RTView.State.Historical
+import           Cardano.Tracer.Handlers.RTView.State.Last
+import           Cardano.Tracer.Handlers.RTView.System
+import           Cardano.Tracer.Handlers.RTView.Update.Chain
+import           Cardano.Tracer.Handlers.RTView.Update.Leadership
+import           Cardano.Tracer.Handlers.RTView.Update.Resources
+import           Cardano.Tracer.Handlers.RTView.Update.Transactions
+import           Cardano.Tracer.Handlers.RTView.Update.Utils
+import           Cardano.Tracer.Handlers.RTView.Utils
+import           Cardano.Tracer.Types
+import           Cardano.Tracer.Utils
+
 import           Control.Concurrent.Async (forConcurrently_)
 import           Control.Concurrent.STM (atomically)
 import           Control.Concurrent.STM.TVar (modifyTVar', readTVar, readTVarIO)
@@ -35,20 +49,6 @@ import           System.Directory.Extra (listFiles)
 import           System.FilePath (takeBaseName, (</>))
 import           System.Time.Extra (sleep)
 import           Text.Read (readMaybe)
-
-import           Cardano.Tracer.Environment
-import           Cardano.Tracer.Handlers.Metrics.Utils
-import           Cardano.Tracer.Handlers.RTView.State.Historical
-import           Cardano.Tracer.Handlers.RTView.State.Last
-import           Cardano.Tracer.Handlers.RTView.System
-import           Cardano.Tracer.Handlers.RTView.Update.Chain
-import           Cardano.Tracer.Handlers.RTView.Update.Leadership
-import           Cardano.Tracer.Handlers.RTView.Update.Resources
-import           Cardano.Tracer.Handlers.RTView.Update.Transactions
-import           Cardano.Tracer.Handlers.RTView.Update.Utils
-import           Cardano.Tracer.Handlers.RTView.Utils
-import           Cardano.Tracer.Types
-import           Cardano.Tracer.Utils
 
 -- | A lot of information received from the node is useful as historical data.
 --   It means that such an information should be displayed on time charts,

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/KES.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/KES.hs
@@ -7,14 +7,6 @@ module Cardano.Tracer.Handlers.RTView.Update.KES
   ( updateKESInfo
   ) where
 
-import           Control.Concurrent.STM.TVar (readTVarIO)
-import           Control.Monad.Extra (whenJust)
-import qualified Data.Map.Strict as M
-import           Data.Text (pack)
-import           Data.Text.Read (decimal)
-import           Graphics.UI.Threepenny.Core (UI, liftIO)
-import           Text.Printf (printf)
-
 import           Cardano.Tracer.Environment
 import           Cardano.Tracer.Handlers.Metrics.Utils
 import           Cardano.Tracer.Handlers.RTView.State.Displayed
@@ -23,6 +15,15 @@ import           Cardano.Tracer.Handlers.RTView.UI.Utils
 import           Cardano.Tracer.Handlers.RTView.Utils
 import           Cardano.Tracer.Types
 import           Cardano.Tracer.Utils
+
+import           Control.Concurrent.STM.TVar (readTVarIO)
+import           Control.Monad.Extra (whenJust)
+import qualified Data.Map.Strict as M
+import           Data.Text (pack)
+import           Data.Text.Read (decimal)
+import           Text.Printf (printf)
+
+import           Graphics.UI.Threepenny.Core (UI, liftIO)
 
 updateKESInfo
   :: TracerEnv

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/Leadership.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/Leadership.hs
@@ -5,11 +5,11 @@ module Cardano.Tracer.Handlers.RTView.Update.Leadership
   ( updateLeadershipHistory
   ) where
 
-import           Data.Time.Clock (UTCTime)
-
 import           Cardano.Tracer.Handlers.Metrics.Utils
 import           Cardano.Tracer.Handlers.RTView.State.Historical
 import           Cardano.Tracer.Types
+
+import           Data.Time.Clock (UTCTime)
 
 updateLeadershipHistory
   :: NodeId

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/Logs.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/Logs.hs
@@ -9,16 +9,7 @@ module Cardano.Tracer.Handlers.RTView.Update.Logs
   , updateLogsLiveViewNodes
   ) where
 
-import           Control.Concurrent.STM.TVar (readTVarIO)
-import           Control.Monad (forM_, void, when)
-import           Control.Monad.Extra (whenJustM, whenM)
-import qualified Data.Text as T
-import           Data.Time.Format (defaultTimeLocale, formatTime)
-import qualified Graphics.UI.Threepenny as UI
-import           Graphics.UI.Threepenny.Core
-
 import           Cardano.Logging (SeverityS (..), showT)
-
 import           Cardano.Tracer.Environment
 import           Cardano.Tracer.Handlers.RTView.State.TraceObjects
 import           Cardano.Tracer.Handlers.RTView.UI.Charts
@@ -30,6 +21,15 @@ import           Cardano.Tracer.Handlers.RTView.Update.Nodes
 import           Cardano.Tracer.Handlers.RTView.Utils
 import           Cardano.Tracer.Types
 import           Cardano.Tracer.Utils
+
+import           Control.Concurrent.STM.TVar (readTVarIO)
+import           Control.Monad (forM_, void, when)
+import           Control.Monad.Extra (whenJustM, whenM)
+import qualified Data.Text as T
+import           Data.Time.Format (defaultTimeLocale, formatTime)
+
+import qualified Graphics.UI.Threepenny as UI
+import           Graphics.UI.Threepenny.Core
 
 updateLogsLiveViewItems
   :: TracerEnv

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/NodeInfo.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/NodeInfo.hs
@@ -5,20 +5,20 @@ module Cardano.Tracer.Handlers.RTView.Update.NodeInfo
   ( askNSetNodeInfo
   ) where
 
-import           Control.Monad (forM_)
-import           Control.Monad.Extra (whenJustM)
-import           Data.Set (Set)
-import qualified Data.Text as T
-import           Data.Time.Format (defaultTimeLocale, formatTime)
-import           Graphics.UI.Threepenny.Core
-
 import           Cardano.Node.Startup (NodeInfo (..))
-
 import           Cardano.Tracer.Environment
 import           Cardano.Tracer.Handlers.RTView.State.Displayed
 import           Cardano.Tracer.Handlers.RTView.UI.Utils
 import           Cardano.Tracer.Handlers.RTView.Update.Utils
 import           Cardano.Tracer.Types
+
+import           Control.Monad (forM_)
+import           Control.Monad.Extra (whenJustM)
+import           Data.Set (Set)
+import qualified Data.Text as T
+import           Data.Time.Format (defaultTimeLocale, formatTime)
+
+import           Graphics.UI.Threepenny.Core
 
 askNSetNodeInfo
   :: TracerEnv

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/NodeState.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/NodeState.hs
@@ -6,19 +6,19 @@ module Cardano.Tracer.Handlers.RTView.Update.NodeState
   ( askNSetNodeState
   ) where
 
-import           Control.Monad.Extra (whenJustM)
-import           Data.Text (pack)
-import           Graphics.UI.Threepenny.Core (UI, liftIO)
-import           Text.Printf (printf)
-
 import           Cardano.Node.Tracing.StateRep
-
 import           Cardano.Tracer.Environment
 import           Cardano.Tracer.Handlers.RTView.State.Displayed
 import           Cardano.Tracer.Handlers.RTView.UI.Utils
 import           Cardano.Tracer.Handlers.RTView.Update.Utils
 import           Cardano.Tracer.Handlers.RTView.Utils
 import           Cardano.Tracer.Types
+
+import           Control.Monad.Extra (whenJustM)
+import           Data.Text (pack)
+import           Text.Printf (printf)
+
+import           Graphics.UI.Threepenny.Core (UI, liftIO)
 
 -- | There is 'NodeState' datapoint, it contains different information
 --   about the current state of the node. For example, its sync progress.

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/Nodes.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/Nodes.hs
@@ -13,6 +13,23 @@ module Cardano.Tracer.Handlers.RTView.Update.Nodes
   , updateNodesUptime
   ) where
 
+import           Cardano.Logging (showT)
+import           Cardano.Tracer.Configuration
+import           Cardano.Tracer.Environment
+import           Cardano.Tracer.Handlers.Metrics.Utils
+import           Cardano.Tracer.Handlers.RTView.State.Displayed
+import           Cardano.Tracer.Handlers.RTView.State.EraSettings
+import           Cardano.Tracer.Handlers.RTView.UI.Charts
+import           Cardano.Tracer.Handlers.RTView.UI.HTML.Node.Column
+import           Cardano.Tracer.Handlers.RTView.UI.HTML.NoNodes
+import           Cardano.Tracer.Handlers.RTView.UI.Types
+import           Cardano.Tracer.Handlers.RTView.UI.Utils
+import           Cardano.Tracer.Handlers.RTView.Update.NodeInfo
+import           Cardano.Tracer.Handlers.RTView.Update.Utils
+import           Cardano.Tracer.Handlers.RTView.Utils
+import           Cardano.Tracer.Types
+import           Cardano.Tracer.Utils
+
 import           Control.Concurrent.STM (atomically)
 import           Control.Concurrent.STM.TVar
 import           Control.Monad (forM_, unless, void, when)
@@ -30,28 +47,11 @@ import           Data.Time.Clock (UTCTime, addUTCTime, diffUTCTime, utctDay)
 import           Data.Time.Clock.System (getSystemTime, systemToUTCTime)
 import           Data.Time.Format (defaultTimeLocale, formatTime)
 import           Data.Word (Word64)
-import qualified Graphics.UI.Threepenny as UI
-import           Graphics.UI.Threepenny.Core
 import           Text.Printf (printf)
 import           Text.Read (readMaybe)
 
-import           Cardano.Logging (showT)
-
-import           Cardano.Tracer.Configuration
-import           Cardano.Tracer.Environment
-import           Cardano.Tracer.Handlers.Metrics.Utils
-import           Cardano.Tracer.Handlers.RTView.State.Displayed
-import           Cardano.Tracer.Handlers.RTView.State.EraSettings
-import           Cardano.Tracer.Handlers.RTView.UI.Charts
-import           Cardano.Tracer.Handlers.RTView.UI.HTML.Node.Column
-import           Cardano.Tracer.Handlers.RTView.UI.HTML.NoNodes
-import           Cardano.Tracer.Handlers.RTView.UI.Types
-import           Cardano.Tracer.Handlers.RTView.UI.Utils
-import           Cardano.Tracer.Handlers.RTView.Update.NodeInfo
-import           Cardano.Tracer.Handlers.RTView.Update.Utils
-import           Cardano.Tracer.Handlers.RTView.Utils
-import           Cardano.Tracer.Types
-import           Cardano.Tracer.Utils
+import qualified Graphics.UI.Threepenny as UI
+import           Graphics.UI.Threepenny.Core
 
 updateNodesUI
   :: TracerEnv

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/Peers.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/Peers.hs
@@ -6,6 +6,16 @@ module Cardano.Tracer.Handlers.RTView.Update.Peers
   ( updateNodesPeers
   ) where
 
+import           Cardano.Logging (showT)
+import           Cardano.Node.Tracing.Peers
+import           Cardano.Tracer.Environment
+import           Cardano.Tracer.Handlers.RTView.State.Peers
+import           Cardano.Tracer.Handlers.RTView.UI.HTML.Node.Peers
+import           Cardano.Tracer.Handlers.RTView.UI.Utils
+import           Cardano.Tracer.Handlers.RTView.Update.Utils
+import           Cardano.Tracer.Handlers.RTView.Utils
+import           Cardano.Tracer.Types
+
 import           Control.Monad (forM_, void)
 import           Control.Monad.Extra (whenJustM)
 import           Data.List (find)
@@ -15,20 +25,9 @@ import           Data.Set ((\\))
 import qualified Data.Set as S
 import           Data.Text (unpack)
 import qualified Data.Text as T
+
 import qualified Graphics.UI.Threepenny as UI
 import           Graphics.UI.Threepenny.Core
-
-import           Cardano.Logging (showT)
-
-import           Cardano.Node.Tracing.Peers
-
-import           Cardano.Tracer.Environment
-import           Cardano.Tracer.Handlers.RTView.State.Peers
-import           Cardano.Tracer.Handlers.RTView.UI.HTML.Node.Peers
-import           Cardano.Tracer.Handlers.RTView.UI.Utils
-import           Cardano.Tracer.Handlers.RTView.Update.Utils
-import           Cardano.Tracer.Handlers.RTView.Utils
-import           Cardano.Tracer.Types
 
 updateNodesPeers
   :: TracerEnv

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/Reload.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/Reload.hs
@@ -4,11 +4,6 @@ module Cardano.Tracer.Handlers.RTView.Update.Reload
   ( updateUIAfterReload
   ) where
 
-import           Control.Concurrent.STM.TVar (readTVarIO)
-import           Data.List.NonEmpty (NonEmpty)
-import qualified Graphics.UI.Threepenny as UI
-import           Graphics.UI.Threepenny.Core
-
 import           Cardano.Tracer.Configuration
 import           Cardano.Tracer.Environment
 import           Cardano.Tracer.Handlers.RTView.State.Displayed
@@ -16,6 +11,12 @@ import           Cardano.Tracer.Handlers.RTView.UI.Charts
 import           Cardano.Tracer.Handlers.RTView.UI.Types
 import           Cardano.Tracer.Handlers.RTView.Update.NodeInfo
 import           Cardano.Tracer.Handlers.RTView.Update.Nodes
+
+import           Control.Concurrent.STM.TVar (readTVarIO)
+import           Data.List.NonEmpty (NonEmpty)
+
+import qualified Graphics.UI.Threepenny as UI
+import           Graphics.UI.Threepenny.Core
 
 updateUIAfterReload
   :: TracerEnv

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/Resources.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/Resources.hs
@@ -7,17 +7,17 @@ module Cardano.Tracer.Handlers.RTView.Update.Resources
   ( updateResourcesHistory
   ) where
 
-import           Control.Concurrent.STM.TVar (readTVarIO)
-import qualified Data.Map.Strict as M
-import           Data.Text.Read (decimal)
-import           Data.Time.Clock (UTCTime)
-import           Data.Word (Word64)
-
 import           Cardano.Tracer.Handlers.Metrics.Utils
 import           Cardano.Tracer.Handlers.RTView.State.Historical
 import           Cardano.Tracer.Handlers.RTView.State.Last
 import           Cardano.Tracer.Handlers.RTView.Update.Utils
 import           Cardano.Tracer.Types
+
+import           Control.Concurrent.STM.TVar (readTVarIO)
+import qualified Data.Map.Strict as M
+import           Data.Text.Read (decimal)
+import           Data.Time.Clock (UTCTime)
+import           Data.Word (Word64)
 
 updateResourcesHistory
   :: NodeId

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/Transactions.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/Transactions.hs
@@ -6,12 +6,12 @@ module Cardano.Tracer.Handlers.RTView.Update.Transactions
   ( updateTransactionsHistory
   ) where
 
-import           Data.Text.Read (decimal)
-import           Data.Time.Clock (UTCTime)
-
 import           Cardano.Tracer.Handlers.Metrics.Utils
 import           Cardano.Tracer.Handlers.RTView.State.Historical
 import           Cardano.Tracer.Types
+
+import           Data.Text.Read (decimal)
+import           Data.Time.Clock (UTCTime)
 
 updateTransactionsHistory
   :: NodeId

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/Utils.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/Utils.hs
@@ -10,6 +10,8 @@ module Cardano.Tracer.Handlers.RTView.Update.Utils
   , nullTime
   ) where
 
+import           Cardano.Tracer.Types
+
 import           Control.Concurrent.Extra (Lock, withLock)
 import           Control.Concurrent.STM.TVar (readTVarIO)
 import           Data.Aeson (FromJSON, decode')
@@ -23,8 +25,6 @@ import           Data.Word (Word64)
 
 import           Trace.Forward.Protocol.DataPoint.Type (DataPointName)
 import           Trace.Forward.Utils.DataPoint (askForDataPoints)
-
-import           Cardano.Tracer.Types
 
 -- | There is a different information the node can provide us by explicit request.
 --   This is a structured data about internal state of the node (for example, its

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Utils.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Utils.hs
@@ -9,13 +9,14 @@ module Cardano.Tracer.Handlers.RTView.Utils
   , forConnectedUI_
   ) where
 
+import           Cardano.Tracer.Environment
+import           Cardano.Tracer.Types
+
 import           Control.Concurrent.STM.TVar (readTVarIO)
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
-import           Graphics.UI.Threepenny.Core
 
-import           Cardano.Tracer.Environment
-import           Cardano.Tracer.Types
+import           Graphics.UI.Threepenny.Core
 
 forConnected :: TracerEnv -> (NodeId -> IO b) -> IO [b]
 forConnected TracerEnv{teConnectedNodes} action =

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/ReForwarder.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/ReForwarder.hs
@@ -15,22 +15,21 @@ module Cardano.Tracer.Handlers.ReForwarder
   ( initReForwarder
   ) where
 
-import           Control.Monad (when)
-import           Data.List (isPrefixOf)
-import qualified Data.Text as Text
-
-import           Ouroboros.Network.Magic (NetworkMagic (..))
-import           Ouroboros.Network.NodeToClient (withIOManager)
-
 import           Cardano.Logging.Forwarding
 import           Cardano.Logging.Trace
 import           Cardano.Logging.Tracer.DataPoint
 import qualified Cardano.Logging.Types as Log
-import           Trace.Forward.Utils.DataPoint
-import           Trace.Forward.Utils.TraceObject (ForwardSink, writeToSink)
-
 import           Cardano.Tracer.Configuration
 import           Cardano.Tracer.MetaTrace
+import           Ouroboros.Network.Magic (NetworkMagic (..))
+import           Ouroboros.Network.NodeToClient (withIOManager)
+
+import           Control.Monad (when)
+import           Data.List (isPrefixOf)
+import qualified Data.Text as Text
+
+import           Trace.Forward.Utils.DataPoint
+import           Trace.Forward.Utils.TraceObject (ForwardSink, writeToSink)
 
 -- | Initialize the reforwarding service if configured to be active.
 --   Returns

--- a/cardano-tracer/src/Cardano/Tracer/MetaTrace.hs
+++ b/cardano-tracer/src/Cardano/Tracer/MetaTrace.hs
@@ -20,6 +20,10 @@ module Cardano.Tracer.MetaTrace
   , traceWith
   ) where
 
+import           Cardano.Logging
+import           Cardano.Logging.Resources
+import           Cardano.Tracer.Configuration
+
 import           Data.Aeson hiding (Error)
 import qualified Data.Aeson as AE
 import           Data.Function
@@ -28,12 +32,6 @@ import           Data.Text (Text)
 import qualified Data.Text as T
 import           GHC.Generics
 import qualified System.IO as Sys
-
-import           Cardano.Logging
-
-import           Cardano.Tracer.Configuration
-
-import           Cardano.Logging.Resources
 
 data TracerTrace
   = TracerParamsAre

--- a/cardano-tracer/src/Cardano/Tracer/Run.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Run.hs
@@ -9,11 +9,6 @@ module Cardano.Tracer.Run
   , runCardanoTracer
   ) where
 
-import           Control.Concurrent.Async.Extra (sequenceConcurrently)
-import           Control.Concurrent.Extra (newLock)
-import           Control.Concurrent.STM.TVar (newTVarIO)
-import           Data.Foldable (for_)
-
 import           Cardano.Logging.Resources
 import           Cardano.Tracer.Acceptors.Run
 import           Cardano.Tracer.CLI
@@ -31,7 +26,11 @@ import           Cardano.Tracer.Utils
 
 import           Control.Concurrent (threadDelay)
 import           Control.Concurrent.Async (async, link)
+import           Control.Concurrent.Async.Extra (sequenceConcurrently)
+import           Control.Concurrent.Extra (newLock)
+import           Control.Concurrent.STM.TVar (newTVarIO)
 import           Control.Monad
+import           Data.Foldable (for_)
 
 -- | Top-level run function, called by 'cardano-tracer' app.
 runCardanoTracer :: TracerParams -> IO ()

--- a/cardano-tracer/src/Cardano/Tracer/Types.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Types.hs
@@ -15,7 +15,6 @@ import           Data.Map.Strict (Map)
 import           Data.Set (Set)
 import           Data.Text (Text)
 import qualified System.Metrics as EKG
-
 import           System.Metrics.Store.Acceptor (MetricsLocalStore)
 
 import           Trace.Forward.Utils.DataPoint (DataPointRequestor)

--- a/cardano-tracer/test/Cardano/Tracer/Test/Acceptor.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/Acceptor.hs
@@ -6,6 +6,15 @@ module Cardano.Tracer.Test.Acceptor
   , launchAcceptorsSimple
   ) where
 
+import           Cardano.Tracer.Acceptors.Run
+import           Cardano.Tracer.Configuration
+import           Cardano.Tracer.Environment
+import           Cardano.Tracer.Handlers.RTView.Run
+import           Cardano.Tracer.Handlers.RTView.State.Historical
+import           Cardano.Tracer.MetaTrace
+import           Cardano.Tracer.Types
+import           Cardano.Tracer.Utils
+
 import           Control.Concurrent.Async.Extra (sequenceConcurrently)
 import           Control.Concurrent.Extra (newLock)
 import           Control.Concurrent.STM.TVar (newTVarIO, readTVarIO)
@@ -16,14 +25,6 @@ import qualified Data.Map.Strict as M
 import qualified Data.Text as T
 import           System.Time.Extra (sleep)
 
-import           Cardano.Tracer.Acceptors.Run
-import           Cardano.Tracer.Configuration
-import           Cardano.Tracer.Environment
-import           Cardano.Tracer.Handlers.RTView.Run
-import           Cardano.Tracer.Handlers.RTView.State.Historical
-import           Cardano.Tracer.MetaTrace
-import           Cardano.Tracer.Types
-import           Cardano.Tracer.Utils
 import           Trace.Forward.Utils.DataPoint
 
 data AcceptorsMode = Initiator | Responder

--- a/cardano-tracer/test/Cardano/Tracer/Test/DataPoint/Tests.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/DataPoint/Tests.hs
@@ -6,6 +6,14 @@ module Cardano.Tracer.Test.DataPoint.Tests
   ( tests
   ) where
 
+import           Cardano.Tracer.Configuration
+import           Cardano.Tracer.MetaTrace
+import           Cardano.Tracer.Run (doRunCardanoTracer)
+import           Cardano.Tracer.Test.Forwarder
+import           Cardano.Tracer.Test.TestSetup
+import           Cardano.Tracer.Test.Utils
+import           Cardano.Tracer.Utils (applyBrake, initDataPointRequestors, initProtocolsBrake)
+
 import           Control.Concurrent.Async (withAsync)
 import           Control.Concurrent.STM (atomically)
 import           Control.Concurrent.STM.TVar (TVar, modifyTVar', newTVarIO, readTVarIO)
@@ -13,20 +21,12 @@ import           Data.Aeson (decode')
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 import           System.Time.Extra
+
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
 import           Trace.Forward.Protocol.DataPoint.Type
 import           Trace.Forward.Utils.DataPoint (askForDataPoints)
-
-import           Cardano.Tracer.Configuration
-import           Cardano.Tracer.MetaTrace
-import           Cardano.Tracer.Run (doRunCardanoTracer)
-import           Cardano.Tracer.Utils (applyBrake, initDataPointRequestors, initProtocolsBrake)
-
-import           Cardano.Tracer.Test.Forwarder
-import           Cardano.Tracer.Test.TestSetup
-import           Cardano.Tracer.Test.Utils
 
 tests :: TestSetup Identity -> TestTree
 tests ts = localOption (QuickCheckTests 1) $ testGroup "Test.DataPoint"

--- a/cardano-tracer/test/Cardano/Tracer/Test/Forwarder.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/Forwarder.hs
@@ -13,24 +13,13 @@ module Cardano.Tracer.Test.Forwarder
   , mkTestDataPoint
   ) where
 
-import           Codec.CBOR.Term (Term)
-import           Control.Concurrent (threadDelay)
-import           Control.Concurrent.Async
-import           Control.DeepSeq (NFData)
-import           Control.Monad (forever)
-import           "contra-tracer" Control.Tracer (contramap, nullTracer, stdoutTracer)
-import           Data.Aeson (FromJSON, ToJSON)
-import qualified Data.ByteString.Lazy as LBS
-import           Data.Time.Clock (getCurrentTime)
-import           Data.Void (Void)
-import           Data.Word (Word16)
-import           GHC.Generics
-import           System.Directory
-import qualified System.Metrics as EKG
-
 import           Cardano.Logging (DetailLevel (..), SeverityS (..), TraceObject (..))
 import           Cardano.Logging.Version (ForwardingVersion (..), ForwardingVersionData (..),
                    forwardingCodecCBORTerm, forwardingVersionCodec)
+import           Cardano.Tracer.Configuration (Verbosity (..))
+import           Cardano.Tracer.Test.TestSetup
+import           Cardano.Tracer.Test.Utils
+import           Cardano.Tracer.Utils
 import           Ouroboros.Network.Driver.Limits (ProtocolTimeLimits)
 import           Ouroboros.Network.ErrorPolicy (nullErrorPolicies)
 import           Ouroboros.Network.IOManager (IOManager, withIOManager)
@@ -48,6 +37,21 @@ import           Ouroboros.Network.Socket (AcceptedConnectionsLimit (..), Handsh
                    SomeResponderApplication (..), cleanNetworkMutableState, connectToNode,
                    newNetworkMutableState, nullNetworkConnectTracers, nullNetworkServerTracers,
                    withServerNode)
+
+import           Codec.CBOR.Term (Term)
+import           Control.Concurrent (threadDelay)
+import           Control.Concurrent.Async
+import           Control.DeepSeq (NFData)
+import           Control.Monad (forever)
+import           "contra-tracer" Control.Tracer (contramap, nullTracer, stdoutTracer)
+import           Data.Aeson (FromJSON, ToJSON)
+import qualified Data.ByteString.Lazy as LBS
+import           Data.Time.Clock (getCurrentTime)
+import           Data.Void (Void)
+import           Data.Word (Word16)
+import           GHC.Generics
+import           System.Directory
+import qualified System.Metrics as EKG
 import qualified System.Metrics.Configuration as EKGF
 import           System.Metrics.Network.Forwarder
 
@@ -57,11 +61,6 @@ import           Trace.Forward.Run.DataPoint.Forwarder
 import           Trace.Forward.Run.TraceObject.Forwarder
 import           Trace.Forward.Utils.DataPoint
 import           Trace.Forward.Utils.TraceObject
-
-import           Cardano.Tracer.Configuration (Verbosity (..))
-import           Cardano.Tracer.Test.TestSetup
-import           Cardano.Tracer.Test.Utils
-import           Cardano.Tracer.Utils
 
 data ForwardersMode = Initiator | Responder
 

--- a/cardano-tracer/test/Cardano/Tracer/Test/ForwardingStressTest/Config.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/ForwardingStressTest/Config.hs
@@ -7,10 +7,11 @@ module Cardano.Tracer.Test.ForwardingStressTest.Config (
   , config4
   ) where
 
-import           Data.Map.Strict (fromList)
-import           Test.QuickCheck
-
 import           Cardano.Logging
+
+import           Data.Map.Strict (fromList)
+
+import           Test.QuickCheck
 
 
 -- | different configurations for testing

--- a/cardano-tracer/test/Cardano/Tracer/Test/ForwardingStressTest/Script.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/ForwardingStressTest/Script.hs
@@ -11,11 +11,17 @@ module Cardano.Tracer.Test.ForwardingStressTest.Script
   , runScriptForwarding
   ) where
 
+import           Cardano.Logging
+import           Cardano.Tracer.Test.ForwardingStressTest.Config ()
+import           Cardano.Tracer.Test.ForwardingStressTest.Messages
+import           Cardano.Tracer.Test.ForwardingStressTest.Types
+import           Cardano.Tracer.Test.TestSetup
+import           Cardano.Tracer.Test.Utils
+
 import           Control.Concurrent (ThreadId, forkFinally, threadDelay)
 import           Control.Concurrent.MVar
 import           Control.Exception.Base (SomeException, throw)
 import           Control.Monad (when)
-import           Data.Functor.Identity
 import           Data.IORef
 import           Data.List (sort)
 import           Data.Map.Strict (fromList)
@@ -23,13 +29,6 @@ import           Data.Maybe
 import           System.FilePath.Glob
 
 import           Test.QuickCheck
-
-import           Cardano.Logging
-import           Cardano.Tracer.Test.ForwardingStressTest.Config ()
-import           Cardano.Tracer.Test.ForwardingStressTest.Messages
-import           Cardano.Tracer.Test.ForwardingStressTest.Types
-import           Cardano.Tracer.Test.TestSetup
-import           Cardano.Tracer.Test.Utils
 
 -- | configuration for testing
 simpleTestConfig :: TraceConfig

--- a/cardano-tracer/test/Cardano/Tracer/Test/ForwardingStressTest/Types.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/ForwardingStressTest/Types.hs
@@ -8,11 +8,12 @@ module Cardano.Tracer.Test.ForwardingStressTest.Types (
   , emptyScriptRes
   ) where
 
+import           Cardano.Logging
+
 import           Data.Aeson (Value (..), (.=))
 import           Data.Text hiding (length)
-import           Test.QuickCheck
 
-import           Cardano.Logging
+import           Test.QuickCheck
 
 type MessageID = Int
 

--- a/cardano-tracer/test/Cardano/Tracer/Test/Logs/Tests.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/Logs/Tests.hs
@@ -7,6 +7,15 @@ module Cardano.Tracer.Test.Logs.Tests
   ( tests
   ) where
 
+import           Cardano.Tracer.Configuration
+import           Cardano.Tracer.Handlers.Logs.Utils (isItLog)
+import           Cardano.Tracer.MetaTrace
+import           Cardano.Tracer.Run (doRunCardanoTracer)
+import           Cardano.Tracer.Test.Forwarder
+import           Cardano.Tracer.Test.TestSetup
+import           Cardano.Tracer.Test.Utils
+import           Cardano.Tracer.Utils (applyBrake, initDataPointRequestors, initProtocolsBrake)
+
 import           Control.Concurrent.Async (withAsync)
 import           Control.Monad (forM)
 import           Data.List.Extra (notNull)
@@ -15,18 +24,9 @@ import           System.Directory
 import           System.Directory.Extra
 import           System.FilePath
 import           System.Time.Extra
+
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
-
-import           Cardano.Tracer.Configuration
-import           Cardano.Tracer.Handlers.Logs.Utils (isItLog)
-import           Cardano.Tracer.MetaTrace
-import           Cardano.Tracer.Run (doRunCardanoTracer)
-import           Cardano.Tracer.Utils (applyBrake, initDataPointRequestors, initProtocolsBrake)
-
-import           Cardano.Tracer.Test.Forwarder
-import           Cardano.Tracer.Test.TestSetup
-import           Cardano.Tracer.Test.Utils
 
 tests :: TestSetup Identity -> TestTree
 tests ts = localOption (QuickCheckTests 1) $ testGroup "Test.Logs"

--- a/cardano-tracer/test/Cardano/Tracer/Test/Queue/Tests.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/Queue/Tests.hs
@@ -4,19 +4,20 @@ module Cardano.Tracer.Test.Queue.Tests
   ( tests
   ) where
 
+import           Cardano.Tracer.Test.Forwarder
+import           Cardano.Tracer.Test.TestSetup
+import           Cardano.Tracer.Test.Utils
+
 import           Control.Concurrent.Async (withAsyncBound)
-import           GHC.IO.Handle (hDuplicate, hDuplicateTo)
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
-import           Test.Tasty
-import           Test.Tasty.QuickCheck
+import           GHC.IO.Handle (hDuplicate, hDuplicateTo)
 import           System.Directory (removeFile)
 import           System.IO
 import           System.Time.Extra (sleep)
 
-import           Cardano.Tracer.Test.Forwarder
-import           Cardano.Tracer.Test.TestSetup
-import           Cardano.Tracer.Test.Utils
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
 
 tests :: TestSetup Identity -> TestTree
 tests ts = localOption (QuickCheckTests 1) $ testGroup "Test.Queue"

--- a/cardano-tracer/test/Cardano/Tracer/Test/Restart/Tests.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/Restart/Tests.hs
@@ -6,6 +6,16 @@ module Cardano.Tracer.Test.Restart.Tests
   ( tests
   ) where
 
+import           Cardano.Logging (Trace (..))
+import           Cardano.Tracer.Configuration
+import           Cardano.Tracer.MetaTrace
+import           Cardano.Tracer.Run
+import           Cardano.Tracer.Test.Forwarder
+import           Cardano.Tracer.Test.TestSetup
+import           Cardano.Tracer.Test.Utils
+import           Cardano.Tracer.Utils
+import           Ouroboros.Network.Magic (NetworkMagic (..))
+
 import           Control.Concurrent.Async (asyncBound, uninterruptibleCancel)
 import           Control.Monad (forM_)
 import           Control.Monad.Extra (ifM)
@@ -13,23 +23,11 @@ import qualified Data.List.NonEmpty as NE
 import           System.Directory (removePathForcibly)
 import           System.Directory.Extra (listDirectories)
 import           System.FilePath ((</>))
+import qualified System.IO as Sys
 import           System.Time.Extra (sleep)
+
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
-
-import           Ouroboros.Network.Magic (NetworkMagic (..))
-
-import           Cardano.Tracer.Configuration
-import           Cardano.Tracer.MetaTrace
-import           Cardano.Tracer.Run
-import           Cardano.Tracer.Utils
-
-import           Cardano.Tracer.Test.Forwarder
-import           Cardano.Tracer.Test.TestSetup
-import           Cardano.Tracer.Test.Utils
-
-import           Cardano.Logging (Trace (..))
-import qualified System.IO as Sys
 
 tests :: TestSetup Identity -> TestTree
 tests ts = localOption (QuickCheckTests 1) $ testGroup "Test.Restart"

--- a/cardano-tracer/test/Cardano/Tracer/Test/TestSetup.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/TestSetup.hs
@@ -11,17 +11,17 @@ module Cardano.Tracer.Test.TestSetup
   )
 where
 
+import           Ouroboros.Network.Magic (NetworkMagic (..))
+
 import           Control.Monad (join)
 import           Data.Functor ((<&>))
 import           Data.Functor.Identity
 import           Data.Maybe
 import           Data.Monoid
-import           Generic.Data (gmappend)
 import           GHC.Generics (Generic)
-
 import           Options.Applicative
 
-import           Ouroboros.Network.Magic (NetworkMagic (..))
+import           Generic.Data (gmappend)
 
 
 data TestSetup a

--- a/cardano-tracer/test/Cardano/Tracer/Test/Utils.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/Utils.hs
@@ -4,14 +4,14 @@ module Cardano.Tracer.Test.Utils
   , module Data.Functor.Identity
   ) where
 
-import           Data.Functor.Identity
+import           Cardano.Tracer.Test.TestSetup
 
+import           Data.Functor.Identity
 import           System.Directory.Extra (listDirectories)
 import           System.FilePath (dropDrive, dropExtension)
 import           System.Info.Extra (isMac, isWindows)
 import           System.IO.Extra (newTempDirWithin)
 
-import           Cardano.Tracer.Test.TestSetup
 import           Test.Tasty.QuickCheck
 
 unI :: Identity a -> a

--- a/cardano-tracer/test/cardano-tracer-test-ext.hs
+++ b/cardano-tracer/test/cardano-tracer-test-ext.hs
@@ -3,11 +3,17 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -Wno-unused-matches #-}
 
+import           Cardano.Logging
+import           Cardano.Tracer.Test.ForwardingStressTest.Script
+import           Cardano.Tracer.Test.ForwardingStressTest.Types
+import           Cardano.Tracer.Test.Utils
+import           Ouroboros.Network.Magic (NetworkMagic (..))
+import           Ouroboros.Network.NodeToClient (withIOManager)
+
 import           Control.Concurrent (threadDelay)
 import           Control.Exception
 import           Control.Monad.Extra
 import           Data.Functor ((<&>))
-import           Data.Functor.Identity
 import           Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import qualified Data.List as L
 import           Data.Maybe (fromMaybe)
@@ -17,15 +23,9 @@ import           System.Environment (lookupEnv, setEnv, unsetEnv)
 import qualified System.IO as Sys
 import           System.PosixCompat.Files (fileExist)
 import qualified System.Process as Sys
+
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
-
-import           Cardano.Logging
-import           Cardano.Tracer.Test.ForwardingStressTest.Script
-import           Cardano.Tracer.Test.ForwardingStressTest.Types
-import           Cardano.Tracer.Test.Utils
-import           Ouroboros.Network.Magic (NetworkMagic (..))
-import           Ouroboros.Network.NodeToClient (withIOManager)
 
 main :: IO ()
 main = do

--- a/cardano-tracer/test/cardano-tracer-test.hs
+++ b/cardano-tracer/test/cardano-tracer-test.hs
@@ -1,22 +1,19 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -Wno-unused-matches #-}
 
+import qualified Cardano.Tracer.Test.DataPoint.Tests as DataPoint
+import qualified Cardano.Tracer.Test.Logs.Tests as Logs
+import           Cardano.Tracer.Test.TestSetup
+import           Cardano.Tracer.Test.Utils
+
 import           Control.Exception
 import           Control.Monad.Extra
-import           Data.Functor.Identity
 import           Data.Monoid
 import qualified System.Directory as Sys
 import           System.Environment (setEnv, unsetEnv)
 import           System.PosixCompat.Files (fileExist)
+
 import           Test.Tasty
-
-import qualified Cardano.Tracer.Test.DataPoint.Tests as DataPoint
-import qualified Cardano.Tracer.Test.Logs.Tests as Logs
--- import qualified Cardano.Tracer.Test.Queue.Tests as Queue
--- import qualified Cardano.Tracer.Test.Restart.Tests as Restart
-
-import           Cardano.Tracer.Test.TestSetup
-import           Cardano.Tracer.Test.Utils
 
 main :: IO ()
 main = do

--- a/trace-dispatcher/bench/trace-dispatcher-bench.hs
+++ b/trace-dispatcher/bench/trace-dispatcher-bench.hs
@@ -1,13 +1,14 @@
-import           Criterion.Main
-import           Data.IORef
-
 import           Cardano.Logging
 import           Cardano.Logging.Test.Config
 import           Cardano.Logging.Test.Oracles
 import           Cardano.Logging.Test.Script
 import           Cardano.Logging.Test.Tracer
 import           Cardano.Logging.Test.Types
+
+import           Data.IORef
 import           System.Remote.Monitoring (forkServer)
+
+import           Criterion.Main
 
 
 -- Can be run with:

--- a/trace-dispatcher/src/Cardano/Logging.hs
+++ b/trace-dispatcher/src/Cardano/Logging.hs
@@ -18,4 +18,5 @@ import           Cardano.Logging.Tracer.Forward as X
 import           Cardano.Logging.Tracer.Standard as X
 import           Cardano.Logging.Types as X
 import           Cardano.Logging.Utils as X
+
 import           Control.Tracer as X hiding (Tracer, nullTracer, traceWith)

--- a/trace-dispatcher/src/Cardano/Logging/Configuration.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Configuration.hs
@@ -23,23 +23,22 @@ module Cardano.Logging.Configuration
   , getBackends
   ) where
 
+import           Cardano.Logging.DocuGenerator (addFiltered, addLimiter, addSilent)
+import           Cardano.Logging.FrequencyLimiter (limitFrequency)
+import           Cardano.Logging.Trace
+import           Cardano.Logging.TraceDispatcherMessage
+import           Cardano.Logging.Types
+
 import           Control.Monad (unless)
 import           Control.Monad.IO.Class (MonadIO, liftIO)
 import           Control.Monad.IO.Unlift (MonadUnliftIO)
+import qualified Control.Tracer as T
 import           Data.IORef (IORef, modifyIORef, newIORef, readIORef, writeIORef)
 import           Data.List (maximumBy, nub)
 import qualified Data.Map as Map
 import           Data.Maybe (fromMaybe, mapMaybe)
 import qualified Data.Set as Set
 import           Data.Text (Text, intercalate, unpack)
-
-import qualified Control.Tracer as T
-
-import           Cardano.Logging.DocuGenerator (addFiltered, addLimiter, addSilent)
-import           Cardano.Logging.FrequencyLimiter (limitFrequency)
-import           Cardano.Logging.Trace
-import           Cardano.Logging.TraceDispatcherMessage
-import           Cardano.Logging.Types
 
 
 -- | Call this function at initialisation, and later for reconfiguration.

--- a/trace-dispatcher/src/Cardano/Logging/ConfigurationParser.hs
+++ b/trace-dispatcher/src/Cardano/Logging/ConfigurationParser.hs
@@ -11,6 +11,8 @@ module Cardano.Logging.ConfigurationParser
   , configToRepresentation
   ) where
 
+import           Cardano.Logging.Types
+
 import           Control.Applicative ((<|>))
 import           Control.Exception (throwIO)
 import qualified Data.Aeson as AE
@@ -21,8 +23,6 @@ import qualified Data.Map.Strict as Map
 import           Data.Maybe (catMaybes, listToMaybe)
 import           Data.Text (Text, intercalate, split)
 import           Data.Yaml
-
-import           Cardano.Logging.Types
 
 -- -----------------------------------------------------------------------------
 -- Configuration file

--- a/trace-dispatcher/src/Cardano/Logging/Consistency.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Consistency.hs
@@ -4,14 +4,13 @@ module Cardano.Logging.Consistency (
   , checkTraceConfiguration'
 ) where
 
+import           Cardano.Logging.ConfigurationParser
+import           Cardano.Logging.Types
+
 import           Data.Foldable (foldl')
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (mapMaybe)
 import qualified Data.Text as T
-
-
-import           Cardano.Logging.ConfigurationParser
-import           Cardano.Logging.Types
 
 -- | Warnings as a list of text
 type NSWarnings = [T.Text]

--- a/trace-dispatcher/src/Cardano/Logging/DocuGenerator.hs
+++ b/trace-dispatcher/src/Cardano/Logging/DocuGenerator.hs
@@ -23,8 +23,13 @@ module Cardano.Logging.DocuGenerator (
   , DocTracer(..)
 ) where
 
+import           Cardano.Logging.ConfigurationParser ()
+import           Cardano.Logging.Types
+
 import           Prelude hiding (lines, unlines)
 
+import           Control.Monad.IO.Class (MonadIO, liftIO)
+import qualified Control.Tracer as TR
 import qualified Data.Aeson.Encode.Pretty as AE
 import           Data.IORef (modifyIORef, newIORef, readIORef)
 import           Data.List (groupBy, intersperse, nub, sortBy)
@@ -35,11 +40,6 @@ import           Data.Text.Internal.Builder (toLazyText)
 import           Data.Text.Lazy (toStrict)
 import           Data.Text.Lazy.Builder (Builder, fromString, fromText, singleton)
 import           Data.Time (getZonedTime)
-
-import           Cardano.Logging.ConfigurationParser ()
-import           Cardano.Logging.Types
-import           Control.Monad.IO.Class (MonadIO, liftIO)
-import qualified Control.Tracer as TR
 
 import           Trace.Forward.Utils.DataPoint (DataPoint (..))
 

--- a/trace-dispatcher/src/Cardano/Logging/Formatter.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Formatter.hs
@@ -15,6 +15,12 @@ module Cardano.Logging.Formatter (
   , humanFormatter'
 ) where
 
+import           Cardano.Logging.Trace (contramapM)
+import           Cardano.Logging.Types
+import           Cardano.Logging.Utils (showT)
+
+import           Control.Concurrent (myThreadId)
+import           Control.Monad.IO.Class (MonadIO, liftIO)
 import qualified Control.Tracer as T
 import           Data.Aeson ((.=))
 import qualified Data.Aeson as AE
@@ -26,12 +32,6 @@ import           Data.Text.Lazy (toStrict)
 import           Data.Text.Lazy.Builder as TB
 import           Data.Text.Lazy.Encoding (decodeUtf8)
 import           Data.Time (UTCTime, defaultTimeLocale, formatTime, getCurrentTime)
-
-import           Cardano.Logging.Trace (contramapM)
-import           Cardano.Logging.Types
-import           Cardano.Logging.Utils (showT)
-import           Control.Concurrent (myThreadId)
-import           Control.Monad.IO.Class (MonadIO, liftIO)
 import           Network.HostName
 
 

--- a/trace-dispatcher/src/Cardano/Logging/Forwarding.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Forwarding.hs
@@ -9,16 +9,9 @@ module Cardano.Logging.Forwarding
     initForwarding
   ) where
 
-import           Codec.CBOR.Term (Term)
-import           Control.Concurrent.Async (async, race_, wait)
-import           Control.Monad (void)
-import           Control.Monad.IO.Class
-
-import           "contra-tracer" Control.Tracer (Tracer, contramap, nullTracer, stdoutTracer)
-import qualified Data.ByteString.Lazy as LBS
-import           Data.Void (Void)
-import           Data.Word (Word16)
-
+import           Cardano.Logging.Types
+import           Cardano.Logging.Utils (runInLoop)
+import           Cardano.Logging.Version
 import           Ouroboros.Network.Driver.Limits (ProtocolTimeLimits)
 import           Ouroboros.Network.ErrorPolicy (nullErrorPolicies)
 import           Ouroboros.Network.IOManager (IOManager)
@@ -38,20 +31,25 @@ import           Ouroboros.Network.Socket (AcceptedConnectionsLimit (..), Handsh
                    newNetworkMutableState, nullNetworkConnectTracers, nullNetworkServerTracers,
                    withServerNode)
 
+import           Codec.CBOR.Term (Term)
+import           Control.Concurrent.Async (async, race_, wait)
+import           Control.Monad (void)
+import           Control.Monad.IO.Class
+import           "contra-tracer" Control.Tracer (Tracer, contramap, nullTracer, stdoutTracer)
+import qualified Data.ByteString.Lazy as LBS
+import           Data.Void (Void)
+import           Data.Word (Word16)
 import           System.IO (hPutStrLn, stderr)
 import qualified System.Metrics as EKG
 import qualified System.Metrics.Configuration as EKGF
 import           System.Metrics.Network.Forwarder
+
 import qualified Trace.Forward.Configuration.DataPoint as DPF
 import qualified Trace.Forward.Configuration.TraceObject as TF
 import           Trace.Forward.Run.DataPoint.Forwarder
 import           Trace.Forward.Run.TraceObject.Forwarder
 import           Trace.Forward.Utils.DataPoint
 import           Trace.Forward.Utils.TraceObject
-
-import           Cardano.Logging.Types
-import           Cardano.Logging.Utils (runInLoop)
-import           Cardano.Logging.Version
 
 initForwarding :: forall m. (MonadIO m)
   => IOManager

--- a/trace-dispatcher/src/Cardano/Logging/FrequencyLimiter.hs
+++ b/trace-dispatcher/src/Cardano/Logging/FrequencyLimiter.hs
@@ -6,15 +6,14 @@ module Cardano.Logging.FrequencyLimiter (
   , LimiterSpec (..)
 )where
 
-import           Control.Monad.IO.Unlift
-import           Data.Text
-import           Data.Time.Clock.System
-
-import qualified Control.Tracer as T
-
 import           Cardano.Logging.Trace
 import           Cardano.Logging.TraceDispatcherMessage
 import           Cardano.Logging.Types
+
+import           Control.Monad.IO.Unlift
+import qualified Control.Tracer as T
+import           Data.Text
+import           Data.Time.Clock.System
 
 -- | Threshold for starting and stopping of the limiter
 budgetLimit :: Double

--- a/trace-dispatcher/src/Cardano/Logging/Trace.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Trace.hs
@@ -37,14 +37,15 @@ module Cardano.Logging.Trace (
   , withInnerNames
   ) where
 
+import           Cardano.Logging.Types
+
 import           Control.Monad (forM_, join)
 import           Control.Monad.IO.Unlift
 import qualified Control.Tracer as T
 import           Data.Maybe (isJust)
 import           Data.Text (Text)
-import           UnliftIO.MVar
 
-import           Cardano.Logging.Types
+import           UnliftIO.MVar
 
 -- | Adds a message object to a trace
 traceWith :: Monad m => Trace m a -> a -> m ()

--- a/trace-dispatcher/src/Cardano/Logging/TraceDispatcherMessage.hs
+++ b/trace-dispatcher/src/Cardano/Logging/TraceDispatcherMessage.hs
@@ -6,14 +6,14 @@ module Cardano.Logging.TraceDispatcherMessage
   , TraceDispatcherMessage (..)
   ) where
 
+import           Cardano.Logging.ConfigurationParser ()
+import           Cardano.Logging.Types
+
 import           Data.Aeson hiding (Error)
 import           Data.ByteString.Lazy (toStrict)
 import qualified Data.Map as Map
 import           Data.Text
 import           Data.Text.Encoding
-
-import           Cardano.Logging.ConfigurationParser ()
-import           Cardano.Logging.Types
 
 data UnknownNamespaceKind =
     UKFSeverity

--- a/trace-dispatcher/src/Cardano/Logging/Tracer/Composed.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Tracer/Composed.hs
@@ -19,11 +19,11 @@ import           Cardano.Logging.Formatter
 import           Cardano.Logging.Trace
 import           Cardano.Logging.TraceDispatcherMessage
 import           Cardano.Logging.Types
-import qualified Control.Tracer as T
 
 import           Control.Concurrent.MVar
 import           Control.Monad (when)
 import           Control.Monad.IO.Class (MonadIO, liftIO)
+import qualified Control.Tracer as T
 import           Data.IORef
 import qualified Data.List as L
 import qualified Data.Map as Map

--- a/trace-dispatcher/src/Cardano/Logging/Tracer/DataPoint.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Tracer/DataPoint.hs
@@ -9,17 +9,17 @@ module Cardano.Logging.Tracer.DataPoint
   , mkDataPointTracer
   ) where
 
-import           Control.DeepSeq (NFData)
-import           Control.Monad.IO.Class
-import           Data.Aeson.Types (ToJSON)
-import           Data.Text (Text, intercalate)
-
-import qualified Control.Tracer as NT
-import           Trace.Forward.Utils.DataPoint (DataPoint (..), DataPointStore, writeToStore)
-
 import           Cardano.Logging.DocuGenerator
 import           Cardano.Logging.Trace
 import           Cardano.Logging.Types
+
+import           Control.DeepSeq (NFData)
+import           Control.Monad.IO.Class
+import qualified Control.Tracer as NT
+import           Data.Aeson.Types (ToJSON)
+import           Data.Text (Text, intercalate)
+
+import           Trace.Forward.Utils.DataPoint (DataPoint (..), DataPointStore, writeToStore)
 
 ---------------------------------------------------------------------------
 

--- a/trace-dispatcher/src/Cardano/Logging/Tracer/Forward.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Tracer/Forward.hs
@@ -7,13 +7,13 @@ module Cardano.Logging.Tracer.Forward
     forwardTracer
   ) where
 
-import           Control.Monad.IO.Class
-
-import qualified Control.Tracer as T
-import           Trace.Forward.Utils.TraceObject (ForwardSink, writeToSink)
-
 import           Cardano.Logging.DocuGenerator
 import           Cardano.Logging.Types
+
+import           Control.Monad.IO.Class
+import qualified Control.Tracer as T
+
+import           Trace.Forward.Utils.TraceObject (ForwardSink, writeToSink)
 
 
 ---------------------------------------------------------------------------

--- a/trace-dispatcher/src/Cardano/Logging/Tracer/Standard.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Tracer/Standard.hs
@@ -5,22 +5,21 @@ module Cardano.Logging.Tracer.Standard (
     standardTracer
 ) where
 
+import           Cardano.Logging.DocuGenerator
+import           Cardano.Logging.Types
+
 import           Control.Concurrent (myThreadId)
 import           Control.Concurrent.Async
 import           Control.Concurrent.Chan.Unagi.Bounded
 import           Control.Monad (forever, when)
 import           Control.Monad.IO.Class
+import qualified Control.Tracer as T
 import           Data.IORef (IORef, modifyIORef', newIORef, readIORef)
 import           Data.Maybe (isNothing)
 import           Data.Text (Text)
 import qualified Data.Text.IO as TIO
 import           GHC.Conc (labelThread)
 import           System.IO (hFlush, stdout)
-
-import           Cardano.Logging.DocuGenerator
-import           Cardano.Logging.Types
-
-import qualified Control.Tracer as T
 
 -- | The state of a standard tracer
 newtype StandardTracerState =  StandardTracerState {

--- a/trace-dispatcher/src/Cardano/Logging/Types.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Types.hs
@@ -55,7 +55,10 @@ module Cardano.Logging.Types (
 ) where
 
 
+import           Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
+
 import           Codec.Serialise (Serialise (..))
+import qualified Control.Tracer as T
 import qualified Data.Aeson as AE
 import qualified Data.Aeson.Encoding as AE
 import qualified Data.Aeson.KeyMap as AE
@@ -71,10 +74,6 @@ import           Data.Text.Lazy.Encoding (decodeUtf8)
 import           Data.Time (UTCTime)
 import           GHC.Generics
 import           Network.HostName (HostName)
-
-import qualified Control.Tracer as T
-
-import           Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
 
 
 -- | The Trace carries the underlying tracer Tracer from the contra-tracer package.

--- a/trace-dispatcher/src/Cardano/Logging/Version.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Version.hs
@@ -8,16 +8,15 @@ module Cardano.Logging.Version
   , forwardingCodecCBORTerm
   ) where
 
-import           Data.Text (Text)
-import qualified Data.Text as T
-import           Data.Typeable (Typeable)
-
-import qualified Codec.CBOR.Term as CBOR
-
 import           Ouroboros.Network.CodecCBORTerm
 import           Ouroboros.Network.Magic
 import           Ouroboros.Network.Protocol.Handshake.Version (Accept (..), Acceptable (..),
                    Queryable (..))
+
+import qualified Codec.CBOR.Term as CBOR
+import           Data.Text (Text)
+import qualified Data.Text as T
+import           Data.Typeable (Typeable)
 
 data ForwardingVersion
   = ForwardingV_1

--- a/trace-dispatcher/src/Control/Tracer.hs
+++ b/trace-dispatcher/src/Control/Tracer.hs
@@ -75,10 +75,10 @@ module Control.Tracer
 
 import           Control.Arrow (arr, runKleisli, (&&&), (|||))
 import           Control.Category ((>>>))
-import           Data.Functor.Contravariant (Contravariant (..))
-import           Debug.Trace (traceM)
-
 import qualified Control.Tracer.Arrow as Arrow
+import           Data.Functor.Contravariant (Contravariant (..))
+
+import           Debug.Trace (traceM)
 
 -- | This type describes some effect in @m@ which depends upon some value of
 -- type @a@, for which the /output value/ is not of interest (only the effects).

--- a/trace-dispatcher/src/Control/Tracer/Arrow.hs
+++ b/trace-dispatcher/src/Control/Tracer/Arrow.hs
@@ -18,9 +18,10 @@ module Control.Tracer.Arrow
   , nat
   ) where
 
+import           Prelude hiding (id, (.))
+
 import           Control.Arrow
 import           Control.Category
-import           Prelude hiding (id, (.))
 
 -- | Formal representation of a tracer arrow as a Kleisli arrow over some
 -- monad, but tagged so that we know whether it has any effects which will emit

--- a/trace-dispatcher/test/Cardano/Logging/Test/Config.hs
+++ b/trace-dispatcher/test/Cardano/Logging/Test/Config.hs
@@ -7,10 +7,11 @@ module Cardano.Logging.Test.Config (
   , config4
   ) where
 
-import           Data.Map.Strict (fromList)
-import           Test.QuickCheck
-
 import           Cardano.Logging
+
+import           Data.Map.Strict (fromList)
+
+import           Test.QuickCheck
 
 
 -- | different configurations for testing

--- a/trace-dispatcher/test/Cardano/Logging/Test/Oracles.hs
+++ b/trace-dispatcher/test/Cardano/Logging/Test/Oracles.hs
@@ -6,13 +6,14 @@ module Cardano.Logging.Test.Oracles (
   , occurrences
   ) where
 
-import           Data.Maybe (fromMaybe)
-import qualified Data.Text as T
-import           Test.QuickCheck
-import           Text.Read (readMaybe)
-
 import           Cardano.Logging
 import           Cardano.Logging.Test.Types
+
+import           Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import           Text.Read (readMaybe)
+
+import           Test.QuickCheck
 
 
 -- | Checks for every message that it appears or does not appear at the right

--- a/trace-dispatcher/test/Cardano/Logging/Test/Script.hs
+++ b/trace-dispatcher/test/Cardano/Logging/Test/Script.hs
@@ -10,6 +10,11 @@ module Cardano.Logging.Test.Script
   , runScriptMultithreadedWithConstantReconfig
   ) where
 
+import           Cardano.Logging
+import           Cardano.Logging.Test.Config ()
+import           Cardano.Logging.Test.Tracer
+import           Cardano.Logging.Test.Types
+
 import           Control.Concurrent (ThreadId, forkFinally, threadDelay)
 import           Control.Concurrent.MVar
 import           Control.Exception.Base (SomeException, throw)
@@ -18,12 +23,8 @@ import           Data.IORef (newIORef, readIORef)
 import           Data.List (sort)
 import           Data.Maybe (mapMaybe)
 import           Data.Time.Clock.System
-import           Test.QuickCheck
 
-import           Cardano.Logging
-import           Cardano.Logging.Test.Config ()
-import           Cardano.Logging.Test.Tracer
-import           Cardano.Logging.Test.Types
+import           Test.QuickCheck
 
 
 -- | Run a script in a single thread and uses the oracle to test for correctness

--- a/trace-dispatcher/test/Cardano/Logging/Test/Tracer.hs
+++ b/trace-dispatcher/test/Cardano/Logging/Test/Tracer.hs
@@ -10,15 +10,14 @@ module Cardano.Logging.Test.Tracer (
   , testLoggingMessagesEq
   ) where
 
-import           Cardano.Logging.Types
+import           Cardano.Logging
+
 import           Control.Monad.IO.Class
 import           Data.Aeson (FromJSON (..), Object, decodeStrict, withObject, (.:))
 import           Data.IORef
 import           Data.Text (Text, pack, unpack)
 import           Data.Text.Encoding (encodeUtf8)
 import           Data.Time (UTCTime)
-
-import           Cardano.Logging
 
 
 testTracer :: MonadIO m

--- a/trace-dispatcher/test/Cardano/Logging/Test/Types.hs
+++ b/trace-dispatcher/test/Cardano/Logging/Test/Types.hs
@@ -10,11 +10,12 @@ module Cardano.Logging.Test.Types (
   , setMessageID
   ) where
 
+import           Cardano.Logging
+
 import           Data.Aeson (Value (..), (.=))
 import           Data.Text hiding (length)
-import           Test.QuickCheck
 
-import           Cardano.Logging
+import           Test.QuickCheck
 
 type MessageID = Int
 

--- a/trace-dispatcher/test/Cardano/Logging/Test/Unit/Aggregation.hs
+++ b/trace-dispatcher/test/Cardano/Logging/Test/Unit/Aggregation.hs
@@ -9,13 +9,13 @@ module Cardano.Logging.Test.Unit.Aggregation (
 , testAggResult
 ) where
 
+import           Cardano.Logging
+import           Cardano.Logging.Test.Tracer
+
 import           Data.Aeson (Value (..), (.=))
 import           Data.IORef
 import           Data.Text (Text, pack)
 import           GHC.Generics (Generic)
-
-import           Cardano.Logging
-import           Cardano.Logging.Test.Tracer
 
 data BaseStats = BaseStats {
     bsMeasure :: Double,

--- a/trace-dispatcher/test/Cardano/Logging/Test/Unit/Configuration.hs
+++ b/trace-dispatcher/test/Cardano/Logging/Test/Unit/Configuration.hs
@@ -5,15 +5,15 @@ module Cardano.Logging.Test.Unit.Configuration (
   , testConfigResult
 ) where
 
+import           Cardano.Logging
+import           Cardano.Logging.Test.Tracer
+
 import           Control.Monad.IO.Class
 import qualified Data.Aeson as AE
 import qualified Data.Aeson.KeyMap as KeyMap
 import           Data.IORef (IORef, newIORef, readIORef)
 import qualified Data.Map.Strict as Map
 import           Data.Text (Text)
-
-import           Cardano.Logging
-import           Cardano.Logging.Test.Tracer
 
 newtype TestMessage = TestMessage Text
   deriving Show

--- a/trace-dispatcher/test/Cardano/Logging/Test/Unit/DataPoint.hs
+++ b/trace-dispatcher/test/Cardano/Logging/Test/Unit/DataPoint.hs
@@ -11,16 +11,17 @@ module Cardano.Logging.Test.Unit.DataPoint (
   , testDataPointResult
 ) where
 
+import           Cardano.Logging
+
 import           Control.DeepSeq (NFData)
 import qualified Data.Aeson as A
 import           Data.ByteString.Lazy.UTF8
 import qualified Data.Map.Strict as M
 import           GHC.Conc
 import           GHC.Generics (Generic)
+
 import           Trace.Forward.Protocol.DataPoint.Type (DataPointName)
 import           Trace.Forward.Utils.DataPoint (DataPoint (..))
-
-import           Cardano.Logging
 
 
 data BaseStats = BaseStats {

--- a/trace-dispatcher/test/Cardano/Logging/Test/Unit/Documentation.hs
+++ b/trace-dispatcher/test/Cardano/Logging/Test/Unit/Documentation.hs
@@ -7,13 +7,13 @@ module Cardano.Logging.Test.Unit.Documentation (
     docTracers
 ) where
 
-import           Data.IORef
-import qualified Data.Map as Map
-import qualified Data.Text as T
-
 import           Cardano.Logging
 import           Cardano.Logging.Test.Tracer
 import           Cardano.Logging.Test.Unit.TestObjects
+
+import           Data.IORef
+import qualified Data.Map as Map
+import qualified Data.Text as T
 
 docTracers :: IO T.Text
 docTracers = do

--- a/trace-dispatcher/test/Cardano/Logging/Test/Unit/EKG.hs
+++ b/trace-dispatcher/test/Cardano/Logging/Test/Unit/EKG.hs
@@ -5,8 +5,8 @@ module Cardano.Logging.Test.Unit.EKG (
 ) where
 
 import           Cardano.Logging
-import           Control.Concurrent
 
+import           Control.Concurrent
 import qualified Data.Aeson as AE
 import           Data.Text (pack)
 import           System.Metrics (newStore)

--- a/trace-dispatcher/test/Cardano/Logging/Test/Unit/FrequencyLimiting.hs
+++ b/trace-dispatcher/test/Cardano/Logging/Test/Unit/FrequencyLimiting.hs
@@ -3,13 +3,13 @@ module Cardano.Logging.Test.Unit.FrequencyLimiting (
   , testLimitingResult
 ) where
 
-import           Control.Concurrent
-import           Data.IORef
-import           Data.Text (Text)
-
 import           Cardano.Logging
 import           Cardano.Logging.Test.Tracer
 import           Cardano.Logging.Test.Unit.TestObjects
+
+import           Control.Concurrent
+import           Data.IORef
+import           Data.Text (Text)
 
 repeated :: Trace IO (TraceForgeEvent LogBlock) -> Int -> Int -> IO ()
 repeated _ 0 _ = pure ()

--- a/trace-dispatcher/test/Cardano/Logging/Test/Unit/Routing.hs
+++ b/trace-dispatcher/test/Cardano/Logging/Test/Unit/Routing.hs
@@ -8,6 +8,7 @@ module Cardano.Logging.Test.Unit.Routing (
 import           Cardano.Logging
 import           Cardano.Logging.Test.Tracer
 import           Cardano.Logging.Test.Unit.TestObjects
+
 import           Data.IORef
 import           Data.Text (Text)
 

--- a/trace-dispatcher/test/Cardano/Logging/Test/Unit/TestObjects.hs
+++ b/trace-dispatcher/test/Cardano/Logging/Test/Unit/TestObjects.hs
@@ -20,6 +20,7 @@ module Cardano.Logging.Test.Unit.TestObjects (
 ) where
 
 import           Cardano.Logging
+
 import qualified Data.Aeson as AE
 import qualified Data.Aeson.KeyMap as KeyMap
 import           Data.Kind (Type)

--- a/trace-forward/src/Trace/Forward/Configuration/DataPoint.hs
+++ b/trace-forward/src/Trace/Forward/Configuration/DataPoint.hs
@@ -3,10 +3,10 @@ module Trace.Forward.Configuration.DataPoint
   , ForwarderConfiguration (..)
   ) where
 
+import           Ouroboros.Network.Driver (TraceSendRecv)
+
 import           Control.Concurrent.STM.TVar (TVar)
 import           Control.Tracer (Tracer)
-
-import           Ouroboros.Network.Driver (TraceSendRecv)
 
 import           Trace.Forward.Protocol.DataPoint.Type
 

--- a/trace-forward/src/Trace/Forward/Configuration/TraceObject.hs
+++ b/trace-forward/src/Trace/Forward/Configuration/TraceObject.hs
@@ -3,10 +3,10 @@ module Trace.Forward.Configuration.TraceObject
   , ForwarderConfiguration (..)
   ) where
 
+import           Ouroboros.Network.Driver (TraceSendRecv)
+
 import           Control.Concurrent.STM.TVar (TVar)
 import           Control.Tracer (Tracer)
-
-import           Ouroboros.Network.Driver (TraceSendRecv)
 
 import           Trace.Forward.Protocol.TraceObject.Type
 

--- a/trace-forward/src/Trace/Forward/Protocol/DataPoint/Codec.hs
+++ b/trace-forward/src/Trace/Forward/Protocol/DataPoint/Codec.hs
@@ -13,11 +13,10 @@ import qualified Codec.CBOR.Encoding as CBOR
 import           Codec.CBOR.Read (DeserialiseFailure)
 import           Control.Monad.Class.MonadST (MonadST)
 import qualified Data.ByteString.Lazy as LBS
-import           Text.Printf (printf)
-
 import           Network.TypedProtocol.Codec (Codec, PeerHasAgency (..), PeerRole (..),
                    SomeMessage (..))
 import           Network.TypedProtocol.Codec.CBOR (mkCodecCborLazyBS)
+import           Text.Printf (printf)
 
 import           Trace.Forward.Protocol.DataPoint.Type
 

--- a/trace-forward/src/Trace/Forward/Protocol/DataPoint/Type.hs
+++ b/trace-forward/src/Trace/Forward/Protocol/DataPoint/Type.hs
@@ -19,11 +19,11 @@ module Trace.Forward.Protocol.DataPoint.Type
   , NobodyHasAgency (..)
   ) where
 
+import           Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
+
 import qualified Data.ByteString.Lazy as LBS
 import           Data.Text (Text)
-
 import           Network.TypedProtocol.Core (Protocol (..))
-import           Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
 
 -- | A kind to identify our protocol, and the types of the states in the state
 -- transition diagram of the protocol.

--- a/trace-forward/src/Trace/Forward/Protocol/TraceObject/Codec.hs
+++ b/trace-forward/src/Trace/Forward/Protocol/TraceObject/Codec.hs
@@ -14,11 +14,10 @@ import           Codec.CBOR.Read (DeserialiseFailure)
 import           Control.Monad.Class.MonadST (MonadST)
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.List.NonEmpty as NE
-import           Text.Printf (printf)
-
 import           Network.TypedProtocol.Codec (Codec, PeerHasAgency (..), PeerRole (..),
                    SomeMessage (..))
 import           Network.TypedProtocol.Codec.CBOR (mkCodecCborLazyBS)
+import           Text.Printf (printf)
 
 import           Trace.Forward.Protocol.TraceObject.Type
 

--- a/trace-forward/src/Trace/Forward/Protocol/TraceObject/Type.hs
+++ b/trace-forward/src/Trace/Forward/Protocol/TraceObject/Type.hs
@@ -22,14 +22,14 @@ module Trace.Forward.Protocol.TraceObject.Type
   , BlockingReplyList (..)
   ) where
 
+import           Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
+
 import           Codec.Serialise (Serialise (..))
 import           Data.List.NonEmpty (NonEmpty)
 import           Data.Proxy (Proxy (..))
 import           Data.Word (Word16)
 import           GHC.Generics (Generic)
-
 import           Network.TypedProtocol.Core (Protocol (..))
-import           Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
 
 -- | A kind to identify our protocol, and the types of the states in the state
 -- transition diagram of the protocol.

--- a/trace-forward/src/Trace/Forward/Run/DataPoint/Acceptor.hs
+++ b/trace-forward/src/Trace/Forward/Run/DataPoint/Acceptor.hs
@@ -6,6 +6,9 @@ module Trace.Forward.Run.DataPoint.Acceptor
   , acceptDataPointsResp
   ) where
 
+import           Ouroboros.Network.Driver.Simple (runPeer)
+import           Ouroboros.Network.Mux (MiniProtocolCb (..), MuxMode (..), RunMiniProtocol (..))
+
 import qualified Codec.Serialise as CBOR
 import           Control.Concurrent.STM.TMVar (putTMVar)
 import           Control.Concurrent.STM.TVar (modifyTVar', readTVar, readTVarIO)
@@ -15,8 +18,6 @@ import           Control.Monad.Extra (ifM)
 import           Control.Monad.STM (atomically, check)
 import qualified Data.ByteString.Lazy as LBS
 import           Data.Void (Void)
-import           Ouroboros.Network.Driver.Simple (runPeer)
-import           Ouroboros.Network.Mux (MiniProtocolCb (..), MuxMode (..), RunMiniProtocol (..))
 
 import           Trace.Forward.Configuration.DataPoint (AcceptorConfiguration (..))
 import qualified Trace.Forward.Protocol.DataPoint.Acceptor as Acceptor

--- a/trace-forward/src/Trace/Forward/Run/DataPoint/Forwarder.hs
+++ b/trace-forward/src/Trace/Forward/Run/DataPoint/Forwarder.hs
@@ -5,11 +5,12 @@ module Trace.Forward.Run.DataPoint.Forwarder
   , forwardDataPointsResp
   ) where
 
+import           Ouroboros.Network.Driver.Simple (runPeer)
+import           Ouroboros.Network.Mux (MiniProtocolCb (..), MuxMode (..), RunMiniProtocol (..))
+
 import qualified Codec.Serialise as CBOR
 import qualified Data.ByteString.Lazy as LBS
 import           Data.Void (Void)
-import           Ouroboros.Network.Driver.Simple (runPeer)
-import           Ouroboros.Network.Mux (MiniProtocolCb (..), MuxMode (..), RunMiniProtocol (..))
 
 import           Trace.Forward.Configuration.DataPoint (ForwarderConfiguration (..))
 import qualified Trace.Forward.Protocol.DataPoint.Codec as Forwarder

--- a/trace-forward/src/Trace/Forward/Run/TraceObject/Acceptor.hs
+++ b/trace-forward/src/Trace/Forward/Run/TraceObject/Acceptor.hs
@@ -8,6 +8,10 @@ module Trace.Forward.Run.TraceObject.Acceptor
   , acceptTraceObjectsResp
   ) where
 
+import           Ouroboros.Network.Driver.Simple (runPeer)
+import           Ouroboros.Network.Mux (MiniProtocolCb (..), MuxMode (..), RunMiniProtocol (..))
+import           Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
+
 import qualified Codec.Serialise as CBOR
 import           Control.Concurrent.Async (race)
 import           Control.Concurrent.STM.TVar (TVar, readTVar, readTVarIO, registerDelay)
@@ -17,10 +21,6 @@ import           Control.Monad.STM (atomically, check)
 import qualified Data.ByteString.Lazy as LBS
 import           Data.Typeable (Typeable)
 import           Data.Void (Void)
-
-import           Ouroboros.Network.Driver.Simple (runPeer)
-import           Ouroboros.Network.Mux (MiniProtocolCb (..), MuxMode (..), RunMiniProtocol (..))
-import           Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
 
 import           Trace.Forward.Configuration.TraceObject (AcceptorConfiguration (..))
 import qualified Trace.Forward.Protocol.TraceObject.Acceptor as Acceptor

--- a/trace-forward/src/Trace/Forward/Run/TraceObject/Forwarder.hs
+++ b/trace-forward/src/Trace/Forward/Run/TraceObject/Forwarder.hs
@@ -5,12 +5,13 @@ module Trace.Forward.Run.TraceObject.Forwarder
   , forwardTraceObjectsResp
   ) where
 
-import qualified Codec.Serialise as CBOR
-import qualified Data.ByteString.Lazy as LBS
-import           Data.Void (Void)
 import           Ouroboros.Network.Driver.Simple (runPeer)
 import           Ouroboros.Network.Mux (MiniProtocolCb (..), MuxMode (..), RunMiniProtocol (..))
 import           Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
+
+import qualified Codec.Serialise as CBOR
+import qualified Data.ByteString.Lazy as LBS
+import           Data.Void (Void)
 
 import           Trace.Forward.Configuration.TraceObject (ForwarderConfiguration (..))
 import qualified Trace.Forward.Protocol.TraceObject.Codec as Forwarder

--- a/trace-forward/test/Main.hs
+++ b/trace-forward/test/Main.hs
@@ -3,7 +3,6 @@ module Main
   ) where
 
 import           Test.Tasty
-
 import qualified Test.Trace.Forward.Protocol.DataPoint.Tests as DataPoint
 import qualified Test.Trace.Forward.Protocol.TraceObject.Tests as TraceObject
 

--- a/trace-forward/test/Test/Trace/Forward/Protocol/DataPoint/Codec.hs
+++ b/trace-forward/test/Test/Trace/Forward/Protocol/DataPoint/Codec.hs
@@ -5,13 +5,12 @@
 module Test.Trace.Forward.Protocol.DataPoint.Codec () where
 
 import qualified Data.Aeson as A
-import           Test.QuickCheck
-
 import           Network.TypedProtocol.Codec
 
-import           Trace.Forward.Protocol.DataPoint.Type
-
+import           Test.QuickCheck
 import           Test.Trace.Forward.Protocol.DataPoint.Item
+
+import           Trace.Forward.Protocol.DataPoint.Type
 
 instance Arbitrary (AnyMessageAndAgency DataPointForward) where
   arbitrary = oneof

--- a/trace-forward/test/Test/Trace/Forward/Protocol/DataPoint/Tests.hs
+++ b/trace-forward/test/Test/Trace/Forward/Protocol/DataPoint/Tests.hs
@@ -6,6 +6,9 @@ module Test.Trace.Forward.Protocol.DataPoint.Tests
   ( tests
   ) where
 
+import           Ouroboros.Network.Channel
+import           Ouroboros.Network.Driver.Simple (runConnectedPeers)
+
 import qualified Codec.Serialise as CBOR
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadST
@@ -13,24 +16,20 @@ import           Control.Monad.Class.MonadThrow
 import           Control.Monad.IOSim (runSimOrThrow)
 import           Control.Monad.ST (runST)
 import           Control.Tracer (nullTracer)
-import           Test.Tasty
-import           Test.Tasty.QuickCheck
-
 import           Network.TypedProtocol.Codec
 import           Network.TypedProtocol.Proofs
-import           Ouroboros.Network.Channel
-import           Ouroboros.Network.Driver.Simple (runConnectedPeers)
+
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+import           Test.Trace.Forward.Protocol.Common
+import           Test.Trace.Forward.Protocol.DataPoint.Codec ()
+import           Test.Trace.Forward.Protocol.DataPoint.Direct
+import           Test.Trace.Forward.Protocol.DataPoint.Examples
 
 import           Trace.Forward.Protocol.DataPoint.Acceptor
 import           Trace.Forward.Protocol.DataPoint.Codec
 import           Trace.Forward.Protocol.DataPoint.Forwarder
 import           Trace.Forward.Protocol.DataPoint.Type
-
-import           Test.Trace.Forward.Protocol.DataPoint.Codec ()
-import           Test.Trace.Forward.Protocol.DataPoint.Direct
-import           Test.Trace.Forward.Protocol.DataPoint.Examples
-
-import           Test.Trace.Forward.Protocol.Common
 
 tests :: TestTree
 tests = testGroup "Trace.Forward.Protocol.DataPoint"

--- a/trace-forward/test/Test/Trace/Forward/Protocol/TraceObject/Codec.hs
+++ b/trace-forward/test/Test/Trace/Forward/Protocol/TraceObject/Codec.hs
@@ -3,13 +3,12 @@
 
 module Test.Trace.Forward.Protocol.TraceObject.Codec () where
 
-import           Test.QuickCheck
-
 import           Network.TypedProtocol.Codec
 
-import           Trace.Forward.Protocol.TraceObject.Type
-
+import           Test.QuickCheck
 import           Test.Trace.Forward.Protocol.TraceObject.Item
+
+import           Trace.Forward.Protocol.TraceObject.Type
 
 instance Arbitrary NumberOfTraceObjects where
   arbitrary = oneof

--- a/trace-forward/test/Test/Trace/Forward/Protocol/TraceObject/Item.hs
+++ b/trace-forward/test/Test/Trace/Forward/Protocol/TraceObject/Item.hs
@@ -6,13 +6,14 @@ module Test.Trace.Forward.Protocol.TraceObject.Item
   ( TraceItem (..)
   ) where
 
+import           Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
+
 import           Codec.Serialise (Serialise (..))
 import           Data.List.NonEmpty (NonEmpty, fromList)
 import           Data.Text (Text)
 import           GHC.Generics
-import           Test.QuickCheck
 
-import           Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
+import           Test.QuickCheck
 
 data Severity = Debug | Info | Notice
   deriving (Show, Eq, Ord, Enum, Generic)

--- a/trace-forward/test/Test/Trace/Forward/Protocol/TraceObject/Tests.hs
+++ b/trace-forward/test/Test/Trace/Forward/Protocol/TraceObject/Tests.hs
@@ -5,6 +5,9 @@ module Test.Trace.Forward.Protocol.TraceObject.Tests
   ( tests
   ) where
 
+import           Ouroboros.Network.Channel
+import           Ouroboros.Network.Driver.Simple (runConnectedPeers)
+
 import qualified Codec.Serialise as CBOR
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadST
@@ -12,25 +15,21 @@ import           Control.Monad.Class.MonadThrow
 import           Control.Monad.IOSim (runSimOrThrow)
 import           Control.Monad.ST (runST)
 import           Control.Tracer (nullTracer)
-import           Test.Tasty
-import           Test.Tasty.QuickCheck
-
 import           Network.TypedProtocol.Codec
 import           Network.TypedProtocol.Proofs
-import           Ouroboros.Network.Channel
-import           Ouroboros.Network.Driver.Simple (runConnectedPeers)
 
-import           Trace.Forward.Protocol.TraceObject.Acceptor
-import           Trace.Forward.Protocol.TraceObject.Codec
-import           Trace.Forward.Protocol.TraceObject.Forwarder
-import           Trace.Forward.Protocol.TraceObject.Type
-
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+import           Test.Trace.Forward.Protocol.Common
 import           Test.Trace.Forward.Protocol.TraceObject.Codec ()
 import           Test.Trace.Forward.Protocol.TraceObject.Direct
 import           Test.Trace.Forward.Protocol.TraceObject.Examples
 import           Test.Trace.Forward.Protocol.TraceObject.Item
 
-import           Test.Trace.Forward.Protocol.Common
+import           Trace.Forward.Protocol.TraceObject.Acceptor
+import           Trace.Forward.Protocol.TraceObject.Codec
+import           Trace.Forward.Protocol.TraceObject.Forwarder
+import           Trace.Forward.Protocol.TraceObject.Type
 
 tests :: TestTree
 tests = testGroup "Trace.Forward.Protocol.TraceObject"

--- a/trace-resources/src/Cardano/Logging/Resources/Dummy.hs
+++ b/trace-resources/src/Cardano/Logging/Resources/Dummy.hs
@@ -4,6 +4,7 @@ module Cardano.Logging.Resources.Dummy
     ) where
 
 import           Cardano.Logging.Resources.Types
+
 import           Data.Word
 import qualified GHC.Stats as GhcStats
 import           System.CPUTime

--- a/trace-resources/src/Cardano/Logging/Resources/Types.hs
+++ b/trace-resources/src/Cardano/Logging/Resources/Types.hs
@@ -11,6 +11,7 @@ module Cardano.Logging.Resources.Types
 
 
 import           Cardano.Logging
+
 import           Data.Aeson
 import           Data.Text (pack)
 import           Data.Word

--- a/trace-resources/test/trace-resources-test.hs
+++ b/trace-resources/test/trace-resources-test.hs
@@ -1,13 +1,14 @@
 {-# OPTIONS_GHC -Wno-unused-imports  #-}
 
-import           Control.Monad.IO.Class
-import           Data.IORef
-import           Test.Tasty
-import           Test.Tasty.QuickCheck
-
 import           Cardano.Logging
 import           Cardano.Logging.Resources
 import           Cardano.Logging.Resources.Types
+
+import           Control.Monad.IO.Class
+import           Data.IORef
+
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
 
 
 main :: IO ()


### PR DESCRIPTION
# Description

This PR adds stylish-haskell configuration for imports and reformats all the imports '.hs' files in the repo.

This PR consists of three commits:
* `Add stylish haskell import grouping rules` - stylish rule addition, GHA fixup
* `REMOVEME - utility for the purpose of creation of this PR` - shell utility (a copy of stylish GHA) to format the codebase - to be removed
* `Reformat all imports in the repository` - actual reformatting of imports

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
