### PR TITLE
Only log tx errors on higher detail level

### DIFF
--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
@@ -858,11 +858,13 @@ instance
       , "mempoolSize" .= forMachine dtal mpSzAfter
       ]
   forMachine dtal (TraceMempoolRejectedTx tx txApplyErr mpSz) =
-    mconcat
+    mconcat $
       [ "kind" .= String "TraceMempoolRejectedTx"
-      , "err" .= forMachine dtal txApplyErr
       , "tx" .= forMachine dtal tx
       , "mempoolSize" .= forMachine dtal mpSz
+      ] <>
+      [ "err" .= forMachine dtal txApplyErr
+      | dtal >= DDetailed
       ]
   forMachine dtal (TraceMempoolRemoveTxs txs mpSz) =
     mconcat
@@ -870,9 +872,11 @@ instance
       , "txs"
           .= map
             ( \(tx, err) ->
-                Aeson.object
+                Aeson.object $
                   [ "tx" .= forMachine dtal (txForgetValidated tx)
-                  , "reason" .= forMachine dtal err
+                  ] <>
+                  [ "err" .= forMachine dtal err
+                  | dtal >= DDetailed
                   ]
             )
             txs

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
@@ -1326,11 +1326,13 @@ instance ( ToObject (ApplyTxErr blk), ToObject (GenTx blk),
       , "mempoolSize" .= toObject verb mpSzAfter
       ]
   toObject verb (TraceMempoolRejectedTx tx txApplyErr mpSz) =
-    mconcat
+    mconcat $
       [ "kind" .= String "TraceMempoolRejectedTx"
-      , "err" .= toObject verb txApplyErr
       , "tx" .= toObject verb tx
       , "mempoolSize" .= toObject verb mpSz
+      ] <>
+      [ "err" .= toObject verb txApplyErr
+      | verb == MaximalVerbosity
       ]
   toObject verb (TraceMempoolRemoveTxs txs mpSz) =
     mconcat
@@ -1338,9 +1340,11 @@ instance ( ToObject (ApplyTxErr blk), ToObject (GenTx blk),
       , "txs"
           .= map
             ( \(tx, err) ->
-                Aeson.object
+                Aeson.object $
                   [ "tx" .= toObject verb (txForgetValidated tx)
-                  , "reason" .= toObject verb err
+                  ] <>
+                  [ "err" .= toObject verb err
+                  | verb == MaximalVerbosity
                   ]
             )
             txs


### PR DESCRIPTION
# Description

It turns out that the default logging output for `ApplyTxErr`s is quite verbose, which causes annoyances in benchmarking as well as in relays with all mempool logging enabled.

This PR only emits the reason for transaction removal/rejection on a higher-then-default detail level/verbosity. With the new tracing system, this can be configured like this:
```yaml
TraceOptions:
  Mempool:
    severity: Info
    detail: DDetailed
```
or slightly more fine-grained:
```yaml
TraceOptions:
  Mempool.RemoveTxs:
    detail: DDetailed
  Mempool.RejectedTx:
    detail: DDetailed
```

---

An alternative approach would be to unconditionally trace the error, but make sure that it is very terse with the default detail level.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
