### PR TITLE
cardano-testnet: better API for using custom genesis files

### DIFF
--- a/cardano-testnet/src/Cardano/Testnet.hs
+++ b/cardano-testnet/src/Cardano/Testnet.hs
@@ -13,6 +13,8 @@ module Cardano.Testnet (
   TestnetNodeOptions(..),
   cardanoDefaultTestnetOptions,
   cardanoDefaultTestnetNodeOptions,
+  getDefaultAlonzoGenesis,
+  getDefaultShelleyGenesis,
 
   -- * Configuration
   Conf(..),

--- a/cardano-testnet/src/Testnet/Start/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Start/Cardano.hs
@@ -262,13 +262,12 @@ cardanoTestnet
       (tmpAbsPath </> "byron.genesis.spec.json")
       (tmpAbsPath </> "byron-gen-command")
 
-    -- Write Alonzo genesis file
-    alonzoGenesisJsonFile <- H.noteShow $ tmpAbsPath </> "genesis.alonzo.spec.json"
-    H.evalIO $ LBS.writeFile alonzoGenesisJsonFile $ Aeson.encode alonzoGenesis
-
-    -- Write Conway genesis file
-    conwayGenesisJsonFile <- H.noteShow $ tmpAbsPath </> "genesis.conway.spec.json"
-    H.evalIO $ LBS.writeFile conwayGenesisJsonFile $ Aeson.encode conwayGenesis
+    -- Write specification files. Those are the same as the genesis files
+    -- used for launching the nodes, but omitting the content regarding stake, utxos, etc.
+    -- They are used by benchmarking: as templates to CLI commands,
+    -- as evidence of what was run, and as cache keys.
+    writeGenesisSpecFile "alonzo" alonzoGenesis
+    writeGenesisSpecFile "conway" conwayGenesis
 
     configurationFile <- H.noteShow $ tmpAbsPath </> "configuration.yaml"
 
@@ -423,5 +422,10 @@ cardanoTestnet
       H.assertExpectedSposInLedgerState stakePoolsFp testnetOptions execConfig
 
       pure runtime
+  where
+    writeGenesisSpecFile :: (MonadTest m, MonadIO m, HasCallStack) => ToJSON a => FilePath -> a -> m ()
+    writeGenesisSpecFile eraName toWrite = GHC.withFrozenCallStack $ do
+      genesisJsonFile <- H.noteShow $ tmpAbsPath </> "genesis." <> eraName <> ".spec.json"
+      H.evalIO $ LBS.writeFile genesisJsonFile $ Aeson.encode toWrite
 
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Node/Shutdown.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Node/Shutdown.hs
@@ -13,13 +13,13 @@ module Cardano.Testnet.Test.Node.Shutdown
 import           Cardano.Api
 
 import           Cardano.Testnet
+import qualified Cardano.Testnet as Testnet
 
 import           Prelude
 
 import           Control.Monad
 import           Data.Aeson
 import           Data.Aeson.Types
-import           Data.Bifunctor
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import           Data.Either (isRight)
 import qualified Data.List as L
@@ -96,7 +96,7 @@ hprop_shutdown = H.integrationRetryWorkspace 2 "shutdown" $ \tempAbsBasePath' ->
 
   -- 2. Create Alonzo genesis
   alonzoBabbageTestGenesisJsonTargetFile <- H.noteShow $ tempAbsPath' </> shelleyDir </> "genesis.alonzo.spec.json"
-  gen <- H.evalEither $ first (docToString . prettyError) defaultAlonzoGenesis
+  gen <- Testnet.getDefaultAlonzoGenesis
   H.evalIO $ LBS.writeFile alonzoBabbageTestGenesisJsonTargetFile $ encode gen
 
   -- 2. Create Conway genesis


### PR DESCRIPTION
# Context

Right now, if you want to create a testnet using custom genesis files, it's cumbersome, because you need to provide a [shelley genesis file](https://github.com/IntersectMBO/cardano-node/blob/c862dfef5b34b62cd6268eaf4137c7d1cba42421/cardano-testnet/src/Testnet/Start/Cardano.hs#L103) with the [right timestamp](https://github.com/IntersectMBO/cardano-node/blob/c862dfef5b34b62cd6268eaf4137c7d1cba42421/cardano-testnet/src/Testnet/Start/Cardano.hs#L106). This is clunky.

The same goes for [providing the default alonzo genesis file](https://github.com/IntersectMBO/cardano-node/blob/c862dfef5b34b62cd6268eaf4137c7d1cba42421/cardano-testnet/src/Testnet/Start/Cardano.hs#L198), obtaining it [is clunky](https://github.com/IntersectMBO/cardano-node/blob/master/cardano-testnet/src/Testnet/Defaults.hs#L84).

# What this PR does

This PR provides new functions to obtain the shelley and alonzo genesis files that are not clunky, because they deal with clunkiness of obtaining those files within the test monad. So from within tests, those functions are handy.

This new API will be used in upcoming PRs of mine.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] CI passes.
- [X] Self-reviewed the diff