### PR TITLE
Update `checkStakeKeyRegistered` to use `foldEpochState`

### DIFF
--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -44,6 +44,7 @@ library
                       , cardano-ledger-binary
                       , cardano-ledger-byron
                       , cardano-ledger-conway
+                      , cardano-ledger-api
                       , cardano-ledger-conway
                       , cardano-ledger-core
                       , cardano-ledger-core:testlib

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/LeadershipSchedule.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/LeadershipSchedule.hs
@@ -47,7 +47,6 @@ import           Testnet.Runtime
 
 import           Hedgehog (Property, (===))
 import qualified Hedgehog as H
-import           Hedgehog.Extras (threadDelay)
 import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
@@ -92,9 +91,17 @@ hprop_leadershipSchedule = H.integrationRetryWorkspace 2 "babbage-leadership-sch
   utxo1Json <- H.leftFailM . H.readJsonFile $ work </> "utxo-1.json"
   UTxO utxo1 <- H.noteShowM $ decodeEraUTxO sbe utxo1Json
   txin1 <- H.noteShow =<< H.headM (Map.keys utxo1)
-
+  let node1SocketPath = Api.File $ IO.sprocketSystemName node1sprocket
+      nodeConfigFile = Api.File configurationFile
+      termEpoch = 15
   (stakePoolIdNewSpo, stakePoolColdSigningKey, stakePoolColdVKey, vrfSkey, _)
-    <- registerSingleSpo 1 tempAbsPath cTestnetOptions execConfig (txin1, utxoSKeyFile, utxoAddr)
+    <- registerSingleSpo 1 tempAbsPath
+         (Api.File configurationFile)
+         node1SocketPath
+         10
+         cTestnetOptions
+         execConfig
+         (txin1, utxoSKeyFile, utxoAddr)
 
   -- Create test stake address to delegate to the new stake pool
   -- NB: We need to fund the payment credential of the overall address
@@ -194,14 +201,14 @@ hprop_leadershipSchedule = H.integrationRetryWorkspace 2 "babbage-leadership-sch
            , "--tx-file", delegRegTestDelegatorTxFp
            ]
 
-  -- TODO: Can be removed if checkStakeKeyRegistered uses foldEpochState
-  threadDelay 15_000000
-
   -------------------------------------------------------------------
 
   let testDelegatorStakeAddressInfoOutFp = work </> "test-delegator-stake-address-info.json"
   void $ checkStakeKeyRegistered
            tempAbsPath
+           nodeConfigFile
+           node1SocketPath
+           termEpoch
            execConfig
            testDelegatorStakeAddress
            testDelegatorStakeAddressInfoOutFp
@@ -258,7 +265,7 @@ hprop_leadershipSchedule = H.integrationRetryWorkspace 2 "babbage-leadership-sch
 
   -- Wait for 2 epochs to pass
   void $ waitUntilEpoch (Api.File configurationFile)
-                        (Api.File $ IO.sprocketSystemName node1sprocket) (EpochNo 3)
+                        node1SocketPath (EpochNo 3)
 
   currentLeaderShipScheduleFile <- H.noteTempFile work "current-schedule.log"
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/LeadershipSchedule.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/LeadershipSchedule.hs
@@ -93,12 +93,12 @@ hprop_leadershipSchedule = H.integrationRetryWorkspace 2 "babbage-leadership-sch
   txin1 <- H.noteShow =<< H.headM (Map.keys utxo1)
   let node1SocketPath = Api.File $ IO.sprocketSystemName node1sprocket
       nodeConfigFile = Api.File configurationFile
-      termEpoch = 15
+      termEpoch = EpochNo 15
   (stakePoolIdNewSpo, stakePoolColdSigningKey, stakePoolColdVKey, vrfSkey, _)
     <- registerSingleSpo 1 tempAbsPath
          (Api.File configurationFile)
          node1SocketPath
-         10
+         (EpochNo 10)
          cTestnetOptions
          execConfig
          (txin1, utxoSKeyFile, utxoAddr)

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/KesPeriodInfo.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/KesPeriodInfo.hs
@@ -43,6 +43,7 @@ import           Hedgehog (Property)
 import qualified Hedgehog as H
 import           Hedgehog.Extras (threadDelay)
 import           Hedgehog.Extras.Stock (sprocketSystemName)
+import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -86,8 +87,17 @@ hprop_kes_period_info = H.integrationRetryWorkspace 2 "kes-period-info" $ \tempA
   UTxO utxo1 <- H.noteShowM $ decodeEraUTxO sbe utxo1Json
   txin1 <- H.noteShow =<< H.headM (Map.keys utxo1)
 
+  let node1SocketPath = Api.File $ IO.sprocketSystemName node1sprocket
+      nodeConfigFile = Api.File configurationFile
+      termEpoch = 3
   (stakePoolId, stakePoolColdSigningKey, stakePoolColdVKey, _, _)
-    <- registerSingleSpo 1 tempAbsPath cTestnetOptions execConfig (txin1, utxoSKeyFile, utxoAddr)
+    <- registerSingleSpo 1 tempAbsPath
+         nodeConfigFile
+         node1SocketPath
+         termEpoch
+         cTestnetOptions
+         execConfig
+         (txin1, utxoSKeyFile, utxoAddr)
 
   -- Create test stake address to delegate to the new stake pool
   -- NB: We need to fund the payment credential of the overall address
@@ -187,11 +197,12 @@ hprop_kes_period_info = H.integrationRetryWorkspace 2 "kes-period-info" $ \tempA
            , "--tx-file", delegRegTestDelegatorTxFp
            ]
 
-  threadDelay 20_000_000
-
   let testDelegatorStakeAddressInfoOutFp = work </> "test-delegator-stake-address-info.json"
   void $ checkStakeKeyRegistered
            tempAbsPath
+           nodeConfigFile
+           node1SocketPath
+           termEpoch
            execConfig
            testDelegatorStakeAddress
            testDelegatorStakeAddressInfoOutFp

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/KesPeriodInfo.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/KesPeriodInfo.hs
@@ -89,7 +89,7 @@ hprop_kes_period_info = H.integrationRetryWorkspace 2 "kes-period-info" $ \tempA
 
   let node1SocketPath = Api.File $ IO.sprocketSystemName node1sprocket
       nodeConfigFile = Api.File configurationFile
-      termEpoch = 3
+      termEpoch = EpochNo 3
   (stakePoolId, stakePoolColdSigningKey, stakePoolColdVKey, _, _)
     <- registerSingleSpo 1 tempAbsPath
          nodeConfigFile


### PR DESCRIPTION
# Description

Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
