### PR TITLE
wb | Nomad host_volume

### DIFF
--- a/nix/workbench/backend/nomad-job.nix
+++ b/nix/workbench/backend/nomad-job.nix
@@ -476,13 +476,6 @@ let
             }
           ];
         };
-
-        # The Consul namespace in which group and task-level services within the
-        # group will be registered. Use of template to access Consul KV will read
-        # from the specified Consul namespace. Specifying namespace takes
-        # precedence over the -consul-namespace command line argument in job run.
-        # namespace = "";
-        # Not available as the documentations says: Extraneous JSON object property; No argument or block type is named "namespace".
       }
       //
       # If it needs host volumes add the constraints (can't be "null" or "[]".)

--- a/nix/workbench/backend/nomad-job.nix
+++ b/nix/workbench/backend/nomad-job.nix
@@ -578,12 +578,12 @@ let
             # address of an AWS EC2 instance set this to
             # ${attr.unique.platform.aws.public-ipv4}.
             address =
-              # When using the dedicated P&T Nomad cluster on AWS we use public
-              # IPs/routing, all the other cloud runs are behind a VPC/firewall.
-              # Local runs just use 12.0.0.1.
-              if lib.strings.hasInfix "-nomadperf" profileData.profileName
+              # When using dedicated Nomad clusters on AWS we want to use public
+              # IPs/routing, all the other cloud runs will run behind a
+              # VPC/firewall.
+              if profileData.value.cluster.aws.use_public_routing
               then "\${attr.unique.platform.aws.public-ipv4}"
-              else ""
+              else "" # Local runs just use 127.0.0.1.
             ;
             # Specifies the port to advertise for this service. The value of
             # port depends on which address_mode is being used:
@@ -1398,7 +1398,7 @@ let
       [
         # Address string to
         (
-          if lib.strings.hasInfix "-nomadperf" profileData.profileName
+          if profileData.value.cluster.aws.use_public_routing
           then ''--host-addr {{ env "attr.unique.platform.aws.local-ipv4" }}''
           else ''--host-addr 0.0.0.0''
         )

--- a/nix/workbench/backend/nomad.sh
+++ b/nix/workbench/backend/nomad.sh
@@ -3855,7 +3855,7 @@ client {
 
   # Specifies an arbitrary string used to logically group client nodes by
   # user-defined class. This can be used during job placement as a filter.
-  node_class = "perf" # Using the "world.dev.cardano.org" testing class for "perf".
+  node_class = "" # Make sure we are not using namespaces locally.
 
   # "artifact" parameters (fail fast!!!)
   ######################################

--- a/nix/workbench/profile/prof0-defaults.jq
+++ b/nix/workbench/profile/prof0-defaults.jq
@@ -96,6 +96,8 @@ def era_defaults($era):
         { producer: {cores: 2, memory: 15000, memory_max: 16000}
         , explorer: {cores: 2, memory: 15000, memory_max: 16000}
         }
+      # Volumes like {source: "ssd1", destination: "/ssd1", read_only: false}
+      , host_volumes: null
       , fetch_logs_ssh: false
       }
     , aws:

--- a/nix/workbench/profile/prof0-defaults.jq
+++ b/nix/workbench/profile/prof0-defaults.jq
@@ -105,6 +105,8 @@ def era_defaults($era):
         { producer: "c5.2xlarge"
         , explorer: "m5.4xlarge"
         }
+      # "attr.unique.platform.aws.public-ipv4" to bind and service definition.
+      , use_public_routing: false
       }
     , minimun_storage:
       { producer: 12582912 # 12×1024×1024

--- a/nix/workbench/profile/prof1-variants.jq
+++ b/nix/workbench/profile/prof1-variants.jq
@@ -193,6 +193,7 @@ def all_profile_variants:
           { producer: "c5.2xlarge"
           , explorer: "m5.4xlarge"
           }
+        , use_public_routing: true
         }
       # We are requiring 10.5GB on the explorer node and 9GB on the others.
       , minimun_storage:
@@ -224,6 +225,7 @@ def all_profile_variants:
           { producer: "c5.9xlarge"
           , explorer: null
           }
+        , use_public_routing: true
         }
       , minimun_storage: null
       , keep_running: true


### PR DESCRIPTION
# Description

- Add to the profile definition support for Nomad's `host_volume`s in the form of a list of mounts wanted, each with a `source` and a `destination`, the former being how it is named in the Nomad Client config and the latter where it will be mounted inside the Task isolated directory.
- Make the use of public IP routing a flag inside the cluster definition.
- Fix an error with local/test runs

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
