### PR TITLE
tx-generator | plutus-scripts-bench: fix build constraints and shell inputs

### DIFF
--- a/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
+++ b/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
@@ -1,6 +1,6 @@
 cabal-version:          3.0
 name:                   plutus-scripts-bench
-version:                1.0.1.0
+version:                1.0.2.0
 synopsis:               Plutus scripts used for benchmarking
 description:            Plutus scripts used for benchmarking.
 category:               Cardano,
@@ -27,7 +27,7 @@ common project-config
   if os(windows)
     buildable: False
 
-  -- This echos the ghc range in the plutus-tx-plugin cabal file.
+  -- This echoes the ghc range in the plutus-tx-plugin cabal file.
   if (impl(ghc <9.6) || impl(ghc >=9.7))
     buildable: False
 

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   tx-generator
-version:                2.10
+version:                2.11
 synopsis:               A transaction workload generator for Cardano clusters
 description:            A transaction workload generator for Cardano clusters.
 category:               Cardano,
@@ -26,13 +26,12 @@ common project-config
     buildable: False
 
 common with-library
-  if impl(ghc >= 9.6)
-    build-depends:      plutus-scripts-bench
+  -- This is the inverse to the "buildable" GHC version constraint in plutus-scripts-bench.
+  -- It makes sure, we only depend on that package if it is buildable.
+  -- The tx-generator will fall back to pre-serialized Plutus scripts if this package is not present.
+  if !(impl(ghc <9.6) || impl(ghc >=9.7))
+    build-depends:      plutus-scripts-bench ^>= 1.0.2
     cpp-options:        -DWITH_LIBRARY
-
-  -- This echos the ghc range in the plutus-tx-plugin cabal file.
-  if (impl(ghc <9.6) || impl(ghc >=9.7))
-    buildable: False
 
 library
   import:               project-config, with-library
@@ -179,10 +178,6 @@ executable tx-generator
                         -rtsopts
                         "-with-rtsopts=-T"
 
-  -- This echos the ghc range in the plutus-tx-plugin cabal file.
-  if (impl(ghc <9.6) || impl(ghc >=9.7))
-    buildable: False
-
   build-depends:        base
                       , tx-generator
 
@@ -197,10 +192,6 @@ test-suite tx-generator-apitest
                         -Wall
                         -rtsopts
                         "-with-rtsopts=-T"
-
-  -- This echos the ghc range in the plutus-tx-plugin cabal file.
-  if (impl(ghc <9.6) || impl(ghc >=9.7))
-    buildable: False
 
   build-depends:        base
                       , aeson
@@ -235,10 +226,6 @@ test-suite tx-generator-test
   hs-source-dirs:       test
   main-is:              Main.hs
   type:                 exitcode-stdio-1.0
-
-  -- This echos the ghc range in the plutus-tx-plugin cabal file.
-  if (impl(ghc <9.6) || impl(ghc >=9.7))
-    buildable: False
 
   build-depends:        base
                       , tasty

--- a/cabal.project
+++ b/cabal.project
@@ -27,13 +27,10 @@ packages:
   bench/cardano-topology
   bench/locli
   bench/plutus-scripts-bench
+  bench/tx-generator
   trace-dispatcher
   trace-resources
   trace-forward
-
-if impl(ghc >9.6) && impl(ghc <9.7)
-  packages:
-    bench/tx-generator
 
 program-options
   ghc-options: -Werror

--- a/flake.nix
+++ b/flake.nix
@@ -255,7 +255,7 @@
                   roots.project = project.roots;
                   plan-nix.project = project.plan-nix;
                 };
-                profiled = lib.genAttrs (lib.filter (n: packages ? ${n}) [ "cardano-node" "tx-generator" "locli" ]) (n:
+                profiled = lib.genAttrs (lib.filter (n: packages ? n) [ "cardano-node" "tx-generator" "locli" ]) (n:
                   packages.${n}.passthru.profiled
                 );
                 asserted = lib.genAttrs [ "cardano-node" ] (n:

--- a/flake.nix
+++ b/flake.nix
@@ -255,7 +255,7 @@
                   roots.project = project.roots;
                   plan-nix.project = project.plan-nix;
                 };
-                profiled = lib.genAttrs (lib.filter (n: packages ? n) [ "cardano-node" "tx-generator" "locli" ]) (n:
+                profiled = lib.genAttrs [ "cardano-node" "tx-generator" "locli" ] (n:
                   packages.${n}.passthru.profiled
                 );
                 asserted = lib.genAttrs [ "cardano-node" ] (n:

--- a/flake.nix
+++ b/flake.nix
@@ -200,11 +200,10 @@
                     cardano-node-rev = pkgs.gitrev;
                   }).workbench-profile-run;
           in
-          ({
+          {
             "dockerImage/node" = pkgs.dockerImage;
             "dockerImage/submit-api" = pkgs.submitApiDockerImage;
 
-          } // optionalAttrs (exes ? tx-generator) {
             ## This is a very light profile, no caching&pinning needed.
             workbench-ci-test =
               workbenchTest { profileName        = "ci-test-bage";
@@ -213,7 +212,7 @@
               workbenchTest { profileName        = "ci-test-bage";
                               workbenchStartArgs = [ "--trace" ];
                             };
-          } // {
+
             inherit (pkgs) all-profiles-json;
 
             system-tests = pkgs.writeShellApplication {
@@ -236,7 +235,7 @@
                   nix develop --accept-flake-config .#base -c ./.github/regression.sh 2>&1
               '';
             };
-          }))
+          })
           # Add checks to be able to build them individually
           // (prefixNamesWith "checks/" checks);
 
@@ -251,7 +250,7 @@
               cardano-deployment = pkgs.cardanoLib.mkConfigHtml { inherit (pkgs.cardanoLib.environments) mainnet preview preprod; };
             } // optionalAttrs (system == "x86_64-linux") {
               native = packages // {
-                shells = removeAttrs devShells (lib.optional (!(exes ? tx-generator)) "devops");
+                shells = devShells;
                 internal = {
                   roots.project = project.roots;
                   plan-nix.project = project.plan-nix;
@@ -319,7 +318,7 @@
                   platform = "macos";
                   exes = lib.collect lib.isDerivation (collectExes project);
                 };
-                shells = removeAttrs devShells ([ "profiled" ] ++ lib.optional (!(exes ? tx-generator)) "devops");
+                shells = removeAttrs devShells [ "profiled" ];
                 internal = {
                   roots.project = project.roots;
                   plan-nix.project = project.plan-nix;

--- a/shell.nix
+++ b/shell.nix
@@ -114,6 +114,7 @@ let
       cardano-topology
       cardano-tracer
       locli
+      tx-generator
       pkgs.graphviz
       python3Packages.supervisor
       python3Packages.ipython
@@ -124,7 +125,7 @@ let
       workbench-interactive-start
       workbench-interactive-stop
       workbench-interactive-restart
-    ] ++ lib.optional (cardanoNodePackages ? tx-generator) cardanoNodePackages.tx-generator;
+    ];
 
     # Disable build tools for all of hsPkgs (would include duplicates for cardano-cli, cardano-node, etc.)
     allToolDeps = false;


### PR DESCRIPTION
# Description

This fixes erroneously removing `tx-generator` as a shell input from PR #5659.

Additionally, new minor package versions are introduced to reflect the updated set of build constraints.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff
