### PR TITLE
UTxO-HD: SSD configuration flags in preparation for benchmarking

### DIFF
--- a/.github/workflows/check-mainnet-config.yml
+++ b/.github/workflows/check-mainnet-config.yml
@@ -50,7 +50,7 @@ jobs:
         for f in "${test_files[@]}"; do
           nix_file="result/$f"
           repo_file="configuration/cardano/$f"
-          if ! jq -e --argfile nix "$nix_file" --argfile repo "$repo_file" -n '$repo | reduce keys[] as $k (true; . and $repo[$k] == $nix[$k])' &>/dev/null ; then
+          if ! jq -e --slurpfile nix "$nix_file" --slurpfile repo "$repo_file" -n '$repo | reduce keys[] as $k (true; . and $repo[$k] == $nix[$k])' &>/dev/null ; then
             echo "Nix file $nix_file does not have all the same top-level entries as the file from repository $repo_file"
             diff "$nix_file" "$repo_file"
             exit 1

--- a/.github/workflows/lmdb.pc
+++ b/.github/workflows/lmdb.pc
@@ -1,0 +1,11 @@
+prefix=/usr/local
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${exec_prefix}/include
+
+Name: liblmdb
+Description: Lightning Memory-Mapped Database
+URL: https://symas.com/products/lightning-memory-mapped-database/
+Version: 0.9.29
+Libs: -L${libdir} -llmdb
+Cflags: -I${includedir}

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,7 @@
 /cabal.project.old
 configuration/defaults/simpleview/genesis/
 configuration/defaults/liveview/genesis/
-dist-newstyle/
-dist-profiled/
+dist-*
 dist/
 *~
 \#*
@@ -24,7 +23,7 @@ stack.yaml.lock
 /db
 /db-[0-9]
 /logs
-/mainnet
+/mainnet*
 /profile
 /launch_*
 /state-*

--- a/bench/locli/locli.cabal
+++ b/bench/locli/locli.cabal
@@ -121,7 +121,7 @@ library
                       , optparse-generic
                       , ouroboros-consensus
                       -- for Data.SOP.Strict:
-                      , ouroboros-network ^>= 0.11
+                      , ouroboros-network ^>= 0.12
                       , ouroboros-network-api
                       , process
                       , quiet
@@ -175,7 +175,7 @@ test-suite test-locli
   build-depends:        cardano-prelude
                       , containers
                       , hedgehog
-                      , hedgehog-extras ^>= 0.6.1.0
+                      , hedgehog-extras < 0.6.2
                       , locli
                       , text
 

--- a/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
+++ b/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
@@ -73,7 +73,7 @@ library
   -- IOG dependencies
   --------------------------
   build-depends:
-    , cardano-api             ^>= 8.39
+    , cardano-api             ^>= 8.39.2.0
     , plutus-ledger-api       >=1.0.0
     , plutus-tx               >=1.0.0
     , plutus-tx-plugin        ^>=1.21

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -100,9 +100,9 @@ library
                       , attoparsec-aeson
                       , base16-bytestring
                       , bytestring
-                      , cardano-api ^>= 8.39
+                      , cardano-api ^>= 8.39.2.0
                       , cardano-binary
-                      , cardano-cli ^>= 8.20.2.0
+                      , cardano-cli ^>= 8.20.3.0
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
                       , cardano-data

--- a/cabal.project
+++ b/cabal.project
@@ -13,8 +13,8 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state:
-  , hackage.haskell.org 2024-02-21T10:56:14Z
-  , cardano-haskell-packages 2024-02-23T22:53:00Z
+  , hackage.haskell.org 2024-02-26T18:07:09Z
+  , cardano-haskell-packages 2024-02-26T17:55:44Z
 
 packages:
   cardano-git-rev

--- a/cabal.project
+++ b/cabal.project
@@ -13,7 +13,7 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state:
-  , hackage.haskell.org 2024-02-26T18:07:09Z
+  , hackage.haskell.org 2024-02-27T08:06:51Z
   , cardano-haskell-packages 2024-02-26T17:55:44Z
 
 packages:

--- a/cabal.project
+++ b/cabal.project
@@ -32,6 +32,15 @@ packages:
   trace-resources
   trace-forward
 
+  ../ouroboros-consensus/ouroboros-consensus
+  ../ouroboros-consensus/ouroboros-consensus-cardano
+  ../ouroboros-consensus/ouroboros-consensus-diffusion
+  ../ouroboros-consensus/ouroboros-consensus-protocol
+  ../ouroboros-consensus/sop-extras
+  ../ouroboros-consensus/strict-sop-core
+
+  ../cardano-api/cardano-api
+
 program-options
   ghc-options: -Werror
 
@@ -60,3 +69,11 @@ package plutus-scripts-bench
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
 
 -- `smtp-mail` should depend on `crypton-connection` rather than `connection`!
+
+source-repository-package
+  type: git
+  location: https://github.com/jasagredo/latex-svg
+  tag: 05dc866baadcdd04a23ed1a488440372f97afb70
+  --sha256: 1amaipl1f516m4yh9x02cqsbv50riszmbdjdmvfpw19vspv1szsx
+  subdir:
+    latex-svg-image

--- a/cardano-node-chairman/app/Cardano/Chairman.hs
+++ b/cardano-node-chairman/app/Cardano/Chairman.hs
@@ -343,7 +343,7 @@ chainSyncClient tracer sockPath chainsVar secParam = ChainSyncClient $ pure $
     }
   where
     clientStIdle :: ClientStIdle BlockInMode ChainPoint ChainTip IO ()
-    clientStIdle = SendMsgRequestNext clientStNext (pure clientStNext)
+    clientStIdle = SendMsgRequestNext (pure ()) clientStNext
 
     clientStNext :: ClientStNext BlockInMode ChainPoint ChainTip IO ()
     clientStNext = ClientStNext

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -72,7 +72,7 @@ test-suite chairman-tests
                       , cardano-crypto-class ^>= 2.1.2
                       , filepath
                       , hedgehog
-                      , hedgehog-extras ^>= 0.6.1.0
+                      , hedgehog-extras < 0.6.2
                       , network
                       , process
                       , random
@@ -88,5 +88,5 @@ test-suite chairman-tests
   ghc-options:          -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
 
   build-tool-depends:   cardano-node:cardano-node
-                      , cardano-cli:cardano-cli ^>= 8.20.2.0
+                      , cardano-cli:cardano-cli ^>= 8.20.3.0
                       , cardano-node-chairman:cardano-node-chairman

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -44,7 +44,7 @@ executable cardano-node-chairman
   build-depends:        cardano-api
                       , cardano-crypto-class
                       , cardano-git-rev
-                      , cardano-node ^>= 8.8
+                      , cardano-node ^>= 8.9
                       , cardano-prelude
                       , containers
                       , contra-tracer

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -70,6 +70,7 @@ library
   exposed-modules:      Cardano.Node.Configuration.Logging
                         Cardano.Node.Configuration.NodeAddress
                         Cardano.Node.Configuration.POM
+                        Cardano.Node.Configuration.LedgerDB
                         Cardano.Node.Configuration.Socket
                         Cardano.Node.Configuration.Topology
                         Cardano.Node.Configuration.TopologyP2P
@@ -201,6 +202,9 @@ library
                       , stm
                       , strict-sop-core
                       , strict-stm
+                      , sop-core
+                      , sop-extras
+                      , text >= 2.0
                       , time
                       , trace-dispatcher ^>= 2.5
                       , trace-forward ^>= 2.2

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -144,7 +144,7 @@ library
                       , async
                       , base16-bytestring
                       , bytestring
-                      , cardano-api ^>= 8.39
+                      , cardano-api ^>= 8.39.2.0
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
                       , cardano-git-rev
@@ -171,7 +171,7 @@ library
                       , formatting
                       , generic-data
                       , hostname
-                      , io-classes >= 0.3
+                      , io-classes >= 1.4
                       , iohk-monitoring
                       , iproute
                       , lobemo-backend-aggregation
@@ -183,14 +183,14 @@ library
                       , network-mux >= 0.4
                       , nothunks
                       , optparse-applicative-fork >= 0.18.1
-                      , ouroboros-consensus ^>= 0.15
-                      , ouroboros-consensus-cardano ^>= 0.13
-                      , ouroboros-consensus-diffusion ^>= 0.10
+                      , ouroboros-consensus ^>= 0.16
+                      , ouroboros-consensus-cardano ^>= 0.14
+                      , ouroboros-consensus-diffusion ^>= 0.11
                       , ouroboros-consensus-protocol
                       , ouroboros-network-api
-                      , ouroboros-network ^>= 0.11
+                      , ouroboros-network ^>= 0.12
                       , ouroboros-network-framework
-                      , ouroboros-network-protocols ^>= 0.7
+                      , ouroboros-network-protocols ^>= 0.8
                       , prettyprinter
                       , prettyprinter-ansi-terminal
                       , psqueues

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-node
-version:                8.8.1
+version:                8.9.0
 synopsis:               The cardano full node
 description:            The cardano full node.
 category:               Cardano,

--- a/cardano-node/src/Cardano/Node/Configuration/LedgerDB.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/LedgerDB.hs
@@ -1,0 +1,89 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.Node.Configuration.LedgerDB (
+    BackingStoreSelectorFlag(..)
+  , Gigabytes
+  , toBytes
+  , defaultLMDBLimits
+  ) where
+
+import           Prelude
+
+import qualified Data.Aeson.Types as Aeson (FromJSON)
+import           Ouroboros.Consensus.Storage.LedgerDB.V1.BackingStore.Impl.LMDB (LMDBLimits (..))
+
+-- | Choose the LedgerDB Backend
+--
+-- As of UTxO-HD, the LedgerDB now uses either an in-memory backend or LMDB to
+-- keep track of differences in the UTxO set.
+--
+-- - 'InMemory': uses more memory than the minimum requirements but is somewhat
+--   faster.
+-- - 'LMDB': uses less memory but is somewhat slower.
+--
+-- See 'Ouroboros.Consnesus.Storage.LedgerDB.OnDisk.BackingStoreSelector'.
+data BackingStoreSelectorFlag =
+    LMDB (Maybe Gigabytes) -- ^ A map size can be specified, this is the maximum
+                          -- disk space the LMDB database can fill. If not
+                          -- provided, the default of 16GB will be used.
+  | InMemory
+  deriving (Eq, Show)
+
+-- | A number of gigabytes.
+newtype Gigabytes = Gigabytes Int
+  deriving stock (Eq, Show)
+  deriving newtype (Read, Aeson.FromJSON)
+
+-- | Convert a number of Gigabytes to the equivalent number of bytes.
+toBytes :: Gigabytes -> Int
+toBytes (Gigabytes x) = x * 1024 * 1024 * 1024
+
+-- | Recommended settings for the LMDB backing store.
+--
+-- === @'lmdbMapSize'@
+-- The default @'LMDBLimits'@ uses an @'lmdbMapSize'@ of @1024 * 1024 * 1024 * 16@
+-- bytes, or 16 Gigabytes. @'lmdbMapSize'@ sets the size of the memory map
+-- that is used internally by the LMDB backing store, and is also the
+-- maximum size of the on-disk database. 16 GB should be sufficient for the
+-- medium term, i.e., it is sufficient until a more performant alternative to
+-- the LMDB backing store is implemented, which will probably replace the LMDB
+-- backing store altogether.
+--
+-- Note(jdral): It is recommended not to set the @'lmdbMapSize'@ to a value
+-- that is much smaller than 16 GB through manual configuration: the node will
+-- die with a fatal error as soon as the database size exceeds the
+-- @'lmdbMapSize'@. If this fatal error were to occur, we would expect that
+-- the node can continue normal operation if it is restarted with a higher
+-- @'lmdbMapSize'@ configured. Nonetheless, this situation should be avoided.
+--
+-- === @'lmdbMaxDatabases'@
+-- The @'lmdbMaxDatabases'@ is set to 10, which means that the LMDB backing
+-- store will allow up @<= 10@ internal databases. We say /internal/
+-- databases, since they are not exposed outside the backing store interface,
+-- such that from the outside view there is just one /logical/ database.
+-- Two of these internal databases are reserved for normal operation of the
+-- backing store, while the remaining databases will be used to store ledger
+-- tables. At the moment, there is at most one ledger table that will be
+-- stored in an internal database: the UTxO. Nonetheless, we set
+-- @'lmdbMaxDatabases'@ to @10@ in order to future-proof these limits.
+--
+-- === @'lmdbMaxReaders'@
+-- The @'lmdbMaxReaders'@ limit sets the maximum number of threads that can
+-- read from the LMDB database. Currently, there should only be a single reader
+-- active. Again, we set @'lmdbMaxReaders'@ to @16@ in order to future-proof
+-- these limits.
+--
+-- === References
+-- For more information about LMDB limits, one should inspect:
+-- * The @lmdb-simple@ and @haskell-lmdb@ forked repositories.
+-- * The official LMDB API documentation at
+--    <http://www.lmdb.tech/doc/group__mdb.html>.
+defaultLMDBLimits :: LMDBLimits
+defaultLMDBLimits = LMDBLimits {
+    lmdbMapSize = 16 * 1024 * 1024 * 1024
+  , lmdbMaxDatabases = 10
+  , lmdbMaxReaders = 16
+  }

--- a/cardano-node/src/Cardano/Node/Configuration/POM.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/POM.hs
@@ -34,7 +34,8 @@ import           Cardano.Tracing.OrphanInstances.Network ()
 import           Ouroboros.Consensus.Mempool (MempoolCapacityBytes (..),
                    MempoolCapacityBytesOverride (..))
 import qualified Ouroboros.Consensus.Node as Consensus (NetworkP2PMode (..))
-import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy (SnapshotInterval (..))
+import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy (NumOfDiskSnapshots (..),
+                   SnapshotInterval (..))
 import           Ouroboros.Network.NodeToNode (AcceptedConnectionsLimit (..), DiffusionMode (..))
 import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
 
@@ -101,8 +102,9 @@ data NodeConfiguration
        , ncProtocolConfig :: !NodeProtocolConfiguration
 
          -- Node parameters, not protocol-specific:
-       , ncDiffusionMode    :: !DiffusionMode
-       , ncSnapshotInterval :: !SnapshotInterval
+       , ncDiffusionMode      :: !DiffusionMode
+       , ncNumOfDiskSnapshots :: !NumOfDiskSnapshots
+       , ncSnapshotInterval   :: !SnapshotInterval
 
          -- | During the development and integration of new network protocols
          -- (node-to-node and node-to-client) we wish to be able to test them
@@ -182,8 +184,9 @@ data PartialNodeConfiguration
        , pncProtocolConfig :: !(Last NodeProtocolConfiguration)
 
          -- Node parameters, not protocol-specific:
-       , pncDiffusionMode    :: !(Last DiffusionMode)
-       , pncSnapshotInterval :: !(Last SnapshotInterval)
+       , pncDiffusionMode      :: !(Last DiffusionMode  )
+       , pncNumOfDiskSnapshots :: !(Last NumOfDiskSnapshots)
+       , pncSnapshotInterval   :: !(Last SnapshotInterval)
        , pncExperimentalProtocolsEnabled :: !(Last Bool)
 
          -- BlockFetch configuration
@@ -241,6 +244,8 @@ instance FromJSON PartialNodeConfiguration where
       pncSocketPath <- Last <$> v .:? "SocketPath"
       pncDiffusionMode
         <- Last . fmap getDiffusionMode <$> v .:? "DiffusionMode"
+      pncNumOfDiskSnapshots
+        <- Last . fmap RequestedNumOfDiskSnapshots <$> v .:? "NumOfDiskSnapshots"
       pncSnapshotInterval
         <- Last . fmap RequestedSnapshotInterval <$> v .:? "SnapshotInterval"
       pncExperimentalProtocolsEnabled <- fmap Last $ do
@@ -320,6 +325,7 @@ instance FromJSON PartialNodeConfiguration where
              pncProtocolConfig
            , pncSocketConfig = Last . Just $ SocketConfig mempty mempty mempty pncSocketPath
            , pncDiffusionMode
+           , pncNumOfDiskSnapshots
            , pncSnapshotInterval
            , pncExperimentalProtocolsEnabled
            , pncMaxConcurrencyBulkSync
@@ -490,6 +496,7 @@ defaultPartialNodeConfiguration =
     , pncLoggingSwitch = Last $ Just True
     , pncSocketConfig = Last . Just $ SocketConfig mempty mempty mempty mempty
     , pncDiffusionMode = Last $ Just InitiatorAndResponderDiffusionMode
+    , pncNumOfDiskSnapshots = Last $ Just DefaultNumOfDiskSnapshots
     , pncSnapshotInterval = Last $ Just DefaultSnapshotInterval
     , pncExperimentalProtocolsEnabled = Last $ Just False
     , pncTopologyFile = Last . Just $ TopologyFile "configuration/cardano/mainnet-topology.json"
@@ -541,6 +548,7 @@ makeNodeConfiguration pnc = do
   logMetrics <- lastToEither "Missing LogMetrics" $ pncLogMetrics pnc
   traceConfig <- first Text.unpack $ partialTraceSelectionToEither $ pncTraceConfig pnc
   diffusionMode <- lastToEither "Missing DiffusionMode" $ pncDiffusionMode pnc
+  numOfDiskSnapshots <- lastToEither "Missing NumOfDiskSnapshots" $ pncNumOfDiskSnapshots pnc
   snapshotInterval <- lastToEither "Missing SnapshotInterval" $ pncSnapshotInterval pnc
   shutdownConfig <- lastToEither "Missing ShutdownConfig" $ pncShutdownConfig pnc
   socketConfig <- lastToEither "Missing SocketConfig" $ pncSocketConfig pnc
@@ -609,6 +617,7 @@ makeNodeConfiguration pnc = do
              , ncProtocolConfig = protocolConfig
              , ncSocketConfig = socketConfig
              , ncDiffusionMode = diffusionMode
+             , ncNumOfDiskSnapshots = numOfDiskSnapshots
              , ncSnapshotInterval = snapshotInterval
              , ncExperimentalProtocolsEnabled = experimentalProtocols
              , ncMaxConcurrencyBulkSync = getLast $ pncMaxConcurrencyBulkSync pnc

--- a/cardano-node/src/Cardano/Node/Configuration/TopologyP2P.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/TopologyP2P.hs
@@ -30,7 +30,9 @@ import           Cardano.Node.Startup (StartupTrace (..))
 import           Cardano.Node.Types
 import           Cardano.Tracing.OrphanInstances.Network ()
 import           Ouroboros.Network.NodeToNode (PeerAdvertise (..))
-import           Ouroboros.Network.PeerSelection.LedgerPeers (UseLedgerAfter (..))
+import           Ouroboros.Network.PeerSelection.Bootstrap (UseBootstrapPeers (..))
+import           Ouroboros.Network.PeerSelection.LedgerPeers.Type (UseLedgerPeers (..))
+import           Ouroboros.Network.PeerSelection.PeerTrustable (PeerTrustable (..))
 import           Ouroboros.Network.PeerSelection.RelayAccessPoint (RelayAccessPoint (..))
 import           Ouroboros.Network.PeerSelection.State.LocalRootPeers (HotValency (..),
                    WarmValency (..))
@@ -53,7 +55,7 @@ data NodeSetup = NodeSetup
   , nodeIPv4Address :: !(Maybe NodeIPv4Address)
   , nodeIPv6Address :: !(Maybe NodeIPv6Address)
   , producers       :: ![RootConfig]
-  , useLedger       :: !UseLedger
+  , useLedger       :: !UseLedgerPeers
   } deriving (Eq, Show)
 
 instance FromJSON NodeSetup where
@@ -63,7 +65,7 @@ instance FromJSON NodeSetup where
                   <*> o .:  "nodeIPv4Address"
                   <*> o .:  "nodeIPv6Address"
                   <*> o .:  "producers"
-                  <*> o .:? "useLedgerAfterSlot" .!= UseLedger DontUseLedger
+                  <*> o .:? "useLedgerAfterSlot" .!= DontUseLedgerPeers
 
 instance ToJSON NodeSetup where
   toJSON ns =
@@ -85,7 +87,7 @@ data RootConfig = RootConfig
     -- or domain name and a port number.
   , rootAdvertise    :: PeerAdvertise
     -- ^ 'advertise' configures whether the root should be advertised through
-    -- gossip.
+    -- peer sharing.
   } deriving (Eq, Show)
 
 instance FromJSON RootConfig where
@@ -121,6 +123,9 @@ data LocalRootPeersGroup = LocalRootPeersGroup
   { localRoots :: RootConfig
   , hotValency :: HotValency
   , warmValency :: WarmValency
+  , trustable   :: PeerTrustable
+    -- ^ 'trustable' configures whether the root should be trusted in fallback
+    -- state.
   } deriving (Eq, Show)
 
 -- | Does not use the 'FromJSON' instance of 'RootConfig', so that
@@ -134,6 +139,7 @@ instance FromJSON LocalRootPeersGroup where
                   <$> parseJSON (Object o)
                   <*> pure hv
                   <*> o .:? "warmValency" .!= WarmValency v
+                  <*> o .:? "trustable" .!= IsNotTrustable
 
 instance ToJSON LocalRootPeersGroup where
   toJSON lrpg =
@@ -142,6 +148,7 @@ instance ToJSON LocalRootPeersGroup where
       , "advertise" .= rootAdvertise (localRoots lrpg)
       , "hotValency" .= hotValency lrpg
       , "warmValency" .= warmValency lrpg
+      , "trustable" .= trustable lrpg
       ]
 
 newtype LocalRootPeersGroups = LocalRootPeersGroups
@@ -164,22 +171,32 @@ instance FromJSON PublicRootPeers where
 instance ToJSON PublicRootPeers where
   toJSON = toJSON . publicRoots
 
-data NetworkTopology = RealNodeTopology !LocalRootPeersGroups ![PublicRootPeers] !UseLedger
+data NetworkTopology = RealNodeTopology { ntLocalRootPeersGroups :: !LocalRootPeersGroups
+                                        , ntPublicRootPeers      :: ![PublicRootPeers]
+                                        , ntUseLedgerPeers       :: !UseLedgerPeers
+                                        , ntUseBootstrapPeers    :: !UseBootstrapPeers
+                                        }
   deriving (Eq, Show)
 
 instance FromJSON NetworkTopology where
   parseJSON = withObject "NetworkTopology" $ \o ->
-                RealNodeTopology <$> (o .: "localRoots"                                     )
-                                 <*> (o .: "publicRoots"                                    )
-                                 <*> (o .:? "useLedgerAfterSlot" .!= UseLedger DontUseLedger)
+                RealNodeTopology <$> (o .: "localRoots"                                  )
+                                 <*> (o .: "publicRoots"                                 )
+                                 <*> (o .:? "useLedgerAfterSlot" .!= DontUseLedgerPeers  )
+                                 <*> (o .:? "bootstrapPeers" .!= DontUseBootstrapPeers)
 
 instance ToJSON NetworkTopology where
   toJSON top =
     case top of
-      RealNodeTopology lrpg prp ul -> object [ "localRoots"         .= lrpg
-                                             , "publicRoots"        .= prp
-                                             , "useLedgerAfterSlot" .= ul
-                                             ]
+      RealNodeTopology { ntLocalRootPeersGroups
+                       , ntPublicRootPeers
+                       , ntUseLedgerPeers
+                       , ntUseBootstrapPeers
+                       } -> object [ "localRoots"         .= ntLocalRootPeersGroups
+                                   , "publicRoots"        .= ntPublicRootPeers
+                                   , "useLedgerAfterSlot" .= ntUseLedgerPeers
+                                   , "bootstrapPeers"     .= ntUseBootstrapPeers
+                                   ]
 
 --
 -- Legacy p2p topology file format
@@ -195,10 +212,12 @@ instance FromJSON (Legacy a) => FromJSON (Legacy [a]) where
 instance FromJSON (Legacy LocalRootPeersGroup) where
   parseJSON = withObject "LocalRootPeersGroup" $ \o -> do
                 hv@(HotValency v) <- o .: "hotValency"
+                wv <- o .:? "warmValency" .!= WarmValency v
                 fmap Legacy $ LocalRootPeersGroup
                   <$> o .: "localRoots"
                   <*> pure hv
-                  <*> pure (WarmValency v)
+                  <*> pure wv
+                  <*> o .: "trustable"
 
 instance FromJSON (Legacy LocalRootPeersGroups) where
   parseJSON = withObject "LocalRootPeersGroups" $ \o ->
@@ -213,9 +232,10 @@ instance FromJSON (Legacy PublicRootPeers) where
 instance FromJSON (Legacy NetworkTopology) where
   parseJSON = fmap Legacy
             . withObject "NetworkTopology" (\o ->
-                RealNodeTopology <$> fmap getLegacy (o .: "LocalRoots")
-                                 <*> fmap getLegacy (o .: "PublicRoots")
-                                 <*> (o .:? "useLedgerAfterSlot" .!= UseLedger DontUseLedger))
+              RealNodeTopology <$> fmap getLegacy (o .: "LocalRoots")
+                               <*> fmap getLegacy (o .: "PublicRoots")
+                               <*> (o .:? "useLedgerAfterSlot" .!= DontUseLedgerPeers)
+                               <*> pure DontUseBootstrapPeers)
 
 -- | Read the `NetworkTopology` configuration from the specified file.
 --
@@ -228,7 +248,12 @@ readTopologyFile tr nc = do
     Left e -> return . Left $ handler e
     Right bs ->
       let bs' = LBS.fromStrict bs in
-      first handlerJSON (eitherDecode bs')
+      (case eitherDecode bs' of
+        Left err -> Left (handlerJSON err)
+        Right t
+          | isValidTrustedPeerConfiguration t -> Right t
+          | otherwise                         -> Left handlerBootstrap
+      )
       `combine`
       first handlerJSON (eitherDecode bs')
 
@@ -256,6 +281,13 @@ readTopologyFile tr nc = do
     , "configuration flag. "
     , Text.pack err
     ]
+  handlerBootstrap :: Text
+  handlerBootstrap = mconcat
+    [ "You seem to have not configured any trustable peers. "
+    , "This is important in order for the node to make progress "
+    , "in bootstrap mode. Make sure you provide at least one bootstrap peer "
+    , "source. "
+    ]
 
 readTopologyFileOrError :: Tracer IO (StartupTrace blk)
                         -> NodeConfiguration -> IO NetworkTopology
@@ -264,3 +296,25 @@ readTopologyFileOrError tr nc =
   >>= either (\err -> error $ "Cardano.Node.Configuration.TopologyP2P.readTopologyFile: "
                            <> Text.unpack err)
              pure
+
+--
+-- Checking for chance of progress in bootstrap phase
+--
+
+-- | This function returns false if non-trustable peers are configured
+--
+isValidTrustedPeerConfiguration :: NetworkTopology -> Bool
+isValidTrustedPeerConfiguration (RealNodeTopology (LocalRootPeersGroups lprgs) _ _ ubp) =
+    case ubp of
+      DontUseBootstrapPeers   -> True
+      UseBootstrapPeers []    -> anyTrustable
+      UseBootstrapPeers (_:_) -> True
+  where
+    anyTrustable =
+      any (\(LocalRootPeersGroup lr _ _ pt) -> case pt of
+              IsNotTrustable -> False
+              IsTrustable    -> not
+                              . null
+                              . rootAccessPoints
+                              $ lr
+          ) lprgs

--- a/cardano-node/src/Cardano/Node/Parsers.hs
+++ b/cardano-node/src/Cardano/Node/Parsers.hs
@@ -22,7 +22,8 @@ import           Cardano.Node.Types
 import           Cardano.Prelude (ConvertText (..))
 import           Ouroboros.Consensus.Mempool (MempoolCapacityBytes (..),
                    MempoolCapacityBytesOverride (..))
-import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy (SnapshotInterval (..))
+import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy (NumOfDiskSnapshots (..),
+                   SnapshotInterval (..))
 
 import           Data.Foldable
 import           Data.Maybe (fromMaybe)
@@ -69,7 +70,8 @@ nodeRunParser = do
 
   -- NodeConfiguration filepath
   nodeConfigFp <- lastOption parseConfigFile
-  snapshotInterval <- lastOption parseSnapshotInterval
+  numOfDiskSnapshots <- lastOption parseNumOfDiskSnapshots
+  snapshotInterval   <- lastOption parseSnapshotInterval
 
   validate <- lastOption parseValidateDB
   shutdownIPC <- lastOption parseShutdownIPC
@@ -88,6 +90,7 @@ nodeRunParser = do
            , pncTopologyFile = TopologyFile <$> topFp
            , pncDatabaseFile = DbFile <$> dbFp
            , pncDiffusionMode = mempty
+           , pncNumOfDiskSnapshots = numOfDiskSnapshots
            , pncSnapshotInterval = snapshotInterval
            , pncExperimentalProtocolsEnabled = mempty
            , pncProtocolFiles = Last $ Just ProtocolFilepaths
@@ -327,6 +330,15 @@ parseStartAsNonProducingNode =
         ]
     ]
 
+parseNumOfDiskSnapshots :: Parser NumOfDiskSnapshots
+parseNumOfDiskSnapshots = fmap RequestedNumOfDiskSnapshots parseNum
+  where
+  parseNum = Opt.option auto
+    ( long "num-of-disk-snapshots"
+        <> metavar "NUMOFDISKSNAPSHOTS"
+        <> help "Number of ledger snapshots stored on disk."
+    )
+
 -- TODO revisit because it sucks
 parseSnapshotInterval :: Parser SnapshotInterval
 parseSnapshotInterval = fmap (RequestedSnapshotInterval . secondsToDiffTime) parseDifftime
@@ -334,7 +346,7 @@ parseSnapshotInterval = fmap (RequestedSnapshotInterval . secondsToDiffTime) par
   parseDifftime = Opt.option auto
     ( long "snapshot-interval"
         <> metavar "SNAPSHOTINTERVAL"
-        <> help "Snapshot Interval (in second)"
+        <> help "Snapshot Interval (in seconds)"
     )
 
 -- | Produce just the brief help header for a given CLI option parser,

--- a/cardano-node/src/Cardano/Node/Parsers.hs
+++ b/cardano-node/src/Cardano/Node/Parsers.hs
@@ -22,8 +22,6 @@ import           Cardano.Node.Types
 import           Cardano.Prelude (ConvertText (..))
 import           Ouroboros.Consensus.Mempool (MempoolCapacityBytes (..),
                    MempoolCapacityBytesOverride (..))
-import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy (NumOfDiskSnapshots (..),
-                   SnapshotInterval (..))
 
 import           Data.Foldable
 import           Data.Maybe (fromMaybe)
@@ -36,6 +34,12 @@ import qualified Options.Applicative as Opt
 import qualified Options.Applicative.Help as OptI
 import           System.Posix.Types (Fd (..))
 import           Text.Read (readMaybe)
+
+import           Ouroboros.Consensus.Storage.LedgerDB.V1.Args (FlushFrequency (..),
+                   QueryBatchSize (..))
+import           Ouroboros.Consensus.Storage.LedgerDB.Impl.Snapshots (SnapshotInterval (..))
+
+import           Cardano.Node.Configuration.LedgerDB
 
 nodeCLIParser  :: Parser PartialNodeConfiguration
 nodeCLIParser = subparser
@@ -70,14 +74,18 @@ nodeRunParser = do
 
   -- NodeConfiguration filepath
   nodeConfigFp <- lastOption parseConfigFile
-  numOfDiskSnapshots <- lastOption parseNumOfDiskSnapshots
-  snapshotInterval   <- lastOption parseSnapshotInterval
 
   validate <- lastOption parseValidateDB
   shutdownIPC <- lastOption parseShutdownIPC
   shutdownOnLimit <- lastOption parseShutdownOn
 
   maybeMempoolCapacityOverride <- lastOption parseMempoolCapacityOverride
+
+  -- LedgerDB configuration
+  snapshotInterval  <- lastOption parseSnapshotInterval
+  ledgerDBBackend   <- lastOption parseLedgerDBBackend
+  pncFlushFrequency <- lastOption parseFlushFrequency
+  pncQueryBatchSize <- lastOption parseQueryBatchSize
 
   pure $ PartialNodeConfiguration
            { pncSocketConfig =
@@ -90,8 +98,6 @@ nodeRunParser = do
            , pncTopologyFile = TopologyFile <$> topFp
            , pncDatabaseFile = DbFile <$> dbFp
            , pncDiffusionMode = mempty
-           , pncNumOfDiskSnapshots = numOfDiskSnapshots
-           , pncSnapshotInterval = snapshotInterval
            , pncExperimentalProtocolsEnabled = mempty
            , pncProtocolFiles = Last $ Just ProtocolFilepaths
              { byronCertFile
@@ -113,6 +119,10 @@ nodeRunParser = do
            , pncTraceConfig = mempty
            , pncTraceForwardSocket = traceForwardSocket
            , pncMaybeMempoolCapacityOverride = maybeMempoolCapacityOverride
+           , pncSnapshotInterval = snapshotInterval
+           , pncLedgerDBBackend = ledgerDBBackend
+           , pncFlushFrequency
+           , pncQueryBatchSize
            , pncProtocolIdleTimeout = mempty
            , pncTimeWaitTimeout = mempty
            , pncChainSyncIdleTimeout = mempty
@@ -221,8 +231,62 @@ parseMempoolCapacityOverride = parseOverride <|> parseNoOverride
     parseNoOverride =
       flag' NoMempoolCapacityBytesOverride
         (  long "no-mempool-capacity-override"
-        <> help "The port number"
+        <> help "Don't override the mempool capacity"
         )
+
+parseLedgerDBBackend :: Parser BackingStoreSelectorFlag
+parseLedgerDBBackend = parseInMemory <|> parseLMDB <*> optional parseMapSize
+  where
+    parseInMemory :: Parser BackingStoreSelectorFlag
+    parseInMemory =
+      flag' InMemory (  long "in-memory-ledger-db-backend"
+                     <> help "Use the InMemory ledger DB backend. \
+                             \ Incompatible with `--lmdb-ledger-db-backend`. \
+                             \ The node uses the in-memory backend by default \
+                             \ if no ``--*-db-backend`` flags are set."
+                     )
+
+    parseLMDB :: Parser (Maybe Gigabytes -> BackingStoreSelectorFlag)
+    parseLMDB =
+      flag' LMDB (  long "lmdb-ledger-db-backend"
+                 <> help "Use the LMDB ledger DB backend. By default, the \
+                         \ mapsize (maximum database size) of the backend \
+                         \ is set to 16 Gigabytes. Warning: if the database \
+                         \ size exceeds the given mapsize, the node will \
+                         \ abort. Therefore, the mapsize should be set to a \
+                         \ value high enough to guarantee that the maximum \
+                         \ database size will not be reached during the \
+                         \ expected node uptime. \
+                         \ Incompatible with `--in-memory-ledger-db-backend`."
+                )
+
+    parseMapSize :: Parser Gigabytes
+    parseMapSize =
+      option auto (
+           long "lmdb-mapsize"
+        <> metavar "NR_GIGABYTES"
+        <> help "The maximum database size defined in number of Gigabytes."
+      )
+
+parseFlushFrequency :: Parser FlushFrequency
+parseFlushFrequency = RequestedFlushFrequency <$>
+  option auto (
+      long "flush-frequency"
+    <> metavar "WORD"
+    <> help "Flush parts of the ledger state to disk after WORD blocks have \
+            \moved into the immutable part of the chain. This should be at \
+            \least 0."
+    )
+
+parseQueryBatchSize :: Parser QueryBatchSize
+parseQueryBatchSize = RequestedQueryBatchSize <$>
+  option auto (
+       long "query-batch-size"
+    <> metavar "WORD"
+    <> help "When reading large amounts of ledger state data from disk for a \
+            \ledger state query, perform reads in batches of WORD size. This \
+            \should be at least 1."
+    )
 
 parseDbPath :: Parser FilePath
 parseDbPath =
@@ -329,15 +393,6 @@ parseStartAsNonProducingNode =
         , "credentials are specified."
         ]
     ]
-
-parseNumOfDiskSnapshots :: Parser NumOfDiskSnapshots
-parseNumOfDiskSnapshots = fmap RequestedNumOfDiskSnapshots parseNum
-  where
-  parseNum = Opt.option auto
-    ( long "num-of-disk-snapshots"
-        <> metavar "NUMOFDISKSNAPSHOTS"
-        <> help "Number of ledger snapshots stored on disk."
-    )
 
 -- TODO revisit because it sucks
 parseSnapshotInterval :: Parser SnapshotInterval

--- a/cardano-node/src/Cardano/Node/Queries.hs
+++ b/cardano-node/src/Cardano/Node/Queries.hs
@@ -36,6 +36,14 @@ module Cardano.Node.Queries
   , fromSMaybe
   ) where
 
+import           Control.Monad.STM (atomically)
+import           Data.ByteString (ByteString)
+import           Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import qualified Data.Map.Strict as Map
+import           Data.SOP
+import           Data.SOP.Functors
+import           Data.Word (Word64)
+
 import qualified Cardano.Chain.Block as Byron
 import qualified Cardano.Chain.UTxO as Byron
 import qualified Cardano.Crypto.Hash as Crypto
@@ -59,7 +67,7 @@ import           Ouroboros.Consensus.HardFork.Combinator
 import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras (OneEraForgeStateInfo (..),
                    OneEraForgeStateUpdateError (..))
 import           Ouroboros.Consensus.HardFork.Combinator.Embed.Unary
-import           Ouroboros.Consensus.Ledger.Abstract (IsLedger)
+import           Ouroboros.Consensus.Ledger.Abstract (EmptyMK)
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState)
 import           Ouroboros.Consensus.Node (NodeKernel (..))
 import qualified Ouroboros.Consensus.Protocol.Ledger.HotKey as HotKey
@@ -73,13 +81,6 @@ import           Ouroboros.Consensus.Util.Orphans ()
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.NodeToClient (LocalConnectionId)
 import           Ouroboros.Network.NodeToNode (RemoteAddress, RemoteConnectionId)
-
-import           Control.Monad.STM (atomically)
-import           Data.ByteString (ByteString)
-import           Data.IORef (IORef, newIORef, readIORef, writeIORef)
-import qualified Data.Map.Strict as Map
-import           Data.SOP
-import           Data.Word (Word64)
 
 --
 -- * TxId -> ByteString projection
@@ -229,8 +230,8 @@ instance All GetKESInfo xs => GetKESInfo (HardForkBlock xs) where
 -- * General ledger
 --
 class LedgerQueries blk where
