### PR TITLE
[workbench] modular configuration for genesis

### DIFF
--- a/nix/workbench/evaluate/evaluate.sh
+++ b/nix/workbench/evaluate/evaluate.sh
@@ -1,0 +1,70 @@
+# shellcheck shell=bash
+
+# This is a small wrapper around nix-instantiate, which is exposed as `wb evaluate`.
+
+usage_evaluate() {
+	cat <<-EOF
+		$(red USAGE:)
+
+		   $(helpcmd evaluate \[FLAGS..] \[ATTRS...])
+
+		   $(blue FLAGS):
+		      $(helpopt --profile-json PROFILE-JSON)     Import the specified profile
+		            defaults to $(yellow \$WB_SHELL_PROFILE_DATA/profile.json) if set
+
+		      $(helpopt --node-specs NODE-SPECS)         Import the specified environment specification
+		            defaults to $(yellow \$WB_SHELL_PROFILE_DATA/node-specs.json) if set
+
+		      $(helpopt --help)                          This help message
+
+		   $(blue ATTRS):
+		          List of attributes to evaluate, defaults to the whole configuration.
+
+		   Example:
+
+		   wb evaluate evaluate genesis.create-staked-args
+	EOF
+}
+
+evaluate() {
+	local profile_json node_specs
+	local attrs=()
+	local defaultAttrs=(--attr config)
+
+	while [ "$#" -gt 0 ]; do
+		case "$1" in
+		--)
+			extra_args+=("$@")
+			shift 1
+			break
+			;;
+		--help)
+			usage_evaluate
+			exit 1
+			;;
+		--profile)
+			profile_json=${2:?No value for argument $1}
+			shift 2
+			;;
+		--node-specs)
+			node_specs=${2:?No value for argument $1}
+			shift 2
+			;;
+		*)
+			attrs+=(--attr "config.$1")
+			shift 1
+			;;
+		esac
+	done
+
+  local err_missing_profile="You need to provide a profile: WB_SHELL_PROFILE_DATA is not set and at least one of --profile-json or --node-specs is missing."
+  profile_json=${profile_json:-${WB_SHELL_PROFILE_DATA:?$err_missing_profile}/profile.json}
+  node_specs=${node_specs:-${WB_SHELL_PROFILE_DATA:?$err_missing_profile}/node-specs.json}
+
+	nix-instantiate --eval --strict --json --no-warn-dirty --show-trace \
+		--argstr profile-json "${profile_json}" \
+		--argstr node-specs "${node_specs}" \
+		"$WB_CARDANO_NODE_REPO_ROOT/nix/workbench/wb.nix" \
+		"${attrs[@]:-${defaultAttrs[@]}}" \
+		"${extra_args[@]}"
+}

