### PR TITLE
Fix test filtering

### DIFF
--- a/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
+++ b/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
@@ -23,8 +23,11 @@ import qualified Cardano.Testnet.Test.SubmitApi.Babbage.Transaction
 
 import           Prelude
 
+import qualified Control.Concurrent.QSem as IO
 import qualified System.Environment as E
+import qualified System.IO as IO
 import           System.IO (BufferMode (LineBuffering), hSetBuffering, hSetEncoding, stdout, utf8)
+import qualified System.IO.Unsafe as IO
 
 import qualified Testnet.Property.Run as H
 
@@ -32,67 +35,75 @@ import qualified Test.Tasty as T
 import           Test.Tasty (TestTree)
 import qualified Test.Tasty.Ingredients as T
 
+sem :: IO.QSem
+sem = IO.unsafePerformIO $ IO.newQSem 1
+{-# NOINLINE sem #-}
+
+-- | Designate a test section that can be run concurrently or sequentially.
+-- When running sequentially, the section will be protected by a semaphore.
+mkSection :: Bool -> IO (TestTree -> TestTree)
+mkSection concurrent =
+  if concurrent
+    then do
+      IO.putStrLn "With concurrent sections"
+      pure id
+    else do
+      IO.putStrLn "With sequential sections"
+      pure $ T.withResource (IO.waitQSem sem) (const (IO.signalQSem sem)) . const
+
 tests :: IO TestTree
 tests = do
-  testGroup <- runTestGroup <$> shouldRunInParallel
-  pure $ testGroup "test/Spec.hs"
-    [ testGroup "Spec"
-        [ testGroup "Ledger Events"
-            [ H.ignoreOnWindows "Sanity Check" LedgerEvents.hprop_ledger_events_sanity_check
-            , H.ignoreOnWindows "Treasury Growth" LedgerEvents.prop_check_if_treasury_is_growing
-            -- TODO: Replace foldBlocks with checkLedgerStateCondition
-            , testGroup "Governance"
-                [ H.ignoreOnMacAndWindows "ProposeAndRatifyNewConstitution" Cardano.Testnet.Test.LedgerEvents.Gov.ProposeNewConstitution.hprop_ledger_events_propose_new_constitution
-                  -- FIXME Those tests are flaky
-                  -- , H.ignoreOnWindows "InfoAction" LedgerEvents.hprop_ledger_events_info_action
-                , H.ignoreOnWindows "ProposeNewConstitutionSPO" LedgerEvents.hprop_ledger_events_propose_new_constitution_spo
-                , H.ignoreOnWindows "DRepRetirement" DRepRetirement.hprop_drep_retirement
-                ]
-            , testGroup "Plutus"
-                [ H.ignoreOnWindows "PlutusV3" Cardano.Testnet.Test.Cli.Conway.Plutus.hprop_plutus_v3]
+  section <- shouldRunConcurrently >>= mkSection
+  pure $ T.testGroup "test/Spec.hs"
+    [ T.testGroup "Spec"
+      [ T.testGroup "Ledger Events"
+        [ section $ H.ignoreOnWindows "Sanity Check" LedgerEvents.hprop_ledger_events_sanity_check
+        , section $ H.ignoreOnWindows "Treasury Growth" LedgerEvents.prop_check_if_treasury_is_growing
+        -- TODO: Replace foldBlocks with checkLedgerStateCondition
+        , T.testGroup "Governance"
+            [ section $ H.ignoreOnMacAndWindows "ProposeAndRatifyNewConstitution" Cardano.Testnet.Test.LedgerEvents.Gov.ProposeNewConstitution.hprop_ledger_events_propose_new_constitution
+              -- FIXME Those tests are flaky
+              -- , H.ignoreOnWindows "InfoAction" LedgerEvents.hprop_ledger_events_info_action
+            , section $ H.ignoreOnWindows "ProposeNewConstitutionSPO" LedgerEvents.hprop_ledger_events_propose_new_constitution_spo
+            , section $ H.ignoreOnWindows "DRepRetirement" DRepRetirement.hprop_drep_retirement
             ]
-        , testGroup "CLI"
-          [ H.ignoreOnWindows "Shutdown" Cardano.Testnet.Test.Node.Shutdown.hprop_shutdown
-          -- ShutdownOnSigint fails on Mac with
-          -- "Log file: /private/tmp/tmp.JqcjW7sLKS/kes-period-info-2-test-30c2d0d8eb042a37/logs/test-spo.stdout.log had no logs indicating the relevant node has minted blocks."
-          , H.ignoreOnMacAndWindows "ShutdownOnSigint" Cardano.Testnet.Test.Node.Shutdown.hprop_shutdownOnSigint
-          -- ShutdownOnSlotSynced FAILS Still. The node times out and it seems the "shutdown-on-slot-synced" flag does nothing
-          -- , H.ignoreOnWindows "ShutdownOnSlotSynced" Cardano.Testnet.Test.Node.Shutdown.hprop_shutdownOnSlotSynced
-          , testGroup "Babbage"
-              [ H.ignoreOnMacAndWindows "leadership-schedule" Cardano.Testnet.Test.Cli.Babbage.LeadershipSchedule.hprop_leadershipSchedule -- FAILS
-              , H.ignoreOnWindows "stake-snapshot" Cardano.Testnet.Test.Cli.Babbage.StakeSnapshot.hprop_stakeSnapshot
-              , H.ignoreOnWindows "transaction" Cardano.Testnet.Test.Cli.Babbage.Transaction.hprop_transaction
-              ]
-          -- TODO: Conway -  Re-enable when create-staked is working in conway again
-          --, testGroup "Conway"
-          --  [ H.ignoreOnWindows "stake-snapshot" Cardano.Testnet.Test.Cli.Conway.StakeSnapshot.hprop_stakeSnapshot
-          --  ]
-            -- Ignored on Windows due to <stdout>: commitBuffer: invalid argument (invalid character)
-            -- as a result of the kes-period-info output to stdout.
-          , H.ignoreOnWindows "kes-period-info" Cardano.Testnet.Test.Cli.KesPeriodInfo.hprop_kes_period_info
-          , H.ignoreOnWindows "query-slot-number" Cardano.Testnet.Test.Cli.QuerySlotNumber.hprop_querySlotNumber
-          , H.ignoreOnWindows "foldBlocks receives ledger state" Cardano.Testnet.Test.FoldBlocks.prop_foldBlocks
-          , H.ignoreOnWindows "CliQueries" Cardano.Testnet.Test.Cli.Queries.hprop_cli_queries
-          ]
-        ]
-    , testGroup "SubmitApi"
-        [ testGroup "Babbage"
-            [ H.ignoreOnWindows "transaction" Cardano.Testnet.Test.SubmitApi.Babbage.Transaction.hprop_transaction
+        , T.testGroup "Plutus"
+            [ section $ H.ignoreOnWindows "PlutusV3" Cardano.Testnet.Test.Cli.Conway.Plutus.hprop_plutus_v3
             ]
         ]
+      , T.testGroup "CLI"
+        [ section $ H.ignoreOnWindows "Shutdown" Cardano.Testnet.Test.Node.Shutdown.hprop_shutdown
+        -- ShutdownOnSigint fails on Mac with
+        -- "Log file: /private/tmp/tmp.JqcjW7sLKS/kes-period-info-2-test-30c2d0d8eb042a37/logs/test-spo.stdout.log had no logs indicating the relevant node has minted blocks."
+        , section $ H.ignoreOnMacAndWindows "ShutdownOnSigint" Cardano.Testnet.Test.Node.Shutdown.hprop_shutdownOnSigint
+        -- ShutdownOnSlotSynced FAILS Still. The node times out and it seems the "shutdown-on-slot-synced" flag does nothing
+        -- , H.ignoreOnWindows "ShutdownOnSlotSynced" Cardano.Testnet.Test.Node.Shutdown.hprop_shutdownOnSlotSynced
+        , T.testGroup "Babbage"
+            [ section $ H.ignoreOnMacAndWindows "leadership-schedule" Cardano.Testnet.Test.Cli.Babbage.LeadershipSchedule.hprop_leadershipSchedule -- FAILS
+            , section $ H.ignoreOnWindows "stake-snapshot" Cardano.Testnet.Test.Cli.Babbage.StakeSnapshot.hprop_stakeSnapshot
+            , section $ H.ignoreOnWindows "transaction" Cardano.Testnet.Test.Cli.Babbage.Transaction.hprop_transaction
+            ]
+        -- TODO: Conway -  Re-enable when create-staked is working in conway again
+        --, T.testGroup "Conway"
+        --  [ H.ignoreOnWindows "stake-snapshot" Cardano.Testnet.Test.Cli.Conway.StakeSnapshot.hprop_stakeSnapshot
+        --  ]
+          -- Ignored on Windows due to <stdout>: commitBuffer: invalid argument (invalid character)
+          -- as a result of the kes-period-info output to stdout.
+        , section $ H.ignoreOnWindows "kes-period-info" Cardano.Testnet.Test.Cli.KesPeriodInfo.hprop_kes_period_info
+        , section $ H.ignoreOnWindows "query-slot-number" Cardano.Testnet.Test.Cli.QuerySlotNumber.hprop_querySlotNumber
+        , section $ H.ignoreOnWindows "foldBlocks receives ledger state" Cardano.Testnet.Test.FoldBlocks.prop_foldBlocks
+        , section $ H.ignoreOnWindows "CliQueries" Cardano.Testnet.Test.Cli.Queries.hprop_cli_queries
+        ]
+      ]
+    , T.testGroup "SubmitApi"
+      [ T.testGroup "Babbage"
+        [ section $ H.ignoreOnWindows "transaction" Cardano.Testnet.Test.SubmitApi.Babbage.Transaction.hprop_transaction
+        ]
+      ]
     ]
 
-shouldRunInParallel :: IO Bool
-shouldRunInParallel = (== Just "1") <$> E.lookupEnv "PARALLEL_TESTNETS"
-
--- FIXME Right now when running tests concurrently it makes them flaky
-runTestGroup
-  :: Bool -- ^ True to run in parallel
-  -> T.TestName
-  -> [TestTree]
-  -> TestTree
-runTestGroup True name = T.testGroup name
-runTestGroup False name = T.sequentialTestGroup name T.AllFinish
+shouldRunConcurrently :: IO Bool
+shouldRunConcurrently = (== Just "1") <$> E.lookupEnv "CONCURRENT_TESTS"
 
 ingredients :: [T.Ingredient]
 ingredients = T.defaultIngredients


### PR DESCRIPTION
# Description

Avoid use of `sequentialTestGroup` to sequentialise tests.  Rename `PARALLEL_TESTNETS` to `CONCURRENT_TESTS` because that more accurately describes what we're doing.

# Context

The use of `sequentialTestGroup` causes the `tasty` test filter to include preceding sibling tests which results in tests included by the filter that shouldn't be.  See https://github.com/UnkindPartition/tasty/issues/411

The use of the problematic `sequentialTestGroup` is avoided by using a semaphore to sequentialise tests instead.

# Validation

## Before

```
$ cabal test cardano-testnet-test --test-options '--list-tests --pattern /kes/'
Resolving dependencies...
Build profile: -w ghc-9.6.4 -O1
In order, the following will be built (use -v for more details):
 - cardano-testnet-8.8.0 (test:cardano-testnet-test) (first run)
Preprocessing test suite 'cardano-testnet-test' for cardano-testnet-8.8.0..
Building test suite 'cardano-testnet-test' for cardano-testnet-8.8.0..
Running 1 test suites...
Test suite cardano-testnet-test: RUNNING...
test/Spec.hs.Spec.Ledger Events.Sanity Check
test/Spec.hs.Spec.Ledger Events.Treasury Growth
test/Spec.hs.Spec.Ledger Events.Governance.ProposeAndRatifyNewConstitution
test/Spec.hs.Spec.Ledger Events.Governance.ProposeNewConstitutionSPO
test/Spec.hs.Spec.Ledger Events.Governance.DRepRetirement
test/Spec.hs.Spec.Ledger Events.Plutus.PlutusV3
test/Spec.hs.Spec.CLI.Shutdown
test/Spec.hs.Spec.CLI.ShutdownOnSigint
test/Spec.hs.Spec.CLI.Babbage.leadership-schedule
test/Spec.hs.Spec.CLI.Babbage.stake-snapshot
test/Spec.hs.Spec.CLI.Babbage.transaction
test/Spec.hs.Spec.CLI.kes-period-info
Test suite cardano-testnet-test: PASS
Test suite logged to:
/home/jky/wrk/intersect/cardano-node/dist-newstyle/build/x86_64-linux/ghc-9.6.4/cardano-testnet-8.8.0/t/cardano-testnet-test/test/cardano-testnet-8.8.0-cardano-testnet-test.log
1 of 1 test suites (1 of 1 test cases) passed.
```

## After

Sequentially:

```
$ cabal test cardano-testnet-test --test-options '--list-tests --pattern /kes/'
Resolving dependencies...
Build profile: -w ghc-9.6.4 -O1
In order, the following will be built (use -v for more details):
 - cardano-testnet-8.8.0 (test:cardano-testnet-test) (first run)
Preprocessing test suite 'cardano-testnet-test' for cardano-testnet-8.8.0..
Building test suite 'cardano-testnet-test' for cardano-testnet-8.8.0..
Running 1 test suites...
Test suite cardano-testnet-test: RUNNING...
With sequential sections
test/Spec.hs.Spec.CLI.kes-period-info
Test suite cardano-testnet-test: PASS
Test suite logged to:
/home/jky/wrk/intersect/cardano-node/dist-newstyle/build/x86_64-linux/ghc-9.6.4/cardano-testnet-8.8.0/t/cardano-testnet-test/test/cardano-testnet-8.8.0-cardano-testnet-test.log
1 of 1 test suites (1 of 1 test cases) passed.
```

Concurrently:

```
CONCURRENT_TESTS=1 cabal test cardano-testnet-test --test-options '--list-tests --pattern /kes/'
Resolving dependencies...
Build profile: -w ghc-9.6.4 -O1
In order, the following will be built (use -v for more details):
 - cardano-testnet-8.8.0 (test:cardano-testnet-test) (first run)
Preprocessing test suite 'cardano-testnet-test' for cardano-testnet-8.8.0..
Building test suite 'cardano-testnet-test' for cardano-testnet-8.8.0..
Running 1 test suites...
Test suite cardano-testnet-test: RUNNING...
With concurrent sections
test/Spec.hs.Spec.CLI.kes-period-info
Test suite cardano-testnet-test: PASS
Test suite logged to:
/home/jky/wrk/intersect/cardano-node/dist-newstyle/build/x86_64-linux/ghc-9.6.4/cardano-testnet-8.8.0/t/cardano-testnet-test/test/cardano-testnet-8.8.0-cardano-testnet-test.log
1 of 1 test suites (1 of 1 test cases) passed.
```

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
