### PR TITLE
Prepare update of cardano-cli to TODO and cardano-api to 8.40.0.0

### DIFF
--- a/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
+++ b/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
@@ -73,7 +73,7 @@ library
   -- IOG dependencies
   --------------------------
   build-depends:
-    , cardano-api             ^>= 8.39.2.0
+    , cardano-api             ^>= 8.40.0.0
     , plutus-ledger-api       >=1.0.0
     , plutus-tx               >=1.0.0
     , plutus-tx-plugin        ^>=1.21

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -100,7 +100,7 @@ library
                       , attoparsec-aeson
                       , base16-bytestring
                       , bytestring
-                      , cardano-api ^>= 8.39.2.0
+                      , cardano-api ^>= 8.40.0.0
                       , cardano-binary
                       , cardano-cli ^>= 8.20.3.0
                       , cardano-crypto-class

--- a/cabal.project
+++ b/cabal.project
@@ -13,8 +13,8 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state:
-  , hackage.haskell.org 2024-03-07T07:48:20Z
-  , cardano-haskell-packages 2024-03-05T10:16:08Z
+  , hackage.haskell.org 2024-03-14T09:21:08Z
+  , cardano-haskell-packages 2024-03-14T09:14:40Z
 
 packages:
   cardano-git-rev

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -144,7 +144,7 @@ library
                       , async
                       , base16-bytestring
                       , bytestring
-                      , cardano-api ^>= 8.39.2.0
+                      , cardano-api ^>= 8.40.0.0
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
                       , cardano-git-rev

--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -39,7 +39,7 @@ library
                       , aeson
                       , async
                       , bytestring
-                      , cardano-api ^>= 8.39.2.0
+                      , cardano-api ^>= 8.40.0.0
                       , cardano-binary
                       , cardano-cli ^>= 8.20.3.0
                       , cardano-crypto-class ^>= 2.1.2

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -34,7 +34,7 @@ library
   build-depends:        aeson
                       , ansi-terminal
                       , bytestring
-                      , cardano-api ^>= 8.39.2.0
+                      , cardano-api ^>= 8.40.0.0
                       , cardano-cli ^>= 8.20.3.0
                       , cardano-crypto-class
                       , cardano-crypto-wrapper

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1709731402,
-        "narHash": "sha256-7h4/ns3WRI3BtK1FbUEm6nMqW1ahNNehiHr7eQ03muk=",
+        "lastModified": 1710408447,
+        "narHash": "sha256-zfERQOTVkZp4DDIrRE6V5xLMd5DRnXEdRn89WlLEJvI=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "8e4f211a8e537c8c939b65e887556bd7441c774c",
+        "rev": "37b94f464b015f4f5857c7c20f82347cb5f79af9",
         "type": "github"
       },
       "original": {
@@ -624,11 +624,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1709770751,
-        "narHash": "sha256-mL09hxG1rOpC01xXT2CriE1dfSVgSHxW2QaPOYJxjvA=",
+        "lastModified": 1710375729,
+        "narHash": "sha256-L4aXTQeVFNNni1a1ktZ6aMj2QPl9vZg244V5M0ZlUPw=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "bb33c267712d3d27329eed24f67ab027cb48a1f0",
+        "rev": "42b004321911ea41f0b117393f758dbc929655c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Description

This PR updates `cardano-cli` to TODO (blocked on https://github.com/IntersectMBO/cardano-cli/pull/646 being merged and released) and `cardano-api` to 8.40.0.0. So far this PR has been tested locally with a locally-updated `cardano-cli`.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] The version bounds in `.cabal` files are updated
- [X] CI passes.
- [X] Self-reviewed the diff