--- a/nix/workbench/genesis/genesis.jq
+++ b/nix/workbench/genesis/genesis.jq
@@ -5,7 +5,7 @@ def fmt_decimal_10_5($x):
 
 def profile_cli_args($p):
 { common:
-  { createStackedArgs:
+  { createStakedArgs:
     ([ "--supply",                 fmt_decimal_10_5($p.genesis.funds_balance)
      , "--gen-utxo-keys",          1
      , "--gen-genesis-keys",       $p.composition.n_bft_hosts

--- a/nix/workbench/lib.sh
+++ b/nix/workbench/lib.sh
@@ -179,12 +179,21 @@ red() {
     eval $restore_trace
 }
 
+info() {
+    eval $muffle_trace_set_exit
+
+    local subsys=$1; shift
+    msg "$(with_color cyan "$subsys"):  $*"
+
+    eval $restore_trace
+}
+
 verbose() {
     eval $muffle_trace_set_exit
 
     if test -n "${verbose:-}"
     then local subsys=$1; shift
-         msg "$(with_color blue $subsys):  $*"
+         msg "$(with_color blue "$subsys"):  $*"
     fi
 
     eval $restore_trace
@@ -194,7 +203,7 @@ progress() {
     eval $muffle_trace_set_exit
 
     local subsys=$1; shift
-    msg "$(with_color green $subsys):  $(with_color blue "$@")"
+    msg "$(with_color green "$subsys"):  $(with_color blue "$@")"
 
     eval $restore_trace
 }

--- a/nix/workbench/modules/documentation.nix
+++ b/nix/workbench/modules/documentation.nix
@@ -1,0 +1,21 @@
+{ options, lib, pkgs, ... }:
+
+#
+# Documentation generation
+#
+
+with lib;
+
+let docs = pkgs.nixosOptionsDoc { inherit options; };
+in
+
+{
+  options.documentation = mkOption {
+    description = "Documentation";
+    type = with types; attrsOf package;
+  };
+
+  config.documentation = {
+    inherit (docs) optionsAsciiDoc optionsCommonMark optionsJSON;
+  };
+}

--- a/nix/workbench/modules/genesis.nix
+++ b/nix/workbench/modules/genesis.nix
@@ -1,0 +1,321 @@
+{ config, pkgs, lib, ... }:
+
+#
+# Module describing the genesis component of a profile.
+#
+
+with lib;
+
+let
+  json = pkgs.formats.json { };
+
+  # handy aliases
+  inherit (config) composition derived genesis;
+in
+
+{
+  options = {
+    genesis = {
+      ## NOTE: The following defaults follow the values in prof0-defaults
+
+      ## Trivia
+
+      network_magic = mkOption {
+        description = "The network magic id";
+        type = types.ints.unsigned;
+        default = 42;
+      };
+
+      ## Incrementality
+
+      single_shot = mkOption {
+        description = "Incrementality: single_shot";
+        type = types.bool;
+        default = true;
+      };
+
+      ## UTxO & delegation
+
+      per_pool_balance = mkOption {
+        # part of the profile
+        description = "UTxO & delegation: per_pool_balance";
+        type = types.int;
+        default = 1000000000000000;
+      };
+
+      funds_balance = mkOption {
+        description = "UTxO & delegation: funds_balance";
+        type = types.int;
+        default = 10000000000000;
+      };
+
+      utxo = mkOption {
+        description = "UTxO & delegation: utxo";
+        type = types.int;
+        default = 0;
+      };
+
+      ## Blockchain time & block density
+
+      active_slots_coeff = mkOption {
+        description = "Blockchain time & block density: active_slots_coeff";
+        type = types.float;
+        default = 0.05;
+      };
+
+      epoch_length = mkOption {
+        description = "Blockchain time & block density: epoch_length. Ought to be at least (10 * k / f)";
+        type = types.ints.unsigned;
+        default = 600;
+      };
+
+      parameter_k = mkOption {
+        description = "Blockchain time & block density: k";
+        type = types.ints.unsigned;
+        default = 3;
+      };
+
+      slot_duration = mkOption {
+        description = "Blockchain time & block density: slot_duration";
+        type = types.ints.unsigned;
+        default = 1;
+      };
+
+      ## Protocol parameters
+
+      pparamsEpoch = mkOption {
+        description = "Blockchain time & block density: pparamsEpoch";
+        type = types.ints.unsigned;
+        default = 300;
+        # NOTE: See pparams/epoch-timeline.jq
+      };
+
+      pparamsOverlays = mkOption {
+        description = "Blockchain time & block density: pparamsOverlays";
+        type = types.anything; # FIXME: is this right?
+        default = [ ];
+      };
+
+      ##
+      ## NOTE: The following options are defined in prof3-derived.
+      ##
+
+      delegator_coin = mkOption {
+        description = "delegator_coin";
+        type = types.ints.unsigned;
+      };
+
+      delegators = mkOption {
+        description = "delegators";
+        type = types.ints.unsigned;
+      };
+
+      pool_coin = mkOption {
+        # Only needed for genesis creation, to be removed from profile
+        description = "pool_coin";
+        type = types.ints.unsigned;
+      };
+
+      # NOTE:
+      #
+      # In defining the options for the genesis templates, we use mkDefault in the definition
+      # of the submodule, rather than specifying a default value for the option.
+      #
+      # i.e.
+      #
+      # { type = submodule { freeformType = _; config = mkDefault { a = 1; b = 2; }; }; default = { }; }
+      #
+      # rather than
+      #
+      # { type = submodule { freeformType = _; }; default = { a = 1; b = 2; }; }
+      #
+      # In this way each single value is a default value. While in the second case the default
+      # value would be all or nothing.
+      #
+      # i.e.
+      #
+      # (evalModules {
+      #   modules = [{
+      #     options.abc = mkOption {
+      #       type = types.submodule {
+      #         freeformType = (pkgs.formats.json { }).type;
+      #         config = mkDefault { a = 1; b = 2; };
+      #       };
+      #     };
+      #     config.abc.a = 10;
+      #   }];
+      # }).config
+      #
+      # evaluates to
+      #
+      # { abc = { a = 10; b = 2; }; }
+      #
+      # while
+      #
+      # (evalModules {
+      #   modules = [{
+      #     options.abc = mkOption {
+      #       type = types.submodule {
+      #         freeformType = (pkgs.formats.json { }).type;
+      #       };
+      #       default = { a = 1; b = 2; };
+      #     };
+      #     config.abc.a = 10;
+      #   }];
+      # }).config
+      #
+      # evaluates to
+      #
+      # { abc = { a = 10; }; }
+
+      alonzo = mkOption {
+        description = "The Alonzo genesis template";
+        type = types.submodule {
+          freeformType = json.type;
+          # See note above about mkDefault
+          config = mkDefault (importJSON ../profile/presets/mainnet/genesis/genesis.alonzo.json);
+        };
+        default = { };
+      };
+
+      shelley = mkOption {
+        description = "The Shelley genesis template";
+        type = types.submodule {
+          freeformType = json.type;
+          # See note above about mkDefault
+          config = mkDefault (importJSON ../profile/presets/mainnet/genesis/genesis-shelley.json);
+        };
+        default = { };
+      };
+
+      conway = mkOption {
+        description = "The Conway genesis template";
+        type = types.submodule {
+          freeformType = json.type;
+          # See note above about mkDefault
+          config = mkDefault (importJSON ../profile/presets/mainnet/genesis/genesis.conway.json);
+        };
+        default = { };
+      };
+
+      byron = mkOption {
+        description = "Byron protocol parameters";
+        type = types.submodule {
+          freeformType = json.type;
+          config = mkDefault {
+            heavyDelThd = "300000";
+            maxBlockSize = "641000";
+            maxHeaderSize = "200000";
+            maxProposalSize = "700";
+            maxTxSize = "4096";
+            mpcThd = "200000";
+            scriptVersion = 0;
+            slotDuration = "20000";
+            softforkRule = {
+              initThd = "900000";
+              minThd = "600000";
+              thdDecrement = "100000";
+            };
+            txFeePolicy = {
+              multiplier = "439460";
+              summand = "155381";
+            };
+            unlockStakeEpoch = "184467";
+            updateImplicit = "10000";
+            updateProposalThd = "100000";
+            updateVoteThd = "100000";
+          };
+        };
+        default = { };
+      };
+
+      create-staked-args = mkOption {
+        description = "Arguments to cardano-cli genesis create-staked";
+        type = types.separatedString " ";
+      };
+
+      byron-genesis-args = mkOption {
+        description = "Arguments to cardano-cli byron genesis genesis";
+        type = types.separatedString " ";
+      };
+
+      pool-relays = mkOption {
+        description = "pool-relays.json";
+        type = types.submodule { freeformType = json.type; };
+      };
+
+      cache-key = mkOption {
+        type = types.str;
+        readOnly = true;
+      };
+
+      cache-key-input = mkOption {
+        type = types.submodule { freeformType = json.type; };
+        readOnly = true;
+      };
+
+      extra_future_offset = mkOption {
+        description = ''
+          Blockchain time & block density: extra_future_offset.
+
+          Related to automation, genesis creation takes some time and it cannot be created in the future or too far in the past. It depends on the dataset size.
+        '';
+        type = types.ints.unsigned;
+        default = 0;
+      };
+    };
+  };
+
+  config = {
+    genesis = {
+      create-staked-args = concatStringsSep " " ([
+        "--supply ${toString genesis.funds_balance}"
+        "--gen-utxo-keys 1"
+        "--gen-genesis-keys ${toString composition.n_bft_hosts}"
+        "--supply-delegated ${toString derived.supply_delegated}"
+        "--gen-pools ${toString composition.n_pools}"
+        "--gen-stake-delegs ${toString derived.delegators_effective}"
+        "--num-stuffed-utxo ${toString derived.utxo_stuffed}"
+        "--testnet-magic ${toString genesis.network_magic}"
+      ]
+      ++ optional (composition.dense_pool_density != 1) [
+        "--bulk-pool-cred-files ${toString composition.n_dense_hosts}"
+        "--bulk-pools-per-file ${toString composition.dense_pool_density}"
+      ]);
+
+      byron-genesis-args = concatStringsSep " " ([
+        "--k ${toString genesis.parameter_k}"
+        "--protocol-magic ${toString genesis.network_magic}"
+        "--n-poor-addresses 1"
+        "--n-delegate-addresses 1"
+        "--total-balance 300000"
+        "--delegate-share 0.9"
+        "--avvm-entry-count 0"
+        "--avvm-entry-balance 0"
+      ]);
+
+      cache-key-input = {
+        inherit (composition) n_pools n_bft_hosts n_dense_hosts dense_pool_density;
+        inherit (derived) utxo_stuffed;
+        inherit (genesis) delegators funds_balance network_magic per_pool_balance pool_coin;
+      };
+
+      cache-key =
+        concatStringsSep "-"
+          ([ "k${toString composition.n_pools}" ]
+            ++ optional (composition.dense_pool_density != 1) "d${toString composition.dense_pool_density}"
+            ++ [
+            "${toString (genesis.delegators / 1000)}kD"
+            "${toString (derived.utxo_stuffed / 1000)}kU"
+            (substring 0 7 (builtins.hashString "sha1" (builtins.toJSON genesis.cache-key-input)))
+          ]);
+
+      pool-relays = mapAttrs'
+        (name: value: {
+          name = toString value.i;
+          value = [{ "single host name" = { dnsName = name; port = value.port; }; }];
+        })
+        config.node-specs;
+    };
+  };
+}

--- a/nix/workbench/modules/profile.nix
+++ b/nix/workbench/modules/profile.nix
@@ -1,0 +1,37 @@
+{ lib, pkgs, ... }:
+
+#
+# Configuration for a workbench profile.
+#
+# The overall structure matches what we currently have in profile.json,
+# but so far it only includes what is needed for the genesis creation.
+#
+
+with lib;
+
+let format = pkgs.formats.json { }; in
+
+{
+  imports = [
+    ./genesis.nix
+  ];
+
+  options = {
+    # The following containts only what is required for genesis.
+
+    composition = mkOption {
+      type = types.submodule { freeformType = format.type; };
+      default = { };
+    };
+
+    derived = mkOption {
+      type = types.submodule { freeformType = format.type; };
+      default = { };
+    };
+
+    node-specs = mkOption {
+      type = types.submodule { freeformType = format.type; };
+      default = { };
+    };
+  };
+}

--- a/nix/workbench/wb
+++ b/nix/workbench/wb
@@ -35,8 +35,7 @@ global_basedir=${global_basedir:-$(realpath "$(dirname "$0")")}
 
 usage_main() {
     set +x
-    test $# -lt 1 ||
-        msg "Unknown op: $1"
+    test $# -lt 1 || msg "Unknown op: $1"
      __usage "OP" "Top-level OPs" <<EOF
     $(red profile)      ($(red p))      Cluster profile ops.  Default subop is $(yellow $profile_default_op)
     $(red run)          ($(red r))      Managing cluster runs.  Default subop is $(yellow $run_default_op)
@@ -64,7 +63,7 @@ usage_extra() {
 	cat >&2 <<EOF
   $(blue Extra top-level OPs):
 
-    $(red start $(green [FLAGS..]))       Start a run of profile chosen at 'nix-shell' entry
+    $(red start $(green \[FLAGS..]))       Start a run of profile chosen at 'nix-shell' entry
     $(red finish)                Finish an active cluster run
     $(red scenario)     ($(red s))      Run scenario control
     $(red backend)      ($(red b))      Backend calls
@@ -115,7 +114,7 @@ $(red USAGE:)
 
    $(blue Flags):
 
-      $(helpopt --batch-name NAME)               Override the batch name (default: $(green ${batchName:-default}))
+      $(helpopt --batch-name NAME)               Override the batch name (default: $(green "${batchName:-default}"))
 
       $(helpopt --iterations \| --times \| --iter \| -n ITERATIONS)
                                       Run this many iterations of the profile.
@@ -150,7 +149,6 @@ start() {
     local node_rev=
     local ident=${ID:-}
     local cabal_mode=
-    local skip_prebuild=
     local prebuild_done=
     local manifest="{}"
     local iterations=1
@@ -167,8 +165,8 @@ start() {
         --batch-name )                   batch_name=$2;   shift;;
         --ident )                        ident=$2; shift;;
         --iterations | --times | --iter | -n ) iterations=$2; no_retry_failed_runs=; shift;;
-        --cache-dir )                    setenvjqstr 'cacheDir' $2; shift;;
-        --base-port )                    setenvjq    'basePort' $2; shift;;
+        --cache-dir )                    setenvjqstr 'cacheDir' "$2"; shift;;
+        --base-port )                    setenvjq    'basePort' "$2"; shift;;
 
         --backend-data )                 backend_data=$2; shift;;
 
@@ -197,7 +195,6 @@ start() {
         --verbose | -v )                 export verbose=t;;
         --trace | --debug )              set -x;;
         --trace-wb | --trace-workbench ) export WB_EXTRA_FLAGS=--trace;;
