### PR TITLE
testnet: reduce log length significantly, by not logging the config

### DIFF
--- a/cardano-testnet/src/Testnet/Process/Run.hs
+++ b/cardano-testnet/src/Testnet/Process/Run.hs
@@ -47,7 +47,6 @@ import           Hedgehog (MonadTest)
 import           Hedgehog.Extras.Internal.Plan (Component (..), Plan (..))
 import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
 import qualified Hedgehog.Extras.Stock.OS as OS
-import           Hedgehog.Extras.Test.Base
 import           Hedgehog.Extras.Test.Process (ExecConfig)
 import qualified Hedgehog.Extras.Test.Process as H
 import qualified Hedgehog.Internal.Property as H
@@ -163,7 +162,7 @@ mkExecConfig :: ()
 mkExecConfig tempBaseAbsPath sprocket networkId = do
   env' <- H.evalIO IO.getEnvironment
 
-  noteShow H.ExecConfig
+  return H.ExecConfig
     { H.execConfigEnv = Last $ Just $
       [ ("CARDANO_NODE_SOCKET_PATH", IO.sprocketArgumentName sprocket)
       , ("CARDANO_NODE_NETWORK_ID", show networkId)


### PR DESCRIPTION
# Description

When a test runs, we log its [ExecConfig](https://github.com/input-output-hk/hedgehog-extras/blob/56cb83973b39a08acda7408e97d1be3a33443d73/src/Hedgehog/Extras/Test/Process.hs#L71) which contains the [full environment](https://github.com/IntersectMBO/cardano-node/blob/f7900cd232b33aa96e18e7a533454ce077d299c1/cardano-testnet/src/Testnet/Process/Run.hs#L164) of the shell it runs in.

As a consequence, on Nix, the output log is polluted with a gigantic line of the form (there are actually multiple screens of output like this, only showing 1):

![image](https://github.com/IntersectMBO/cardano-node/assets/634720/551e6aab-ce7d-4fea-ab64-ad9ae43fc18e)

## What this PR does

This PR removes logging the `ExecConfig` value, as it's making harder to find other valuable info.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff