### PR TITLE
Update cardano-ping to the same version as cardano-cli

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -38,7 +38,7 @@ jobs:
 
     env:
       # Modify this value to "invalidate" the cabal cache.
-      CABAL_CACHE_VERSION: "2024-02-29"
+      CABAL_CACHE_VERSION: "2024-03-07"
 
     concurrency:
       group: >

--- a/README.rst
+++ b/README.rst
@@ -16,9 +16,9 @@
 
 .. contents:: Contents
 
-*************************
+*******************************************
 Overview of the ``cardano-node`` repository
-*************************
+*******************************************
 
 Integration of the `ledger <https://github.com/input-output-hk/cardano-ledger-specs>`_, `consensus <https://github.com/input-output-hk/ouroboros-consensus>`_,
 `networking <https://github.com/input-output-hk/ouroboros-network/tree/master/ouroboros-network>`_ and

--- a/cabal.project
+++ b/cabal.project
@@ -13,8 +13,8 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state:
-  , hackage.haskell.org 2024-02-27T08:06:51Z
-  , cardano-haskell-packages 2024-02-26T17:55:44Z
+  , hackage.haskell.org 2024-03-07T07:48:20Z
+  , cardano-haskell-packages 2024-03-05T10:16:08Z
 
 packages:
   cardano-git-rev

--- a/cardano-testnet/CHANGELOG.md
+++ b/cardano-testnet/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for cardano-testnet
 
+## Next version
+
+* Update `cardano-ping` dependency
+
 ## 8.7.0
 
 * Using `cardano-node-8.7.0`, `cardano-api-8.33` and `cardano-cli-8.15`

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -48,7 +48,7 @@ library
                       , cardano-ledger-core:testlib
                       , cardano-ledger-shelley
                       , cardano-node
-                      , cardano-ping ^>= 0.2.0.10
+                      , cardano-ping ^>= 0.2.0.13
                       , contra-tracer
                       , containers
                       , data-default-class

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1708970955,
-        "narHash": "sha256-k6Y9WjDej7wCkUowVi/tdsWP6EWUMZTSRU9r+4lMJmU=",
+        "lastModified": 1709731402,
+        "narHash": "sha256-7h4/ns3WRI3BtK1FbUEm6nMqW1ahNNehiHr7eQ03muk=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "f09964311e8894a5f09e258f308a9c3d4221f029",
+        "rev": "8e4f211a8e537c8c939b65e887556bd7441c774c",
         "type": "github"
       },
       "original": {
@@ -624,11 +624,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1708993343,
-        "narHash": "sha256-8EbbR5ReQK61yP/7VYtFSCerBXSE59VtfV+Wahdsuqg=",
+        "lastModified": 1709770751,
+        "narHash": "sha256-mL09hxG1rOpC01xXT2CriE1dfSVgSHxW2QaPOYJxjvA=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "f823c9258e9316cb4da256fc93e9c0407f0c296a",
+        "rev": "bb33c267712d3d27329eed24f67ab027cb48a1f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Description

* Same update as https://github.com/IntersectMBO/cardano-cli/pull/633, to make it easier to use a custom `cardano-cli`
* Prepare a future update of cardano-cli

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Any changes are noted in the `CHANGELOG.md` for affected package
- [X] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
- [X] Self-reviewed the diff