-        --skip-prebuild | -sp )          skip_prebuild=t;;
 
         --help )                         usage_start
                                          exit 1;;
@@ -248,24 +245,25 @@ start() {
        current_run_path=$(run current-path)
        mkdir -p "$current_run_path"
 
-       run ${run_args[@]} 'start'    ${run_start_args[@]} $run
+       run "${run_args[@]}" start "${run_start_args[@]}" "$run"
 
-       if test -n "$no_analysis" -o $analysis_type = null; then continue; fi
+       if test -n "$no_analysis" -o "$analysis_type" = null; then continue; fi
 
-       progress "top-level | analysis" "analysis type $(with_color yellow $analysis_type) on $(with_color white $run)"
+       progress "top-level | analysis" "analysis type $(with_color yellow "$analysis_type") on $(with_color white "$run")"
 
-       local runspec=$(test -n "$ident" && echo $ident:)$run
-       analyse ${analyse_args[@]} $analysis_type $runspec &&
-           progress "run | analysis" "done for $(white $runspec)" ||
+       local runspec=$(test -n "$ident" && echo "$ident":)$run
+
+       analyse "${analyse_args[@]}" "$analysis_type" "$runspec" &&
+           progress "run | analysis" "done for $(white "$runspec")" ||
            if test -n "$analysis_can_fail" -a -z "$no_retry_failed_runs"
-           then progress "run | analysis" "log processing failed, but --analysis-can-fail prevents failure:  $(with_color red $runspec)"
+           then progress "run | analysis" "log processing failed, but --analysis-can-fail prevents failure:  $(with_color red "$runspec")"
                 iterations=$((iterations + 1))
            else fail "analysis failed:  $run"
                 false; fi
     done
 
-    if test -z "$no_analysis" -a $analysis_type != null -a $iterations -gt 1
-    then analyse variance ${runs[*]}
+    if test -z "$no_analysis" -a "$analysis_type" != null -a "$iterations" -gt 1
+    then analyse variance "${runs[@]}"
     fi
 }
 

