### PR TITLE
Make testnet's nodes' ports allocation dynamic

### DIFF
--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -199,6 +199,7 @@ test-suite cardano-testnet-test
                       , cardano-crypto-class
                       , cardano-ledger-conway
                       , cardano-ledger-shelley
+                      , cardano-node
                       , cardano-testnet
                       , containers
                       , directory

--- a/cardano-testnet/src/Cardano/Testnet.hs
+++ b/cardano-testnet/src/Cardano/Testnet.hs
@@ -6,6 +6,7 @@ module Cardano.Testnet (
   -- ** Start a testnet
   cardanoTestnet,
   cardanoTestnetDefault,
+  requestAvailablePortNumbers,
 
   -- ** Testnet options
   CardanoTestnetOptions(..),

--- a/cardano-testnet/src/Testnet/Start/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Start/Cardano.hs
@@ -3,11 +3,6 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
-
-#if __GLASGOW_HASKELL__ >= 908
-{-# OPTIONS_GHC -Wno-x-partial #-}
-#endif
 
 module Testnet.Start.Cardano
   ( ForkPoint(..)
@@ -22,6 +17,7 @@ module Testnet.Start.Cardano
 
   , cardanoTestnet
   , cardanoTestnetDefault
+  , requestAvailablePortNumbers
   ) where
 
 
@@ -30,6 +26,7 @@ import           Cardano.Api.Ledger (StandardCrypto)
 
 import           Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis)
 import           Cardano.Ledger.Conway.Genesis (ConwayGenesis)
+import           Cardano.Node.Configuration.Topology
 
 import           Prelude hiding (lines)
 
@@ -40,15 +37,21 @@ import qualified Data.Aeson as Aeson
 import           Data.Bifunctor (first)
 import qualified Data.ByteString.Lazy as LBS
 import           Data.Either
+import           Data.IORef
 import qualified Data.List as L
 import           Data.Maybe
+import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Time (UTCTime)
 import qualified Data.Time.Clock as DTC
 import           Data.Word (Word32)
+import           GHC.IO.Unsafe (unsafePerformIO)
+import           GHC.Stack
 import qualified GHC.Stack as GHC
+import           Network.Socket (PortNumber)
 import           System.FilePath ((</>))
 import qualified System.Info as OS
+import           Text.Printf (printf)
 
 import           Testnet.Components.Configuration
 import qualified Testnet.Defaults as Defaults
@@ -60,20 +63,16 @@ import           Testnet.Runtime as TR hiding (shelleyGenesis)
 import qualified Testnet.Start.Byron as Byron
 import           Testnet.Start.Types
 
+import           Hedgehog (MonadTest)
 import qualified Hedgehog as H
 import           Hedgehog.Extras (failMessage)
 import qualified Hedgehog.Extras.Stock.OS as OS
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
-{- HLINT ignore "Redundant flip" -}
-{- HLINT ignore "Redundant id" -}
-{- HLINT ignore "Use let" -}
-
-
 -- | There are certain conditions that need to be met in order to run
 -- a valid node cluster.
-testnetMinimumConfigurationRequirements :: CardanoTestnetOptions -> H.Integration ()
+testnetMinimumConfigurationRequirements :: MonadTest m => CardanoTestnetOptions -> m ()
 testnetMinimumConfigurationRequirements cTestnetOpts = do
   let actualLength = length (cardanoNodes cTestnetOpts)
   when (actualLength < 2) $ do
@@ -105,6 +104,37 @@ cardanoTestnetDefault opts conf = do
   cardanoTestnet
     opts conf startTime
     (Defaults.defaultShelleyGenesis startTime opts) alonzoGenesis Defaults.defaultConwayGenesis
+
+-- | Hardcoded testnet IP address
+testnetIpv4Address :: Text
+testnetIpv4Address = "127.0.0.1"
+
+-- | Starting port number, from which testnet nodes will get new ports.
+defaultTestnetNodeStartingPortNumber :: PortNumber
+defaultTestnetNodeStartingPortNumber = 23000
+
+-- | Global counter used to track which testnet node's ports were already allocated
+availablePortNumber :: IORef PortNumber
+availablePortNumber = unsafePerformIO $ newIORef defaultTestnetNodeStartingPortNumber
+{-# NOINLINE availablePortNumber #-}
+
+-- | Request a list of unused port numbers for testnet nodes. This shifts 'availablePortNumber' by
+-- 'maxPortsPerRequest' in order to make sure that each node gets an unique port.
+requestAvailablePortNumbers
+  :: HasCallStack
+  => MonadIO m
+  => MonadTest m
+  => Int -- ^ Number of ports to request
+  -> m [PortNumber]
+requestAvailablePortNumbers numberOfPorts
+  | numberOfPorts > fromIntegral maxPortsPerRequest = withFrozenCallStack $ do
+    H.note_ $ "Tried to allocate " <> show numberOfPorts <> " port numbers in one request. "
+      <> "It's allowed to allocate no more than " <> show maxPortsPerRequest <> " per request."
+    H.failure
+  | otherwise = liftIO $ atomicModifyIORef' availablePortNumber $ \n ->
+      (n + maxPortsPerRequest, [n..n + fromIntegral numberOfPorts - 1])
+    where
+      maxPortsPerRequest = 50
 
 -- | Setup a number of credentials and pools, like this:
 --
@@ -159,6 +189,7 @@ cardanoTestnetDefault opts conf = do
 -- >     └── utxo{1,2,3}
 -- >         └── utxo.{addr,skey,vkey}
 cardanoTestnet :: ()
+  => HasCallStack
   => CardanoTestnetOptions -- ^ The options to use. Must be consistent with the genesis files.
   -> Conf
   -> UTCTime -- ^ The starting time. Must be the same as the one in the shelley genesis.
@@ -177,6 +208,8 @@ cardanoTestnet
       numPoolNodes = length $ cardanoNodes testnetOptions
       nbPools = numPools testnetOptions
       era = cardanoNodeEra testnetOptions
+
+  portNumbers <- requestAvailablePortNumbers numPoolNodes
 
    -- Sanity checks
   testnetMinimumConfigurationRequirements testnetOptions
@@ -241,12 +274,12 @@ cardanoTestnet
     wallets <- forM [1..3] $ \idx -> do
       let paymentSKeyFile = makeUTxOSkeyFp idx
       let paymentVKeyFile = makeUTxOVKeyFp idx
-      let paymentAddrFile = tmpAbsPath </> "utxo-keys" </> "utxo" <> show @Int idx </> "utxo.addr"
+      let paymentAddrFile = tmpAbsPath </> "utxo-keys" </> "utxo" <> show idx </> "utxo.addr"
 
       execCli_
         [ "address", "build"
         , "--payment-verification-key-file", makeUTxOVKeyFp idx
-        , "--testnet-magic", show @Int testnetMagic
+        , "--testnet-magic", show testnetMagic
         , "--out-file", paymentAddrFile
         ]
 
@@ -260,23 +293,23 @@ cardanoTestnet
         , paymentKeyInfoAddr = Text.pack paymentAddr
         }
 
-    _delegators <- forM [1..3] $ \idx -> do
+    _delegators <- forM [1..3] $ \(idx :: Int) -> do
       pure $ Delegator
         { paymentKeyPair = PaymentKeyPair
-          { paymentSKey = tmpAbsPath </> "stake-delegator-keys/payment" <> show @Int idx <> ".skey"
-          , paymentVKey = tmpAbsPath </> "stake-delegator-keys/payment" <> show @Int idx <> ".vkey"
+          { paymentSKey = tmpAbsPath </> "stake-delegator-keys/payment" <> show idx <> ".skey"
+          , paymentVKey = tmpAbsPath </> "stake-delegator-keys/payment" <> show idx <> ".vkey"
           }
         , stakingKeyPair = StakingKeyPair
-          { stakingSKey = tmpAbsPath </> "stake-delegator-keys/staking" <> show @Int idx <> ".skey"
-          , stakingVKey = tmpAbsPath </> "stake-delegator-keys/staking" <> show @Int idx <> ".vkey"
+          { stakingSKey = tmpAbsPath </> "stake-delegator-keys/staking" <> show idx <> ".skey"
+          , stakingVKey = tmpAbsPath </> "stake-delegator-keys/staking" <> show idx <> ".vkey"
           }
         }
 
     -- TODO: This should come from the configuration!
     let poolKeyDir :: Int -> FilePath
-        poolKeyDir i = "pools-keys" </> "pool" <> show i
-        poolKeysFps = map poolKeyDir [1 .. numPoolNodes]
-
+        poolKeyDir i = "pools-keys" </> mkNodeName i
+        mkNodeName :: Int -> String
+        mkNodeName i = "pool" <> show i
 
     -- Add Byron, Shelley and Alonzo genesis hashes to node configuration
     finalYamlConfig <- createConfigYaml (TmpAbsolutePath tmpAbsPath) era
@@ -284,102 +317,42 @@ cardanoTestnet
     H.evalIO $ LBS.writeFile configurationFile finalYamlConfig
 
     -- Byron related
-
-    H.renameFile (tmpAbsPath </> "byron-gen-command/delegate-keys.000.key") (tmpAbsPath </> poolKeyDir 1 </> "byron-delegate.key")
-    H.renameFile (tmpAbsPath </> "byron-gen-command/delegate-keys.001.key") (tmpAbsPath </> poolKeyDir 2 </> "byron-delegate.key")
-    H.renameFile (tmpAbsPath </> "byron-gen-command/delegate-keys.002.key") (tmpAbsPath </> poolKeyDir 3 </> "byron-delegate.key")
-
-    H.renameFile (tmpAbsPath </> "byron-gen-command/delegation-cert.000.json") (tmpAbsPath </> poolKeyDir 1 </>"byron-delegation.cert")
-    H.renameFile (tmpAbsPath </> "byron-gen-command/delegation-cert.001.json") (tmpAbsPath </> poolKeyDir 2 </>"byron-delegation.cert")
-    H.renameFile (tmpAbsPath </> "byron-gen-command/delegation-cert.002.json") (tmpAbsPath </> poolKeyDir 3 </>"byron-delegation.cert")
-
-    H.writeFile (tmpAbsPath </> poolKeyDir 1 </> "port") "3001"
-    H.writeFile (tmpAbsPath </> poolKeyDir 2 </> "port") "3002"
-    H.writeFile (tmpAbsPath </> poolKeyDir 3 </> "port") "3003"
-
+    forM_ (zip [1..] portNumbers) $ \(i, portNumber) -> do
+      let iStr = printf "%03d" (i - 1)
+      H.renameFile (tmpAbsPath </> "byron-gen-command" </> "delegate-keys." <> iStr <> ".key") (tmpAbsPath </> poolKeyDir i </> "byron-delegate.key")
+      H.renameFile (tmpAbsPath </> "byron-gen-command" </> "delegation-cert." <> iStr <> ".json") (tmpAbsPath </> poolKeyDir i </>"byron-delegation.cert")
+      H.writeFile (tmpAbsPath </> poolKeyDir i </> "port") (show portNumber)
 
     -- Make topology files
-    -- TODO generalise this over the N BFT nodes and pool nodes
+    forM_ (zip [1..] portNumbers) $ \(i, myPortNumber) -> do
+      let producers = flip map (filter (/= myPortNumber) portNumbers) $ \otherProducerPort ->
+            RemoteAddress
+              { raAddress = testnetIpv4Address
+              , raPort = otherProducerPort
+              , raValency = 1
+              }
 
-    H.lbsWriteFile (tmpAbsPath </> poolKeyDir 1 </> "topology.json") $ encode $
-      object
-      [ "Producers" .= toJSON
-        [ object
-          [ "addr"    .= toJSON @String "127.0.0.1"
-          , "port"    .= toJSON @Int 3002
-          , "valency" .= toJSON @Int 1
-          ]
-        , object
-          [ "addr"    .= toJSON @String "127.0.0.1"
-          , "port"    .= toJSON @Int 3003
-          , "valency" .= toJSON @Int 1
-          ]
-        , object
-          [ "addr"    .= toJSON @String "127.0.0.1"
-          , "port"    .= toJSON @Int 3005
-          , "valency" .= toJSON @Int 1
-          ]
-        ]
-      ]
+      H.lbsWriteFile (tmpAbsPath </> poolKeyDir i </> "topology.json") . encode $
+        RealNodeTopology producers
 
-    H.lbsWriteFile (tmpAbsPath </> poolKeyDir 2 </> "topology.json")  $ encode $
-      object
-      [ "Producers" .= toJSON
-        [ object
-          [ "addr"    .= toJSON @String "127.0.0.1"
-          , "port"    .= toJSON @Int 3001
-          , "valency" .= toJSON @Int 1
-          ]
-        , object
-          [ "addr"    .= toJSON @String "127.0.0.1"
-          , "port"    .= toJSON @Int 3003
-          , "valency" .= toJSON @Int 1
-          ]
-        , object
-          [ "addr"    .= toJSON @String "127.0.0.1"
-          , "port"    .= toJSON @Int 3005
-          , "valency" .= toJSON @Int 1
-          ]
-        ]
-      ]
-
-    H.lbsWriteFile (tmpAbsPath </> poolKeyDir 3 </> "topology.json") $ encode $
-      object
-      [ "Producers" .= toJSON
-        [ object
-          [ "addr"    .= toJSON @String "127.0.0.1"
-          , "port"    .= toJSON @Int 3001
-          , "valency" .= toJSON @Int 1
-          ]
-        , object
-          [ "addr"    .= toJSON @String "127.0.0.1"
-          , "port"    .= toJSON @Int 3002
-          , "valency" .= toJSON @Int 1
-          ]
-        , object
-          [ "addr"    .= toJSON @String "127.0.0.1"
-          , "port"    .= toJSON @Int 3005
-          , "valency" .= toJSON @Int 1
-          ]
-        ]
-      ]
-
-    let spoNodesWithPortNos = L.zip poolKeysFps [3001..]
-    ePoolNodes <- forM (L.zip spoNodesWithPortNos poolKeys) $ \((node, port),key) -> do
-      let nodeName = tail $ dropWhile (/= '/') node
+    let keysWithPorts = L.zip3 [1..] poolKeys portNumbers
+    ePoolNodes <- forM keysWithPorts $ \(i, key, port) -> do
+      let nodeName = mkNodeName i
+          keyDir = tmpAbsPath </> poolKeyDir i
       H.note_ $ "Node name: " <> nodeName
-      eRuntime <- lift . lift . runExceptT $ startNode (TmpAbsolutePath tmpAbsPath) nodeName port testnetMagic
-                                  [ "run"
-                                  , "--config", configurationFile
-                                  , "--topology", tmpAbsPath </> node </> "topology.json"
-                                  , "--database-path", tmpAbsPath </> node </> "db"
-                                  , "--shelley-kes-key", tmpAbsPath </> node </> "kes.skey"
-                                  , "--shelley-vrf-key", tmpAbsPath </> node </> "vrf.skey"
-                                  , "--byron-delegation-certificate", tmpAbsPath </> node </> "byron-delegation.cert"
-                                  , "--byron-signing-key", tmpAbsPath </> node </> "byron-delegate.key"
-                                  , "--shelley-operational-certificate", tmpAbsPath </> node </> "opcert.cert"
-                                  ]
-      return $ flip PoolNode key <$> eRuntime
+      eRuntime <- lift . lift . runExceptT $
+        startNode (TmpAbsolutePath tmpAbsPath) nodeName testnetIpv4Address port testnetMagic
+          [ "run"
+          , "--config", configurationFile
+          , "--topology", keyDir </> "topology.json"
+          , "--database-path", keyDir </> "db"
+          , "--shelley-kes-key", keyDir </> "kes.skey"
+          , "--shelley-vrf-key", keyDir </> "vrf.skey"
+          , "--byron-delegation-certificate", keyDir </> "byron-delegation.cert"
+          , "--byron-signing-key", keyDir </> "byron-delegate.key"
+          , "--shelley-operational-certificate", keyDir </> "opcert.cert"
+          ]
+      pure $ flip PoolNode key <$> eRuntime
 
     if any isLeft ePoolNodes
     -- TODO: We can render this in a nicer way

--- a/cardano-testnet/src/Testnet/Start/Types.hs
+++ b/cardano-testnet/src/Testnet/Start/Types.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Testnet.Start.Types
@@ -29,10 +30,6 @@ import           Hedgehog (MonadTest)
 import qualified Hedgehog.Extras as H
 
 
-{- HLINT ignore "Redundant flip" -}
-{- HLINT ignore "Redundant id" -}
-{- HLINT ignore "Use let" -}
-
 data CardanoTestnetOptions = CardanoTestnetOptions
   { -- | List of node options. Each option will result in a single node being
     -- created.
@@ -54,8 +51,8 @@ cardanoDefaultTestnetOptions = CardanoTestnetOptions
   , cardanoEpochLength = 500
   , cardanoSlotLength = 0.1
   , cardanoTestnetMagic = 42
-  , cardanoActiveSlotsCoeff = 0.1
-  , cardanoMaxSupply = 10020000000
+  , cardanoActiveSlotsCoeff = 0.05
+  , cardanoMaxSupply = 10_020_000_000
   , cardanoEnableP2P = False
   , cardanoNodeLoggingFormat = NodeLoggingFormatAsJson
   }

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/cardano.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/cardano.cli
@@ -30,7 +30,7 @@ Available options:
   --slot-length SECONDS    Slot length (default: 0.1)
   --testnet-magic INT      Specify a testnet magic id.
   --active-slots-coeff DOUBLE
-                           Active slots co-efficient (default: 0.1)
+                           Active slots co-efficient (default: 5.0e-2)
   --max-lovelace-supply WORD64
                            Max lovelace supply that your testnet starts with.
                            (default: 10020000000)

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/StakeSnapshot.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/StakeSnapshot.hs
@@ -42,7 +42,6 @@ hprop_stakeSnapshot = H.integrationRetryWorkspace 2 "conway-stake-snapshot" $ \t
     era = BabbageEra
     options = cardanoDefaultTestnetOptions
                         { cardanoNodes = cardanoDefaultTestnetNodeOptions
-                        , cardanoSlotLength = 0.1
                         , cardanoNodeEra = AnyCardanoEra era -- TODO: We should only support the latest era and the upcoming era
                         }
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/FoldBlocks.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/FoldBlocks.hs
@@ -43,10 +43,8 @@ prop_foldBlocks = H.integrationRetryWorkspace 2 "foldblocks" $ \tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath $ tempAbsPath conf
       era = BabbageEra
       options = cardanoDefaultTestnetOptions
-                          { cardanoNodes = cardanoDefaultTestnetNodeOptions
-                          , cardanoSlotLength = 0.1
-                          , cardanoNodeEra = AnyCardanoEra era -- TODO: We should only support the latest era and the upcoming era
-                          }
+                  { cardanoNodeEra = AnyCardanoEra era -- TODO: We should only support the latest era and the upcoming era
+                  }
 
   runtime@TestnetRuntime{configurationFile} <- cardanoTestnetDefault options conf
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/InfoAction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/InfoAction.hs
@@ -274,15 +274,14 @@ hprop_ledger_events_info_action = H.integrationRetryWorkspace 0 "info-hash" $ \t
 
   -- We check that info action was succcessfully ratified
   !meInfoRatified
-    <- H.timeout 720_000_000 $ runExceptT $ foldBlocks
+    <- H.timeout 120_000_000 $ runExceptT $ foldBlocks
                       (File configurationFile)
                       (File socketPath)
                       FullValidation
                       (InfoActionState False False)  -- Initial accumulator state
                       (foldBlocksCheckInfoAction (tempAbsPath' </> "events.log") governanceActionIndex )
 
-  eInfoRatified <- H.nothingFail meInfoRatified
-  case eInfoRatified of
+  H.nothingFail meInfoRatified >>= \case
     Left e ->
       H.failMessage callStack
         $ "foldBlocksCheckInfoAction failed with: " <> displayError e

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Node/Shutdown.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Node/Shutdown.hs
@@ -220,8 +220,7 @@ hprop_shutdownOnSlotSynced = H.integrationRetryWorkspace 2 "shutdown-on-slot-syn
     (Right s):_ -> return s
 
   let epsilon = 50
-
-  H.assert (maxSlot <= slotTip && slotTip <= maxSlot + epsilon)
+  H.assertWithinTolerance slotTip maxSlot epsilon
 
 hprop_shutdownOnSigint :: Property
 hprop_shutdownOnSigint = H.integrationRetryWorkspace 2 "shutdown-on-sigint" $ \tempAbsBasePath' -> do
@@ -231,7 +230,6 @@ hprop_shutdownOnSigint = H.integrationRetryWorkspace 2 "shutdown-on-sigint" $ \t
 
   let fastTestnetOptions = cardanoDefaultTestnetOptions
         { cardanoEpochLength = 300
-        , cardanoSlotLength = 0.01
         }
   testnetRuntime
     <- cardanoTestnetDefault fastTestnetOptions conf

--- a/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
+++ b/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
@@ -53,8 +53,6 @@ tests = pure $ sequentialTestGroup "test/Spec.hs"
         -- ShutdownOnSlotSynced FAILS Still. The node times out and it seems the "shutdown-on-slot-synced" flag does nothing
         -- , H.ignoreOnWindows "ShutdownOnSlotSynced" Cardano.Testnet.Test.Node.Shutdown.hprop_shutdownOnSlotSynced
         , sequentialTestGroup "Babbage"
-            -- TODO: Babbage --next leadership schedule still fails. Once this fix is propagated to the cli (https://github.com/input-output-hk/cardano-api/pull/274)
-            -- this should remedy. Double check and make sure we have re-enabled it and remove this comment.
             [ H.ignoreOnMacAndWindows "leadership-schedule" Cardano.Testnet.Test.Cli.Babbage.LeadershipSchedule.hprop_leadershipSchedule -- FAILS
             , H.ignoreOnWindows "stake-snapshot" Cardano.Testnet.Test.Cli.Babbage.StakeSnapshot.hprop_stakeSnapshot
             , H.ignoreOnWindows "transaction" Cardano.Testnet.Test.Cli.Babbage.Transaction.hprop_transaction
@@ -63,7 +61,7 @@ tests = pure $ sequentialTestGroup "test/Spec.hs"
         --, sequentialTestGroup "Conway"
         --  [ H.ignoreOnWindows "stake-snapshot" Cardano.Testnet.Test.Cli.Conway.StakeSnapshot.hprop_stakeSnapshot
         --  ]
-          -- Ignored on Windows due to <stdout>: cosmmitBuffer: invalid argument (invalid character)
+          -- Ignored on Windows due to <stdout>: commitBuffer: invalid argument (invalid character)
           -- as a result of the kes-period-info output to stdout.
         , H.ignoreOnWindows "kes-period-info" Cardano.Testnet.Test.Cli.KesPeriodInfo.hprop_kes_period_info
         , H.ignoreOnWindows "query-slot-number" Cardano.Testnet.Test.Cli.QuerySlotNumber.hprop_querySlotNumber
@@ -78,7 +76,7 @@ tests = pure $ sequentialTestGroup "test/Spec.hs"
       ]
   ]
 
--- FIXME Right now when running tests concurrently it makes tests flaky and sometimes stuck
+-- FIXME Right now when running tests concurrently it makes them flaky
 sequentialTestGroup :: T.TestName -> [TestTree] -> TestTree
 sequentialTestGroup name = T.sequentialTestGroup name T.AllFinish
 


### PR DESCRIPTION
# Description

This PR changes how testnet nodes get their port numbers. Instead of hardcoding ports 3000, a mutable variable with global port number is used to track already used ports and provide available port numbers dynamically.

This is a prerequisite for enabling concurrent execution of testnets.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
