### PR TITLE
cardano-tracer: Lower allocation by persisting file handles

### DIFF
--- a/cardano-tracer/CHANGELOG.md
+++ b/cardano-tracer/CHANGELOG.md
@@ -1,5 +1,12 @@
 # ChangeLog
 
+## 0.2.3 (April 19, 2024)
+
+* The field `rpMaxAgeHours` of `RotationParams` is changed to
+  `rpMaxAgeMinutes`. `rpMaxAgeHours` can still be used as a virtual
+  field.
+* Add `HandleRegistry` to `TracerEnv`, to track handles that have been opened.
+
 ## 0.2.2
 
 * Add resource tracing for `cardano-tracer`.

--- a/cardano-tracer/README.md
+++ b/cardano-tracer/README.md
@@ -12,7 +12,7 @@ For more details please [read its documentation](https://github.com/intersectmbo
 
 ## Developers
 
-Benchmarking team is responsible for this service. The primary developer is [@denisshevchenko](https://github.com/denisshevchenko).
+Performance and Tracing team is responsible for this service. The primary developer is [Baldur Blöndal](https://github.com/Icelandjack).
 
 ## Feedback
 

--- a/cardano-tracer/cardano-tracer.cabal
+++ b/cardano-tracer/cardano-tracer.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-tracer
-version:                0.2.2
+version:                0.2.3
 synopsis:               A service for logging and monitoring over Cardano nodes
 description:            A service for logging and monitoring over Cardano nodes.
 category:               Cardano,
@@ -22,9 +22,12 @@ common project-config
 
   default-extensions:   BlockArguments
                       , CPP
+                      , DerivingStrategies
+                      , GeneralizedNewtypeDeriving
                       , ImportQualifiedPost
                       , InstanceSigs
                       , ScopedTypeVariables
+                      , TypeApplications
 
   ghc-options:          -Wall
                         -Wcompat
@@ -134,7 +137,7 @@ library
   build-depends:        aeson
                       , async
                       , async-extras
-                      , bimap >= 0.4.0
+                      , bimap
                       , blaze-html
                       , bytestring
                       , cardano-git-rev ^>=0.2.2
@@ -174,7 +177,6 @@ library
 
   if os(linux)
     build-depends:      libsystemd-journal >= 1.4.4
-
   if os(windows)
     build-depends:      Win32
   else
@@ -230,6 +232,9 @@ library demo-forwarder-lib
                       , time
                       , trace-dispatcher
                       , trace-forward
+                      , vector
+                      , vector-algorithms
+                      , QuickCheck
 
 executable demo-forwarder
   import:               project-config
@@ -269,6 +274,9 @@ library demo-acceptor-lib
                       , text
                       , tasty-quickcheck
                       , trace-forward
+                      , vector
+                      , vector-algorithms
+                      , QuickCheck
 
 executable demo-acceptor
   import:               project-config
@@ -329,6 +337,9 @@ test-suite cardano-tracer-test
                       , trace-dispatcher
                       , trace-forward
                       , unix-compat
+                      , vector
+                      , vector-algorithms
+                      , QuickCheck
 
   ghc-options:          -threaded
                         -rtsopts
@@ -386,6 +397,8 @@ test-suite cardano-tracer-test-ext
                       , trace-dispatcher
                       , trace-forward
                       , unix-compat
+                      , vector
+                      , vector-algorithms
 
   ghc-options:          -threaded
                         -rtsopts
@@ -402,6 +415,7 @@ benchmark cardano-tracer-bench
   build-depends:        cardano-tracer
                       , criterion
                       , directory
+                      , deepseq
                       , extra
                       , filepath
                       , stm

--- a/cardano-tracer/docs/cardano-tracer.md
+++ b/cardano-tracer/docs/cardano-tracer.md
@@ -329,7 +329,7 @@ The field `rpLogLimitBytes` specifies the maximum size of the log file, in bytes
 
 The field `rpKeepFilesNum` specifies the number of the log files that will be kept. In this example, `rpKeepFilesNum` is `3`, which means that 3 _last_ log files will always be kept.
 
-The field `rpMaxAgeHours` specifies the lifetime of the log file, in hours. In this example, `rpMaxAgeHours` is `1`, which means that each log file will be kept for 1 hour only. After that, the log file is treated as outdated and will be deleted. Please note that N _last_ log files (specified by `rpKeepFilesNum`) will be kept even if they are outdated.
+The fields `rpMaxAgeMinutes`, `rpMaxAgeHours` specify the lifetime of the log file, in minutes, or hours. In this example, `rpMaxAgeHours` is `1`, which means that each log file will be kept for 1 hour only. After that, the log file is treated as outdated and will be deleted. Please note that N _last_ log files (specified by `rpKeepFilesNum`) will be kept even if they are outdated. If both fields are specified, `rpMaxAgeMinutes` takes precedence.
 
 ## Prometheus
 

--- a/cardano-tracer/src/Cardano/Tracer/Acceptors/Client.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Acceptors/Client.hs
@@ -11,7 +11,7 @@ import           Cardano.Tracer.Acceptors.Utils (notifyAboutNodeDisconnected,
                    prepareDataPointRequestor, prepareMetricsStores, removeDisconnectedNode)
 import qualified Cardano.Tracer.Configuration as TC
 import           Cardano.Tracer.Environment
-import           Cardano.Tracer.Handlers.Logs.TraceObjects (traceObjectsHandler)
+import           Cardano.Tracer.Handlers.Logs.TraceObjects (deregisterNodeId, traceObjectsHandler)
 import           Cardano.Tracer.MetaTrace
 import           Cardano.Tracer.Utils (connIdToNodeId)
 import           Ouroboros.Network.Context (MinimalInitiatorContext (..), ResponderContext (..))
@@ -76,6 +76,7 @@ runAcceptorsClient tracerEnv p (ekgConfig, tfConfig, dpfConfig) = withIOManager 
       | (protocol, num) <- protocolsWithNums
       ]
   errorHandler connId = do
+    deregisterNodeId tracerEnv (connIdToNodeId connId)
     removeDisconnectedNode tracerEnv connId
     notifyAboutNodeDisconnected tracerEnv connId
 

--- a/cardano-tracer/src/Cardano/Tracer/Acceptors/Server.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Acceptors/Server.hs
@@ -1,3 +1,5 @@
+
+
 {-# LANGUAGE DataKinds #-}
 
 module Cardano.Tracer.Acceptors.Server
@@ -11,7 +13,7 @@ import           Cardano.Tracer.Acceptors.Utils (notifyAboutNodeDisconnected,
                    prepareDataPointRequestor, prepareMetricsStores, removeDisconnectedNode)
 import qualified Cardano.Tracer.Configuration as TC
 import           Cardano.Tracer.Environment
-import           Cardano.Tracer.Handlers.Logs.TraceObjects (traceObjectsHandler)
+import           Cardano.Tracer.Handlers.Logs.TraceObjects (deregisterNodeId, traceObjectsHandler)
 import           Cardano.Tracer.MetaTrace
 import           Cardano.Tracer.Utils (connIdToNodeId)
 import           Ouroboros.Network.Context (MinimalInitiatorContext (..), ResponderContext (..))
@@ -79,6 +81,7 @@ runAcceptorsServer tracerEnv p (ekgConfig, tfConfig, dpfConfig) = withIOManager 
       | (protocol, num) <- protocolsWithNums
       ]
   errorHandler connId = do
+    deregisterNodeId tracerEnv (connIdToNodeId connId)
     removeDisconnectedNode tracerEnv connId
     notifyAboutNodeDisconnected tracerEnv connId
 

--- a/cardano-tracer/src/Cardano/Tracer/Environment.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Environment.hs
@@ -32,4 +32,5 @@ data TracerEnv = TracerEnv
   , teRTViewStateDir        :: !(Maybe FilePath)
   , teTracer                :: !(Trace IO TracerTrace)
   , teReforwardTraceObjects :: !([TraceObject] -> IO ())
+  , teRegistry              :: !HandleRegistry
   }

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/Logs/Journal.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/Logs/Journal.hs
@@ -14,25 +14,21 @@ module Cardano.Tracer.Handlers.Logs.Journal
   ) where
 
 #ifdef LINUX
+import qualified Cardano.Logging as L
+#endif
+import           Cardano.Logging (TraceObject (..))
+import           Cardano.Tracer.Types (NodeName)
+
+#ifdef LINUX
 import           Data.Char (isDigit)
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Text as T
 import           Data.Text.Encoding (encodeUtf8)
 import           Data.Time.Format (defaultTimeLocale, formatTime)
+
 import           Systemd.Journal (Priority (..), message, mkJournalField, priority,
                    sendJournalFields, syslogIdentifier)
 
-import           Cardano.Logging (TraceObject (..))
-import qualified Cardano.Logging as L
-
-import           Cardano.Tracer.Types
-#else
-import           Cardano.Logging (TraceObject)
-
-import           Cardano.Tracer.Types
-#endif
-
-#ifdef LINUX
 -- | Store 'TraceObject's in Linux systemd's journal service.
 writeTraceObjectsToJournal :: NodeName -> [TraceObject] -> IO ()
 writeTraceObjectsToJournal nodeName = mapM_ (sendJournalFields . mkJournalFields)

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/Metrics/Monitoring.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/Metrics/Monitoring.hs
@@ -126,4 +126,5 @@ restartEKGServer TracerEnv{teAcceptedMetrics} newNodeId
     ekgServer <- forkServerWith store
                    (encodeUtf8 . T.pack $ monitorHost)
                    (fromIntegral monitorPort)