--- a/nix/workbench/wb
+++ b/nix/workbench/wb
@@ -7,6 +7,9 @@ export LANG=C.UTF-8
 
 global_basedir=${global_basedir:-$(realpath "$(dirname "$0")")}
 
+# By default the new genesis creation is disabled
+: "${WB_MODULAR_GENESIS:=0}"
+
 . "$global_basedir"/lib.sh
 . "$global_basedir"/env.sh
 . "$global_basedir"/chaindb.sh
@@ -20,6 +23,8 @@ global_basedir=${global_basedir:-$(realpath "$(dirname "$0")")}
 . "$global_basedir"/profile/profile.sh
 . "$global_basedir"/genesis/genesis.sh
 . "$global_basedir"/topology/topology.sh
+
+. "$global_basedir"/evaluate/evaluate.sh
 
 . "$global_basedir"/backend/backend.sh
 . "$global_basedir"/backend/nomad.sh
@@ -38,23 +43,25 @@ usage_main() {
     $(red analyse)      ($(red a))      Analyse cluster runs.  Default subop is $(yellow $analyse_default_op)
     $(red publish)      ($(red u))      Bench data publish.  Default subop is $(yellow $publish_default_op)
 
-  $(blue Secondary top-level OPs):
+    $(blue Secondary top-level OPs):
 
     $(red chaindb)      ($(red c))      ChainDB
     $(red genesis)      ($(red g))      Genesis
     $(red nomad)        ($(red n))      Nomad and Vault
     $(red topology)     ($(red t))      Topology generation
+    $(red evaluate)     ($(red e))      Evaluate workbench module-based configuration
 
-  $(white wb) $(blue options):
+    $(white wb) $(blue options):
 
     $(helpopt --trace / --debug)        Enable workbench tracing (for error reports) ('set -x')
+    $(helpopt --enable-modular-genesis) Enable NixOS modules based genesis configuration
     $(helpopt --help)                   This short help
     $(helpopt --help-full / --aliases)  Extended help (extra ops & subop aliases)
 EOF
 }
 
 usage_extra() {
-    cat >&2 <<EOF
+	cat >&2 <<EOF
   $(blue Extra top-level OPs):
 
     $(red start $(green [FLAGS..]))       Start a run of profile chosen at 'nix-shell' entry
@@ -104,7 +111,7 @@ usage_start()
 {
     cat <<EOF
 $(red USAGE:)
-   $(helpcmd start [FLAGS..])
+   $(helpcmd start \[FLAGS..])
 
    $(blue Flags):
 
@@ -135,8 +142,7 @@ $(red USAGE:)
 EOF
 }
 
-start()
-{
+start() {
     local batch_name=
     local profile_data=
     local backend_data=
@@ -146,7 +152,6 @@ start()
     local cabal_mode=
     local skip_prebuild=
     local prebuild_done=
-    local genesis_cache_entry_dir=
     local manifest="{}"
     local iterations=1
     local no_retry_failed_runs=t
@@ -277,8 +282,9 @@ finish()
 
 while test $# -gt 0
 do case "$1" in
-       --nomad      | --backend-nomad )      export WB_BACKEND=nomad;;
-       --supervisor | --backend-supervisor ) export WB_BACKEND=supervisor;;
+       --nomad      | --backend-nomad )      export WB_BACKEND=nomad      ;;
+       --supervisor | --backend-supervisor ) export WB_BACKEND=supervisor ;;
+       --enable-modular-genesis )            export WB_MODULAR_GENESIS=1  ;;
 
        --cls )                          echo -en "\ec">&2;;
        --verbose | -v )                 export verbose=t;;