-  ledgerUtxoSize     :: LedgerState blk -> Int
-  ledgerDelegMapSize :: LedgerState blk -> Int
+  ledgerUtxoSize     :: LedgerState blk EmptyMK -> Int
+  ledgerDelegMapSize :: LedgerState blk EmptyMK -> Int
 
 instance LedgerQueries Byron.ByronBlock where
   ledgerUtxoSize = Map.size . Byron.unUTxO . Byron.cvsUtxo . Byron.byronLedgerState
@@ -256,8 +257,8 @@ instance LedgerQueries (Shelley.ShelleyBlock protocol era) where
 
 instance (LedgerQueries x, NoHardForks x)
       => LedgerQueries (HardForkBlock '[x]) where
-  ledgerUtxoSize = ledgerUtxoSize . project
-  ledgerDelegMapSize = ledgerDelegMapSize . project
+  ledgerUtxoSize = ledgerUtxoSize . unFlip . project . Flip
+  ledgerDelegMapSize = ledgerDelegMapSize . unFlip . project . Flip
 
 instance LedgerQueries (Cardano.CardanoBlock c) where
   ledgerUtxoSize = \case
@@ -302,8 +303,7 @@ mapNodeKernelDataIO f (NodeKernelData ref) =
   readIORef ref >>= traverse f
 
 nkQueryLedger ::
-     IsLedger (LedgerState blk)
-  => (ExtLedgerState blk -> a)
+     (ExtLedgerState blk EmptyMK -> a)
   -> NodeKernel IO RemoteAddress LocalConnectionId blk
   -> IO a
 nkQueryLedger f NodeKernel{getChainDB} =

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -8,8 +8,8 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE PackageImports #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
 
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 
@@ -22,14 +22,70 @@ module Cardano.Node.Run
   , checkVRFFilePermissions
   ) where
 
-import qualified Ouroboros.Consensus.Storage.LedgerDB.Impl.Args as LDBArgs
 import           Cardano.Api (File (..), FileDirection (..))
 import qualified Cardano.Api as Api
 
+import           Cardano.BM.Data.LogItem (LogObject (..))
+import           Cardano.BM.Data.Tracer (ToLogObject (..), TracingVerbosity (..))
+import           Cardano.BM.Data.Transformers (setHostname)
+import           Cardano.BM.Trace
+import qualified Cardano.Crypto.Init as Crypto
+import           Cardano.Node.Configuration.LedgerDB
+import           Cardano.Node.Configuration.Logging (LoggingLayer (..), createLoggingLayer,
+                   nodeBasicInfo, shutdownLoggingLayer)
+import           Cardano.Node.Configuration.NodeAddress
+import           Cardano.Node.Configuration.POM (NodeConfiguration (..),
+                   PartialNodeConfiguration (..), SomeNetworkP2PMode (..), TimeoutOverride (..),
+                   defaultPartialNodeConfiguration, makeNodeConfiguration, parseNodeConfigurationFP)
+import           Cardano.Node.Configuration.Socket (SocketOrSocketInfo (..),
+                   gatherConfiguredSockets, getSocketOrSocketInfoAddr)
+import qualified Cardano.Node.Configuration.Topology as TopologyNonP2P
+import           Cardano.Node.Configuration.TopologyP2P
+import qualified Cardano.Node.Configuration.TopologyP2P as TopologyP2P
+import           Cardano.Node.Handlers.Shutdown
+import           Cardano.Node.Protocol (ProtocolInstantiationError (..), mkConsensusProtocol)
+import           Cardano.Node.Protocol.Byron (ByronProtocolInstantiationError (CredentialsError))
+import           Cardano.Node.Protocol.Cardano (CardanoProtocolInstantiationError (..))
+import           Cardano.Node.Protocol.Shelley (PraosLeaderCredentialsError (..),
+                   ShelleyProtocolInstantiationError (PraosLeaderCredentialsError))
+import           Cardano.Node.Protocol.Types
+import           Cardano.Node.Queries
+import           Cardano.Node.Startup
+import           Cardano.Node.TraceConstraints (TraceConstraints)
+import           Cardano.Node.Tracing.API
+import           Cardano.Node.Tracing.StateRep (NodeState (NodeKernelOnline))
+import           Cardano.Node.Tracing.Tracers.Startup (getStartupInfo)
+import           Cardano.Node.Types
 import           Cardano.Prelude (FatalError (..), bool, (:~:) (..))
-
-import           Data.Bits
-import           Data.IP (toSockAddr)
+import           Cardano.Tracing.Config (TraceOptions (..), TraceSelection (..))
+import           Cardano.Tracing.Tracers
+import qualified Ouroboros.Consensus.Config as Consensus
+import           Ouroboros.Consensus.Config.SupportsNode (ConfigSupportsNode (..))
+import           Ouroboros.Consensus.Node (NetworkP2PMode (..), RunNodeArgs (..),
+                   StdRunNodeArgs (..), stdChainSyncTimeout)
+import qualified Ouroboros.Consensus.Node as Node (getChainDB, run)
+import           Ouroboros.Consensus.Node.NetworkProtocolVersion
+import           Ouroboros.Consensus.Node.ProtocolInfo
+import qualified Ouroboros.Consensus.Node.Tracers as Consensus
+import qualified Ouroboros.Consensus.Storage.LedgerDB.Impl.Args as LDBArgs
+import           Ouroboros.Consensus.Storage.LedgerDB.V2.Args
+import           Ouroboros.Consensus.Util.Args
+import           Ouroboros.Consensus.Util.Orphans ()
+import qualified Ouroboros.Network.Diffusion as Diffusion
+import qualified Ouroboros.Network.Diffusion.NonP2P as NonP2P
+import qualified Ouroboros.Network.Diffusion.P2P as P2P
+import           Ouroboros.Network.NodeToClient (LocalAddress (..), LocalSocket (..))
+import           Ouroboros.Network.NodeToNode (AcceptedConnectionsLimit (..), ConnectionId,
+                   PeerSelectionTargets (..), RemoteAddress)
+import           Ouroboros.Network.PeerSelection.Bootstrap (UseBootstrapPeers (..))
+import           Ouroboros.Network.PeerSelection.LedgerPeers.Type (UseLedgerPeers)
+import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
+import           Ouroboros.Network.PeerSelection.PeerTrustable (PeerTrustable)
+import           Ouroboros.Network.PeerSelection.RelayAccessPoint (RelayAccessPoint (..))
+import           Ouroboros.Network.PeerSelection.State.LocalRootPeers (HotValency, WarmValency)
+import           Ouroboros.Network.Protocol.ChainSync.Codec
+import           Ouroboros.Network.Subscription (DnsSubscriptionTarget (..),
+                   IPSubscriptionTarget (..))
 
 import           Control.Concurrent (killThread, mkWeakThreadId, myThreadId)
 import           Control.Concurrent.Class.MonadSTM.Strict
@@ -41,7 +97,9 @@ import           Control.Monad.IO.Class (MonadIO (..))
 import           Control.Monad.Trans.Except (ExceptT, runExceptT)
 import           Control.Monad.Trans.Except.Extra (left)
 import           "contra-tracer" Control.Tracer
+import           Data.Bits
 import           Data.Either (partitionEithers)
+import           Data.IP (toSockAddr)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (catMaybes, fromMaybe, mapMaybe)
@@ -68,73 +126,7 @@ import           System.Posix.Types (FileMode)
 import           System.Win32.File
 #endif
 
-import           Cardano.BM.Data.LogItem (LogObject (..))
-import           Cardano.BM.Data.Tracer (ToLogObject (..), TracingVerbosity (..))
-import           Cardano.BM.Data.Transformers (setHostname)
-import           Cardano.BM.Trace
 import           Paths_cardano_node (version)
-
-import qualified Cardano.Crypto.Init as Crypto
-
-import           Cardano.Node.Configuration.Logging (LoggingLayer (..), createLoggingLayer,
-                   nodeBasicInfo, shutdownLoggingLayer)
-import           Cardano.Node.Configuration.NodeAddress
-import           Cardano.Node.Configuration.POM (NodeConfiguration (..),
-                   PartialNodeConfiguration (..), SomeNetworkP2PMode (..), TimeoutOverride (..),
-                   defaultPartialNodeConfiguration, makeNodeConfiguration, parseNodeConfigurationFP)
-import           Cardano.Node.Startup
-import           Cardano.Node.Tracing.API
-import           Cardano.Node.Tracing.StateRep (NodeState (NodeKernelOnline))
-import           Cardano.Node.Tracing.Tracers.Startup (getStartupInfo)
-import           Cardano.Node.Types
-import           Cardano.Tracing.Config (TraceOptions (..), TraceSelection (..))
-
-import qualified Ouroboros.Consensus.Config as Consensus
-import           Ouroboros.Consensus.Config.SupportsNode (ConfigSupportsNode (..))
-import           Ouroboros.Consensus.Node (NetworkP2PMode (..),
-                   RunNodeArgs (..), StdRunNodeArgs (..), stdChainSyncTimeout)
-import qualified Ouroboros.Consensus.Node as Node (getChainDB, run)
-import           Ouroboros.Consensus.Node.NetworkProtocolVersion
-import qualified Ouroboros.Consensus.Node.Tracers as Consensus
-import           Ouroboros.Consensus.Node.ProtocolInfo
-import           Ouroboros.Consensus.Util.Orphans ()
-import qualified Ouroboros.Network.Diffusion as Diffusion
-import qualified Ouroboros.Network.Diffusion.NonP2P as NonP2P
-import qualified Ouroboros.Network.Diffusion.P2P as P2P
-import           Ouroboros.Network.NodeToClient (LocalAddress (..), LocalSocket (..))
-import           Ouroboros.Network.NodeToNode (AcceptedConnectionsLimit (..), ConnectionId,
-                   PeerSelectionTargets (..), RemoteAddress)
-import           Ouroboros.Network.PeerSelection.RelayAccessPoint (RelayAccessPoint (..))
-import           Ouroboros.Network.Protocol.ChainSync.Codec
-import           Ouroboros.Network.Subscription (DnsSubscriptionTarget (..),
-                   IPSubscriptionTarget (..))
-import           Ouroboros.Network.PeerSelection.Bootstrap
-                     (UseBootstrapPeers (..))
-
-import           Cardano.Node.Configuration.Socket (SocketOrSocketInfo (..),
-                   gatherConfiguredSockets, getSocketOrSocketInfoAddr)
-import qualified Cardano.Node.Configuration.Topology as TopologyNonP2P
-import           Cardano.Node.Configuration.TopologyP2P
-import qualified Cardano.Node.Configuration.TopologyP2P as TopologyP2P
-import           Cardano.Node.Handlers.Shutdown
-import           Cardano.Node.Protocol (ProtocolInstantiationError (..), mkConsensusProtocol)
-import           Cardano.Node.Protocol.Byron (ByronProtocolInstantiationError (CredentialsError))
-import           Cardano.Node.Protocol.Cardano (CardanoProtocolInstantiationError (..))
-import           Cardano.Node.Protocol.Shelley (PraosLeaderCredentialsError (..),
-                   ShelleyProtocolInstantiationError (PraosLeaderCredentialsError))
-import           Cardano.Node.Protocol.Types
-import           Cardano.Node.Queries
-import           Cardano.Node.TraceConstraints (TraceConstraints)
-import           Cardano.Tracing.Tracers
-import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
-import           Ouroboros.Network.PeerSelection.State.LocalRootPeers (HotValency, WarmValency)
-import           Ouroboros.Network.PeerSelection.LedgerPeers.Type (UseLedgerPeers)
-import           Ouroboros.Network.PeerSelection.PeerTrustable (PeerTrustable)
-import           Ouroboros.Network.PeerSelection.Bootstrap (UseBootstrapPeers)
-
-import           Cardano.Node.Configuration.LedgerDB
-import           Ouroboros.Consensus.Storage.LedgerDB.V2.Args
-import           Ouroboros.Consensus.Util.Args
 
 {- HLINT ignore "Fuse concatMap/map" -}
 {- HLINT ignore "Redundant <$>" -}
@@ -380,6 +372,7 @@ handleSimpleNode blockType runP p2pMode tracers nc onKernel = do
         Exception.throwIO err
 
   dbPath <- canonDbPath nc
+  ssdPath <- canonSsdPath nc
 
   let diffusionArguments :: Diffusion.Arguments Socket      RemoteAddress
                                                 LocalSocket LocalAddress
@@ -507,7 +500,9 @@ handleSimpleNode blockType runP p2pMode tracers nc onKernel = do
               , srnMaybeMempoolCapacityOverride = ncMaybeMempoolCapacityOverride nc
               , srnChainSyncTimeout             = customizeChainSyncTimeout
               , srnSnapshotInterval             = ncSnapshotInterval nc
-              , srnLdbFlavorArgs = LDBArgs.LedgerDbFlavorArgsV2 srnL
+              , srnLdbFlavorArgs                = LDBArgs.LedgerDbFlavorArgsV2 srnL
+              , srnPutInSSD                     = (ncSsdSnapshotTables nc, ncSsdSnapshotState nc)
+              , srnSSDPath                      = ssdPath
               }
       DisabledP2PMode -> do
         nt <- TopologyNonP2P.readTopologyFileOrError nc
@@ -585,6 +580,8 @@ handleSimpleNode blockType runP p2pMode tracers nc onKernel = do
               , srnMaybeMempoolCapacityOverride = ncMaybeMempoolCapacityOverride nc
               , srnSnapshotInterval            = ncSnapshotInterval nc
               , srnLdbFlavorArgs               = LDBArgs.LedgerDbFlavorArgsV2 srnL
+              , srnPutInSSD                    = (ncSsdSnapshotTables nc, ncSsdSnapshotState nc)
+              , srnSSDPath                     = ssdPath
               }
  where
 
@@ -777,11 +774,18 @@ updateTopologyConfiguration startupTracer nc localRootsVar publicRootsVar useLed
 --------------------------------------------------------------------------------
 
 canonDbPath :: NodeConfiguration -> IO FilePath
-canonDbPath NodeConfiguration{ncDatabaseFile = DbFile dbFp} = do
-  fp <- canonicalizePath =<< makeAbsolute dbFp
-  createDirectoryIfMissing True fp
-  return fp
+canonDbPath NodeConfiguration{ncDatabaseFile = DbFile dbFp} =
+  canonPath dbFp
 
+canonSsdPath :: NodeConfiguration -> IO FilePath
+canonSsdPath NodeConfiguration{ncSsdDatabaseDir} =
+  canonPath ncSsdDatabaseDir
+
+canonPath :: FilePath -> IO FilePath
+canonPath fp = do
+  cfp <- canonicalizePath =<< makeAbsolute fp
+  createDirectoryIfMissing True cfp
+  return cfp
 
 -- | Make sure the VRF private key file is readable only
 -- by the current process owner the node is running under.

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -89,8 +89,8 @@ import           Cardano.Tracing.Config (TraceOptions (..), TraceSelection (..))
 
 import qualified Ouroboros.Consensus.Config as Consensus
 import           Ouroboros.Consensus.Config.SupportsNode (ConfigSupportsNode (..))
