### PR TITLE
Add PARALLEL_TESTNETS flag

### DIFF
--- a/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
+++ b/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
@@ -30,55 +30,65 @@ import           Test.Tasty (TestTree)
 import qualified Test.Tasty.Ingredients as T
 
 tests :: IO TestTree
-tests = pure $ sequentialTestGroup "test/Spec.hs"
-  [ sequentialTestGroup "Spec"
-      [ sequentialTestGroup "Ledger Events"
-          [ H.ignoreOnWindows "Sanity Check" LedgerEvents.hprop_ledger_events_sanity_check
-          -- TODO: Replace foldBlocks with checkLedgerStateCondition
-          , T.testGroup "Governance"
-              -- FIXME Those tests are flaky
-              [ -- H.ignoreOnMacAndWindows "ProposeAndRatifyNewConstitution" LedgerEvents.hprop_ledger_events_propose_new_constitution
-                -- , H.ignoreOnWindows "InfoAction" LedgerEvents.hprop_ledger_events_info_action
-                H.ignoreOnWindows "ProposeNewConstitutionSPO" LedgerEvents.hprop_ledger_events_propose_new_constitution_spo
-              , H.ignoreOnWindows "DRepRetirement" DRepRetirement.hprop_drep_retirement
-              ]
-          , T.testGroup "Plutus"
-              [ H.ignoreOnWindows "PlutusV3" Cardano.Testnet.Test.Cli.Conway.Plutus.hprop_plutus_v3]
-          ]
-      , sequentialTestGroup "CLI"
-        [ H.ignoreOnWindows "Shutdown" Cardano.Testnet.Test.Node.Shutdown.hprop_shutdown
-        -- ShutdownOnSigint fails on Mac with
-        -- "Log file: /private/tmp/tmp.JqcjW7sLKS/kes-period-info-2-test-30c2d0d8eb042a37/logs/test-spo.stdout.log had no logs indicating the relevant node has minted blocks."
-        , H.ignoreOnMacAndWindows "ShutdownOnSigint" Cardano.Testnet.Test.Node.Shutdown.hprop_shutdownOnSigint
-        -- ShutdownOnSlotSynced FAILS Still. The node times out and it seems the "shutdown-on-slot-synced" flag does nothing
-        -- , H.ignoreOnWindows "ShutdownOnSlotSynced" Cardano.Testnet.Test.Node.Shutdown.hprop_shutdownOnSlotSynced
-        , sequentialTestGroup "Babbage"
-            [ H.ignoreOnMacAndWindows "leadership-schedule" Cardano.Testnet.Test.Cli.Babbage.LeadershipSchedule.hprop_leadershipSchedule -- FAILS
-            , H.ignoreOnWindows "stake-snapshot" Cardano.Testnet.Test.Cli.Babbage.StakeSnapshot.hprop_stakeSnapshot
-            , H.ignoreOnWindows "transaction" Cardano.Testnet.Test.Cli.Babbage.Transaction.hprop_transaction
+tests = do
+  testGroup <- runTestGroup <$> shouldRunInParallel
+  pure $ testGroup "test/Spec.hs"
+    [ testGroup "Spec"
+        [ testGroup "Ledger Events"
+            [ H.ignoreOnWindows "Sanity Check" LedgerEvents.hprop_ledger_events_sanity_check
+            -- TODO: Replace foldBlocks with checkLedgerStateCondition
+            , testGroup "Governance"
+                -- FIXME Those tests are flaky
+                [ -- H.ignoreOnMacAndWindows "ProposeAndRatifyNewConstitution" LedgerEvents.hprop_ledger_events_propose_new_constitution
+                  -- , H.ignoreOnWindows "InfoAction" LedgerEvents.hprop_ledger_events_info_action
+                  H.ignoreOnWindows "ProposeNewConstitutionSPO" LedgerEvents.hprop_ledger_events_propose_new_constitution_spo
+                , H.ignoreOnWindows "DRepRetirement" DRepRetirement.hprop_drep_retirement
+                ]
+            , testGroup "Plutus"
+                [ H.ignoreOnWindows "PlutusV3" Cardano.Testnet.Test.Cli.Conway.Plutus.hprop_plutus_v3]
             ]
-        -- TODO: Conway -  Re-enable when create-staked is working in conway again
-        --, sequentialTestGroup "Conway"
-        --  [ H.ignoreOnWindows "stake-snapshot" Cardano.Testnet.Test.Cli.Conway.StakeSnapshot.hprop_stakeSnapshot
-        --  ]
-          -- Ignored on Windows due to <stdout>: commitBuffer: invalid argument (invalid character)
-          -- as a result of the kes-period-info output to stdout.
-        , H.ignoreOnWindows "kes-period-info" Cardano.Testnet.Test.Cli.KesPeriodInfo.hprop_kes_period_info
-        , H.ignoreOnWindows "query-slot-number" Cardano.Testnet.Test.Cli.QuerySlotNumber.hprop_querySlotNumber
-        , H.ignoreOnWindows "foldBlocks receives ledger state" Cardano.Testnet.Test.FoldBlocks.prop_foldBlocks
-        ]
-
-      ]
-  , sequentialTestGroup "SubmitApi"
-      [ sequentialTestGroup "Babbage"
-          [ H.ignoreOnWindows "transaction" Cardano.Testnet.Test.SubmitApi.Babbage.Transaction.hprop_transaction
+        , testGroup "CLI"
+          [ H.ignoreOnWindows "Shutdown" Cardano.Testnet.Test.Node.Shutdown.hprop_shutdown
+          -- ShutdownOnSigint fails on Mac with
+          -- "Log file: /private/tmp/tmp.JqcjW7sLKS/kes-period-info-2-test-30c2d0d8eb042a37/logs/test-spo.stdout.log had no logs indicating the relevant node has minted blocks."
+          , H.ignoreOnMacAndWindows "ShutdownOnSigint" Cardano.Testnet.Test.Node.Shutdown.hprop_shutdownOnSigint
+          -- ShutdownOnSlotSynced FAILS Still. The node times out and it seems the "shutdown-on-slot-synced" flag does nothing
+          -- , H.ignoreOnWindows "ShutdownOnSlotSynced" Cardano.Testnet.Test.Node.Shutdown.hprop_shutdownOnSlotSynced
+          , testGroup "Babbage"
+              [ H.ignoreOnMacAndWindows "leadership-schedule" Cardano.Testnet.Test.Cli.Babbage.LeadershipSchedule.hprop_leadershipSchedule -- FAILS
+              , H.ignoreOnWindows "stake-snapshot" Cardano.Testnet.Test.Cli.Babbage.StakeSnapshot.hprop_stakeSnapshot
+              , H.ignoreOnWindows "transaction" Cardano.Testnet.Test.Cli.Babbage.Transaction.hprop_transaction
+              ]
+          -- TODO: Conway -  Re-enable when create-staked is working in conway again
+          --, testGroup "Conway"
+          --  [ H.ignoreOnWindows "stake-snapshot" Cardano.Testnet.Test.Cli.Conway.StakeSnapshot.hprop_stakeSnapshot
+          --  ]
+            -- Ignored on Windows due to <stdout>: commitBuffer: invalid argument (invalid character)
+            -- as a result of the kes-period-info output to stdout.
+          , H.ignoreOnWindows "kes-period-info" Cardano.Testnet.Test.Cli.KesPeriodInfo.hprop_kes_period_info
+          , H.ignoreOnWindows "query-slot-number" Cardano.Testnet.Test.Cli.QuerySlotNumber.hprop_querySlotNumber
+          , H.ignoreOnWindows "foldBlocks receives ledger state" Cardano.Testnet.Test.FoldBlocks.prop_foldBlocks
           ]
-      ]
-  ]
+
+        ]
+    , testGroup "SubmitApi"
+        [ testGroup "Babbage"
+            [ H.ignoreOnWindows "transaction" Cardano.Testnet.Test.SubmitApi.Babbage.Transaction.hprop_transaction
+            ]
+        ]
+    ]
+
+shouldRunInParallel :: IO Bool
+shouldRunInParallel = (== Just "1") <$> E.lookupEnv "PARALLEL_TESTNETS"
 
 -- FIXME Right now when running tests concurrently it makes them flaky
-sequentialTestGroup :: T.TestName -> [TestTree] -> TestTree
-sequentialTestGroup name = T.sequentialTestGroup name T.AllFinish
+runTestGroup
+  :: Bool -- ^ True to run in parallel
+  -> T.TestName
+  -> [TestTree]
+  -> TestTree
+runTestGroup True name = T.testGroup name
+runTestGroup False name = T.sequentialTestGroup name T.AllFinish
 
 ingredients :: [T.Ingredient]
 ingredients = T.defaultIngredients


### PR DESCRIPTION
# Description

This PR adds `PARALLEL_TESTNETS` environment flag which controls concurrent execution of testnets. By default concurrent execution is disabled.


This is also a workaround for broken `TASTY_PATTERN` which does not seem to work with `sequentialTestGroup`. To run a single test with a matching pattern, execute:
```bash
PARALLEL_TESTNETS=1 TASTY_PATTERN='/leadership-schedule/' cabal test cardano-testnet-test
```

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
