### PR TITLE
Restore codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,25 @@
+# catch-all
+
+* @intersectmbo/core-tech
+
+# Specific reviewers for code pieces
+# NB - The last matching pattern takes precedence
+
+# Perf/Tracing
+bench/                                                        @intersectmbo/performance-and-tracing
+nix/workbench/                                                @intersectmbo/performance-and-tracing
+trace-dispatcher/                                             @intersectmbo/performance-and-tracing
+trace-forward/                                                @intersectmbo/performance-and-tracing
+trace-resources/                                              @intersectmbo/performance-and-tracing
+Makefile                                                      @intersectmbo/performance-and-tracing
+*.mk                                                          @intersectmbo/performance-and-tracing
+
+# DevOps
+nix/                                                          @intersectmbo/core-tech-devx @intersectmbo/core-tech-release-1
+*.nix                                                         @intersectmbo/core-tech-devx @intersectmbo/core-tech-release-1
+flake.lock                                                    @intersectmbo/core-tech-devx @intersectmbo/core-tech-release-1
+.github/workflows                                             @intersectmbo/core-tech-devx @intersectmbo/core-tech-release-1 @intersectmbo/core-tech
+ci/                                                           @intersectmbo/core-tech-devx @intersectmbo/core-tech-release-1
+configuration/                                                @intersectmbo/core-tech-devx @intersectmbo/core-tech-release-1
+docker-compose.yml                                            @intersectmbo/core-tech-devx @intersectmbo/core-tech-release-1
+


### PR DESCRIPTION
# Description

Restore part of codeowners removed in https://github.com/IntersectMBO/cardano-node/pull/5493/files

`docs-access` is not present in `intersectmbo` so I skipped it.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