-    atomically $ putTMVar currentServer (newNodeId, serverThreadId ekgServer)
+    atomically do
+      putTMVar currentServer (newNodeId, serverThreadId ekgServer)

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/Metrics/Prometheus.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/Metrics/Prometheus.hs
@@ -159,4 +159,3 @@ getMetricsFromNode tracerEnv nodeId acceptedMetrics =
                                                 Just rep -> p' : (rep,mv) : accu)
                             []
                             metricsList
-

--- a/cardano-tracer/src/Cardano/Tracer/Run.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Run.hs
@@ -83,6 +83,8 @@ doRunCardanoTracer config rtViewStateDir tr protocolsBrake dpRequestors = do
 
   (reforwardTraceObject,_trDataPoint) <- initReForwarder config tr
 
+  registry <- newRegistry
+
   -- Environment for all following functions.
   let tracerEnv =
         TracerEnv
@@ -103,6 +105,7 @@ doRunCardanoTracer config rtViewStateDir tr protocolsBrake dpRequestors = do
           , teRTViewStateDir        = rtViewStateDir
           , teTracer                = tr
           , teReforwardTraceObjects = reforwardTraceObject
+          , teRegistry              = registry
           }
 
   -- Specify what should be done before 'cardano-tracer' stops.

--- a/cardano-tracer/src/Cardano/Tracer/Types.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Types.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE StandaloneKindSignatures #-}
+
 module Cardano.Tracer.Types
   ( AcceptedMetrics
   , ConnectedNodes
@@ -7,13 +9,20 @@ module Cardano.Tracer.Types
   , NodeId (..)
   , NodeName
   , ProtocolsBrake
+  , Registry (..)
+  , HandleRegistry
   ) where
 
+import           Cardano.Tracer.Configuration
+
+import           Control.Concurrent.MVar (MVar)
 import           Control.Concurrent.STM.TVar (TVar)
 import           Data.Bimap (Bimap)
+import           Data.Kind
 import           Data.Map.Strict (Map)
 import           Data.Set (Set)
 import           Data.Text (Text)
+import           System.IO (Handle)
 import qualified System.Metrics as EKG
 import           System.Metrics.Store.Acceptor (MetricsLocalStore)
 
@@ -48,3 +57,9 @@ type ConnectedNodesNames = TVar (Bimap NodeId NodeName)
 
 -- | The flag we use to stop the protocols from their acceptor's side.
 type ProtocolsBrake = TVar Bool
+
+type    Registry :: Type -> Type -> Type
+newtype Registry a b = Registry { getRegistry :: MVar (Map a b) }
+
+type HandleRegistry :: Type
+type HandleRegistry = Registry (NodeName, LoggingParams) (Handle, FilePath)

--- a/cardano-tracer/test/Cardano/Tracer/Test/Acceptor.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/Acceptor.hs
@@ -53,6 +53,8 @@ launchAcceptorsSimple mode localSock dpName = do
 
   tr <- mkTracerTracer $ SeverityF $ Just Warning
 
+  registry <- newRegistry
+
   let tracerEnv =
         TracerEnv
           { teConfig                = mkConfig
@@ -72,6 +74,7 @@ launchAcceptorsSimple mode localSock dpName = do
           , teRTViewStateDir        = Nothing
           , teTracer                = tr
           , teReforwardTraceObjects = \_-> pure ()
+          , teRegistry              = registry
           }
             -- NOTE: no reforwarding in this acceptor.
   void . sequenceConcurrently $

