### PR TITLE
Make sure epoch length equation is satisfied for testnet

### DIFF
--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/InfoAction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/InfoAction.hs
@@ -274,15 +274,14 @@ hprop_ledger_events_info_action = H.integrationRetryWorkspace 0 "info-hash" $ \t
 
   -- We check that info action was succcessfully ratified
   !meInfoRatified
-    <- H.timeout 720_000_000 $ runExceptT $ foldBlocks
+    <- H.timeout 120_000_000 $ runExceptT $ foldBlocks
                       (File configurationFile)
                       (File socketPath)
                       FullValidation
                       (InfoActionState False False)  -- Initial accumulator state
                       (foldBlocksCheckInfoAction (tempAbsPath' </> "events.log") governanceActionIndex )
 
-  eInfoRatified <- H.nothingFail meInfoRatified
-  case eInfoRatified of
+  H.nothingFail meInfoRatified >>= \case
     Left e ->
       H.failMessage callStack
         $ "foldBlocksCheckInfoAction failed with: " <> displayError e


### PR DESCRIPTION
# Description

This PR makes sure that epoch length equation is satisfied for the testnet.

Additionally, 140s timeout is removed for `InfoAction` test.

This is an attempt towards fixing:
- https://github.com/IntersectMBO/cardano-node/issues/5762

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