-import           Ouroboros.Consensus.Node (NetworkP2PMode (..), RunNodeArgs (..),
-                   StdRunNodeArgs (..), stdChainSyncTimeout)
+import           Ouroboros.Consensus.Node (DiskPolicyArgs (..), NetworkP2PMode (..),
+                   RunNodeArgs (..), StdRunNodeArgs (..), stdChainSyncTimeout)
 import qualified Ouroboros.Consensus.Node as Node (getChainDB, run)
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.ProtocolInfo
@@ -483,7 +483,7 @@ handleSimpleNode blockType runP p2pMode tracers nc onKernel = do
               { srnBfcMaxConcurrencyBulkSync    = unMaxConcurrencyBulkSync <$> ncMaxConcurrencyBulkSync nc
               , srnBfcMaxConcurrencyDeadline    = unMaxConcurrencyDeadline <$> ncMaxConcurrencyDeadline nc
               , srnChainDbValidateOverride      = ncValidateDB nc
-              , srnSnapshotInterval             = ncSnapshotInterval nc
+              , srnDiskPolicyArgs               = diskPolicyArgs
               , srnDatabasePath                 = dbPath
               , srnDiffusionArguments           = diffusionArguments
               , srnDiffusionArgumentsExtra      = diffusionArgumentsExtra
@@ -533,7 +533,7 @@ handleSimpleNode blockType runP p2pMode tracers nc onKernel = do
               { srnBfcMaxConcurrencyBulkSync   = unMaxConcurrencyBulkSync <$> ncMaxConcurrencyBulkSync nc
               , srnBfcMaxConcurrencyDeadline   = unMaxConcurrencyDeadline <$> ncMaxConcurrencyDeadline nc
               , srnChainDbValidateOverride     = ncValidateDB nc
-              , srnSnapshotInterval            = ncSnapshotInterval nc
+              , srnDiskPolicyArgs              = diskPolicyArgs
               , srnDatabasePath                = dbPath
               , srnDiffusionArguments          = diffusionArguments
               , srnDiffusionArgumentsExtra     = mkNonP2PArguments ipProducers dnsProducers
@@ -601,6 +601,12 @@ handleSimpleNode blockType runP p2pMode tracers nc onKernel = do
       case prj $ latestReleasedNodeVersion (Proxy @blk) of
         Nothing       -> id
         Just version_ -> Map.takeWhileAntitone (<= version_)
+
+  diskPolicyArgs :: DiskPolicyArgs
+  diskPolicyArgs =
+    DiskPolicyArgs
+      (ncSnapshotInterval nc)
+      (ncNumOfDiskSnapshots nc)
 
 --------------------------------------------------------------------------------
 -- SIGHUP Handlers

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE PackageImports #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TupleSections #-}
 
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 
@@ -100,7 +101,6 @@ import qualified Ouroboros.Network.Diffusion.P2P as P2P
 import           Ouroboros.Network.NodeToClient (LocalAddress (..), LocalSocket (..))
 import           Ouroboros.Network.NodeToNode (AcceptedConnectionsLimit (..), ConnectionId,
                    PeerSelectionTargets (..), RemoteAddress)
-import           Ouroboros.Network.PeerSelection.LedgerPeers (UseLedgerAfter (..))
 import           Ouroboros.Network.PeerSelection.RelayAccessPoint (RelayAccessPoint (..))
 import           Ouroboros.Network.Protocol.ChainSync.Codec
 import           Ouroboros.Network.Subscription (DnsSubscriptionTarget (..),
@@ -123,6 +123,9 @@ import           Cardano.Node.TraceConstraints (TraceConstraints)
 import           Cardano.Tracing.Tracers
 import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
 import           Ouroboros.Network.PeerSelection.State.LocalRootPeers (HotValency, WarmValency)
+import           Ouroboros.Network.PeerSelection.LedgerPeers.Type (UseLedgerPeers)
+import           Ouroboros.Network.PeerSelection.PeerTrustable (PeerTrustable)
+import           Ouroboros.Network.PeerSelection.Bootstrap (UseBootstrapPeers)
 
 {- HLINT ignore "Fuse concatMap/map" -}
 {- HLINT ignore "Redundant <$>" -}
@@ -433,15 +436,19 @@ handleSimpleNode blockType runP p2pMode tracers nc onKernel = do
       EnabledP2PMode -> do
         traceWith (startupTracer tracers)
                   (StartupP2PInfo (ncDiffusionMode nc))
-        nt <- TopologyP2P.readTopologyFileOrError (startupTracer tracers) nc
+        nt@TopologyP2P.RealNodeTopology
+          { ntUseLedgerPeers
+          , ntUseBootstrapPeers
+          } <- TopologyP2P.readTopologyFileOrError (startupTracer tracers) nc
         let (localRoots, publicRoots) = producerAddresses nt
         traceWith (startupTracer tracers)
                 $ NetworkConfig localRoots
                                 publicRoots
-                                (useLedgerAfterSlot nt)
+                                ntUseLedgerPeers
         localRootsVar <- newTVarIO localRoots
         publicRootsVar <- newTVarIO publicRoots
-        useLedgerVar   <- newTVarIO (useLedgerAfterSlot nt)
+        useLedgerVar   <- newTVarIO ntUseLedgerPeers
+        useBootstrapVar <- newTVarIO ntUseBootstrapPeers
 #ifdef UNIX
         -- initial `SIGHUP` handler, which only rereads the topology file but
         -- doesn't update block forging.  The latter is only possible once
@@ -451,7 +458,7 @@ handleSimpleNode blockType runP p2pMode tracers nc onKernel = do
               (Signals.Catch $ do
                 updateTopologyConfiguration
                   (startupTracer tracers) nc
-                  localRootsVar publicRootsVar useLedgerVar
+                  localRootsVar publicRootsVar useLedgerVar useBootstrapVar
                 traceWith (startupTracer tracers) (BlockForgingUpdate NotEffective)
               )
               Nothing
@@ -462,13 +469,14 @@ handleSimpleNode blockType runP p2pMode tracers nc onKernel = do
                   (readTVar localRootsVar)
                   (readTVar publicRootsVar)
                   (readTVar useLedgerVar)
+                  (readTVar useBootstrapVar)
           in
           Node.run
             nodeArgs {
                 rnNodeKernelHook = \registry nodeKernel -> do
                   -- reinstall `SIGHUP` handler
                   installP2PSigHUPHandler (startupTracer tracers) blockType nc nodeKernel
-                                          localRootsVar publicRootsVar useLedgerVar
+                                          localRootsVar publicRootsVar useLedgerVar useBootstrapVar
                   rnNodeKernelHook nodeArgs registry nodeKernel
             }
             StdRunNodeArgs
@@ -604,19 +612,21 @@ installP2PSigHUPHandler :: Tracer IO (StartupTrace blk)
                         -> Api.BlockType blk
                         -> NodeConfiguration
                         -> NodeKernel IO RemoteAddress (ConnectionId LocalAddress) blk
-                        -> StrictTVar IO [(HotValency, WarmValency, Map RelayAccessPoint PeerAdvertise)]
+                        -> StrictTVar IO [(HotValency, WarmValency, Map RelayAccessPoint (PeerAdvertise, PeerTrustable))]
                         -> StrictTVar IO (Map RelayAccessPoint PeerAdvertise)
-                        -> StrictTVar IO UseLedgerAfter
+                        -> StrictTVar IO UseLedgerPeers
+                        -> StrictTVar IO UseBootstrapPeers
                         -> IO ()
 #ifndef UNIX
-installP2PSigHUPHandler _ _ _ _ _ _ _ = return ()
+installP2PSigHUPHandler _ _ _ _ _ _ _ _ = return ()
 #else
-installP2PSigHUPHandler startupTracer blockType nc nodeKernel localRootsVar publicRootsVar useLedgerVar =
+installP2PSigHUPHandler startupTracer blockType nc nodeKernel localRootsVar publicRootsVar useLedgerVar
+                        useBootstrapPeersVar =
   void $ Signals.installHandler
     Signals.sigHUP
     (Signals.Catch $ do
       updateBlockForging startupTracer blockType nodeKernel nc
-      updateTopologyConfiguration startupTracer nc localRootsVar publicRootsVar useLedgerVar
+      updateTopologyConfiguration startupTracer nc localRootsVar publicRootsVar useLedgerVar useBootstrapPeersVar
     )
     Nothing
 #endif
@@ -693,11 +703,13 @@ updateBlockForging startupTracer blockType nodeKernel nc = do
 
 updateTopologyConfiguration :: Tracer IO (StartupTrace blk)
                             -> NodeConfiguration
-                            -> StrictTVar IO [(HotValency, WarmValency, Map RelayAccessPoint PeerAdvertise)]
+                            -> StrictTVar IO [(HotValency, WarmValency, Map RelayAccessPoint (PeerAdvertise, PeerTrustable))]
                             -> StrictTVar IO (Map RelayAccessPoint PeerAdvertise)
-                            -> StrictTVar IO UseLedgerAfter
+                            -> StrictTVar IO UseLedgerPeers
+                            -> StrictTVar IO UseBootstrapPeers
                             -> IO ()
-updateTopologyConfiguration startupTracer nc localRootsVar publicRootsVar useLedgerVar = do
+updateTopologyConfiguration startupTracer nc localRootsVar publicRootsVar useLedgerVar
+                            useBootsrapPeersVar = do
     traceWith startupTracer NetworkConfigUpdate
     result <- try $ readTopologyFileOrError startupTracer nc
     case result of
@@ -705,14 +717,17 @@ updateTopologyConfiguration startupTracer nc localRootsVar publicRootsVar useLed
         traceWith startupTracer
                 $ NetworkConfigUpdateError
                 $ pack "Error reading topology configuration file:" <> err
-      Right nt -> do
+      Right nt@RealNodeTopology { ntUseLedgerPeers
+                                , ntUseBootstrapPeers
+                                } -> do
         let (localRoots, publicRoots) = producerAddresses nt
         traceWith startupTracer
-                $ NetworkConfig localRoots publicRoots (useLedgerAfterSlot nt)
+                $ NetworkConfig localRoots publicRoots ntUseLedgerPeers
         atomically $ do
           writeTVar localRootsVar localRoots
           writeTVar publicRootsVar publicRoots
-          writeTVar useLedgerVar (useLedgerAfterSlot nt)
+          writeTVar useLedgerVar ntUseLedgerPeers
+          writeTVar useBootsrapPeersVar ntUseBootstrapPeers
 #endif
 
 --------------------------------------------------------------------------------
@@ -766,11 +781,12 @@ checkVRFFilePermissions (File vrfPrivKey) = do
 
 mkP2PArguments
   :: NodeConfiguration
-  -> STM IO [(HotValency, WarmValency, Map RelayAccessPoint PeerAdvertise)]
+  -> STM IO [(HotValency, WarmValency, Map RelayAccessPoint (PeerAdvertise, PeerTrustable))]
      -- ^ non-overlapping local root peers groups; the 'Int' denotes the
      -- valency of its group.
   -> STM IO (Map RelayAccessPoint PeerAdvertise)
-  -> STM IO UseLedgerAfter
+  -> STM IO UseLedgerPeers
+  -> STM IO UseBootstrapPeers
   -> Diffusion.ExtraArguments 'Diffusion.P2P IO
 mkP2PArguments NodeConfiguration {
                  ncTargetNumberOfRootPeers,
@@ -786,12 +802,14 @@ mkP2PArguments NodeConfiguration {
                }
                daReadLocalRootPeers
                daReadPublicRootPeers
-               daReadUseLedgerAfter =
+               daReadUseLedgerPeers
+               daReadUseBootstrapPeers =
     Diffusion.P2PArguments P2P.ArgumentsExtra
       { P2P.daPeerSelectionTargets
       , P2P.daReadLocalRootPeers
       , P2P.daReadPublicRootPeers
-      , P2P.daReadUseLedgerAfter
+      , P2P.daReadUseLedgerPeers
+      , P2P.daReadUseBootstrapPeers
       , P2P.daProtocolIdleTimeout   = ncProtocolIdleTimeout
       , P2P.daTimeWaitTimeout       = ncTimeWaitTimeout
       , P2P.daDeadlineChurnInterval = 3300
@@ -833,27 +851,26 @@ producerAddressesNonP2P nt =
       $ producers'
     TopologyNonP2P.MockNodeTopology nodeSetup ->
         partitionEithers
-      . mapMaybe TopologyNonP2P.remoteAddressToNodeAddress
-      . concatMap TopologyNonP2P.producers
+      . concatMap
+          ( mapMaybe TopologyNonP2P.remoteAddressToNodeAddress
+          . TopologyNonP2P.producers
+          )
       $ nodeSetup
 
 producerAddresses
   :: NetworkTopology
-  -> ([(HotValency, WarmValency, Map RelayAccessPoint PeerAdvertise)], Map RelayAccessPoint PeerAdvertise)
-producerAddresses nt =
-  case nt of
-    RealNodeTopology lrpg prp _ ->
-      ( map (\lrp -> ( hotValency lrp
-                     , warmValency lrp
-                     , Map.fromList $ rootConfigToRelayAccessPoint
-                                    $ localRoots lrp
-                     )
-            )
-            (groups lrpg)
-      , foldMap (Map.fromList . rootConfigToRelayAccessPoint . publicRoots) prp
-      )
-
-useLedgerAfterSlot
-  :: NetworkTopology
-  -> UseLedgerAfter
-useLedgerAfterSlot (RealNodeTopology _ _ (UseLedger ul)) = ul
+  -> ( [(HotValency, WarmValency, Map RelayAccessPoint (PeerAdvertise, PeerTrustable))]
+     , Map RelayAccessPoint PeerAdvertise)
+producerAddresses RealNodeTopology { ntLocalRootPeersGroups
+                                   , ntPublicRootPeers
+                                   } =
+  ( map (\lrp -> ( hotValency lrp
+                 , warmValency lrp
+                 , Map.fromList $ map (fmap (, trustable lrp))
+                                $ rootConfigToRelayAccessPoint
+                                $ localRoots lrp
+                 )
+        )
+        (groups ntLocalRootPeersGroups)
+  , foldMap (Map.fromList . rootConfigToRelayAccessPoint . publicRoots) ntPublicRootPeers
+  )

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -105,6 +105,8 @@ import           Ouroboros.Network.PeerSelection.RelayAccessPoint (RelayAccessPo
 import           Ouroboros.Network.Protocol.ChainSync.Codec
 import           Ouroboros.Network.Subscription (DnsSubscriptionTarget (..),
                    IPSubscriptionTarget (..))
+import           Ouroboros.Network.PeerSelection.Bootstrap
+                     (UseBootstrapPeers (..))
 
 import           Cardano.Node.Configuration.Socket (SocketOrSocketInfo (..),
                    gatherConfiguredSockets, getSocketOrSocketInfoAddr)
@@ -411,28 +413,7 @@ handleSimpleNode blockType runP p2pMode tracers nc onKernel = do
                          ))
 
   withShutdownHandling (ncShutdownConfig nc) (shutdownTracer tracers) $
-    let nodeArgs = RunNodeArgs
-          { rnTraceConsensus = consensusTracers tracers
-          , rnTraceNTN       = nodeToNodeTracers tracers
-          , rnTraceNTC       = nodeToClientTracers tracers
-          , rnProtocolInfo   = pInfo
-          , rnNodeKernelHook = \registry nodeKernel -> do
-              -- set the initial block forging
-              blockForging <- snd (Api.protocolInfo runP)
-
-              unless (ncStartAsNonProducingNode nc) $
-                setBlockForging nodeKernel blockForging
-
-              maybeSpawnOnSlotSyncedShutdownHandler
-                (ncShutdownConfig nc)
-                (shutdownTracer tracers)
-                registry
-                (Node.getChainDB nodeKernel)
-              onKernel nodeKernel
-          , rnEnableP2P      = p2pMode
-          , rnPeerSharing    = ncPeerSharing nc
-          }
-    in case p2pMode of
+    case p2pMode of
       EnabledP2PMode -> do
         traceWith (startupTracer tracers)
                   (StartupP2PInfo (ncDiffusionMode nc))
@@ -449,6 +430,28 @@ handleSimpleNode blockType runP p2pMode tracers nc onKernel = do
         publicRootsVar <- newTVarIO publicRoots
         useLedgerVar   <- newTVarIO ntUseLedgerPeers
         useBootstrapVar <- newTVarIO ntUseBootstrapPeers
+        let nodeArgs = RunNodeArgs
+              { rnTraceConsensus = consensusTracers tracers
+              , rnTraceNTN       = nodeToNodeTracers tracers
+              , rnTraceNTC       = nodeToClientTracers tracers
+              , rnProtocolInfo   = pInfo
+              , rnNodeKernelHook = \registry nodeKernel -> do
+                  -- set the initial block forging
+                  blockForging <- snd (Api.protocolInfo runP)
+
+                  unless (ncStartAsNonProducingNode nc) $
+                    setBlockForging nodeKernel blockForging
+
+                  maybeSpawnOnSlotSyncedShutdownHandler
+                    (ncShutdownConfig nc)
+                    (shutdownTracer tracers)
+                    registry
+                    (Node.getChainDB nodeKernel)
+                  onKernel nodeKernel
+              , rnEnableP2P      = p2pMode
+              , rnPeerSharing    = ncPeerSharing nc
+              , rnGetUseBootstrapPeers = readTVar useBootstrapVar
+              }
 #ifdef UNIX
         -- initial `SIGHUP` handler, which only rereads the topology file but
         -- doesn't update block forging.  The latter is only possible once
@@ -509,6 +512,29 @@ handleSimpleNode blockType runP p2pMode tracers nc onKernel = do
                            | (NodeAddress (NodeHostIPAddress addr) port) <- ipProducerAddrs
                            ]
                            (length ipProducerAddrs)
+
+            nodeArgs = RunNodeArgs
+                { rnTraceConsensus = consensusTracers tracers
+                , rnTraceNTN       = nodeToNodeTracers tracers
+                , rnTraceNTC       = nodeToClientTracers tracers
+                , rnProtocolInfo   = pInfo
+                , rnNodeKernelHook = \registry nodeKernel -> do
+                    -- set the initial block forging
+                    blockForging <- snd (Api.protocolInfo runP)
+
+                    unless (ncStartAsNonProducingNode nc) $
+                      setBlockForging nodeKernel blockForging
+
+                    maybeSpawnOnSlotSyncedShutdownHandler
+                      (ncShutdownConfig nc)
+                      (shutdownTracer tracers)
+                      registry
+                      (Node.getChainDB nodeKernel)
+                    onKernel nodeKernel
+                , rnEnableP2P      = p2pMode
+                , rnPeerSharing    = ncPeerSharing nc
+                , rnGetUseBootstrapPeers = pure DontUseBootstrapPeers
+                }
 #ifdef UNIX
         -- initial `SIGHUP` handler; it only warns that neither updating of
         -- topology is supported nor updating block forging is yet possible.

--- a/cardano-node/src/Cardano/Node/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Startup.hs
@@ -116,9 +116,6 @@ data StartupTrace blk =
   -- | Warn when 'EnableP2P' is set.
   | P2PWarning
 
-  -- | Warn when 'EnableP2P' is set.
-  | PeerSharingWarning
-
   -- | Warn when 'ExperimentalProtocolsEnabled' is set and affects
   -- node-to-node protocol.
   --

--- a/cardano-node/src/Cardano/Node/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Startup.hs
@@ -32,7 +32,8 @@ import           Ouroboros.Network.Magic (NetworkMagic (..))
 import           Ouroboros.Network.NodeToClient (LocalAddress (..), LocalSocket,
                    NodeToClientVersion)
 import           Ouroboros.Network.NodeToNode (DiffusionMode (..), NodeToNodeVersion, PeerAdvertise)
-import           Ouroboros.Network.PeerSelection.LedgerPeers (UseLedgerAfter (..))
+import           Ouroboros.Network.PeerSelection.LedgerPeers.Type (UseLedgerPeers)
+import           Ouroboros.Network.PeerSelection.PeerTrustable (PeerTrustable)
 import           Ouroboros.Network.PeerSelection.RelayAccessPoint (RelayAccessPoint)
 import           Ouroboros.Network.PeerSelection.State.LocalRootPeers (HotValency, WarmValency)
 import           Ouroboros.Network.Subscription.Dns (DnsSubscriptionTarget (..))
@@ -108,9 +109,9 @@ data StartupTrace blk =
   -- | Log peer-to-peer network configuration, either on startup or when its
   -- updated.
   --
-  | NetworkConfig [(HotValency, WarmValency, Map RelayAccessPoint PeerAdvertise)]
+  | NetworkConfig [(HotValency, WarmValency, Map RelayAccessPoint (PeerAdvertise, PeerTrustable))]
                   (Map RelayAccessPoint PeerAdvertise)
-                  UseLedgerAfter
+                  UseLedgerPeers
 
   -- | Warn when 'EnableP2P' is set.
   | P2PWarning

--- a/cardano-node/src/Cardano/Node/Tracing/API.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/API.hs
@@ -24,6 +24,8 @@ import           Cardano.Node.Types
 import           Ouroboros.Consensus.Ledger.Inspect (LedgerEvent)
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client (TraceChainSyncClientEvent)
 import           Ouroboros.Consensus.Node (NetworkP2PMode)
+import           Ouroboros.Consensus.Node.GSM
+import           Ouroboros.Network.Block
 import           Ouroboros.Network.ConnectionId (ConnectionId)
 import           Ouroboros.Network.Magic (NetworkMagic)
 import           Ouroboros.Network.NodeToClient (withIOManager)
@@ -46,6 +48,7 @@ initTraceDispatcher ::
   , LogFormatting (LedgerEvent blk)
   , LogFormatting
     (TraceLabelPeer (ConnectionId RemoteAddress) (TraceChainSyncClientEvent blk))
+  , LogFormatting (TraceGsmEvent (Tip blk))
   )
   => NodeConfiguration
   -> SomeConsensusProtocol

--- a/cardano-node/src/Cardano/Node/Tracing/StateRep.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/StateRep.hs
@@ -32,6 +32,7 @@ import qualified Ouroboros.Consensus.Node.NetworkProtocolVersion as NPV
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal
 import qualified Ouroboros.Consensus.Storage.LedgerDB as LgrDb
+import qualified Ouroboros.Consensus.Storage.LedgerDB as LedgerDB
 import           Ouroboros.Network.Block (pointSlot)
 
 import           Control.DeepSeq (NFData)
@@ -40,6 +41,8 @@ import           Data.Text (Text)
 import           Data.Time.Clock
 import           Data.Time.Clock.POSIX
 import           GHC.Generics (Generic)
+import           Cardano.Slotting.Slot (withOrigin)
+import           Cardano.Tracing.OrphanInstances.Network ()
 
 deriving instance FromJSON ChunkNo
 
@@ -65,8 +68,8 @@ data OpeningDbs
 deriving instance (NFData OpeningDbs)
 
 data Replays
-  = ReplayFromGenesis  (WithOrigin SlotNo)
-  | ReplayFromSnapshot SlotNo (WithOrigin SlotNo) (WithOrigin SlotNo)
+  = ReplayFromGenesis
+  | ReplayFromSnapshot SlotNo
   | ReplayedBlock      SlotNo (WithOrigin SlotNo) (WithOrigin SlotNo)
   deriving (Generic, FromJSON, ToJSON)
 
@@ -214,21 +217,23 @@ traceNodeStateChainDB _scp tr ev =
           traceWith tr $ NodeOpeningDbs $ OpenedImmutableDB (pointSlot p) chunk
         ChainDB.StartedOpeningVolatileDB ->
           traceWith tr $ NodeOpeningDbs StartedOpeningVolatileDB
-        ChainDB.OpenedVolatileDB ->
+        ChainDB.OpenedVolatileDB {} ->
           traceWith tr $ NodeOpeningDbs OpenedVolatileDB
         ChainDB.StartedOpeningLgrDB ->
           traceWith tr $ NodeOpeningDbs StartedOpeningLgrDB
         ChainDB.OpenedLgrDB ->
           traceWith tr $ NodeOpeningDbs OpenedLgrDB
         _ -> return ()
-    ChainDB.TraceLedgerReplayEvent ev' ->
+    ChainDB.TraceLedgerDBEvent (LedgerDB.LedgerReplayEvent ev') ->
       case ev' of
-        LgrDb.ReplayFromGenesis (LgrDb.ReplayGoal p) ->
-          traceWith tr $ NodeReplays $ ReplayFromGenesis (pointSlot p)
-        LgrDb.ReplayFromSnapshot _ (RP.RealPoint s _) (LgrDb.ReplayStart rs) (LgrDb.ReplayGoal rp) ->
-          traceWith tr $ NodeReplays $ ReplayFromSnapshot s (pointSlot rs) (pointSlot rp)
-        LgrDb.ReplayedBlock (RP.RealPoint s _) _ (LgrDb.ReplayStart rs) (LgrDb.ReplayGoal rp) ->
-          traceWith tr $ NodeReplays $ ReplayedBlock s (pointSlot rs) (pointSlot rp)
+        LedgerDB.TraceReplayStartEvent ev'' -> case ev'' of
+          LgrDb.ReplayFromGenesis ->
+            traceWith tr $ NodeReplays $ ReplayFromGenesis
+          LgrDb.ReplayFromSnapshot _ (LgrDb.ReplayStart rs) ->
+            traceWith tr $ NodeReplays $ ReplayFromSnapshot (withOrigin undefined id $ pointSlot rs)
+        LedgerDB.TraceReplayProgressEvent ev'' -> case ev'' of
+          LgrDb.ReplayedBlock (RP.RealPoint s _) _ (LgrDb.ReplayStart rs) (LgrDb.ReplayGoal rp) ->
+            traceWith tr $ NodeReplays $ ReplayedBlock s (pointSlot rs) (pointSlot rp)
     ChainDB.TraceInitChainSelEvent ev' ->
       case ev' of
         ChainDB.StartedInitChainSelection ->

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
@@ -127,8 +127,9 @@ mkDispatchTracers nodeKernel trBase trForward mbTrEKG trDataPoint trConfig enabl
     configureTracers configReflection trConfig [chainDBTr]
     -- Filter out replayed blocks for this tracer
     let chainDBTr' = filterTrace
-                      (\case (_, ChainDB.TraceLedgerReplayEvent
-                                            LedgerDB.ReplayedBlock {}) -> False
+                      (\case (_, ChainDB.TraceLedgerDBEvent
+                                            (LedgerDB.LedgerReplayEvent (LedgerDB.TraceReplayProgressEvent
+                                                                        (LedgerDB.ReplayedBlock {})))) -> False
                              (_, _) -> True)
                       chainDBTr
 

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/BlockReplayProgress.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/BlockReplayProgress.hs
@@ -74,8 +74,10 @@ replayBlockStats :: MonadIO m
   -> ChainDB.TraceEvent blk
   -> m ReplayBlockStats
 replayBlockStats ReplayBlockStats {..} _context
-    (ChainDB.TraceLedgerReplayEvent (LedgerDB.ReplayedBlock pt []
-                                      (LedgerDB.ReplayStart replayTo) _)) = do
+    (ChainDB.TraceLedgerDBEvent
+     (LedgerDB.LedgerReplayEvent
+      (LedgerDB.TraceReplayProgressEvent
+       (LedgerDB.ReplayedBlock pt [] (LedgerDB.ReplayStart replayTo) _)))) = do
       let slotno = toInteger $ unSlotNo (realPointSlot pt)
           endslot = toInteger $ withOrigin 0 unSlotNo (pointSlot replayTo)
           progress' = (fromInteger slotno * 100.0) / fromInteger (max slotno endslot)

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
@@ -846,6 +846,7 @@ instance
   , LogFormatting (GenTx blk)
   , ToJSON (GenTxId blk)
   , LedgerSupportsMempool blk
+  , ConvertRawHash blk
   ) => LogFormatting (TraceEventMempool blk) where
   forMachine dtal (TraceMempoolAddedTx tx _mpSzBefore mpSzAfter) =
     mconcat
@@ -885,6 +886,34 @@ instance
       , "txsInvalidated" .= map (forMachine dtal . txForgetValidated) txs1
       , "mempoolSize" .= forMachine dtal mpSz
       ]
+  forMachine _ TraceMempoolAttemptingSync =
+    mconcat
+      [ "kind" .= String "TraceMempoolAttemptingSync"
+      ]
+  forMachine dtal (TraceMempoolSyncNotNeeded t _) =
+    mconcat
+      [ "kind" .= String "TraceMempoolSyncNotNeeded"
+      , "tip" .= forMachine dtal t
+      ]
+  forMachine _ TraceMempoolSyncDone =
+    mconcat
+      [ "kind" .= String "TraceMempoolSyncDone"
+      ]
+  forMachine dtal (TraceMempoolAttemptingAdd tx) =
+    mconcat
+      [ "kind" .= String "TraceMempoolAttemptingAdd"
+      , "tx" .= forMachine dtal tx
+      ]
+  forMachine dtal (TraceMempoolLedgerFound p) =
+    mconcat
+      [ "kind" .= String "TraceMempoolLedgerFound"
+      , "tip" .= forMachine dtal p
+      ]
+  forMachine dtal (TraceMempoolLedgerNotFound p) =
+    mconcat
+      [ "kind" .= String "TraceMempoolLedgerNotFound"
+      , "tip" .= forMachine dtal p
+      ]
 
   asMetrics (TraceMempoolAddedTx _tx _mpSzBefore mpSz) =
     [ IntM "Mempool.TxsInMempool" (fromIntegral $ msNumTxs mpSz)
@@ -894,19 +923,22 @@ instance
     [ IntM "Mempool.TxsInMempool" (fromIntegral $ msNumTxs mpSz)
     , IntM "Mempool.MempoolBytes" (fromIntegral $ msNumBytes mpSz)
     ]
-  asMetrics (TraceMempoolRemoveTxs _txs mpSz) =
+  asMetrics (TraceMempoolRemoveTxs txs mpSz) =
     [ IntM "Mempool.TxsInMempool" (fromIntegral $ msNumTxs mpSz)
     , IntM "Mempool.MempoolBytes" (fromIntegral $ msNumBytes mpSz)
-    ]
-  asMetrics (TraceMempoolManuallyRemovedTxs [] _txs1 mpSz) =
-    [ IntM "Mempool.TxsInMempool" (fromIntegral $ msNumTxs mpSz)
-    , IntM "Mempool.MempoolBytes" (fromIntegral $ msNumBytes mpSz)
+    , CounterM "Mempool.TxsRemovedNum" (Just (fromIntegral $ length txs))
     ]
   asMetrics (TraceMempoolManuallyRemovedTxs txs _txs1 mpSz) =
     [ IntM "Mempool.TxsInMempool" (fromIntegral $ msNumTxs mpSz)
     , IntM "Mempool.MempoolBytes" (fromIntegral $ msNumBytes mpSz)
-    , CounterM "Mempool.TxsProcessedNum" (Just (fromIntegral $ length txs))
+    , CounterM "Mempool.TxsRemovedNum" (Just (fromIntegral $ length txs))
     ]
+  asMetrics TraceMempoolAttemptingSync = []
+  asMetrics TraceMempoolSyncNotNeeded {} = []
+  asMetrics TraceMempoolSyncDone = []
+  asMetrics TraceMempoolAttemptingAdd {} = []
+  asMetrics TraceMempoolLedgerFound {} = []
+  asMetrics TraceMempoolLedgerNotFound {} = []
 
 instance LogFormatting MempoolSize where
   forMachine _dtal MempoolSize{msNumTxs, msNumBytes} =
@@ -921,11 +953,23 @@ instance MetaTrace (TraceEventMempool blk) where
     namespaceFor TraceMempoolRejectedTx {} = Namespace [] ["RejectedTx"]
     namespaceFor TraceMempoolRemoveTxs {} = Namespace [] ["RemoveTxs"]
     namespaceFor TraceMempoolManuallyRemovedTxs {} = Namespace [] ["ManuallyRemovedTxs"]
+    namespaceFor TraceMempoolAttemptingSync = Namespace [] ["MempoolAttemptingSync"]
+    namespaceFor TraceMempoolSyncNotNeeded {} = Namespace [] ["MempoolSyncNotNeeded"]
+    namespaceFor TraceMempoolSyncDone = Namespace [] ["MempoolSyncDone"]
+    namespaceFor TraceMempoolAttemptingAdd {} = Namespace [] ["MempoolAttemptAdd"]
+    namespaceFor TraceMempoolLedgerFound {} = Namespace [] ["MempoolLedgerFound"]
+    namespaceFor TraceMempoolLedgerNotFound {} = Namespace [] ["MempoolLedgerNotFound"]
 
     severityFor (Namespace _ ["AddedTx"]) _ = Just Info
     severityFor (Namespace _ ["RejectedTx"]) _ = Just Info
-    severityFor (Namespace _ ["RemoveTxs"]) _ = Just Info
-    severityFor (Namespace _ ["ManuallyRemovedTxs"]) _ = Just Info
+    severityFor (Namespace _ ["RemoveTxs"]) _ = Just Debug
+    severityFor (Namespace _ ["ManuallyRemovedTxs"]) _ = Just Warning
+    severityFor (Namespace _ ["MempoolAttemptingSync"]) _ = Just Debug
+    severityFor (Namespace _ ["MempoolSyncNotNeeded"]) _ = Just Debug
+    severityFor (Namespace _ ["MempoolSyncDone"]) _ = Just Debug
+    severityFor (Namespace _ ["MempoolAttemptAdd"]) _ = Just Debug
+    severityFor (Namespace _ ["MempoolLedgerFound"]) _ = Just Debug
+    severityFor (Namespace _ ["MempoolLedgerNotFound"]) _ = Just Debug
     severityFor _ _ = Nothing
 
     metricsDocFor (Namespace _ ["AddedTx"]) =
@@ -950,7 +994,7 @@ instance MetaTrace (TraceEventMempool blk) where
     documentFor (Namespace _ ["AddedTx"]) = Just
       "New, valid transaction that was added to the Mempool."
     documentFor (Namespace _ ["RejectedTx"]) = Just $ mconcat
-      [ "New, invalid transaction thas was rejected and thus not added to"
+      [ "New, invalid transaction that was rejected and thus not added to"
       , " the Mempool."
       ]
     documentFor (Namespace _ ["RemoveTxs"]) = Just $ mconcat
@@ -960,6 +1004,20 @@ instance MetaTrace (TraceEventMempool blk) where
       ]
     documentFor (Namespace _ ["ManuallyRemovedTxs"]) = Just
       "Transactions that have been manually removed from the Mempool."
+    documentFor (Namespace _ ["MempoolAttemptingSync"]) = Just
+      "Mempool attempting to perform a sync with the LedgerDB."
+    documentFor (Namespace _ ["MempoolSyncNotNeeded"]) = Just
+      "The mempool and the LedgerDB are in sync already."
+    documentFor (Namespace _ ["MempoolSyncDone"]) = Just
+      "The mempool and the LedgerDB are in sync now."
+    documentFor (Namespace _ ["MempoolAttemptAdd"]) = Just
+      "Mempool is about to try to validate and add a transaction."
+    documentFor (Namespace _ ["MempoolLedgerNotFound"]) = Just $ mconcat
+      [ "Ledger state requested by the mempool no longer in LedgerDB."
+      , " Will have to re-sync."
+      ]
+    documentFor (Namespace _ ["MempoolLedgerFound"]) = Just
+      "Ledger state requested by the mempool is in the LedgerDB."
     documentFor _ = Nothing
 
     allNamespaces =
@@ -967,6 +1025,12 @@ instance MetaTrace (TraceEventMempool blk) where
       , Namespace [] ["RejectedTx"]
       , Namespace [] ["RemoveTxs"]
       , Namespace [] ["ManuallyRemovedTxs"]
+      , Namespace [] ["MempoolAttemptingSync"]
+      , Namespace [] ["MempoolSyncNotNeeded"]
+      , Namespace [] ["MempoolSyncDone"]
+      , Namespace [] ["MempoolAttemptAdd"]
+      , Namespace [] ["MempoolLedgerNotFound"]
+      , Namespace [] ["MempoolLedgerFound"]
       ]
 
 --------------------------------------------------------------------------------

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
@@ -1052,7 +1052,7 @@ instance LogFormatting TraceStartLeadershipCheckPlus where
         mconcat [ "kind" .= String "TraceStartLeadershipCheck"
                 , "slot" .= toJSON (unSlotNo tsSlotNo)
                 , "utxoSize" .= Number (fromIntegral tsUtxoSize)
-                , "delegMapSize" .= Number (fromIntegral tsUtxoSize)
+                , "delegMapSize" .= Number (fromIntegral tsDelegMapSize)
                 , "chainDensity" .= Number (fromRational (toRational tsChainDensity))
                 ]
   forHuman TraceStartLeadershipCheckPlus {..} =

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Diffusion.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Diffusion.hs
@@ -23,14 +23,13 @@ import           Network.Mux (MuxTrace (..), WithMuxBearer (..))
 import           Network.Mux.Types
 import           Network.TypedProtocol.Codec (AnyMessageAndAgency (..))
 
-import           Cardano.Node.Types (UseLedger (..))
-
 import qualified Data.List as List
 import qualified Ouroboros.Network.Diffusion as ND
 import qualified Ouroboros.Network.NodeToNode as NtN
 import           Ouroboros.Network.PeerSelection.LedgerPeers (NumberOfPeers (..), PoolStake (..),
                    TraceLedgerPeers (..))
 import qualified Ouroboros.Network.Protocol.Handshake.Type as HS
+import Cardano.Node.Configuration.TopologyP2P ()
 
 
 --------------------------------------------------------------------------------
@@ -799,10 +798,10 @@ instance LogFormatting TraceLedgerPeers where
     mconcat
       [ "kind" .= String "DisabledLedgerPeers"
       ]
-  forMachine _dtal (TraceUseLedgerAfter ula) =
+  forMachine _dtal (TraceUseLedgerPeers ulp) =
     mconcat
-      [ "kind" .= String "UseLedgerAfter"
-      , "useLedgerAfter" .= UseLedger ula
+      [ "kind" .= String "UseLedgerPeers"
+      , "useLedgerPeers" .= ulp
       ]
   forMachine _dtal WaitingOnRequest =
     mconcat
@@ -866,8 +865,8 @@ instance MetaTrace TraceLedgerPeers where
       Namespace [] ["FetchingNewLedgerState"]
     namespaceFor DisabledLedgerPeers {} =
       Namespace [] ["DisabledLedgerPeers"]
-    namespaceFor TraceUseLedgerAfter {} =
-      Namespace [] ["TraceUseLedgerAfter"]
+    namespaceFor TraceUseLedgerPeers {} =
+      Namespace [] ["TraceUseLedgerPeers"]
     namespaceFor WaitingOnRequest {} =
       Namespace [] ["WaitingOnRequest"]
     namespaceFor RequestForPeers {} =

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/P2P.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/P2P.hs
@@ -27,8 +27,8 @@ import qualified Ouroboros.Network.InboundGovernor as InboundGovernor
 import           Ouroboros.Network.InboundGovernor.State (InboundGovernorCounters (..))
 import qualified Ouroboros.Network.NodeToNode as NtN
 import           Ouroboros.Network.PeerSelection.Governor (DebugPeerSelection (..),
-                   PeerSelectionCounters (..), PeerSelectionState (..), PeerSelectionTargets (..),
-                   TracePeerSelection (..))
+                   DebugPeerSelectionState (..), PeerSelectionCounters (..),
+                   PeerSelectionState (..), PeerSelectionTargets (..), TracePeerSelection (..))
 import           Ouroboros.Network.PeerSelection.PeerStateActions (PeerSelectionActionsTrace (..))
 import           Ouroboros.Network.PeerSelection.RelayAccessPoint (RelayAccessPoint)
 import           Ouroboros.Network.PeerSelection.RootPeersDNS.LocalRootPeers
@@ -509,9 +509,28 @@ instance LogFormatting (TracePeerSelection SockAddr) where
     mconcat [ "kind" .= String "OutboundGovernorCriticalFailure"
             , "reason" .= show err
             ]
-  forMachine _dtal (TraceDebugState _ dpst) =
+  forMachine _dtal (TraceDebugState mtime ds) =
     mconcat [ "kind" .= String "DebugState"
-            , "peerSelectionState" .= show dpst
+            , "monotonicTime" .= show mtime
+            , "targets" .= peerSelectionTargetsToObject (dpssTargets ds)
+            , "localRootPeers" .= dpssLocalRootPeers ds
+            , "publicRootPeers" .= dpssPublicRootPeers ds
+            , "knownPeers" .= (KnownPeers.allPeers $ dpssKnownPeers ds)
+            , "establishedPeers" .= dpssEstablishedPeers ds
+            , "activePeers" .= dpssActivePeers ds
+            , "publicRootBackoffs" .= dpssPublicRootBackoffs ds
+            , "publicRootRetryTime" .= dpssPublicRootRetryTime ds
+            , "bigLedgerPeerBackoffs" .= dpssBigLedgerPeerBackoffs ds
+            , "bigLedgerPeerRetryTime" .= dpssBigLedgerPeerRetryTime ds
+            , "inProgressBigLedgerPeersReq" .= dpssInProgressBigLedgerPeersReq ds
+            , "inProgressPeerShareReqs" .= dpssInProgressPeerShareReqs ds
+            , "inProgressPromoteCold" .= dpssInProgressPromoteCold ds
+            , "inProgressPromoteWarm" .= dpssInProgressPromoteWarm ds
+            , "inProgressDemoteWarm" .= dpssInProgressDemoteWarm ds
+            , "inProgressDemoteHot" .= dpssInProgressDemoteHot ds
+            , "inProgressDemoteToCold" .= dpssInProgressDemoteToCold ds
+            , "upstreamyness" .= dpssUpstreamyness ds
+            , "fetchynessBlocks" .= dpssFetchynessBlocks ds
             ]
 
   forHuman = pack . show

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/P2P.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/P2P.hs
@@ -515,7 +515,7 @@ instance LogFormatting (TracePeerSelection SockAddr) where
             , "targets" .= peerSelectionTargetsToObject (dpssTargets ds)
             , "localRootPeers" .= dpssLocalRootPeers ds
             , "publicRootPeers" .= dpssPublicRootPeers ds
-            , "knownPeers" .= (KnownPeers.allPeers $ dpssKnownPeers ds)
+            , "knownPeers" .= KnownPeers.allPeers (dpssKnownPeers ds)
             , "establishedPeers" .= dpssEstablishedPeers ds
             , "activePeers" .= dpssActivePeers ds
             , "publicRootBackoffs" .= dpssPublicRootBackoffs ds
@@ -804,12 +804,19 @@ peerSelectionTargetsToObject
   PeerSelectionTargets { targetNumberOfRootPeers,
                          targetNumberOfKnownPeers,
                          targetNumberOfEstablishedPeers,
-                         targetNumberOfActivePeers } =
+                         targetNumberOfActivePeers,
+                         targetNumberOfKnownBigLedgerPeers,
+                         targetNumberOfEstablishedBigLedgerPeers,
+                         targetNumberOfActiveBigLedgerPeers
+                       } =
     Object $
       mconcat [ "roots" .= targetNumberOfRootPeers
                , "knownPeers" .= targetNumberOfKnownPeers
                , "established" .= targetNumberOfEstablishedPeers
                , "active" .= targetNumberOfActivePeers
+               , "knownBigLedgerPeers" .= targetNumberOfKnownBigLedgerPeers
+               , "establishedBigLedgerPeers" .= targetNumberOfEstablishedBigLedgerPeers
+               , "activeBigLedgerPeers" .= targetNumberOfActiveBigLedgerPeers
                ]
 
 instance MetaTrace (DebugPeerSelection SockAddr) where

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Peer.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Peer.hs
@@ -38,6 +38,7 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import           Data.Text (Text)
 import qualified Data.Text as Text
+import           GHC.Conc (labelThread, myThreadId)
 import           Text.Printf (printf)
 
 {- HLINT ignore "Use =<<" -}
@@ -49,7 +50,7 @@ startPeerTracer
   -> Int
   -> IO ()
 startPeerTracer tr nodeKern delayMilliseconds = do
-    as <- async peersThread
+    as <- async $ myThreadId >>= flip labelThread "PeersCapturing" >> peersThread
     link as
   where
     peersThread :: IO ()

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Resources.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Resources.hs
@@ -10,6 +10,8 @@ import           Control.Concurrent (threadDelay)
 import           Control.Concurrent.Async (async)
 import           Control.Monad (forM_, forever)
 import           Control.Monad.Class.MonadAsync (link)
+import           GHC.Conc (labelThread, myThreadId)
+
 import           "contra-tracer" Control.Tracer
 
 startResourceTracer
@@ -17,13 +19,11 @@ startResourceTracer
   -> Int
   -> IO ()
 startResourceTracer tr delayMilliseconds = do
-    as <- async resourceThread
+    as <- async (myThreadId >>= flip labelThread "ResourceCapturing" >> resourceThread)
     link as
   where
     resourceThread :: IO ()
     resourceThread = forever $ do
       mbrs <- readResourceStats
-      forM_ mbrs $ \rs -> traceWith tr rs
-      threadDelay (delayMilliseconds * 1000)
       forM_ mbrs $ \rs -> traceWith tr rs
       threadDelay (delayMilliseconds * 1000)

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
@@ -233,9 +233,6 @@ instance ( Show (BlockNodeToNodeVersion blk)
   forMachine _dtal P2PWarning =
       mconcat [ "kind" .= String "P2PWarning"
                , "message" .= String p2pWarningMessage ]
-  forMachine _dtal PeerSharingWarning =
-      mconcat [ "kind" .= String "PeerSharingWarning"
-               , "message" .= String peerSharingWarningMessage ]
   forMachine _ver (WarningDevelopmentNodeToNodeVersions ntnVersions) =
       mconcat [ "kind" .= String "WarningDevelopmentNodeToNodeVersions"
                , "message" .= String "enabled development network protocols"
@@ -308,8 +305,6 @@ instance MetaTrace  (StartupTrace blk) where
     Namespace [] ["NetworkConfigLegacy"]
   namespaceFor P2PWarning {}  =
     Namespace [] ["P2PWarning"]
-  namespaceFor PeerSharingWarning {}  =
-    Namespace [] ["PeerSharingWarning"]
   namespaceFor WarningDevelopmentNodeToNodeVersions {}  =
     Namespace [] ["WarningDevelopmentNodeToNodeVersions"]
   namespaceFor WarningDevelopmentNodeToClientVersions {}  =
@@ -528,8 +523,6 @@ ppStartupInfoTrace NetworkConfigLegacy = p2pNetworkConfigLegacyMessage
 
 ppStartupInfoTrace P2PWarning = p2pWarningMessage
 
-ppStartupInfoTrace PeerSharingWarning = peerSharingWarningMessage
-
 ppStartupInfoTrace (WarningDevelopmentNodeToNodeVersions ntnVersions) =
      "enabled development node-to-node versions: "
   <> showT ntnVersions
@@ -576,16 +569,6 @@ p2pNetworkConfigLegacyMessage =
   , "See https://github.com/intersectmbo/cardano-node/issues/4559"
   , "Note that the legacy p2p format will be removed in `1.37` release."
   ]
-
-peerSharingWarningMessage :: Text
-peerSharingWarningMessage =
-    "Warning: Enabling PeerSharing can expose you to significant risks, including "
-  <> "the possibility of eclipse attacks. By turning on this feature, you may "
-  <> "inadvertently give malicious actors the ability to isolate your device, "
-  <> "manipulate your view of the network, and compromise your data integrity. "
-  <> "It is crucial to carefully consider the potential consequences before "
-  <> "enabling PeerSharing. If you are unsure, it is strongly advised to consult "
-  <> "a security expert for guidance. Proceed with caution."
 
 -- | Pretty print 'SocketOrSocketInfo'.
 --

--- a/cardano-node/src/Cardano/Node/Types.hs
+++ b/cardano-node/src/Cardano/Node/Types.hs
@@ -17,7 +17,6 @@ module Cardano.Node.Types
   , MaxConcurrencyBulkSync(..)
   , MaxConcurrencyDeadline(..)
     -- * Networking
-  , UseLedger(..)
   , TopologyFile(..)
   , NodeDiffusionMode (..)
     -- * Consensus protocol configuration
@@ -37,10 +36,8 @@ import           Cardano.Crypto (RequiresNetworkMagic (..))
 import qualified Cardano.Crypto.Hash as Crypto
 import           Cardano.Node.Configuration.Socket (SocketConfig (..))
 import           Ouroboros.Network.NodeToNode (DiffusionMode (..))
-import           Ouroboros.Network.PeerSelection.LedgerPeers (UseLedgerAfter (..))
 
 import           Control.Exception
-import           Control.Monad (MonadPlus (..))
 import           Data.Aeson
 import           Data.ByteString (ByteString)
 import           Data.Monoid (Last)
@@ -282,25 +279,6 @@ data NodeHardForkProtocolConfiguration =
      , npcTestConwayHardForkAtVersion       :: Maybe Word
      }
   deriving (Eq, Show)
-
--- | A newtype wrapper around 'UseLedgerAfter' which provides 'FromJSON' and
--- 'ToJSON' instances.
---
--- 'UseLedgerAfter' is used to configure from which slot a p2p node can use on
--- chain root peers.
---
-newtype UseLedger = UseLedger UseLedgerAfter deriving (Eq, Show)
-
-instance FromJSON UseLedger where
-  parseJSON (Data.Aeson.Number n) =
-    if n >= 0 then return $ UseLedger $ UseLedgerAfter $ SlotNo $ floor n
-              else return $ UseLedger   DontUseLedger
-  parseJSON _ = mzero
-
-instance ToJSON UseLedger where
-  toJSON (UseLedger (UseLedgerAfter (SlotNo n))) = Number $ fromIntegral n
-  toJSON (UseLedger DontUseLedger)               = Number (-1)
-
 
 newtype TopologyFile = TopologyFile
   { unTopology :: FilePath }

--- a/cardano-node/src/Cardano/Tracing/Config.hs
+++ b/cardano-node/src/Cardano/Tracing/Config.hs
@@ -159,6 +159,7 @@ type TraceLocalTxMonitorProtocol = ("TraceLocalTxMonitorProtocol" :: Symbol)
 type TraceLocalTxSubmissionProtocol = ("TraceLocalTxSubmissionProtocol" :: Symbol)
 type TraceLocalTxSubmissionServer = ("TraceLocalTxSubmissionServer" :: Symbol)
 type TraceMempool = ("TraceMempool" :: Symbol)
+type TraceBackingStore = ("TraceBackingStore" :: Symbol)
 type TraceMux = ("TraceMux" :: Symbol)
 type TraceLocalMux = ("TraceLocalMux" :: Symbol)
 type TracePeerSelection = ("TracePeerSelection" :: Symbol)
@@ -232,6 +233,7 @@ data TraceSelection
   , traceLocalTxSubmissionProtocol :: OnOff TraceLocalTxSubmissionProtocol
   , traceLocalTxSubmissionServer :: OnOff TraceLocalTxSubmissionServer
   , traceMempool :: OnOff TraceMempool
+  , traceBackingStore :: OnOff TraceBackingStore
   , traceMux :: OnOff TraceMux
   , tracePeerSelection :: OnOff TracePeerSelection
   , tracePeerSelectionCounters :: OnOff TracePeerSelectionCounters
@@ -295,6 +297,7 @@ data PartialTraceSelection
       , pTraceLocalTxSubmissionProtocol :: Last (OnOff TraceLocalTxSubmissionProtocol)
       , pTraceLocalTxSubmissionServer :: Last (OnOff TraceLocalTxSubmissionServer)
       , pTraceMempool :: Last (OnOff TraceMempool)
+      , pTraceBackingStore :: Last (OnOff TraceBackingStore)
       , pTraceMux :: Last (OnOff TraceMux)
       , pTracePeerSelection :: Last (OnOff TracePeerSelection)
       , pTracePeerSelectionCounters :: Last (OnOff TracePeerSelectionCounters)
@@ -359,6 +362,7 @@ instance FromJSON PartialTraceSelection where
       <*> parseTracer (Proxy @TraceLocalTxSubmissionProtocol) v
       <*> parseTracer (Proxy @TraceLocalTxSubmissionServer) v
       <*> parseTracer (Proxy @TraceMempool) v
+      <*> parseTracer (Proxy @TraceBackingStore) v
       <*> parseTracer (Proxy @TraceMux) v
       <*> parseTracer (Proxy @TracePeerSelection) v
       <*> parseTracer (Proxy @TracePeerSelectionCounters) v
@@ -420,6 +424,7 @@ defaultPartialTraceConfiguration =
     , pTraceLocalTxSubmissionProtocol = pure $ OnOff False
     , pTraceLocalTxSubmissionServer = pure $ OnOff False
     , pTraceMempool = pure $ OnOff True
+    , pTraceBackingStore = pure $ OnOff False
     , pTraceMux = pure $ OnOff True
     , pTracePeerSelection = pure $ OnOff True
     , pTracePeerSelectionCounters = pure $ OnOff True
@@ -483,6 +488,7 @@ partialTraceSelectionToEither (Last (Just (PartialTraceDispatcher pTraceSelectio
    traceLocalTxSubmissionProtocol <- proxyLastToEither (Proxy @TraceLocalTxSubmissionProtocol) pTraceLocalTxSubmissionProtocol
    traceLocalTxSubmissionServer <- proxyLastToEither (Proxy @TraceLocalTxSubmissionServer) pTraceLocalTxSubmissionServer
    traceMempool <- proxyLastToEither (Proxy @TraceMempool) pTraceMempool
+   traceBackingStore <- proxyLastToEither (Proxy @TraceBackingStore) pTraceBackingStore
    traceMux <- proxyLastToEither (Proxy @TraceMux) pTraceMux
    tracePeerSelection <- proxyLastToEither (Proxy @TracePeerSelection) pTracePeerSelection
    tracePeerSelectionCounters <- proxyLastToEither (Proxy @TracePeerSelectionCounters) pTracePeerSelectionCounters
@@ -539,6 +545,7 @@ partialTraceSelectionToEither (Last (Just (PartialTraceDispatcher pTraceSelectio
              , traceLocalTxSubmissionProtocol = traceLocalTxSubmissionProtocol
              , traceLocalTxSubmissionServer = traceLocalTxSubmissionServer
              , traceMempool = traceMempool
+             , traceBackingStore = traceBackingStore
              , traceMux = traceMux
              , tracePeerSelection = tracePeerSelection
              , tracePeerSelectionCounters = tracePeerSelectionCounters
@@ -599,6 +606,7 @@ partialTraceSelectionToEither (Last (Just (PartialTracingOnLegacy pTraceSelectio
   traceLocalTxSubmissionProtocol <- proxyLastToEither (Proxy @TraceLocalTxSubmissionProtocol) pTraceLocalTxSubmissionProtocol
   traceLocalTxSubmissionServer <- proxyLastToEither (Proxy @TraceLocalTxSubmissionServer) pTraceLocalTxSubmissionServer
   traceMempool <- proxyLastToEither (Proxy @TraceMempool) pTraceMempool
+  traceBackingStore <- proxyLastToEither (Proxy @TraceBackingStore) pTraceBackingStore
   traceMux <- proxyLastToEither (Proxy @TraceMux) pTraceMux
   tracePeerSelection <- proxyLastToEither (Proxy @TracePeerSelection) pTracePeerSelection
   tracePeerSelectionCounters <- proxyLastToEither (Proxy @TracePeerSelectionCounters) pTracePeerSelectionCounters
@@ -655,6 +663,7 @@ partialTraceSelectionToEither (Last (Just (PartialTracingOnLegacy pTraceSelectio
             , traceLocalTxSubmissionProtocol = traceLocalTxSubmissionProtocol
             , traceLocalTxSubmissionServer = traceLocalTxSubmissionServer
             , traceMempool = traceMempool
+            , traceBackingStore = traceBackingStore
             , traceMux = traceMux
             , tracePeerSelection = tracePeerSelection
             , tracePeerSelectionCounters = tracePeerSelectionCounters

--- a/cardano-node/src/Cardano/Tracing/Config.hs
+++ b/cardano-node/src/Cardano/Tracing/Config.hs
@@ -173,6 +173,7 @@ type TraceTxInbound = ("TraceTxInbound" :: Symbol)
 type TraceTxOutbound = ("TraceTxOutbound" :: Symbol)
 type TraceTxSubmissionProtocol = ("TraceTxSubmissionProtocol" :: Symbol)
 type TraceTxSubmission2Protocol = ("TraceTxSubmission2Protocol" :: Symbol)
+type TraceGsm = ("TraceGsm" :: Symbol)
 
 newtype OnOff (name :: Symbol) = OnOff { isOn :: Bool } deriving (Eq, Show)
 
@@ -241,6 +242,7 @@ data TraceSelection
   , traceTxOutbound :: OnOff TraceTxOutbound
   , traceTxSubmissionProtocol :: OnOff TraceTxSubmissionProtocol
   , traceTxSubmission2Protocol :: OnOff TraceTxSubmission2Protocol
+  , traceGsm :: OnOff TraceGsm
   } deriving (Eq, Show)
 
 
@@ -303,6 +305,7 @@ data PartialTraceSelection
       , pTraceTxOutbound :: Last (OnOff TraceTxOutbound)
       , pTraceTxSubmissionProtocol :: Last (OnOff TraceTxSubmissionProtocol)
       , pTraceTxSubmission2Protocol :: Last (OnOff TraceTxSubmission2Protocol)
+      , pTraceGsm :: Last (OnOff TraceGsm)
       } deriving (Eq, Generic, Show)
 
 
@@ -366,6 +369,7 @@ instance FromJSON PartialTraceSelection where
       <*> parseTracer (Proxy @TraceTxOutbound) v
       <*> parseTracer (Proxy @TraceTxSubmissionProtocol) v
       <*> parseTracer (Proxy @TraceTxSubmission2Protocol) v
+      <*> parseTracer (Proxy @TraceGsm) v
 
 
 defaultPartialTraceConfiguration :: PartialTraceSelection
@@ -426,6 +430,7 @@ defaultPartialTraceConfiguration =
     , pTraceTxOutbound = pure $ OnOff False
     , pTraceTxSubmissionProtocol = pure $ OnOff False
     , pTraceTxSubmission2Protocol = pure $ OnOff False
+    , pTraceGsm = pure $ OnOff True
     }
 
 
@@ -488,6 +493,7 @@ partialTraceSelectionToEither (Last (Just (PartialTraceDispatcher pTraceSelectio
    traceTxOutbound <- proxyLastToEither (Proxy @TraceTxOutbound) pTraceTxOutbound
    traceTxSubmissionProtocol <- proxyLastToEither (Proxy @TraceTxSubmissionProtocol) pTraceTxSubmissionProtocol
    traceTxSubmission2Protocol <- proxyLastToEither (Proxy @TraceTxSubmission2Protocol) pTraceTxSubmission2Protocol
+   traceGsm <- proxyLastToEither (Proxy @TraceGsm) pTraceGsm
    Right $ TraceDispatcher $ TraceSelection
              { traceVerbosity = traceVerbosity
              , traceAcceptPolicy = traceAcceptPolicy
@@ -543,6 +549,7 @@ partialTraceSelectionToEither (Last (Just (PartialTraceDispatcher pTraceSelectio
              , traceTxOutbound = traceTxOutbound
              , traceTxSubmissionProtocol = traceTxSubmissionProtocol
              , traceTxSubmission2Protocol = traceTxSubmission2Protocol
+             , traceGsm = traceGsm
              }
 
 partialTraceSelectionToEither (Last (Just (PartialTracingOnLegacy pTraceSelection))) = do
@@ -602,6 +609,7 @@ partialTraceSelectionToEither (Last (Just (PartialTracingOnLegacy pTraceSelectio
   traceTxOutbound <- proxyLastToEither (Proxy @TraceTxOutbound) pTraceTxOutbound
   traceTxSubmissionProtocol <- proxyLastToEither (Proxy @TraceTxSubmissionProtocol) pTraceTxSubmissionProtocol
   traceTxSubmission2Protocol <- proxyLastToEither (Proxy @TraceTxSubmission2Protocol) pTraceTxSubmission2Protocol
+  traceGsm <- proxyLastToEither (Proxy @TraceGsm) pTraceGsm
   Right $ TracingOnLegacy $ TraceSelection
             { traceVerbosity = traceVerbosity
             , traceAcceptPolicy = traceAcceptPolicy
@@ -657,6 +665,7 @@ partialTraceSelectionToEither (Last (Just (PartialTracingOnLegacy pTraceSelectio
             , traceTxOutbound = traceTxOutbound
             , traceTxSubmissionProtocol = traceTxSubmissionProtocol
             , traceTxSubmission2Protocol = traceTxSubmission2Protocol
+            , traceGsm = traceGsm
             }
 
 proxyLastToEither :: KnownSymbol name => Proxy name -> Last (OnOff name) -> Either Text (OnOff name)

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -639,7 +639,7 @@ instance (applyTxErr ~ ApplyTxErr blk, ToObject localPeer)
      => Transformable Text IO (TraceLabelPeer localPeer (NtN.TraceSendRecv (LocalTxSubmission (GenTx blk) applyTxErr))) where
   trTransformer = trStructured
 
-instance (LocalStateQuery.ShowQuery (BlockQuery blk), ToObject localPeer)
+instance (forall fp. LocalStateQuery.ShowQuery (BlockQuery blk fp), ToObject localPeer)
      => Transformable Text IO (TraceLabelPeer localPeer (NtN.TraceSendRecv (LocalStateQuery blk (Point blk) (Query blk)))) where
   trTransformer = trStructured
 

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -471,7 +471,7 @@ instance HasSeverityAnnotation (TracePeerSelection addr) where
 
       TraceOutboundGovernorCriticalFailure {} -> Error
 
-      TraceDebugState {} -> Debug
+      TraceDebugState {} -> Info
 
 instance HasPrivacyAnnotation (DebugPeerSelection addr)
 instance HasSeverityAnnotation (DebugPeerSelection addr) where
@@ -1892,7 +1892,7 @@ instance ToObject (TracePeerSelection SockAddr) where
             , "targets" .= peerSelectionTargetsToObject (dpssTargets ds)
             , "localRootPeers" .= dpssLocalRootPeers ds
             , "publicRootPeers" .= dpssPublicRootPeers ds
-            , "knownPeers" .= (KnownPeers.allPeers $ dpssKnownPeers ds)
+            , "knownPeers" .= KnownPeers.allPeers (dpssKnownPeers ds)
             , "establishedPeers" .= dpssEstablishedPeers ds
             , "activePeers" .= dpssActivePeers ds
             , "publicRootBackoffs" .= dpssPublicRootBackoffs ds
@@ -1954,12 +1954,19 @@ peerSelectionTargetsToObject
   PeerSelectionTargets { targetNumberOfRootPeers,
                          targetNumberOfKnownPeers,
                          targetNumberOfEstablishedPeers,
-                         targetNumberOfActivePeers } =
+                         targetNumberOfActivePeers,
+                         targetNumberOfKnownBigLedgerPeers,
+                         targetNumberOfEstablishedBigLedgerPeers,
+                         targetNumberOfActiveBigLedgerPeers
+                       } =
     Object $
       mconcat [ "roots" .= targetNumberOfRootPeers
                , "knownPeers" .= targetNumberOfKnownPeers
                , "established" .= targetNumberOfEstablishedPeers
                , "active" .= targetNumberOfActivePeers
+               , "knownBigLedgerPeers" .= targetNumberOfKnownBigLedgerPeers
+               , "establishedBigLedgerPeers" .= targetNumberOfEstablishedBigLedgerPeers
+               , "activeBigLedgerPeers" .= targetNumberOfActiveBigLedgerPeers
                ]
 
 instance ToObject (DebugPeerSelection SockAddr) where

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -17,7 +17,6 @@
 module Cardano.Tracing.OrphanInstances.Network () where
 
 import           Cardano.Node.Queries (ConvertTxId)
-import           Cardano.Node.Types (UseLedger (..))
 import           Cardano.Tracing.OrphanInstances.Common
 import           Cardano.Tracing.Render
 import           Ouroboros.Consensus.Block (ConvertRawHash (..), Header, getHeader)
@@ -53,13 +52,16 @@ import qualified Ouroboros.Network.NodeToClient as NtC
 import           Ouroboros.Network.NodeToNode (ErrorPolicyTrace (..), NodeToNodeVersion (..),
                    NodeToNodeVersionData (..), RemoteAddress, TraceSendRecv (..), WithAddr (..))
 import qualified Ouroboros.Network.NodeToNode as NtN
+import           Ouroboros.Network.PeerSelection.Bootstrap
 import           Ouroboros.Network.PeerSelection.Governor (DebugPeerSelection (..),
                    PeerSelectionCounters (..), PeerSelectionState (..), PeerSelectionTargets (..),
                    TracePeerSelection (..))
 import           Ouroboros.Network.PeerSelection.LedgerPeers
-import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing)
+import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
 import           Ouroboros.Network.PeerSelection.PeerStateActions (PeerSelectionActionsTrace (..))
-import           Ouroboros.Network.PeerSelection.RelayAccessPoint
+import           Ouroboros.Network.PeerSelection.PeerTrustable
+import           Ouroboros.Network.PeerSelection.PublicRootPeers (PublicRootPeers)
+import qualified Ouroboros.Network.PeerSelection.PublicRootPeers as PublicRootPeers
 import           Ouroboros.Network.PeerSelection.RootPeersDNS.LocalRootPeers
                    (TraceLocalRootPeers (..))
 import           Ouroboros.Network.PeerSelection.RootPeersDNS.PublicRootPeers
@@ -115,7 +117,6 @@ import           Network.Mux (MiniProtocolNum (..), MuxTrace (..), WithMuxBearer
 import           Network.Socket (SockAddr (..))
 import           Network.TypedProtocol.Codec (AnyMessageAndAgency (..))
 import           Network.TypedProtocol.Core (PeerHasAgency (..))
-import qualified Text.Read as Text
 
 {- HLINT ignore "Use record patterns" -}
 
@@ -223,7 +224,7 @@ instance HasSeverityAnnotation TraceLedgerPeers where
       PickedBigLedgerPeers {}        -> Info
       FetchingNewLedgerState {}      -> Info
       DisabledLedgerPeers {}         -> Info
-      TraceUseLedgerAfter {}         -> Info
+      TraceUseLedgerPeers {}         -> Info
       WaitingOnRequest {}            -> Debug
       RequestForPeers {}             -> Debug
       ReusingLedgerState {}          -> Debug
@@ -460,6 +461,16 @@ instance HasSeverityAnnotation (TracePeerSelection addr) where
       TraceDemoteHotBigLedgerPeerDone {}   -> Info
 
       TraceDemoteBigLedgerPeersAsynchronous {} -> Warning
+
+      TraceUseBootstrapPeersChanged {} -> Info
+      TraceBootstrapPeersFlagChangedWhilstInSensitiveState -> Info
+
+      TraceLedgerStateJudgementChanged {} -> Notice
+      TraceOnlyBootstrapPeers {}          -> Notice
+
+      TraceOutboundGovernorCriticalFailure {} -> Error
+
+      TraceDebugState {} -> Debug
 
 instance HasPrivacyAnnotation (DebugPeerSelection addr)
 instance HasSeverityAnnotation (DebugPeerSelection addr) where
@@ -1343,10 +1354,10 @@ instance ToObject TraceLedgerPeers where
     mconcat
       [ "kind" .= String "DisabledLedgerPeers"
       ]
-  toObject _verb (TraceUseLedgerAfter ula) =
+  toObject _verb (TraceUseLedgerPeers ulp) =
     mconcat
-      [ "kind" .= String "UseLedgerAfter"
-      , "useLedgerAfter" .= UseLedger ula
+      [ "kind" .= String "UseLedgerPeers"
+      , "useLedgerPeers" .= ulp
       ]
   toObject _verb WaitingOnRequest =
     mconcat
@@ -1548,6 +1559,14 @@ instance ToJSON PeerSelectionTargets where
                  , "targetActiveBigLedgerPeers" .= nActiveBigLedgerPeers
                  ]
 
+instance ToJSON peerAddr => ToJSON (PublicRootPeers peerAddr) where
+  toJSON prp =
+    Aeson.object [ "kind" .= String "PublicRootPeers"
+                 , "bootstrapPeers" .= PublicRootPeers.getBootstrapPeers prp
+                 , "ledgerPeers" .= PublicRootPeers.getLedgerPeers prp
+                 , "bigLedgerPeers" .= PublicRootPeers.getBigLedgerPeers prp
+                 ]
+
 instance ToJSON RepromoteDelay where
   toJSON = toJSON . repromoteDelay
 
@@ -1573,7 +1592,7 @@ instance ToObject (TracePeerSelection SockAddr) where
              ]
   toObject _verb (TracePublicRootsResults res group dt) =
     mconcat [ "kind" .= String "PublicRootsResults"
-             , "result" .= Aeson.toJSONList (toList res)
+             , "result" .= toJSON res
              , "group" .= group
              , "diffTime" .= dt
              ]
@@ -1834,6 +1853,25 @@ instance ToObject (TracePeerSelection SockAddr) where
     mconcat [ "kind" .= String "KnownInboundConnection"
              , "peer" .= show addr
              , "peerSharing" .= show sharing ]
+  toObject _verb (TraceLedgerStateJudgementChanged new) =
+    mconcat [ "kind" .= String "LedgerStateJudgementChanged"
+             , "new" .= show new ]
+  toObject _verb TraceOnlyBootstrapPeers =
+    mconcat [ "kind" .= String "OnlyBootstrapPeers" ]
+  toObject _verb (TraceUseBootstrapPeersChanged ubp) =
+    mconcat [ "kind" .= String "UseBootstrapPeersChanged"
+             , "bootstrapPeers" .= show ubp ]
+  toObject _verb TraceBootstrapPeersFlagChangedWhilstInSensitiveState =
+    mconcat [ "kind" .= String "BootstrapPeersFlagChangedWhilstInSensitiveState"
+            ]
+  toObject _verb (TraceOutboundGovernorCriticalFailure err) =
+    mconcat [ "kind" .= String "OutboundGovernorCriticalFailure"
+             , "reason" .= show err
+             ]
+  toObject _verb (TraceDebugState _ dpst) =
+    mconcat [ "kind" .= String "OutboundGovernorCriticalFailure"
+             , "peerSelectionState" .= show dpst
+             ]
 
 -- Connection manager abstract state.  For explanation of each state see
 -- <https://hydra.iohk.io/job/Cardano/ouroboros-network/native.network-docs.x86_64-linux/latest/download/2>
@@ -1889,7 +1927,7 @@ peerSelectionTargetsToObject
 
 instance ToObject (DebugPeerSelection SockAddr) where
   toObject verb (TraceGovernorState blockedAt wakeupAfter
-                   PeerSelectionState { targets, knownPeers, establishedPeers, activePeers, bigLedgerPeers })
+                   PeerSelectionState { targets, knownPeers, establishedPeers, activePeers, publicRootPeers })
       | verb <= NormalVerbosity =
     mconcat [ "kind" .= String "DebugPeerSelection"
              , "blockedAt" .= String (pack $ show blockedAt)
@@ -1907,6 +1945,8 @@ instance ToObject (DebugPeerSelection SockAddr) where
                                  ])
 
              ]
+    where
+     bigLedgerPeers = PublicRootPeers.getBigLedgerPeers publicRootPeers
   toObject _ (TraceGovernorState blockedAt wakeupAfter ev) =
     mconcat [ "kind" .= String "DebugPeerSelection"
              , "blockedAt" .= String (pack $ show blockedAt)
@@ -2438,11 +2478,50 @@ instance ToJSON addr
                ]
 
 instance FromJSON PeerSharing where
-  parseJSON = Aeson.withText "PeerSharing" $ \t ->
-    case Text.readMaybe (Text.unpack t) of
-      Nothing -> fail ("PeerSharing.parseJSON: could not parse value: "
-                     ++ Text.unpack t)
-      Just ps -> return ps
+  parseJSON = Aeson.withBool "PeerSharing" $ \b ->
+    pure $ if b then PeerSharingEnabled
+                else PeerSharingDisabled
 
 instance ToJSON PeerSharing where
-  toJSON = String . Text.pack . show
+  toJSON PeerSharingEnabled = Bool True
+  toJSON PeerSharingDisabled = Bool False
+
+instance FromJSON UseLedgerPeers where
+  parseJSON (Number slot) = return $
+    case compare slot 0 of
+      GT -> UseLedgerPeers (After (SlotNo (floor slot)))
+      EQ -> UseLedgerPeers Always
+      LT -> DontUseLedgerPeers
+  parseJSON invalid = fail $ "Parsing of slot number failed due to type mismatch. "
+                            <> "Encountered: " <> show invalid
+
+instance ToJSON LedgerStateJudgement where
+  toJSON YoungEnough = String "YoungEnough"
+  toJSON TooOld      = String "TooOld"
+
+instance FromJSON LedgerStateJudgement where
+  parseJSON (String "YoungEnough") = pure YoungEnough
+  parseJSON (String "TooOld")      = pure TooOld
+  parseJSON _                      = fail "Invalid JSON for LedgerStateJudgement"
+
+instance ToJSON UseLedgerPeers where
+  toJSON DontUseLedgerPeers                  = Number (-1)
+  toJSON (UseLedgerPeers Always)             = Number 0
+  toJSON (UseLedgerPeers (After (SlotNo s))) = Number (fromIntegral s)
+
+instance ToJSON UseBootstrapPeers where
+  toJSON DontUseBootstrapPeers   = Null
+  toJSON (UseBootstrapPeers dps) = toJSON dps
+
+instance FromJSON UseBootstrapPeers where
+  parseJSON Null = pure DontUseBootstrapPeers
+  parseJSON v    = UseBootstrapPeers <$> parseJSON v
+
+instance FromJSON PeerTrustable where
+  parseJSON = Aeson.withBool "PeerTrustable" $ \b ->
+    pure $ if b then IsTrustable
+                else IsNotTrustable
+
+instance ToJSON PeerTrustable where
+  toJSON IsTrustable = Bool True
+  toJSON IsNotTrustable = Bool False

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -461,6 +461,7 @@ mkTracers _ _ _ _ _ enableP2P =
       , Consensus.forgeTracer = nullTracer
       , Consensus.blockchainTimeTracer = nullTracer
       , Consensus.consensusErrorTracer = nullTracer
+      , Consensus.gsmTracer = nullTracer
       }
     , nodeToClientTracers = NodeToClient.Tracers
       { NodeToClient.tChainSyncTracer = nullTracer
@@ -739,6 +740,7 @@ mkConsensusTracers mbEKGDirect trSel verb tr nodeKern fStats = do
           traceWith (toLogObject tr) (readableTraceBlockchainTimeEvent ev)
     , Consensus.consensusErrorTracer =
         Tracer $ \err -> traceWith (toLogObject tr) (ConsensusStartupException err)
+    , Consensus.gsmTracer = tracerOnOff (traceGsm trSel) verb "GSM" tr
     }
  where
    mkForgeTracers :: IO ForgeTracers

--- a/cardano-node/test/Test/Cardano/Node/Gen.hs
+++ b/cardano-node/test/Test/Cardano/Node/Gen.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
@@ -25,9 +26,11 @@ import           Cardano.Node.Configuration.NodeAddress (NodeAddress' (..), Node
 import           Cardano.Node.Configuration.TopologyP2P (LocalRootPeersGroup (..),
                    LocalRootPeersGroups (..), NetworkTopology (..), NodeSetup (..),
                    PeerAdvertise (..), PublicRootPeers (..), RootConfig (..))
-import           Cardano.Node.Types (UseLedger (..))
 import           Cardano.Slotting.Slot (SlotNo (..))
-import           Ouroboros.Network.PeerSelection.LedgerPeers (UseLedgerAfter (..))
+import           Ouroboros.Network.PeerSelection.Bootstrap
+import           Ouroboros.Network.PeerSelection.LedgerPeers.Type (AfterSlot (..),
+                   UseLedgerPeers (..))
+import           Ouroboros.Network.PeerSelection.PeerTrustable
 import           Ouroboros.Network.PeerSelection.RelayAccessPoint (DomainAccessPoint (..),
                    RelayAccessPoint (..))
 import           Ouroboros.Network.PeerSelection.State.LocalRootPeers (HotValency (..),
@@ -51,7 +54,8 @@ genNetworkTopology =
   Gen.choice
     [ RealNodeTopology <$> genLocalRootPeersGroups
                        <*> Gen.list (Range.linear 0 10) genPublicRootPeers
-                       <*> genUseLedger
+                       <*> genUseLedgerPeers
+                       <*> genUseBootstrapPeers
     ]
 
 -- | Generate valid encodings of p2p topology files
@@ -146,7 +150,7 @@ genNodeSetup =
     <*> Gen.maybe (genNodeAddress' genNodeHostIPv4Address)
     <*> Gen.maybe (genNodeAddress' genNodeHostIPv6Address)
     <*> Gen.list (Range.linear 0 6) genRootConfig
-    <*> genUseLedger
+    <*> genUseLedgerPeers
 
 genDomainAddress :: Gen DomainAccessPoint
 genDomainAddress =
@@ -177,7 +181,7 @@ genLocalRootPeersGroup = do
     ra <- genRootConfig
     hval <- Gen.int (Range.linear 0 (length (rootAccessPoints ra)))
     wval <- WarmValency <$> Gen.int (Range.linear 0 hval)
-    return (LocalRootPeersGroup ra (HotValency hval) wval)
+    LocalRootPeersGroup ra (HotValency hval) wval <$> genPeerTrustable
 
 genLocalRootPeersGroups :: Gen LocalRootPeersGroups
 genLocalRootPeersGroups =
@@ -189,8 +193,16 @@ genPublicRootPeers =
   PublicRootPeers
     <$> genRootConfig
 
-genUseLedger :: Gen UseLedger
-genUseLedger = do
+genUseLedgerPeers :: Gen UseLedgerPeers
+genUseLedgerPeers = do
     slot <- Gen.integral (Range.linear (-1) 10) :: Gen Integer
-    if slot >= 0 then return $ UseLedger $ UseLedgerAfter $ SlotNo $ fromIntegral slot
-                 else return $ UseLedger   DontUseLedger
+    if slot >= 0 then return $ UseLedgerPeers $ After $ SlotNo $ fromIntegral slot
+                 else return DontUseLedgerPeers
+
+genUseBootstrapPeers :: Gen UseBootstrapPeers
+genUseBootstrapPeers = do
+  domains <- Gen.list Range.constantBounded genRelayAddress
+  Gen.element [ DontUseBootstrapPeers , UseBootstrapPeers domains ]
+
+genPeerTrustable :: Gen PeerTrustable
+genPeerTrustable = Gen.element [ IsNotTrustable, IsTrustable ]

--- a/cardano-node/test/Test/Cardano/Node/POM.hs
+++ b/cardano-node/test/Test/Cardano/Node/POM.hs
@@ -13,7 +13,8 @@ import           Cardano.Node.Types
 import           Cardano.Tracing.Config (PartialTraceOptions (..), defaultPartialTraceConfiguration,
                    partialTraceSelectionToEither)
 import qualified Ouroboros.Consensus.Node as Consensus (NetworkP2PMode (..))
-import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy (SnapshotInterval (..))
+import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy (NumOfDiskSnapshots (..),
+                   SnapshotInterval (..))
 import           Ouroboros.Network.Block (SlotNo (..))
 import           Ouroboros.Network.NodeToNode (AcceptedConnectionsLimit (..),
                    DiffusionMode (InitiatorAndResponderDiffusionMode))
@@ -115,6 +116,7 @@ testPartialYamlConfig =
     , pncShutdownConfig = Last Nothing
     , pncStartAsNonProducingNode = Last $ Just False
     , pncDiffusionMode = Last Nothing
+    , pncNumOfDiskSnapshots = Last Nothing
     , pncSnapshotInterval = mempty
     , pncExperimentalProtocolsEnabled = Last Nothing
     , pncMaxConcurrencyBulkSync = Last Nothing
@@ -156,6 +158,7 @@ testPartialCliConfig =
     , pncTopologyFile = mempty
     , pncDatabaseFile = mempty
     , pncDiffusionMode = mempty
+    , pncNumOfDiskSnapshots = Last Nothing
     , pncSnapshotInterval = Last . Just . RequestedSnapshotInterval $ secondsToDiffTime 100
     , pncExperimentalProtocolsEnabled = Last $ Just True
     , pncProtocolFiles = Last . Just $ ProtocolFilepaths Nothing Nothing Nothing Nothing Nothing Nothing
@@ -199,6 +202,7 @@ eExpectedConfig = do
     , ncValidateDB = True
     , ncProtocolConfig = testNodeProtocolConfiguration
     , ncDiffusionMode = InitiatorAndResponderDiffusionMode
+    , ncNumOfDiskSnapshots = DefaultNumOfDiskSnapshots
     , ncSnapshotInterval = RequestedSnapshotInterval $ secondsToDiffTime 100
     , ncExperimentalProtocolsEnabled = True
     , ncMaxConcurrencyBulkSync = Nothing

--- a/cardano-node/test/Test/Cardano/Node/POM.hs
+++ b/cardano-node/test/Test/Cardano/Node/POM.hs
@@ -6,6 +6,7 @@ module Test.Cardano.Node.POM
   ) where
 
 import           Cardano.Crypto.ProtocolMagic (RequiresNetworkMagic (..))
+import           Cardano.Node.Configuration.LedgerDB
 import           Cardano.Node.Configuration.POM
 import           Cardano.Node.Configuration.Socket
 import           Cardano.Node.Handlers.Shutdown
@@ -14,6 +15,8 @@ import           Cardano.Tracing.Config (PartialTraceOptions (..), defaultPartia
                    partialTraceSelectionToEither)
 import qualified Ouroboros.Consensus.Node as Consensus (NetworkP2PMode (..))
 import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy (NumOfDiskSnapshots (..),
+import           Ouroboros.Consensus.Storage.LedgerDB
+                   (FlushFrequency (DefaultFlushFrequency), QueryBatchSize (DefaultQueryBatchSize),
                    SnapshotInterval (..))
 import           Ouroboros.Network.Block (SlotNo (..))
 import           Ouroboros.Network.NodeToNode (AcceptedConnectionsLimit (..),
@@ -144,6 +147,9 @@ testPartialYamlConfig =
     , pncTargetNumberOfActiveBigLedgerPeers = mempty
     , pncEnableP2P = Last (Just DisabledP2PMode)
     , pncPeerSharing = Last (Just PeerSharingDisabled)
+    , pncLedgerDBBackend = Last (Just InMemory)
+    , pncFlushFrequency = Last (Just DefaultFlushFrequency)
+    , pncQueryBatchSize = Last (Just DefaultQueryBatchSize)
     }
 
 -- | Example partial configuration theoretically created
@@ -184,6 +190,9 @@ testPartialCliConfig =
     , pncTargetNumberOfActiveBigLedgerPeers = mempty
     , pncEnableP2P = Last (Just DisabledP2PMode)
     , pncPeerSharing = Last (Just PeerSharingDisabled)
+    , pncLedgerDBBackend = Last (Just InMemory)
+    , pncFlushFrequency = Last (Just DefaultFlushFrequency)
+    , pncQueryBatchSize = Last (Just DefaultQueryBatchSize)
     }
 
 -- | Expected final NodeConfiguration
@@ -230,6 +239,9 @@ eExpectedConfig = do
     , ncTargetNumberOfActiveBigLedgerPeers = 5
     , ncEnableP2P = SomeNetworkP2PMode Consensus.DisabledP2PMode
     , ncPeerSharing = PeerSharingDisabled
+    , ncLedgerDBBackend = InMemory
+    , ncFlushFrequency = DefaultFlushFrequency
+    , ncQueryBatchSize = DefaultQueryBatchSize
     }
 
 -- -----------------------------------------------------------------------------

--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -39,9 +39,9 @@ library
                       , aeson
                       , async
                       , bytestring
-                      , cardano-api ^>= 8.39
+                      , cardano-api ^>= 8.39.2.0
                       , cardano-binary
-                      , cardano-cli ^>= 8.20.2.0
+                      , cardano-cli ^>= 8.20.3.0
                       , cardano-crypto-class ^>= 2.1.2
                       , http-media
                       , iohk-monitoring
@@ -49,7 +49,7 @@ library
                       , network
                       , optparse-applicative-fork
                       , ouroboros-consensus-cardano
-                      , ouroboros-network ^>= 0.11
+                      , ouroboros-network ^>= 0.12
                       , ouroboros-network-protocols
                       , prometheus >= 2.2.4
                       , servant

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -34,8 +34,8 @@ library
   build-depends:        aeson
                       , ansi-terminal
                       , bytestring
-                      , cardano-api ^>= 8.39
-                      , cardano-cli ^>= 8.20.2.0
+                      , cardano-api ^>= 8.39.2.0
+                      , cardano-cli ^>= 8.20.3.0
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
                       , cardano-ledger-alonzo
@@ -56,14 +56,14 @@ library
                       , exceptions
                       , filepath
                       , hedgehog
-                      , hedgehog-extras ^>= 0.6.1.0
+                      , hedgehog-extras < 0.6.2
                       , microlens
                       , lens-aeson
                       , mtl
                       , network
                       , network-mux
                       , optparse-applicative-fork
-                      , ouroboros-network ^>= 0.11
+                      , ouroboros-network ^>= 0.12
                       , ouroboros-network-api
                       , prettyprinter
                       , process

--- a/cardano-testnet/src/Testnet/Components/Configuration.hs
+++ b/cardano-testnet/src/Testnet/Components/Configuration.hs
@@ -20,9 +20,9 @@ import           Cardano.Api.Shelley hiding (Value, cardanoEra)
 
 import qualified Cardano.Node.Configuration.Topology as NonP2P
 import qualified Cardano.Node.Configuration.TopologyP2P as P2P
-import           Cardano.Node.Types
+import           Ouroboros.Network.PeerSelection.Bootstrap
 import           Ouroboros.Network.PeerSelection.LedgerPeers
-import           Ouroboros.Network.PeerSelection.RelayAccessPoint
+import           Ouroboros.Network.PeerSelection.PeerTrustable
 import           Ouroboros.Network.PeerSelection.State.LocalRootPeers
 
 import           Control.Monad
@@ -51,7 +51,6 @@ import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Stock.Time as DTC
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
-
 
 createConfigYaml
   :: (MonadTest m, MonadIO m, HasCallStack)
@@ -201,6 +200,7 @@ mkTopologyConfig numNodes allPorts port True = Aeson.encode topologyP2P
         [ P2P.LocalRootPeersGroup rootConfig
                                   (HotValency (numNodes - 1))
                                   (WarmValency (numNodes - 1))
+                                  IsNotTrustable
         ]
 
     topologyP2P :: P2P.NetworkTopology
@@ -208,4 +208,5 @@ mkTopologyConfig numNodes allPorts port True = Aeson.encode topologyP2P
       P2P.RealNodeTopology
         localRootPeerGroups
         []
-        (UseLedger DontUseLedger)
+        DontUseLedgerPeers
+        DontUseBootstrapPeers

--- a/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
+++ b/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
@@ -13,9 +13,7 @@ import qualified Cardano.Testnet.Test.Cli.Conway.Plutus
 import qualified Cardano.Testnet.Test.Cli.KesPeriodInfo
 import qualified Cardano.Testnet.Test.Cli.QuerySlotNumber
 import qualified Cardano.Testnet.Test.FoldBlocks
-import qualified Cardano.Testnet.Test.LedgerEvents.Gov.InfoAction as LedgerEvents
 import qualified Cardano.Testnet.Test.LedgerEvents.Gov.ProposeNewConstitution as LedgerEvents
-import qualified Cardano.Testnet.Test.LedgerEvents.Gov.ProposeNewConstitutionSPO as LedgerEvents
 import qualified Cardano.Testnet.Test.LedgerEvents.SanityCheck as LedgerEvents
 import qualified Cardano.Testnet.Test.Node.Shutdown
 import qualified Cardano.Testnet.Test.SubmitApi.Babbage.Transaction
@@ -40,8 +38,8 @@ tests = pure $ T.testGroup "test/Spec.hs"
           -- TODO: Replace foldBlocks with checkLedgerStateCondition
           , T.testGroup "Governance"
               [ H.ignoreOnMacAndWindows "ProposeAndRatifyNewConstitution" LedgerEvents.hprop_ledger_events_propose_new_constitution
-              , H.ignoreOnWindows "InfoAction" LedgerEvents.hprop_ledger_events_info_action
-              , H.ignoreOnWindows "ProposeNewConstitutionSPO" LedgerEvents.hprop_ledger_events_propose_new_constitution_spo
+              -- , H.ignoreOnWindows "InfoAction" LedgerEvents.hprop_ledger_events_info_action
+              -- , H.ignoreOnWindows "ProposeNewConstitutionSPO" LedgerEvents.hprop_ledger_events_propose_new_constitution_spo
               , H.ignoreOnWindows "DRepRetirement" DRepRetirement.hprop_drep_retirement
               ]
           , T.testGroup "Plutus"

--- a/cardano-tracer/cardano-tracer.cabal
+++ b/cardano-tracer/cardano-tracer.cabal
@@ -152,7 +152,7 @@ library
                       , filepath
                       , mime-mail
                       , optparse-applicative
-                      , ouroboros-network ^>= 0.11
+                      , ouroboros-network ^>= 0.12
                       , ouroboros-network-api
                       , ouroboros-network-framework
                       , signal

--- a/configuration/cardano/mainnet-topology.json
+++ b/configuration/cardano/mainnet-topology.json
@@ -1,29 +1,27 @@
 {
+  "bootstrapPeers": [
+    {
+      "address": "backbone.cardano.iog.io",
+      "port": 3001
+    },
+    {
+      "address": "backbone.mainnet.emurgornd.com",
+      "port": 3001
+    }
+  ],
   "localRoots": [
     {
       "accessPoints": [],
       "advertise": false,
+      "trustable": false,
       "valency": 1
     }
   ],
   "publicRoots": [
     {
-      "accessPoints": [
-        {
-          "address": "backbone.cardano-mainnet.iohk.io",
-          "port": 3001
-        },
-        {
-          "address": "backbone.cardano.iog.io",
-          "port": 3001
-        },
-        {
-          "address": "backbone.mainnet.emurgornd.com",
-          "port": 3001
-        }
-      ],
+      "accessPoints": [],
       "advertise": false
     }
   ],
-  "useLedgerAfterSlot": 110332824
+  "useLedgerAfterSlot": 116812831
 }

--- a/flake.lock
+++ b/flake.lock
@@ -922,15 +922,16 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1707581561,
-        "narHash": "sha256-A9MT8D7M2We0HCBQbClrA91ZquGf7GU+T6tvjMeUUEA=",
+        "lastModified": 1708731686,
+        "narHash": "sha256-6DQ89ktt8rRVV1pXEyX2JwPjaqS0mQkelkmJmka04rg=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "51469c3fc2c74e24b529f63615670259ba1fee38",
+        "rev": "898970b2376e462413c3a4b4d1adf1d5abb1190e",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
+        "ref": "bootstrap-peers",
         "repo": "iohk-nix",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -922,16 +922,15 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1708731686,
+        "lastModified": 1709083850,
         "narHash": "sha256-6DQ89ktt8rRVV1pXEyX2JwPjaqS0mQkelkmJmka04rg=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "898970b2376e462413c3a4b4d1adf1d5abb1190e",
+        "rev": "1c793a53ac0bd99b795c2180eb23d37e8389a74b",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "bootstrap-peers",
         "repo": "iohk-nix",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1708729825,
-        "narHash": "sha256-mufjeGjZjgdfcxXzssMpRM/KggPVWQu6hFbYWPyBY78=",
+        "lastModified": 1708970955,
+        "narHash": "sha256-k6Y9WjDej7wCkUowVi/tdsWP6EWUMZTSRU9r+4lMJmU=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "42963de660ded965e14477f91a4c5df53fb1072d",
+        "rev": "f09964311e8894a5f09e258f308a9c3d4221f029",
         "type": "github"
       },
       "original": {
@@ -624,11 +624,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1708906978,
-        "narHash": "sha256-GTcMtNGWpRJ/LAFkcQjNS+mneNMjcRNyg3x11eKI62g=",
+        "lastModified": 1708647761,
+        "narHash": "sha256-1WiRX2IqiopPq3sQTBPF7BswDacfGB9UUNnN9PYgrXA=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "93d5bc1145240077425ef31bb73eaa76a68e52fa",
+        "rev": "6a164db037c9cb2fd7ea946e7a0d62d7d8f53766",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -624,11 +624,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1708647761,
-        "narHash": "sha256-1WiRX2IqiopPq3sQTBPF7BswDacfGB9UUNnN9PYgrXA=",
+        "lastModified": 1708993343,
+        "narHash": "sha256-8EbbR5ReQK61yP/7VYtFSCerBXSE59VtfV+Wahdsuqg=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "6a164db037c9cb2fd7ea946e7a0d62d7d8f53766",
+        "rev": "f823c9258e9316cb4da256fc93e9c0407f0c296a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
     };
     utils.url = "github:numtide/flake-utils";
     iohkNix = {
-      url = "github:input-output-hk/iohk-nix/bootstrap-peers";
+      url = "github:input-output-hk/iohk-nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     ops-lib = {

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
     };
     utils.url = "github:numtide/flake-utils";
     iohkNix = {
-      url = "github:input-output-hk/iohk-nix";
+      url = "github:input-output-hk/iohk-nix/bootstrap-peers";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     ops-lib = {

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -42,9 +42,10 @@ let
 
         # These programs will be available inside the nix-shell.
         nativeBuildInputs = with pkgs.pkgsBuildBuild; [
+          lmdb
           nix-prefetch-git
           pkg-config
-          hlint
+          hlint          
           ghcid
           haskell-language-server
           cabal

--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -544,8 +544,8 @@ in {
             map (e: {address = e.addr; inherit (e) port;}) envConfig.edgeNodes;
         description = ''
           If set, it will enable bootstrap peers.
-          To disable set this to null.
-          To enable set  this to [{ address = "addr"; port = 0; }]
+          To disable, set this to null.
+          To enable, set this to a list of attributes of address and port, example: [{ address = "addr"; port = 3001; }]
         '';
       };
 

--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -23,10 +23,9 @@ let
       accessPoints = map (e: builtins.removeAttrs e ["valency"]) g.accessPoints;
       advertise = g.advertise or false;
     }) (cfg.publicProducers ++ (cfg.instancePublicProducers i));
+    bootstrapPeers = cfg.bootstrapPeers;
   } // optionalAttrs (cfg.usePeersFromLedgerAfterSlot != null) {
     useLedgerAfterSlot = cfg.usePeersFromLedgerAfterSlot;
-  } // optionalAttrs (cfg.bootstrapPeers != null) {
-    bootstrapPeers = cfg.bootstrapPeers;
   };
 
   oldTopology = i: {
@@ -43,14 +42,14 @@ let
     let
       checkEval = tryEval (
         assert
-          if cfg.useBootstrapPeers == [] && all (e: e.trustable != true) ((newTopology i).localRoots)
+          if cfg.bootstrapPeers == [] && all (e: e.trustable != true) ((newTopology i).localRoots)
           then false
           else true;
       newTopology i);
     in
       if checkEval.success
       then checkEval.value
-      else abort "When useBootstrapPeers is an empty list, at least one localRoot must be trustable, otherwise cardano node will fail to start.";
+      else abort "When bootstrapPeers is an empty list, at least one localRoot must be trustable, otherwise cardano node will fail to start.";
 
   selectTopology = i:
     if cfg.topology != null

--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -39,10 +39,23 @@ let
     );
   };
 
+  assertNewTopology = i:
+    let
+      checkEval = tryEval (
+        assert
+          if cfg.useBootstrapPeers == [] && all (e: e.trustable != true) ((newTopology i).localRoots)
+          then false
+          else true;
+      newTopology i);
+    in
+      if checkEval.success
+      then checkEval.value
+      else abort "When useBootstrapPeers is an empty list, at least one localRoot must be trustable, otherwise cardano node will fail to start.";
+
   selectTopology = i:
     if cfg.topology != null
     then cfg.topology
-    else toFile "topology.yaml" (toJSON (if (cfg.useNewTopology) then newTopology i else oldTopology i));
+    else toFile "topology.yaml" (toJSON (if (cfg.useNewTopology) then assertNewTopology i else oldTopology i));
 
   topology = i:
     if cfg.useSystemdReload

--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -17,6 +17,7 @@ let
       accessPoints = map (e: builtins.removeAttrs e ["valency"]) g.accessPoints;
       advertise = g.advertise or false;
       valency = g.valency or (length g.accessPoints);
+      trustable = g.trustable or false;
     }) (cfg.producers ++ (cfg.instanceProducers i));
     publicRoots = map (g: {
       accessPoints = map (e: builtins.removeAttrs e ["valency"]) g.accessPoints;
@@ -24,6 +25,8 @@ let
     }) (cfg.publicProducers ++ (cfg.instancePublicProducers i));
   } // optionalAttrs (cfg.usePeersFromLedgerAfterSlot != null) {
     useLedgerAfterSlot = cfg.usePeersFromLedgerAfterSlot;
+  } // optionalAttrs (cfg.bootstrapPeers != null) {
+    bootstrapPeers = cfg.bootstrapPeers;
   };
 
   oldTopology = i: {
@@ -510,6 +513,16 @@ in {
           If set, bootstraps from public roots until it reaches given slot,
           then it switches to using the ledger as a source of peers. It maintains a connection to its local roots.
           Default to null for block producers.
+        '';
+      };
+
+      bootstrapPeers = mkOption {
+        type = types.nullOr (types.listOf types.attrs);
+        default = null;
+        description = ''
+          If set, it will enable bootstrap peers.
+          To disable set this to null.
+          To enable set  this to [{ address = "addr"; port = 0; }]
         '';
       };
 

--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -463,7 +463,8 @@ in {
 
       publicProducers = mkOption {
         type = types.listOf types.attrs;
-        default = [{
+        default = [];
+        example = [{
           accessPoints = [{
             address = envConfig.relaysNew;
             port = envConfig.edgePort;
@@ -530,7 +531,17 @@ in {
 
       bootstrapPeers = mkOption {
         type = types.nullOr (types.listOf types.attrs);
-        default = null;
+        default =
+          # Until legacy mainnet relays are deprecated and replaced by IOG bootstrap peers for relaysNew,
+          # filter the legacy relaysNew definition from the mainnet bootstrapPeers list.
+          #
+          # All other envs can use the edgeNodes list as bootstrapPeers.
+          if envConfig.name == "mainnet"
+          then
+            map (e: {address = e.addr; inherit (e) port;})
+              (builtins.filter (e: e.addr != envConfig.relaysNew) envConfig.edgeNodes)
+          else
+            map (e: {address = e.addr; inherit (e) port;}) envConfig.edgeNodes;
         description = ''
           If set, it will enable bootstrap peers.
           To disable set this to null.

--- a/trace-dispatcher/trace-dispatcher.cabal
+++ b/trace-dispatcher/trace-dispatcher.cabal
@@ -60,7 +60,7 @@ library
                       , hostname
                       , network
                       , optparse-applicative-fork
-                      , ouroboros-network ^>= 0.11
+                      , ouroboros-network ^>= 0.12
                       , ouroboros-network-api
                       , ouroboros-network-framework
                       , serialise

--- a/trace-forward/trace-forward.cabal
+++ b/trace-forward/trace-forward.cabal
@@ -64,7 +64,7 @@ library
                       , deepseq
                       , extra
                       , io-classes
-                      , ouroboros-network-api ^>= 0.6
+                      , ouroboros-network-api ^>= 0.7
                       , ouroboros-network-framework
                       , serialise
                       , stm


### PR DESCRIPTION
# Description

Exposes the flags `--ssd-database-dir PATH`, `--ssd-snapshot-state` and `--ssd-snapshot-tables`  as requested in  #5697.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