@@ -302,9 +308,10 @@ main() {
         ## Public, secondary:
         profile      | profiles | prof | ps | p )
                                   profile             "$@";;
-        run          | runs | r ) run                 "$@";;
+        run          | r )        run                 "$@";;
         analyse      | a )        analyse             "$@";;
         publish      | u )        publish             "$@";;
+        evaluate     | e )        evaluate            "$@";;
 
         ## Public, internals-y:
         chaindb      | c )        chaindb             "$@";;
@@ -318,7 +325,7 @@ main() {
         | profile-json                          | pj            \
         | profile-describe         | pdesc      | pd            \
         | profile-node-specs       | node-specs | specs         \
-          )                       profile $op         "$@";;
+          )                       profile "$op"        "$@";;
 
         ## 'run' aliases:
           list-runs                | runs       | lsr           \
@@ -348,17 +355,21 @@ main() {
         | trace-frequencies        | trace-freq | freq | tf     \
         | chain-rejecta-reasons    | chain-rejecta | rejecta    \
         | render-comparison-pdf    | render-pdf | pdf           \
-          )                       analyse $op         "$@";;
+          )                       analyse "$op"        "$@";;
 
         ## Internals:
         #
         scenario     | s )        scenario            "$@";;
         backend      | b )        backend             "$@";;
         call )                                        "$@";;
-        path )                    echo     $global_basedir;;
+        path )                    echo "$global_basedir"  ;;
 
         ## Bail for help:
-        * ) usage_main "$op"; exit 1;; esac
+        * )
+          usage_main "$op"
+          exit 1
+          ;;
+    esac
 }
 
 main "$@"

--- a/nix/workbench/wb.nix
+++ b/nix/workbench/wb.nix
@@ -1,0 +1,20 @@
+let profileData = builtins.getEnv "WB_SHELL_PROFILE_DATA"; in
+{
+  # NOTE: this is a bit of a roundabout way to import legacyPackages as defined in the flake.
+  # It goes thorugh flake-compat.
+  pkgs ? import ../. { }
+, profile-json ? "${profileData}/profile.json"
+, node-specs ? "${profileData}/node-specs.json"
+}:
+
+with pkgs.lib;
+
+evalModules {
+  modules = [
+    ./modules/documentation.nix
+    ./modules/profile.nix
+    { _module.args = { inherit pkgs; }; }
+    { _file = profile-json; inherit (importJSON profile-json) composition derived genesis; }
+    { _file = node-specs; node-specs = importJSON node-specs; }
+  ];
+}


### PR DESCRIPTION
# Description

This introduces a new way to configure the genesis creation, based on
NixOS modules (see [1] and [2] for reference). This replaces some of
the complex jq-based logic present in the workbench.

The new code path is enabled only if either
- the environment variable WB_MODULAR_GENESIS is set to 1
- the option --enable-modular-genesis is passed to `wb`

Workbench changes:
- Introduce configuration modules in `nix/workbench/modules`
- Add `wb evaluate` command to evaluate the configuration

[1] https://nix.dev/tutorials/module-system/module-system
[2] https://nixos.org/manual/nixos/stable/#sec-writing-modules

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