--- a/cardano-tracer/test/Cardano/Tracer/Test/DataPoint/Tests.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/DataPoint/Tests.hs
@@ -38,9 +38,9 @@ propDataPoint ts@TestSetup{..} rootDir localSock = do
   stopProtocols <- initProtocolsBrake
   dpRequestors <- initDataPointRequestors
   savedDPValues :: TVar DataPointValues <- newTVarIO []
-  withAsync (doRunCardanoTracer config (Just $ rootDir <> "/../state") stderrShowTracer stopProtocols dpRequestors) . const $ do
+  withAsync (doRunCardanoTracer config (Just $ rootDir <> "/../state") stderrShowTracer stopProtocols dpRequestors) \_ -> do
     sleep 1.0
-    withAsync (launchForwardersSimple ts Initiator localSock 1000 10000) . const $ do
+    withAsync (launchForwardersSimple ts Initiator localSock 1000 10000) \_ -> do
       sleep 1.5
       -- We know that there is one single "node" only (and one single requestor too).
       -- requestors ((_, dpRequestor):_) <- M.toList <$> readTVarIO dpRequestors

--- a/cardano-tracer/test/Cardano/Tracer/Test/ForwardingStressTest/Types.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/ForwardingStressTest/Types.hs
@@ -5,13 +5,23 @@ module Cardano.Tracer.Test.ForwardingStressTest.Types (
   , Script (..)
   , ScriptRes (..)
   , scriptLength
+  , scriptMessages
   , emptyScriptRes
   ) where
 
 import           Cardano.Logging
+import qualified Cardano.Tracer.Test.Utils as Utils
 
-import           Data.Aeson (Value (..), (.=))
-import           Data.Text hiding (length)
+import           Control.Applicative ((<|>))
+import           Control.Monad (guard)
+import           Data.Aeson (FromJSON (..), Object, Value (..), withObject, (.=))
+import           Data.Aeson.Types (Parser, parseFail, -- parseEither,
+                                   parseField)
+import           Data.Text hiding (empty, length, reverse)
+import qualified Data.Text as Text
+import           Data.Vector (Vector)
+import qualified Data.Vector as Vector
+import           Text.Read (readMaybe)
 
 import           Test.QuickCheck
 
@@ -22,6 +32,61 @@ data Message =
   | Message2 MessageID Text
   | Message3 MessageID Double
   deriving (Eq, Ord, Show)
+
+-- | This instance is written by hand to parse the custom Message
+-- format.
+--
+-- @
+-- {"at":"2024-05-08T15:13:05.005807034Z","ns":["Test","Message1"],"data":..,"sev":"Debug","thread":"26","host":"KindStar"}
+-- @
+--
+-- Where the @data@ field can be of the following form:
+--
+-- @
+-- {"kind":"Message1","mid":"<1>","workload":"3"}
+-- {"kind":"Message2","mid":"<11>","workload":"Hallo"}
+-- {"kind":"Message3","mid":"<4>","workload":"0.7365603545830433"}
+-- @
+instance FromJSON Message where
+  parseJSON :: Value -> Parser Message
+  parseJSON a = parseFromTrace a <|> parseFromObj a
+
+parseFromTrace :: Value -> Parser Message
+parseFromTrace = withObject "Message" \obj -> do
+  -- parseField = (.:), defined in `aeson'.
+  parseFromObjInner =<< parseField @Object obj "data"
+
+parseFromObj :: Value -> Parser Message
+parseFromObj = withObject "Message" parseFromObjInner
+
+parseFromObjInner :: Object -> Parser Message
+parseFromObjInner obj = do
+  messageId_ <- parseField obj "mid"
+  messageId <- maybe (parseFail "parseFromObjInner: No `mid' field found.") pure
+    (stripBrackets messageId_ >>= readMaybe @MessageID . unpack)
+
+  kind     <- parseField @String obj "kind"
+  workload <- parseField @String obj "workload"
+  case kind of
+    "Message1" ->
+      case readMaybe @Int workload of
+        Just workloadInt -> pure $ Message1 messageId workloadInt
+        Nothing -> parseFail ("FromJSON Message: Could not parse 'workload' field: " ++ workload ++ "\n  + " ++ show obj)
+    "Message2" ->
+      pure $ Message2 messageId (pack workload)
+    "Message3" ->
+      case readMaybe @Double workload of
+        Just workloadDouble -> pure $ Message3 messageId workloadDouble
+        Nothing -> parseFail ("FromJSON Message: Could not parse 'workload' field: " ++ workload ++ "\n  + " ++ show obj)
+    _ ->
+      parseFail "FromJSON Message: 'kind' not one of Message1, Message2 or Message3."
+
+stripBrackets :: Text -> Maybe Text
+stripBrackets t = do
+  (ch1, rest)  <- Text.uncons t
+  (rest', chn) <- Text.unsnoc rest
+  guard $ ch1 == '<' && chn == '>'
+  pure rest'
 
 instance LogFormatting Message where
   forMachine _dtal (Message1 mid i) =
@@ -64,27 +129,29 @@ instance Arbitrary Message where
       Message3 0 <$> arbitrary
     ]
 
-
 -- | Adds a time between 0 and 1.
 --   0 is the time of the test start, and 1 the test end
 data ScriptedMessage = ScriptedMessage Double Message
   deriving (Eq, Show)
 
--- Ordered by time
+-- | Ordered by time.
 instance Ord ScriptedMessage where
   compare (ScriptedMessage d1 _m1) (ScriptedMessage d2 _m2) = compare d1 d2
 
 instance Arbitrary ScriptedMessage where
   arbitrary = ScriptedMessage <$> choose (0.0, 1.0) <*> arbitrary
 
-newtype Script = Script [ScriptedMessage]
+newtype Script = Script (Vector ScriptedMessage)
   deriving (Eq, Show)
 
 scriptLength :: Script -> Int
-scriptLength (Script m) = length m
+scriptLength (Script m) = Vector.length m
+
+scriptMessages :: Script -> Vector Message
+scriptMessages (Script messages) = fmap (\(ScriptedMessage _ message) -> message) messages
 
 instance Arbitrary Script where
-  arbitrary = Script <$> listOf arbitrary
+  arbitrary = Script <$> Utils.vectorOf arbitrary
 
 data ScriptRes = ScriptRes {
     srScript     :: Script
@@ -95,7 +162,7 @@ data ScriptRes = ScriptRes {
 
 emptyScriptRes :: ScriptRes
 emptyScriptRes =  ScriptRes {
-    srScript = Script []
+    srScript = Script Vector.empty
   , srStdoutRes = []
   , srForwardRes = []
   , srEkgRes = []

--- a/cardano-tracer/test/Cardano/Tracer/Test/Logs/Tests.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/Logs/Tests.hs
@@ -20,6 +20,7 @@ import           Control.Concurrent.Async (withAsync)
 import           Control.Monad (forM)
 import           Data.List.Extra (notNull)
 import qualified Data.List.NonEmpty as NE
+import           Data.Word (Word64)
 import           System.Directory
 import           System.Directory.Extra
 import           System.FilePath
@@ -30,19 +31,20 @@ import           Test.Tasty.QuickCheck
 
 tests :: TestSetup Identity -> TestTree
 tests ts = localOption (QuickCheckTests 1) $ testGroup "Test.Logs"
-  [ testProperty ".log"  $ propRunInLogsStructure ts (propLogs ts ForHuman)
-  , testProperty ".json" $ propRunInLogsStructure ts (propLogs ts ForMachine)
-  , testProperty "multi, initiator" $ propRunInLogsStructure2 ts (propMultiInit ts ForMachine)
-  , testProperty "multi, responder" $ propRunInLogsStructure ts (propMultiResp ts ForMachine)
+  [ testProperty ".log"             do propRunInLogsStructure  ts (propLogs      ts ForHuman   100 60)
+  , testProperty ".log"             do propRunInLogsStructure  ts (propLogs      ts ForHuman   4   1)
+  , testProperty ".json"            do propRunInLogsStructure  ts (propLogs      ts ForMachine 100 60)
+  , testProperty "multi, initiator" do propRunInLogsStructure2 ts (propMultiInit ts ForMachine)
+  , testProperty "multi, responder" do propRunInLogsStructure  ts (propMultiResp ts ForMachine)
   ]
 
-propLogs :: TestSetup Identity -> LogFormat -> FilePath -> FilePath -> IO Property
-propLogs ts@TestSetup{..} format rootDir localSock = do
+propLogs :: TestSetup Identity -> LogFormat -> Word64 -> Word64 -> FilePath -> FilePath -> IO Property
+propLogs ts@TestSetup{..} format logRotLimitBytes logRotMaxAgeMinutes rootDir localSock = do
   stopProtocols <- initProtocolsBrake
   dpRequestors <- initDataPointRequestors
-  withAsync (doRunCardanoTracer (config rootDir localSock) (Just $ rootDir <> "/../state") stderrShowTracer stopProtocols dpRequestors) . const $ do
+  withAsync (doRunCardanoTracer config (Just $ rootDir <> "/../state") stderrShowTracer stopProtocols dpRequestors) \_ -> do
     sleep 1.0
-    withAsync (launchForwardersSimple ts Initiator localSock 1000 10000) . const $ do
+    withAsync (launchForwardersSimple ts Initiator localSock 1000 10000) \_ -> do
       sleep 8.0 -- Wait till some rotation is done.
       applyBrake stopProtocols
       sleep 0.5
@@ -53,30 +55,30 @@ propLogs ts@TestSetup{..} format rootDir localSock = do
       -- ... and contains one node's subdir...
       listDirectories rootDir >>= \case
         [] -> false "root dir is empty"
-        (subDir:_) -> do
+        subDir:_ -> do
           -- ... with *.log-files inside...
           let pathToSubDir = rootDir </> subDir
           listFiles pathToSubDir >>= \case
             [] -> false "subdir is empty"
-            logsAndSymLink ->
+            logsAndSymLink -> do
               case filter (isItLog format) logsAndSymLink of
                 []        -> false "subdir doesn't contain expected logs"
                 [_oneLog] -> false "there is still 1 single log, no rotation"
                 _logs     -> return $ property True
  where
-  config root p = TracerConfig
+  config = TracerConfig
     { networkMagic   = unNetworkMagic $ unI tsNetworkMagic
-    , network        = AcceptAt (LocalSocket p)
+    , network        = AcceptAt (LocalSocket localSock)
     , loRequestNum   = Just 1
     , ekgRequestFreq = Just 1.0
     , hasEKG         = Nothing
     , hasPrometheus  = Nothing
     , hasRTView      = Nothing
-    , logging        = NE.fromList [LoggingParams root FileMode format]
+    , logging        = NE.fromList [LoggingParams rootDir FileMode format]
     , rotation       = Just $ RotationParams
                          { rpFrequencySecs = 3
-                         , rpLogLimitBytes = 100
-                         , rpMaxAgeHours   = 1
+                         , rpLogLimitBytes = logRotLimitBytes
+                         , rpMaxAgeMinutes = logRotMaxAgeMinutes
                          , rpKeepFilesNum  = 10
                          }
     , verbosity      = Just Minimum
@@ -89,11 +91,11 @@ propMultiInit :: TestSetup Identity -> LogFormat -> FilePath -> FilePath -> File
 propMultiInit ts@TestSetup{..} format rootDir localSock1 localSock2 = do
   stopProtocols <- initProtocolsBrake
   dpRequestors <- initDataPointRequestors
-  withAsync (doRunCardanoTracer (config rootDir localSock1 localSock2) (Just $ rootDir <> "/../state") stderrShowTracer stopProtocols dpRequestors) . const $ do
+  withAsync (doRunCardanoTracer (config rootDir localSock1 localSock2) (Just $ rootDir <> "/../state") stderrShowTracer stopProtocols dpRequestors) \_ -> do
     sleep 1.0
-    withAsync (launchForwardersSimple ts Responder localSock1 1000 10000) . const $ do
+    withAsync (launchForwardersSimple ts Responder localSock1 1000 10000) \_ -> do
       sleep 1.0
-      withAsync (launchForwardersSimple ts Responder localSock2 1000 10000) . const $ do
+      withAsync (launchForwardersSimple ts Responder localSock2 1000 10000) \_ -> do
         sleep 5.0 -- Wait till some work is done.
         applyBrake stopProtocols
         sleep 0.5
@@ -119,11 +121,11 @@ propMultiResp :: TestSetup Identity -> LogFormat -> FilePath -> FilePath -> IO P
 propMultiResp ts@TestSetup{..} format rootDir localSock = do
   stopProtocols <- initProtocolsBrake
   dpRequestors <- initDataPointRequestors
-  withAsync (doRunCardanoTracer (config rootDir localSock) (Just $ rootDir <> "/../state") stderrShowTracer stopProtocols dpRequestors) . const $ do
+  withAsync (doRunCardanoTracer (config rootDir localSock) (Just $ rootDir <> "/../state") stderrShowTracer stopProtocols dpRequestors) \_ -> do
     sleep 1.0
-    withAsync (launchForwardersSimple ts Initiator localSock 1000 10000) . const $ do
+    withAsync (launchForwardersSimple ts Initiator localSock 1000 10000) \_ -> do
       sleep 1.0
-      withAsync (launchForwardersSimple ts Initiator localSock 1000 10000) . const $ do
+      withAsync (launchForwardersSimple ts Initiator localSock 1000 10000) \_ -> do
         sleep 5.0 -- Wait till some work is done.
         applyBrake stopProtocols
         sleep 0.5

--- a/cardano-tracer/test/Cardano/Tracer/Test/Utils.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/Utils.hs
@@ -7,11 +7,15 @@ module Cardano.Tracer.Test.Utils
 import           Cardano.Tracer.Test.TestSetup
 
 import           Data.Functor.Identity
+import           Data.Vector (Vector)
+import qualified Data.Vector as Vector
+import           Data.Vector.Algorithms.Merge
 import           System.Directory.Extra (listDirectories)
 import           System.FilePath (dropDrive, dropExtension)
 import           System.Info.Extra (isMac, isWindows)
 import           System.IO.Extra (newTempDirWithin)
 
+import qualified Test.QuickCheck as QuickCheck
 import           Test.Tasty.QuickCheck
 
 unI :: Identity a -> a
@@ -48,3 +52,14 @@ replaceExtension new f = dropExtension f <> "." <> new
 
 isDirectoryEmpty :: FilePath -> IO Bool
 isDirectoryEmpty = fmap null . listDirectories
+
+vectorOf :: Gen a -> Gen (Vector a)
+vectorOf gen = sized \n -> do
+  len <- chooseInt (0, n)
+  sizedVectorOf len gen
+
+sizedVectorOf :: Int -> Gen a -> Gen (Vector a)
+sizedVectorOf n a = Vector.fromListN n <$> QuickCheck.vectorOf n a
+
+vectorSort :: Ord a => Vector a -> Vector a
+vectorSort = Vector.modify sort

--- a/nix/workbench/service/tracer.nix
+++ b/nix/workbench/service/tracer.nix
@@ -25,6 +25,8 @@ let
           networkMagic = profile.genesis.network_magic;
           dsmPassthrough = {
             # rtsOpts = ["-xc"];
+          } // optionalAttrs (profile.tracer.withresources or false) {
+            rtsOpts = [ "-scardano-tracer.gcstats" ];
           };
           configFile     = "config.json";
           logRoot        = ".";

--- a/trace-forward/src/Trace/Forward/Run/TraceObject/Acceptor.hs
+++ b/trace-forward/src/Trace/Forward/Run/TraceObject/Acceptor.hs
@@ -47,7 +47,7 @@ acceptTraceObjectsResp
   -> (responderCtx -> [lo] -> IO ()) -- ^ The handler for accepted 'TraceObject's.
   -> (responderCtx -> IO ())         -- ^ The handler for exceptions from 'runPeer'.
   -> RunMiniProtocol 'ResponderMode initiatorCtx responderCtx LBS.ByteString IO Void ()
-acceptTraceObjectsResp config loHandler peerErrorHandler =
+acceptTraceObjectsResp config loHandler peerErrorHandler = do
   ResponderProtocolOnly $ runPeerWithHandler config loHandler peerErrorHandler
 
 runPeerWithHandler


### PR DESCRIPTION
# Description

Add Handle Registry feature to the `TracerEnv`, to track handles that have been opened.

```haskell
-- Cardano.Tracer.Types
type    Registry :: Type -> Type -> Type
newtype Registry a b = Registry { getRegistry :: MVar (Map a b) }

type HandleRegistry :: Type
type HandleRegistry = Registry (NodeName, LoggingParams) (Handle, FilePath)
```

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] Any changes are noted in the `CHANGELOG.md` for affected package
- [X] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [X] Self-reviewed the diff

# Graphs

![plot_time_heap](https://github.com/IntersectMBO/cardano-node/assets/501899/ec1a77cc-6031-42c7-b068-c42f66edc2ab)

RTS allocation rate:

![plot_time_alloc](https://github.com/IntersectMBO/cardano-node/assets/501899/50876fbc-6e90-4913-a056-c672cd1ced18)

RTS live dataset:

![plot_time_live](https://github.com/IntersectMBO/cardano-node/assets/501899/eab5ec04-bc06-4d19-92f3-7aae251f3fdb)

# Profiling comparison (`tracer/cardano-tracer.gcstats`)


## Compiled with `WB_PROFILING=time`
### Without Handle Registry (old)

```
'/nix/store/q42z21kj9ic12hmmk39ncfkcjhxpn57j-cardano-tracer-exe-cardano-tracer-0.2.2/bin/cardano-tracer' '--config' 'config.json' +RTS '-T' '-scardano-tracer.gcstats'
  14,894,377,592 bytes allocated in the heap
     758,763,144 bytes copied during GC
       2,956,296 bytes maximum residency (383 sample(s))
         107,528 bytes maximum slop
               9 MiB total memory in use (0 MB lost due to fragmentation)
```

### With Handle Registry (new):

* Allocation decreased to 66.7%.
* GC copies decreased to 26.3%. 

```
'/nix/store/r9mwrmw7xv3k35czq8gan6v3n0k0sp55-cardano-tracer-exe-cardano-tracer-0.2.2/bin/cardano-tracer' '--config' 'config.json' +RTS '-T' '-scardano-tracer.gcstats'
   4,961,702,600 bytes allocated in the heap
     559,019,608 bytes copied during GC
       2,979,504 bytes maximum residency (763 sample(s))
         137,216 bytes maximum slop
               9 MiB total memory in use (0 MB lost due to fragmentation)
```

## Compiled with `WB_PROFILING=time-detail`
### Without Handle Registry (old)

```
'/nix/store/q42z21kj9ic12hmmk39ncfkcjhxpn57j-cardano-tracer-exe-cardano-tracer-0.2.2/bin/cardano-tracer' '--config' 'config.json' +RTS '-T' '-scardano-tracer.gcstats'
  15,246,669,176 bytes allocated in the heap
     768,850,304 bytes copied during GC
       2,992,552 bytes maximum residency (453 sample(s))
         101,104 bytes maximum slop
               9 MiB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     11343 colls,     0 par    2.872s   3.949s     0.0003s    0.0445s
  Gen  1       453 colls,     0 par    1.576s   2.102s     0.0046s    0.0587s

  TASKS: 6 (1 bound, 5 peak workers (5 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.000s  (  0.000s elapsed)
  MUT     time   42.008s  (1250.051s elapsed)
  GC      time    4.448s  (  6.052s elapsed)
  EXIT    time    0.001s  (  0.007s elapsed)
  Total   time   46.458s  (1256.110s elapsed)

  Alloc rate    362,948,083 bytes per MUT second

  Productivity  90.4% of total user, 99.5% of total elapsed
```

### With Handle Registry (new)

* Allocation decreased to 57.6%
* GC copies decreased to 40.53%.
* Max. residency increased to 26.3%.
* Max. slop increased to 41.9%.

```
'/nix/store/r9mwrmw7xv3k35czq8gan6v3n0k0sp55-cardano-tracer-exe-cardano-tracer-0.2.2/bin/cardano-tracer' '--config' 'config.json' +RTS '-T' '-scardano-tracer.gcstats'
   6,462,101,600 bytes allocated in the heap
     457,230,328 bytes copied during GC
       3,000,408 bytes maximum residency (519 sample(s))
         143,496 bytes maximum slop
               9 MiB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0      5509 colls,     0 par    1.447s   1.513s     0.0003s    0.0106s
  Gen  1       519 colls,     0 par    2.180s   2.289s     0.0044s    0.0640s

  TASKS: 5 (1 bound, 4 peak workers (4 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.007s  (  0.074s elapsed)
  MUT     time   34.640s  (1271.401s elapsed)
  GC      time    3.627s  (  3.802s elapsed)
  EXIT    time    0.000s  (  0.002s elapsed)
  Total   time   38.274s  (1275.279s elapsed)

  Alloc rate    186,549,800 bytes per MUT second

  Productivity  90.5% of total user, 99.7% of total elapsed
```
