### PR TITLE
testnet: fix that custom genesis files were not passed to create-testnet-data

### DIFF
--- a/cardano-testnet/src/Testnet/Components/Configuration.hs
+++ b/cardano-testnet/src/Testnet/Components/Configuration.hs
@@ -6,9 +6,10 @@
 {-# LANGUAGE TypeApplications #-}
 
 module Testnet.Components.Configuration
-  ( convertToEraString
+  ( anyEraToString
   , createConfigYaml
   , createSPOGenesisAndFiles
+  , eraToString
   , mkTopologyConfig
   , numSeededUTxOKeys
   , NumPools
@@ -17,9 +18,9 @@ module Testnet.Components.Configuration
 
 import           Cardano.Api.Ledger (StandardCrypto)
 import           Cardano.Api.Shelley hiding (Value, cardanoEra)
+
 import           Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis)
 import           Cardano.Ledger.Conway.Genesis (ConwayGenesis)
-
 import qualified Cardano.Node.Configuration.Topology as NonP2P
 import qualified Cardano.Node.Configuration.TopologyP2P as P2P
 import           Ouroboros.Network.PeerSelection.Bootstrap
@@ -31,20 +32,22 @@ import           Control.Monad
 import           Control.Monad.Catch (MonadCatch)
 import           Data.Aeson
 import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as Aeson
 import qualified Data.Aeson.Lens as L
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.List as List
 import           Data.String
+import qualified Data.Text as Text
 import           GHC.Stack (HasCallStack)
 import qualified GHC.Stack as GHC
 import           Lens.Micro
-import           System.FilePath.Posix (takeDirectory, (</>))
+import           System.FilePath.Posix (takeDirectory, takeFileName, (</>))
 
 import           Testnet.Defaults
 import           Testnet.Filepath
 import           Testnet.Process.Run (execCli_)
 import           Testnet.Property.Utils
-import           Testnet.Start.Types (CardanoTestnetOptions (..))
+import           Testnet.Start.Types (CardanoTestnetOptions (..), anyEraToString, eraToString)
 
 import           Hedgehog
 import qualified Hedgehog as H
@@ -52,31 +55,28 @@ import qualified Hedgehog.Extras.Stock.Time as DTC
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
-createConfigYaml
-  :: (MonadTest m, MonadIO m, HasCallStack)
+-- | Returns JSON encoded hashes of the era, as well as the hard fork configuration toggle.
+createConfigYaml :: ()
+  => (MonadTest m, MonadIO m, HasCallStack)
   => TmpAbsolutePath
-  -> AnyCardanoEra
+  -> AnyCardanoEra -- ^ The era used for generating the hard fork configuration toggle
   -> m LBS.ByteString
-createConfigYaml (TmpAbsolutePath tempAbsPath') anyCardanoEra' = GHC.withFrozenCallStack $ do
-  -- Add Byron, Shelley and Alonzo genesis hashes to node configuration
-  -- TODO: These genesis filepaths should not be hardcoded. Using the cli as a library
-  -- rather as an executable will allow us to get the genesis files paths in a more
-  -- direct fashion.
-
-  byronGenesisHash <- getByronGenesisHash $ tempAbsPath' </> "byron/genesis.json"
-  shelleyGenesisHash <- getShelleyGenesisHash (tempAbsPath' </> defaultShelleyGenesisFp) "ShelleyGenesisHash"
-  alonzoGenesisHash <- getShelleyGenesisHash (tempAbsPath' </> "shelley/genesis.alonzo.json") "AlonzoGenesisHash"
-  conwayGenesisHash <- getShelleyGenesisHash (tempAbsPath' </> "shelley/genesis.conway.json") "ConwayGenesisHash"
-
+createConfigYaml (TmpAbsolutePath tempAbsPath) era = GHC.withFrozenCallStack $ do
+  byronGenesisHash <- getByronGenesisHash $ tempAbsPath </> "byron/genesis.json"
+  shelleyGenesisHash <- getHash ShelleyEra "ShelleyGenesisHash"
+  alonzoGenesisHash  <- getHash AlonzoEra  "AlonzoGenesisHash"
+  conwayGenesisHash  <- getHash ConwayEra  "ConwayGenesisHash"
 
   return . Aeson.encode . Aeson.Object
     $ mconcat [ byronGenesisHash
               , shelleyGenesisHash
               , alonzoGenesisHash
               , conwayGenesisHash
-              , defaultYamlHardforkViaConfig anyCardanoEra'
+              , defaultYamlHardforkViaConfig era
               ]
-
+   where
+    getHash :: (MonadTest m, MonadIO m) => CardanoEra a -> Text.Text -> m (Aeson.KeyMap Aeson.Value)
+    getHash e = getShelleyGenesisHash (tempAbsPath </> defaultGenesisFilepath e)
 
 numSeededUTxOKeys :: Int
 numSeededUTxOKeys = 3
@@ -95,8 +95,8 @@ createSPOGenesisAndFiles
   -> ConwayGenesis StandardCrypto -- ^ The conway genesis to use, for example 'Defaults.defaultConwayGenesis'.
   -> TmpAbsolutePath
   -> m FilePath -- ^ Shelley genesis directory
-createSPOGenesisAndFiles (NumPools numPoolNodes) era shelleyGenesis alonzoGenesis conwayGenesis (TmpAbsolutePath tempAbsPath') = do
-  let genesisShelleyFpAbs = tempAbsPath' </> defaultShelleyGenesisFp
+createSPOGenesisAndFiles (NumPools numPoolNodes) era shelleyGenesis alonzoGenesis conwayGenesis (TmpAbsolutePath tempAbsPath) = do
+  let genesisShelleyFpAbs = tempAbsPath </> defaultGenesisFilepath ShelleyEra
       genesisShelleyDirAbs = takeDirectory genesisShelleyFpAbs
   genesisShelleyDir <- H.createDirectoryIfMissing genesisShelleyDirAbs
   let testnetMagic = sgNetworkMagic shelleyGenesis
@@ -129,7 +129,7 @@ createSPOGenesisAndFiles (NumPools numPoolNodes) era shelleyGenesis alonzoGenesi
   H.note_ $ "Number of seeded UTxO keys: " <> show numSeededUTxOKeys
 
   execCli_
-    [ convertToEraString era, "genesis", "create-testnet-data"
+    [ anyEraToString era, "genesis", "create-testnet-data"
     , "--spec-shelley", genesisShelleyFpAbs
     , "--testnet-magic", show testnetMagic
     , "--pools", show numPoolNodes
@@ -139,7 +139,7 @@ createSPOGenesisAndFiles (NumPools numPoolNodes) era shelleyGenesis alonzoGenesi
     , "--utxo-keys", show numSeededUTxOKeys
     , "--drep-keys", "3"
     , "--start-time", DTC.formatIso8601 startTime
-    , "--out-dir", tempAbsPath'
+    , "--out-dir", tempAbsPath
     ]
 
   -- Here we move all of the keys etc generated by create-testnet-data
@@ -147,20 +147,20 @@ createSPOGenesisAndFiles (NumPools numPoolNodes) era shelleyGenesis alonzoGenesi
 
   -- Move all genesis related files
 
-  genesisByronDir <- H.createDirectoryIfMissing $ tempAbsPath' </> "byron"
+  genesisByronDir <- H.createDirectoryIfMissing $ tempAbsPath </> "byron"
 
-  files <- H.listDirectory tempAbsPath'
+  files <- H.listDirectory tempAbsPath
   forM_ files $ \file -> do
     H.note file
 
   -- TODO: This conway and alonzo genesis creation can be removed,
   -- as this will be done by create-testenet-data when cardano-cli is upgraded above 8.20.3.0.
-  writeGenesisFile genesisShelleyDir "alonzo" alonzoGenesis
-  writeGenesisFile genesisShelleyDir "conway" conwayGenesis
+  writeGenesisFile genesisShelleyDir AlonzoEra alonzoGenesis
+  writeGenesisFile genesisShelleyDir ConwayEra conwayGenesis
 
-  H.renameFile (tempAbsPath' </> "byron-gen-command" </> "genesis.json") (genesisByronDir </> "genesis.json")
+  H.renameFile (tempAbsPath </> "byron-gen-command" </> "genesis.json") (genesisByronDir </> "genesis.json")
   -- TODO: create-testnet-data outputs the new shelley genesis to genesis.json
-  H.renameFile (tempAbsPath' </> "genesis.json") (genesisShelleyDir </> "genesis.shelley.json")
+  H.renameFile (tempAbsPath </> "genesis.json") (genesisShelleyDir </> "genesis.shelley.json")
 
   -- For some reason when setting "--total-supply 10E16" in create-testnet-data, we're getting negative
   -- treasury. TODO: This should be fixed by https://github.com/IntersectMBO/cardano-cli/pull/644
@@ -170,9 +170,10 @@ createSPOGenesisAndFiles (NumPools numPoolNodes) era shelleyGenesis alonzoGenesi
 
   return genesisShelleyDir
   where
-    writeGenesisFile :: (MonadTest m, MonadIO m, HasCallStack) => ToJSON a => FilePath -> String -> a -> m ()
-    writeGenesisFile dir eraName toWrite = GHC.withFrozenCallStack $ do
-      targetJsonFile <- H.noteShow (dir </> "genesis." <> eraName <> ".json")
+    writeGenesisFile :: (MonadTest m, MonadIO m, HasCallStack) => ToJSON b => FilePath -> CardanoEra a -> b -> m ()
+    writeGenesisFile dir era' toWrite = GHC.withFrozenCallStack $ do
+      let filename = takeFileName $ defaultGenesisFilepath era'
+      targetJsonFile <- H.noteShow (dir </> filename)
       H.evalIO $ LBS.writeFile targetJsonFile $ Aeson.encode toWrite
 
 ifaceAddress :: String

--- a/cardano-testnet/src/Testnet/Components/Configuration.hs
+++ b/cardano-testnet/src/Testnet/Components/Configuration.hs
@@ -167,7 +167,8 @@ createSPOGenesisAndFiles (NumPools numPoolNodes) era shelleyGenesis (TmpAbsolute
 
   -- TODO: move this to create-testnet-data
   -- For some reason when setting "--total-supply 10E16" in create-testnet-data, we're getting negative
-  -- treasury
+  -- treasury. This should be fixed by https://github.com/IntersectMBO/cardano-cli/pull/644
+  -- So this can be removed when cardano-cli is upgraded above 8.20.3.0.
   H.rewriteJsonFile @Value (genesisShelleyDir </> "genesis.shelley.json") $ \o -> o
     & L.key "maxLovelaceSupply" . L._Integer .~ 10_000_000_000_000_000
 

--- a/cardano-testnet/src/Testnet/Components/SPO.hs
+++ b/cardano-testnet/src/Testnet/Components/SPO.hs
@@ -157,7 +157,7 @@ createScriptStakeRegistrationCertificate tempAbsP anyCEra scriptFile deposit out
     let tempAbsPath' = unTmpAbsPath tempAbsP
 
     void $ execCli
-      [ convertToEraString anyCEra
+      [ anyEraToString anyCEra
       , "stake-address", "registration-certificate"
       , "--stake-script-file", scriptFile
       , "--key-reg-deposit-amt", show deposit

--- a/cardano-testnet/src/Testnet/Components/SPO.hs
+++ b/cardano-testnet/src/Testnet/Components/SPO.hs
@@ -168,15 +168,7 @@ createScriptStakeRegistrationCertificate tempAbsP anyCEra scriptFile deposit out
 -- TODO: Remove me and replace with new era based commands
 -- i.e "conway", "babbage" etc
 convertToEraFlag :: AnyCardanoEra -> String
-convertToEraFlag (AnyCardanoEra e) =
-  case e of
-    ConwayEra -> "--conway-era"
-    BabbageEra -> "--babbage-era"
-    AlonzoEra -> "--alonzo-era"
-    MaryEra -> "--mary-era"
-    AllegraEra -> "--allegra-era"
-    ShelleyEra -> "--shelley-era"
-    ByronEra -> "--byron-era"
+convertToEraFlag era = "--" <> anyEraToString era  <> "-era"
 
 -- | Related documentation: https://github.com/input-output-hk/cardano-node-wiki/blob/main/docs/stake-pool-operations/8_register_stakepool.md
 registerSingleSpo

--- a/cardano-testnet/src/Testnet/Defaults.hs
+++ b/cardano-testnet/src/Testnet/Defaults.hs
@@ -15,7 +15,7 @@ module Testnet.Defaults
   , defaultYamlConfig
   , defaultConwayGenesis
   , defaultShelleyGenesis
-  , defaultShelleyGenesisFp
+  , defaultGenesisFilepath
   , defaultYamlHardforkViaConfig
   , defaultMainnetTopology
   , plutusV3NonSpendingScript
@@ -64,6 +64,7 @@ import           Data.Word
 import           GHC.Stack
 import           Lens.Micro
 import           Numeric.Natural
+import           System.FilePath.Posix ((</>))
 
 import           Test.Cardano.Ledger.Core.Rational
 import           Testnet.Start.Types
@@ -434,9 +435,9 @@ defaultYamlConfig =
 
     -- Genesis filepaths
     , ("ByronGenesisFile", "byron/genesis.json")
-    , ("ShelleyGenesisFile", Aeson.String $ Text.pack defaultShelleyGenesisFp)
-    , ("AlonzoGenesisFile", "shelley/genesis.alonzo.json")
-    , ("ConwayGenesisFile", "shelley/genesis.conway.json")
+    , ("ShelleyGenesisFile", genesisPath ShelleyEra)
+    , ("AlonzoGenesisFile",  genesisPath AlonzoEra)
+    , ("ConwayGenesisFile",  genesisPath ConwayEra)
 
     -- See: https://github.com/input-output-hk/cardano-ledger/blob/master/eras/byron/ledger/impl/doc/network-magic.md
     , ("RequiresNetworkMagic", "RequiresMagic")
@@ -452,6 +453,8 @@ defaultYamlConfig =
     , ("defaultBackends", Aeson.Array $ Vector.fromList ["KatipBK"])
     , ("options", Aeson.object mempty)
     ]
+  where
+    genesisPath era = Aeson.String $ Text.pack $ defaultGenesisFilepath era
 
 -- | We need a Byron genesis in order to be able to hardfork to the later Shelley based eras.
 -- The values here don't matter as the testnet conditions are ultimately determined
@@ -548,13 +551,8 @@ defaultMainnetTopology =
          }
   in RealNodeTopology [single]
 
--- TODO: These filepaths should really be decoded from the output of
--- create-testnet-data. We are still deciding the best way to pass this information
--- to cardano-testnet.
-
-defaultShelleyGenesisFp :: FilePath
-defaultShelleyGenesisFp = "shelley/genesis.shelley.json"
-
+defaultGenesisFilepath :: CardanoEra a -> FilePath
+defaultGenesisFilepath era = "shelley" </> ("genesis." <> eraToString era <> ".json")
 
 -- TODO: We should not hardcode a script like this. We need to move
 -- plutus-example from plutus apps to cardano-node-testnet. This will

--- a/cardano-testnet/src/Testnet/Property/Utils.hs
+++ b/cardano-testnet/src/Testnet/Property/Utils.hs
@@ -18,7 +18,6 @@ module Testnet.Property.Utils
   , getByronGenesisHash
   , getShelleyGenesisHash
 
-  , convertToEraString
   , decodeEraUTxO
   ) where
 
@@ -36,7 +35,6 @@ import qualified Data.Aeson as Aeson
 import           Data.Aeson.Key
 import           Data.Aeson.KeyMap hiding (map)
 import qualified Data.ByteString as BS
-import           Data.Char (toLower)
 import           Data.Text (Text)
 import           Data.Word
 import           GHC.Stack
@@ -121,9 +119,6 @@ runInBackground act = void . H.evalM $ allocate (H.async act) cleanUp
   where
     cleanUp :: H.Async a -> IO ()
     cleanUp a = H.cancel a >> void (H.link a)
-
-convertToEraString :: AnyCardanoEra -> String
-convertToEraString = map toLower . docToString . pretty
 
 decodeEraUTxO :: (IsShelleyBasedEra era, MonadTest m) => ShelleyBasedEra era -> Aeson.Value -> m (UTxO era)
 decodeEraUTxO _ = H.jsonErrorFail . Aeson.fromJSON

--- a/cardano-testnet/src/Testnet/Start/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Start/Cardano.hs
@@ -389,7 +389,7 @@ cardanoTestnet
 
       let runtime = TestnetRuntime
             { configurationFile
-            , shelleyGenesisFile = tmpAbsPath </> Defaults.defaultShelleyGenesisFp
+            , shelleyGenesisFile = tmpAbsPath </> Defaults.defaultGenesisFilepath ShelleyEra
             , testnetMagic
             , poolNodes
             , wallets = wallets

--- a/cardano-testnet/src/Testnet/Start/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Start/Cardano.hs
@@ -267,7 +267,7 @@ cardanoTestnet
 
     configurationFile <- H.noteShow $ tmpAbsPath </> "configuration.yaml"
 
-    _ <- createSPOGenesisAndFiles nbPools era shelleyGenesis (TmpAbsolutePath tmpAbsPath)
+    _ <- createSPOGenesisAndFiles nbPools era shelleyGenesis alonzoGenesis conwayGenesis (TmpAbsolutePath tmpAbsPath)
 
     poolKeys <- H.noteShow $ flip fmap [1..numPoolNodes] $ \n ->
       PoolNodeKeys

--- a/cardano-testnet/src/Testnet/Start/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Start/Cardano.hs
@@ -178,10 +178,6 @@ requestAvailablePortNumbers numberOfPorts
 -- > │   ├── genesis{1,2,3}
 -- > │   │   └── key.{skey,vkey}
 -- > │   └── README.md
--- > ├── logs
--- > │   └── pool3
--- > │       └── {stderr,stdout}.log
--- > ├── module
 -- > ├── pools-keys
 -- > │   ├── pool{1,2,3}
 -- > │   │   ├── byron-delegate.key
@@ -423,7 +419,7 @@ cardanoTestnet
 
       pure runtime
   where
-    writeGenesisSpecFile :: (MonadTest m, MonadIO m, HasCallStack) => ToJSON a => FilePath -> a -> m ()
+    writeGenesisSpecFile :: (MonadTest m, MonadIO m, HasCallStack) => ToJSON a => String -> a -> m ()
     writeGenesisSpecFile eraName toWrite = GHC.withFrozenCallStack $ do
       genesisJsonFile <- H.noteShow $ tmpAbsPath </> "genesis." <> eraName <> ".spec.json"
       H.evalIO $ LBS.writeFile genesisJsonFile $ Aeson.encode toWrite

--- a/cardano-testnet/src/Testnet/Start/Types.hs
+++ b/cardano-testnet/src/Testnet/Start/Types.hs
@@ -6,6 +6,9 @@ module Testnet.Start.Types
   ( CardanoTestnetOptions(..)
   , cardanoDefaultTestnetOptions
 
+  , anyEraToString
+  , eraToString
+
   , TestnetNodeOptions(..)
   , extraSpoNodeCliArgs
   , cardanoDefaultTestnetNodeOptions
@@ -20,6 +23,7 @@ import           Cardano.Api hiding (cardanoEra)
 
 import           Prelude
 
+import           Data.Char (toLower)
 import           Data.Word
 import           GHC.Stack
 import           System.FilePath (addTrailingPathSeparator)
@@ -94,4 +98,10 @@ mkConf tempAbsPath' = withFrozenCallStack $ do
     { tempAbsPath = TmpAbsolutePath (addTrailingPathSeparator tempAbsPath')
     }
 
+-- | @anyEraToString (AnyCardanoEra ByronEra)@ returns @"byron"@
+anyEraToString :: AnyCardanoEra -> String
+anyEraToString (AnyCardanoEra e) = eraToString e
 
+-- | @eraToString ByronEra@ returns @"byron"@
+eraToString :: CardanoEra a -> String
+eraToString = map toLower . docToString . pretty

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/Plutus.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/Plutus.hs
@@ -80,7 +80,7 @@ hprop_plutus_v3 = H.integrationWorkspace "all-plutus-script-purposes" $ \tempAbs
       utxoSKeyFile2 = paymentSKey . paymentKeyInfoPair $ wallets !! 1
 
   void $ H.execCli' execConfig
-    [ convertToEraString anyEra, "query", "utxo"
+    [ anyEraToString anyEra, "query", "utxo"
     , "--address", utxoAddr
     , "--cardano-mode"
     , "--out-file", work </> "utxo-1.json"
@@ -108,7 +108,7 @@ hprop_plutus_v3 = H.integrationWorkspace "all-plutus-script-purposes" $ \tempAbs
 
   mintingPolicyId <- filter (/= '\n') <$>
     H.execCli' execConfig
-      [ convertToEraString anyEra, "transaction"
+      [ anyEraToString anyEra, "transaction"
       , "policyid"
       , "--script-file", plutusMintingScript
       ]
@@ -135,7 +135,7 @@ hprop_plutus_v3 = H.integrationWorkspace "all-plutus-script-purposes" $ \tempAbs
   -- 1. Put UTxO and datum at Plutus spending script address
   --    Register script stake address
   void $ execCli' execConfig
-    [ convertToEraString anyEra, "transaction", "build"
+    [ anyEraToString anyEra, "transaction", "build"
     , "--change-address", Text.unpack $ paymentKeyInfoAddr $ wallets !! 0
     , "--tx-in", Text.unpack $ renderTxIn txin1
     , "--tx-out", plutusSpendingScriptAddr <> "+" <> show @Int 5_000_000
@@ -159,7 +159,7 @@ hprop_plutus_v3 = H.integrationWorkspace "all-plutus-script-purposes" $ \tempAbs
   H.threadDelay 10_000_000
   -- 2. Successfully spend conway spending script
   void $ H.execCli' execConfig
-    [ convertToEraString anyEra, "query", "utxo"
+    [ anyEraToString anyEra, "query", "utxo"
     , "--address", utxoAddr2
     , "--cardano-mode"
     , "--out-file", work </> "utxo-2.json"
@@ -172,7 +172,7 @@ hprop_plutus_v3 = H.integrationWorkspace "all-plutus-script-purposes" $ \tempAbs
   txinCollateral <- H.noteShow $ keys2 !! 0
 
   void $ H.execCli' execConfig
-    [ convertToEraString anyEra, "query", "utxo"
+    [ anyEraToString anyEra, "query", "utxo"
     , "--address", plutusSpendingScriptAddr
     , "--cardano-mode"
     , "--out-file", work </> "plutus-script-utxo.json"
@@ -192,7 +192,7 @@ hprop_plutus_v3 = H.integrationWorkspace "all-plutus-script-purposes" $ \tempAbs
                       ]
 
   void $ execCli' execConfig
-    [ convertToEraString anyEra, "transaction", "build"
+    [ anyEraToString anyEra, "transaction", "build"
     , "--change-address", Text.unpack $ paymentKeyInfoAddr $ wallets !! 1
     , "--tx-in-collateral", Text.unpack $ renderTxIn txinCollateral
     , "--tx-in", Text.unpack $ renderTxIn plutusScriptTxIn

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/KesPeriodInfo.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/KesPeriodInfo.hs
@@ -75,7 +75,7 @@ hprop_kes_period_info = H.integrationRetryWorkspace 2 "kes-period-info" $ \tempA
   let utxoAddr = Text.unpack $ paymentKeyInfoAddr wallet0
       utxoSKeyFile = paymentSKey $ paymentKeyInfoPair wallet0
   void $ H.execCli' execConfig
-    [ convertToEraString anyEra, "query", "utxo"
+    [ anyEraToString anyEra, "query", "utxo"
     , "--address", utxoAddr
     , "--cardano-mode"
     , "--out-file", work </> "utxo-1.json"
@@ -141,7 +141,7 @@ hprop_kes_period_info = H.integrationRetryWorkspace 2 "kes-period-info" $ \tempA
   H.note_  "Get updated UTxO"
 
   void $ H.execCli' execConfig
-    [ convertToEraString anyEra, "query", "utxo"
+    [ anyEraToString anyEra, "query", "utxo"
     , "--address", utxoAddr
     , "--cardano-mode"
     , "--out-file", work </> "utxo-2.json"

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/ProposeNewConstitution.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/ProposeNewConstitution.hs
@@ -189,7 +189,7 @@ hprop_ledger_events_propose_new_constitution = H.integrationWorkspace "propose-n
   -- only useful for minting scripts
   constitutionScriptHash <- filter (/= '\n') <$>
     H.execCli' execConfig
-      [ convertToEraString cEra, "transaction"
+      [ anyEraToString cEra, "transaction"
       , "policyid"
       , "--script-file", guardRailScriptFp
       ]

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Node/Shutdown.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Node/Shutdown.hs
@@ -111,10 +111,9 @@ hprop_shutdown = H.integrationRetryWorkspace 2 "shutdown" $ \tempAbsBasePath' ->
     , "--start-time", formatIso8601 startTime
     ]
 
-
   byronGenesisHash <- getByronGenesisHash $ tempAbsPath' </> "byron/genesis.json"
-  H.renameFile (tempAbsPath' </> "shelley/genesis.json") (tempAbsPath' </> defaultShelleyGenesisFp)
-  shelleyGenesisHash <- getShelleyGenesisHash (tempAbsPath' </> defaultShelleyGenesisFp) "ShelleyGenesisHash"
+  H.renameFile (tempAbsPath' </> "shelley/genesis.json") (tempAbsPath' </> defaultGenesisFilepath ShelleyEra)
+  shelleyGenesisHash <- getShelleyGenesisHash (tempAbsPath' </> defaultGenesisFilepath ShelleyEra) "ShelleyGenesisHash"
   alonzoGenesisHash <- getShelleyGenesisHash (tempAbsPath' </> "shelley/genesis.alonzo.json") "AlonzoGenesisHash"
 
   let finalYamlConfig :: LBS.ByteString


### PR DESCRIPTION
# Description

Custom genesis files passed to `cardanoTestnet` were not forwarded to `createSPOGenesisAndFiles` (they were only used to alter template `spec` files), making custom genesis files unusable in practice. This PR fixes this.

In addition, this PR improves the handling of the `genesis.era.json` paths, by removing the hardcoding of those paths and using functions parameterized by `CardanoEra` instead.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff