### PR TITLE
Test correct recording of DRep votes in ledger

### DIFF
--- a/cardano-testnet/CHANGELOG.md
+++ b/cardano-testnet/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next version
 
 * Update `cardano-ping` dependency
+* Add `--num-dreps` parameter
 
 ## 8.7.0
 

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -189,6 +189,8 @@ test-suite cardano-testnet-test
                         Cardano.Testnet.Test.Node.Shutdown
                         Cardano.Testnet.Test.SubmitApi.Babbage.Transaction
 
+                        Cardano.Testnet.Test.Utils
+
   type:                 exitcode-stdio-1.0
 
   build-depends:        aeson

--- a/cardano-testnet/src/Parsers/Cardano.hs
+++ b/cardano-testnet/src/Parsers/Cardano.hs
@@ -61,6 +61,13 @@ optsTestnet envCli = CardanoTestnetOptions
       <>  OA.showDefault
       <>  OA.value (cardanoNodeLoggingFormat cardanoDefaultTestnetOptions)
       )
+  <*> OA.option auto
+      (   OA.long "num-dreps"
+      <>  OA.help "Number of delegate representatives (DReps) to generate"
+      <>  OA.metavar "NUMBER"
+      <>  OA.showDefault
+      <>  OA.value 3
+      )
 
 pNumSpoNodes :: Parser [TestnetNodeOptions]
 pNumSpoNodes =

--- a/cardano-testnet/src/Testnet/Components/Configuration.hs
+++ b/cardano-testnet/src/Testnet/Components/Configuration.hs
@@ -14,6 +14,8 @@ module Testnet.Components.Configuration
   , numSeededUTxOKeys
   , NumPools
   , numPools
+  , NumDReps
+  , numDReps
   ) where
 
 import           Cardano.Api.Ledger (StandardCrypto)
@@ -86,16 +88,23 @@ newtype NumPools = NumPools Int
 numPools :: CardanoTestnetOptions -> NumPools
 numPools CardanoTestnetOptions { cardanoNodes } = NumPools $ length cardanoNodes
 
+newtype NumDReps = NumDReps Int
+
+numDReps :: CardanoTestnetOptions -> NumDReps
+numDReps CardanoTestnetOptions { cardanoNumDReps } = NumDReps cardanoNumDReps
+
 createSPOGenesisAndFiles
   :: (MonadTest m, MonadCatch m, MonadIO m, HasCallStack)
   => NumPools -- ^ The number of pools to make
+  -> NumDReps -- ^ The number of pools to make
   -> AnyCardanoEra -- ^ The era to use
   -> ShelleyGenesis StandardCrypto -- ^ The shelley genesis to use.
   -> AlonzoGenesis -- ^ The alonzo genesis to use, for example 'getDefaultAlonzoGenesis' from this module.
   -> ConwayGenesis StandardCrypto -- ^ The conway genesis to use, for example 'Defaults.defaultConwayGenesis'.
   -> TmpAbsolutePath
   -> m FilePath -- ^ Shelley genesis directory
-createSPOGenesisAndFiles (NumPools numPoolNodes) era shelleyGenesis alonzoGenesis conwayGenesis (TmpAbsolutePath tempAbsPath) = do
+createSPOGenesisAndFiles (NumPools numPoolNodes) (NumDReps numDelReps) era shelleyGenesis
+                         alonzoGenesis conwayGenesis (TmpAbsolutePath tempAbsPath) = do
   let genesisShelleyFpAbs = tempAbsPath </> defaultGenesisFilepath ShelleyEra
       genesisShelleyDirAbs = takeDirectory genesisShelleyFpAbs
   genesisShelleyDir <- H.createDirectoryIfMissing genesisShelleyDirAbs
@@ -137,7 +146,7 @@ createSPOGenesisAndFiles (NumPools numPoolNodes) era shelleyGenesis alonzoGenesi
     , "--delegated-supply", show @Int 1_000_000_000_000
     , "--stake-delegators", show numStakeDelegators
     , "--utxo-keys", show numSeededUTxOKeys
-    , "--drep-keys", "3"
+    , "--drep-keys", show numDelReps
     , "--start-time", DTC.formatIso8601 startTime
     , "--out-dir", tempAbsPath
     ]

--- a/cardano-testnet/src/Testnet/Start/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Start/Cardano.hs
@@ -221,6 +221,7 @@ cardanoTestnet
       testnetMagic = cardanoTestnetMagic testnetOptions
       numPoolNodes = length $ cardanoNodes testnetOptions
       nbPools = numPools testnetOptions
+      nbDReps = numDReps testnetOptions
       era = cardanoNodeEra testnetOptions
 
   portNumbers <- requestAvailablePortNumbers numPoolNodes
@@ -267,7 +268,7 @@ cardanoTestnet
 
     configurationFile <- H.noteShow $ tmpAbsPath </> "configuration.yaml"
 
-    _ <- createSPOGenesisAndFiles nbPools era shelleyGenesis alonzoGenesis conwayGenesis (TmpAbsolutePath tmpAbsPath)
+    _ <- createSPOGenesisAndFiles nbPools nbDReps era shelleyGenesis alonzoGenesis conwayGenesis (TmpAbsolutePath tmpAbsPath)
 
     poolKeys <- H.noteShow $ flip fmap [1..numPoolNodes] $ \n ->
       PoolNodeKeys

--- a/cardano-testnet/src/Testnet/Start/Types.hs
+++ b/cardano-testnet/src/Testnet/Start/Types.hs
@@ -46,6 +46,7 @@ data CardanoTestnetOptions = CardanoTestnetOptions
   , cardanoMaxSupply :: Word64 -- ^ The amount of ADA you are starting your testnet with
   , cardanoEnableP2P :: Bool
   , cardanoNodeLoggingFormat :: NodeLoggingFormat
+  , cardanoNumDReps :: Int -- ^ The number of DReps to generate at creation
   } deriving (Eq, Show)
 
 cardanoDefaultTestnetOptions :: CardanoTestnetOptions
@@ -59,6 +60,7 @@ cardanoDefaultTestnetOptions = CardanoTestnetOptions
   , cardanoMaxSupply = 10_020_000_000
   , cardanoEnableP2P = False
   , cardanoNodeLoggingFormat = NodeLoggingFormatAsJson
+  , cardanoNumDReps = 3
   }
 
 -- | Specify a BFT node (Pre-Babbage era only) or an SPO (Shelley era onwards only)

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
@@ -15,6 +15,7 @@ Usage: cardano-testnet cardano [--num-pool-nodes COUNT]
   [--max-lovelace-supply WORD64]
   [--enable-p2p BOOL]
   [--nodeLoggingFormat LOGGING_FORMAT]
+  [--num-dreps NUMBER]
 
   Start a testnet in any era
 

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/cardano.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/cardano.cli
@@ -13,6 +13,7 @@ Usage: cardano-testnet cardano [--num-pool-nodes COUNT]
   [--max-lovelace-supply WORD64]
   [--enable-p2p BOOL]
   [--nodeLoggingFormat LOGGING_FORMAT]
+  [--num-dreps NUMBER]
 
   Start a testnet in any era
 
@@ -38,4 +39,6 @@ Available options:
   --nodeLoggingFormat LOGGING_FORMAT
                            Node logging format (json|text)
                            (default: NodeLoggingFormatAsJson)
+  --num-dreps NUMBER       Number of delegate representatives (DReps) to
+                           generate (default: 3)
   -h,--help                Show this help text

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/InfoAction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/InfoAction.hs
@@ -26,6 +26,7 @@ import           Cardano.Api.Shelley
 import           Cardano.Ledger.Conway.Governance (RatifyState (..))
 import qualified Cardano.Ledger.Conway.Governance as L
 import           Cardano.Testnet
+import           Cardano.Testnet.Test.Utils (filterNewGovProposals, foldBlocksFindLedgerEvent)
 
 import           Prelude
 
@@ -39,15 +40,15 @@ import           Data.Word
 import           GHC.Stack
 import           System.FilePath ((</>))
 
+import           Hedgehog
+import qualified Hedgehog.Extras as H
+import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
+
 import           Testnet.Components.Query
 import qualified Testnet.Process.Cli as P
 import qualified Testnet.Process.Run as H
 import qualified Testnet.Property.Utils as H
 import           Testnet.Runtime
-
-import           Hedgehog
-import qualified Hedgehog.Extras as H
-import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
 
 -- | Execute me with:
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/InfoAction/'@
@@ -207,13 +208,9 @@ hprop_ledger_events_info_action = H.integrationRetryWorkspace 0 "info-hash" $ \t
     , "--tx-file", txbodySignedFp
     ]
 
-  !propSubmittedResult
-    <- runExceptT $ foldBlocks
-                      (File configurationFile)
-                      (File socketPath)
-                      FullValidation
-                      Nothing -- Initial accumulator state
-                      (foldBlocksCheckProposalWasSubmitted (fromString txidString))
+  !propSubmittedResult <- foldBlocksFindLedgerEvent (filterNewGovProposals (fromString txidString))
+                                                    configurationFile
+                                                    socketPath
 
   newProposalEvents <- case propSubmittedResult of
                         Left e ->
@@ -287,21 +284,6 @@ hprop_ledger_events_info_action = H.integrationRetryWorkspace 0 "info-hash" $ \t
         $ "foldBlocksCheckInfoAction failed with: " <> displayError e
     Right _events -> success
 
-foldBlocksCheckProposalWasSubmitted
-  :: TxId -- TxId of submitted tx
-  -> Env
-  -> LedgerState
-  -> [LedgerEvent]
-  -> BlockInMode -- Block i
-  -> Maybe LedgerEvent -- ^ Accumulator at block i - 1
-  -> IO (Maybe LedgerEvent, FoldStatus) -- ^ Accumulator at block i and fold status
-foldBlocksCheckProposalWasSubmitted txid _ _ allEvents _ _ = do
-  let newGovProposal = filter (filterNewGovProposals txid) allEvents
-  if null newGovProposal
-  then return (Nothing, ContinueFold)
-  else return (Just $ newGovProposal !! 0, StopFold)
-
-
 retrieveGovernanceActionIndex
   :: (HasCallStack, MonadTest m)
   => Maybe LedgerEvent
@@ -320,11 +302,6 @@ retrieveGovernanceActionIndex mEvent = do
         $ mconcat ["retrieveGovernanceActionIndex: Expected NewGovernanceProposals, got: "
                   , show unexpectedEvent
                   ]
-
-
-filterNewGovProposals :: TxId -> LedgerEvent -> Bool
-filterNewGovProposals txid (NewGovernanceProposals eventTxId _) = fromShelleyTxId eventTxId == txid
-filterNewGovProposals _ _ = False
 
 -- | Fold accumulator for checking action state
 data InfoActionState = InfoActionState

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/ProposeNewConstitution.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/ProposeNewConstitution.hs
@@ -73,6 +73,15 @@ hprop_ledger_events_propose_new_constitution = H.integrationWorkspace "propose-n
 
   work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
 
+  -- Generate model for votes
+  let allVotes :: [(String, Int)]
+      allVotes = voteList [("yes", 4), ("no", 3), ("abstain", 2)]
+  annotateShow allVotes
+
+  let numVotes :: Int
+      numVotes = length allVotes
+  annotateShow numVotes
+
   let sbe = ShelleyBasedEraConway
       era = toCardanoEra sbe
       cEra = AnyCardanoEra era
@@ -80,6 +89,7 @@ hprop_ledger_events_propose_new_constitution = H.integrationWorkspace "propose-n
         { cardanoEpochLength = 100
         , cardanoSlotLength = 0.1
         , cardanoNodeEra = cEra
+        , cardanoNumDReps = numVotes
         }
 
   TestnetRuntime
@@ -140,8 +150,9 @@ hprop_ledger_events_propose_new_constitution = H.integrationWorkspace "propose-n
 
   -- Create Drep registration certificates
   let drepCertFile :: Int -> FilePath
-      drepCertFile n = gov </> "drep-keys" <>"drep" <> show n <> ".regcert"
-  forM_ [1..3] $ \n -> do
+      drepCertFile n = gov </> "drep-keys" <> "drep" <> show n <> ".regcert"
+
+  forM_ allVotes $ \(_, n) -> do
     H.execCli' execConfig
        [ "conway", "governance", "drep", "registration-certificate"
        , "--drep-verification-key-file", drepVkeyFp n
@@ -150,31 +161,27 @@ hprop_ledger_events_propose_new_constitution = H.integrationWorkspace "propose-n
        ]
 
   -- Retrieve UTxOs for registration submission
-  txin1 <- findLargestUtxoForPaymentKey epochStateView sbe $ wallets !! 0
+  regTxIn1 <- findLargestUtxoForPaymentKey epochStateView sbe $ wallets !! 0
 
   drepRegTxbodyFp <- H.note $ work </> "drep.registration.txbody"
   drepRegTxSignedFp <- H.note $ work </> "drep.registration.tx"
 
-  void $ H.execCli' execConfig
+  void $ H.execCli' execConfig $
     [ "conway", "transaction", "build"
     , "--change-address", Text.unpack $ paymentKeyInfoAddr $ wallets !! 0
-    , "--tx-in", Text.unpack $ renderTxIn txin1
+    , "--tx-in", Text.unpack $ renderTxIn regTxIn1
     , "--tx-out", Text.unpack (paymentKeyInfoAddr (wallets !! 1)) <> "+" <> show @Int 5_000_000
-    , "--certificate-file", drepCertFile 1
-    , "--certificate-file", drepCertFile 2
-    , "--certificate-file", drepCertFile 3
-    , "--witness-override", show @Int 4
+    ] ++ (concat [["--certificate-file", drepCertFile n] | (_, n) <- allVotes]) ++
+    [ "--witness-override", show @Int (numVotes + 1)
     , "--out-file", drepRegTxbodyFp
     ]
 
-  void $ H.execCli' execConfig
+  void $ H.execCli' execConfig $
     [ "conway", "transaction", "sign"
     , "--tx-body-file", drepRegTxbodyFp
     , "--signing-key-file", paymentSKey $ paymentKeyInfoPair $ wallets !! 0
-    , "--signing-key-file", drepSKeyFp 1
-    , "--signing-key-file", drepSKeyFp 2
-    , "--signing-key-file", drepSKeyFp 3
-    , "--out-file", drepRegTxSignedFp
+    ] ++ (concat [["--signing-key-file", drepSKeyFp n] | (_, n) <- allVotes]) ++
+    [ "--out-file", drepRegTxSignedFp
     ]
 
   void $ H.execCli' execConfig
@@ -253,10 +260,10 @@ hprop_ledger_events_propose_new_constitution = H.integrationWorkspace "propose-n
       voteFp n = work </> gov </> "vote-" <> show n
 
   -- Proposal was successfully submitted, now we vote on the proposal and confirm it was ratified
-  forM_ [1..3] $ \n -> do
+  forM_ allVotes $ \(vote, n) -> do
     H.execCli' execConfig
       [ "conway", "governance", "vote", "create"
-      , "--yes"
+      , "--" ++ vote
       , "--governance-action-tx-id", txidString
       , "--governance-action-index", show @Word32 governanceActionIndex
       , "--drep-verification-key-file", drepVkeyFp n
@@ -271,26 +278,22 @@ hprop_ledger_events_propose_new_constitution = H.integrationWorkspace "propose-n
   voteTxBodyFp <- H.note $ work </> gov </> "vote.txbody"
 
   -- Submit votes
-  void $ H.execCli' execConfig
+  void $ H.execCli' execConfig $
     [ "conway", "transaction", "build"
     , "--change-address", Text.unpack $ paymentKeyInfoAddr $ wallets !! 0
     , "--tx-in", Text.unpack $ renderTxIn txin3
     , "--tx-out", Text.unpack (paymentKeyInfoAddr (wallets !! 1)) <> "+" <> show @Int 3_000_000
-    , "--vote-file", voteFp 1
-    , "--vote-file", voteFp 2
-    , "--vote-file", voteFp 3
-    , "--witness-override", show @Int 4
+    ] ++ (concat [["--vote-file", voteFp n] | (_, n) <- allVotes]) ++
+    [ "--witness-override", show @Int (numVotes + 1)
     , "--out-file", voteTxBodyFp
     ]
 
-  void $ H.execCli' execConfig
+  void $ H.execCli' execConfig $
     [ "conway", "transaction", "sign"
     , "--tx-body-file", voteTxBodyFp
     , "--signing-key-file", paymentSKey $ paymentKeyInfoPair $ wallets !! 0
-    , "--signing-key-file", drepSKeyFp 1
-    , "--signing-key-file", drepSKeyFp 2
-    , "--signing-key-file", drepSKeyFp 3
-    , "--out-file", voteTxFp
+    ] ++ (concat [["--signing-key-file", drepSKeyFp n] | (_, n) <- allVotes]) ++
+    [ "--out-file", voteTxFp
     ]
 
   void $ H.execCli' execConfig
@@ -319,6 +322,8 @@ hprop_ledger_events_propose_new_constitution = H.integrationWorkspace "propose-n
     , "--out-file", finalGovState
     ]
 
+  -- Tally registered votes
+
   finalGovFileBS <- liftIO $ LBS.readFile finalGovState
 
   votes <- H.nothingFail $ do (Aeson.Object jsonValue) <- Aeson.decode finalGovFileBS
@@ -327,12 +332,23 @@ hprop_ledger_events_propose_new_constitution = H.integrationWorkspace "propose-n
                               (Aeson.Object votes) <- proposal KeyMap.!? "dRepVotes"
                               KeyMap.foldl' extractVote (Just []) votes
 
-  length (filter (== "VoteYes") votes) === 3
+  length (filter (== "VoteYes") votes) === 4
+  length (filter (== "VoteNo") votes) === 3
+  length (filter (== "Abstain") votes) === 2
+  length votes === numVotes
 
   where
     extractVote :: Maybe [String] -> Aeson.Value -> Maybe [String]
     extractVote (Just acc) (Aeson.String x) = Just $ unpack x:acc
     extractVote _ _ = Nothing
+
+    voteList :: [(a, Int)] -> [(a, Int)]
+    voteList l = go 1 l
+      where
+        go :: Int -> [(a, Int)] -> [(a, Int)]
+        go _ [] = []
+        go n ((s, m):r) | m > 0 = (s, n):go (n + 1) ((s, m - 1):r)
+                        | otherwise = go n r
 
 
 retrieveGovernanceActionIndex

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/ProposeNewConstitution.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/ProposeNewConstitution.hs
@@ -14,7 +14,6 @@
 
 module Cardano.Testnet.Test.LedgerEvents.Gov.ProposeNewConstitution
   ( hprop_ledger_events_propose_new_constitution
-  , foldBlocksCheckProposalWasSubmitted
   , retrieveGovernanceActionIndex
   ) where
 
@@ -28,6 +27,7 @@ import qualified Cardano.Ledger.Conway.Governance as Ledger
 import qualified Cardano.Ledger.Hashes as L
 import qualified Cardano.Ledger.Shelley.LedgerState as L
 import           Cardano.Testnet
+import           Cardano.Testnet.Test.Utils (filterNewGovProposals, foldBlocksFindLedgerEvent)
 
 import           Prelude
 
@@ -39,10 +39,13 @@ import           Data.Maybe.Strict
 import           Data.String
 import qualified Data.Text as Text
 import           Data.Word
-import           GHC.IO.Exception (IOException)
 import           GHC.Stack (HasCallStack, callStack)
 import           Lens.Micro
 import           System.FilePath ((</>))
+
+import           Hedgehog
+import qualified Hedgehog.Extras as H
+import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
 
 import           Testnet.Components.Configuration
 import           Testnet.Components.Query
@@ -52,14 +55,7 @@ import qualified Testnet.Process.Run as H
 import qualified Testnet.Property.Utils as H
 import           Testnet.Runtime
 
-import           Hedgehog
-import qualified Hedgehog.Extras as H
-import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
 
-
-newtype AdditionalCatcher
-  = IOE IOException
-  deriving Show
 
 -- | Execute me with:
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/ProposeAndRatifyNewConstitution/"'@
@@ -236,23 +232,15 @@ hprop_ledger_events_propose_new_constitution = H.integrationWorkspace "propose-n
     [ "transaction", "txid"
     , "--tx-file", txbodySignedFp
     ]
-  !propSubmittedResult
-    <- runExceptT $ handleIOExceptT IOE
-                  $ runExceptT $ foldBlocks
-                      (File configurationFile)
-                      (File socketPath)
-                      FullValidation
-                      Nothing -- Initial accumulator state
-                      (foldBlocksCheckProposalWasSubmitted (fromString txidString))
+  !propSubmittedResult <- foldBlocksFindLedgerEvent (filterNewGovProposals (fromString txidString))
+                                                    configurationFile
+                                                    socketPath
 
   newProposalEvents <- case propSubmittedResult of
-                        Left (IOE e) ->
+                        Left e ->
                           H.failMessage callStack
-                            $ "foldBlocksCheckProposalWasSubmitted failed with: " <> show e
-                        Right (Left e) ->
-                          H.failMessage callStack
-                            $ "foldBlocksCheckProposalWasSubmitted failed with: " <> displayError e
-                        Right (Right events) -> return events
+                            $ "foldBlocksFindLedgerEvent failed with: " <> displayError e
+                        Right events -> return events
 
   governanceActionIndex <- retrieveGovernanceActionIndex newProposalEvents
 
@@ -290,7 +278,6 @@ hprop_ledger_events_propose_new_constitution = H.integrationWorkspace "propose-n
     , "--out-file", voteTxBodyFp
     ]
 
-
   void $ H.execCli' execConfig
     [ "conway", "transaction", "sign"
     , "--tx-body-file", voteTxBodyFp
@@ -319,19 +306,6 @@ hprop_ledger_events_propose_new_constitution = H.integrationWorkspace "propose-n
 
   void $ evalEither eConstitutionAdopted
 
-foldBlocksCheckProposalWasSubmitted
-  :: TxId -- TxId of submitted tx
-  -> Env
-  -> LedgerState
-  -> [LedgerEvent]
-  -> BlockInMode -- Block i
-  -> Maybe LedgerEvent -- ^ Accumulator at block i - 1
-  -> IO (Maybe LedgerEvent, FoldStatus) -- ^ Accumulator at block i and fold status
-foldBlocksCheckProposalWasSubmitted txid _ _ allEvents _ _ = do
-  let newGovProposal = filter (filterNewGovProposals txid) allEvents
-  if null newGovProposal
-  then return (Nothing, ContinueFold)
-  else return (Just $ newGovProposal !! 0, StopFold)
 
 
 retrieveGovernanceActionIndex
@@ -351,14 +325,6 @@ retrieveGovernanceActionIndex mEvent = do
         $ mconcat ["retrieveGovernanceActionIndex: Expected NewGovernanceProposals, got: "
                   , show unexpectedEvent
                   ]
-
-
-filterNewGovProposals :: TxId -> LedgerEvent -> Bool
-filterNewGovProposals txid (NewGovernanceProposals eventTxId (AnyProposals props)) =
-  let _govActionStates = Ledger.proposalsActionsMap props
-  in fromShelleyTxId eventTxId == txid
-filterNewGovProposals _ _ = False
-
 
 foldBlocksCheckConstitutionWasRatified
   :: String -- submitted constitution hash

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/ProposeNewConstitution.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/ProposeNewConstitution.hs
@@ -33,11 +33,16 @@ import           Prelude
 
 import           Control.Monad
 import           Control.Monad.State.Strict (StateT)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Map.Strict as Map
 import           Data.Maybe
 import           Data.Maybe.Strict
 import           Data.String
+import           Data.Text (unpack)
 import qualified Data.Text as Text
+import qualified Data.Vector as Vector
 import           Data.Word
 import           GHC.Stack (HasCallStack, callStack)
 import           Lens.Micro
@@ -306,6 +311,28 @@ hprop_ledger_events_propose_new_constitution = H.integrationWorkspace "propose-n
 
   void $ evalEither eConstitutionAdopted
 
+  finalGovState <- H.note $ work </> gov </> "final_gov_state.json"
+
+  void $ H.execCli' execConfig
+    [ "conway", "query", "gov-state"
+    , "--volatile-tip"
+    , "--out-file", finalGovState
+    ]
+
+  finalGovFileBS <- liftIO $ LBS.readFile finalGovState
+
+  votes <- H.nothingFail $ do (Aeson.Object jsonValue) <- Aeson.decode finalGovFileBS
+                              (Aeson.Array proposals) <- jsonValue KeyMap.!? "proposals"
+                              (Aeson.Object proposal) <- Vector.headM proposals
+                              (Aeson.Object votes) <- proposal KeyMap.!? "dRepVotes"
+                              KeyMap.foldl' extractVote (Just []) votes
+
+  length (filter (== "VoteYes") votes) === 3
+
+  where
+    extractVote :: Maybe [String] -> Aeson.Value -> Maybe [String]
+    extractVote (Just acc) (Aeson.String x) = Just $ unpack x:acc
+    extractVote _ _ = Nothing
 
 
 retrieveGovernanceActionIndex

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Utils.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Utils.hs
@@ -1,0 +1,44 @@
+module Cardano.Testnet.Test.Utils
+  ( filterNewGovProposals
+  , foldBlocksFindLedgerEvent
+  ) where
+
+
+import           Cardano.Api as Api
+import           Cardano.Api.Shelley
+
+import qualified Cardano.Ledger.Conway.Governance as Ledger
+
+import           Prelude
+
+
+foldBlocksFindLedgerEvent :: MonadIO m
+  => (LedgerEvent -> Bool)
+  -> FilePath
+  -> FilePath
+  -> m (Either FoldBlocksError (Maybe LedgerEvent))
+foldBlocksFindLedgerEvent ledgerEventFilter configurationFile socketPath =
+    runExceptT $ foldBlocks (File configurationFile)
+                            (File socketPath)
+                            FullValidation
+                            Nothing -- Initial accumulator state
+                            (go ledgerEventFilter)
+  where
+    go :: (LedgerEvent -> Bool) -- Predicate that ledger event must satisfy
+       -> Env
+       -> LedgerState
+       -> [LedgerEvent]
+       -> BlockInMode -- Block i
+       -> Maybe LedgerEvent -- ^ Accumulator at block i - 1
+       -> IO (Maybe LedgerEvent, FoldStatus) -- ^ Accumulator at block i and fold status
+    go txFilter _ _ allEvents _ _ = do
+      let foundTransactions = filter txFilter allEvents
+      return $ case foundTransactions of
+                  (foundTransaction:_) -> (Just foundTransaction, StopFold)
+                  _ -> (Nothing, ContinueFold)
+
+filterNewGovProposals :: TxId -> LedgerEvent -> Bool
+filterNewGovProposals txid (NewGovernanceProposals eventTxId (AnyProposals props)) =
+  let _govActionStates = Ledger.proposalsActionsMap props
+  in fromShelleyTxId eventTxId == txid
+filterNewGovProposals _ _ = False


### PR DESCRIPTION
# Description

This PR aims to address this issue: https://github.com/IntersectMBO/cardano-node/issues/5598

For that this PR:
- Generalizes and unifies `foldBlocksCheckProposalWasSubmitted` (this turned out not to be necessary but I left it because I think it is improvement, I will probably use it in the future, and it also removed a clone which had diverged a little already)
- It exposes a new parameter `--num-dreps` because the default was `3` and that doesn't allow much testing. Not sure if that is problematic, maybe there is a better way.
- It parametrizes the number of votes, so that the distribution is easier to change, and so that it includes "no" and "abstain" votes.
- It inspects the result of `conway query gov-state` to count the registered votes and checks is the expected amount.

Note for reviewers: I've separated different changes into different commits that make sense by themselves, it is probably much easier to look at them independently.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff
