### PR TITLE
cardano-testnet: simplify queryUtxos by not going through a file

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -60,3 +60,9 @@ package plutus-scripts-bench
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
 
 -- `smtp-mail` should depend on `crypton-connection` rather than `connection`!
+
+source-repository-package
+    type: git
+    location: https://github.com/IntersectMBO/cardano-cli.git
+    tag: 78b4febd70b4c133b31535e64440d473e2f8c9ee
+    subdir: cardano-cli

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/InfoAction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/InfoAction.hs
@@ -22,11 +22,9 @@ import           Cardano.Testnet
 import           Prelude
 
 import           Control.Monad
-import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Except
 import           Data.Bifunctor (first)
 import           Data.Foldable
-import           Data.IORef
 import qualified Data.Map.Strict as Map
 import           Data.String
 import           Data.Text (Text)
@@ -57,7 +55,6 @@ hprop_ledger_events_info_action = H.integrationRetryWorkspace 2 "info-hash" $ \t
       tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
 
   work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
-  utxoFileCounter <- liftIO $ newIORef 1
 
   let sbe = ShelleyBasedEraConway
       era = toCardanoEra sbe
@@ -80,7 +77,7 @@ hprop_ledger_events_info_action = H.integrationRetryWorkspace 2 "info-hash" $ \t
 
   let queryAnyUtxo :: Text -> Integration TxIn
       queryAnyUtxo address = withFrozenCallStack $ do
-        utxos <- queryUtxos execConfig work utxoFileCounter sbe address
+        utxos <- queryUtxos execConfig sbe address
         H.noteShow =<< H.headM (Map.keys utxos)
 
       socketName' = IO.sprocketName poolSprocket1

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/ProposeNewConstitution.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/ProposeNewConstitution.hs
@@ -21,10 +21,8 @@ import           Cardano.Testnet
 import           Prelude
 
 import           Control.Monad
-import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Except
 import           Control.Monad.Trans.Except.Extra
-import           Data.IORef
 import qualified Data.Map.Strict as Map
 import           Data.String
 import           Data.Text (Text)
@@ -60,7 +58,6 @@ hprop_ledger_events_propose_new_constitution = H.integrationWorkspace "propose-n
       tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
 
   work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
-  utxoFileCounter <- liftIO $ newIORef 1
 
   let sbe = ShelleyBasedEraConway
       era = toCardanoEra sbe
@@ -84,7 +81,7 @@ hprop_ledger_events_propose_new_constitution = H.integrationWorkspace "propose-n
 
   let queryAnyUtxo :: Text -> H.Integration TxIn
       queryAnyUtxo address = withFrozenCallStack $ do
-        utxos <- queryUtxos execConfig work utxoFileCounter sbe address
+        utxos <- queryUtxos execConfig sbe address
         H.noteShow =<< H.headM (Map.keys utxos)
       socketName' = IO.sprocketName poolSprocket1
       socketBase = IO.sprocketBase poolSprocket1 -- /tmp

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/ProposeNewConstitutionSPO.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/ProposeNewConstitutionSPO.hs
@@ -31,7 +31,6 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Text as Text
 import           Data.Type.Equality
 import           Data.Word
-import           GHC.IORef (newIORef)
 import           GHC.Stack (HasCallStack, withFrozenCallStack)
 import           Lens.Micro
 import           System.Exit (ExitCode (ExitSuccess))
@@ -60,8 +59,6 @@ hprop_ledger_events_propose_new_constitution_spo = H.integrationWorkspace "propo
   let tempAbsPath' = unTmpAbsPath tempAbsPath
       tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
 
-  utxoFileCounter <- liftIO $ newIORef 1
-
   let sbe = ShelleyBasedEraConway
       era = toCardanoEra sbe
       cEra = AnyCardanoEra era
@@ -85,7 +82,7 @@ hprop_ledger_events_propose_new_constitution_spo = H.integrationWorkspace "propo
 
   let queryAnyUtxo :: Text.Text -> Integration TxIn
       queryAnyUtxo address = withFrozenCallStack $ do
-        utxos <- queryUtxos execConfig work utxoFileCounter sbe address
+        utxos <- queryUtxos execConfig sbe address
         H.noteShow =<< H.headM (Map.keys utxos)
       socketName' = IO.sprocketName poolSprocket1
       socketBase = IO.sprocketBase poolSprocket1 -- /tmp


### PR DESCRIPTION
> [!NOTE]
>
> For the moment, draft PR to test https://github.com/IntersectMBO/cardano-cli/pull/611

> [!WARNING]
>
> Requires https://github.com/IntersectMBO/cardano-cli/pull/611 merged and released to be merged

---

# Description

Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
