### PR TITLE
fix: update docker image location in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,11 +67,11 @@ The download includes cardano-node.exe and a .dll. To run the node with cardano-
 Docker image
 ============
 
-You can pull the docker image with the latest version of cardano-node from `here <https://hub.docker.com/r/inputoutput/cardano-node>`_.
+You can pull the docker image with the latest version of cardano-node from `here <https://github.com/IntersectMBO/cardano-node/pkgs/container/cardano-node>`_.
 
 .. code-block:: console
 
-    docker pull inputoutput/cardano-node
+    docker pull ghcr.io/intersectmbo/cardano-node
 
 ****
 Using ``cardano-node``


### PR DESCRIPTION
This PR updates the docker image location to use the official intersectmbo published images.