### PR TITLE
cardano-testnet: Avoid rewrite of sgMaxLovelaceSupply

### DIFF
--- a/cardano-testnet/src/Testnet/Components/Configuration.hs
+++ b/cardano-testnet/src/Testnet/Components/Configuration.hs
@@ -146,8 +146,8 @@ createSPOGenesisAndFiles (NumPools numPoolNodes) (NumDReps numDelReps) era shell
     , "--spec-conway",  inputGenesisConwayFp
     , "--testnet-magic", show testnetMagic
     , "--pools", show numPoolNodes
-    , "--total-supply",     show @Int 2_000_000_000_000
-    , "--delegated-supply", show @Int 1_000_000_000_000
+    , "--total-supply",     show @Int 2_000_000_000_000 -- 2 trillions
+    , "--delegated-supply", show @Int 1_000_000_000_000 -- 1 trillion
     , "--stake-delegators", show numStakeDelegators
     , "--utxo-keys", show numSeededUTxOKeys
     , "--drep-keys", show numDelReps

--- a/cardano-testnet/src/Testnet/Components/Configuration.hs
+++ b/cardano-testnet/src/Testnet/Components/Configuration.hs
@@ -166,12 +166,6 @@ createSPOGenesisAndFiles (NumPools numPoolNodes) (NumDReps numDelReps) era shell
 
   H.renameFile (tempAbsPath </> "byron-gen-command" </> "genesis.json") (genesisByronDir </> "genesis.json")
 
-  -- For some reason when setting "--total-supply 10E16" in create-testnet-data, we're getting negative
-  -- treasury. TODO: This was supposed to be fixed by https://github.com/IntersectMBO/cardano-cli/pull/644,
-  -- but no, it's still there.
-  H.rewriteJsonFile @Value (tempAbsPath </> defaultGenesisFilepath ShelleyEra) $ \o -> o
-    & L.key "maxLovelaceSupply" . L._Integer .~ 10_000_000_000_000_000
-
   return genesisShelleyDir
   where
     genesisInputFilepath e = "genesis-input." <> anyEraToString (AnyCardanoEra e) <> ".json"

--- a/cardano-testnet/src/Testnet/Defaults.hs
+++ b/cardano-testnet/src/Testnet/Defaults.hs
@@ -434,7 +434,7 @@ defaultShelleyGenesis startTime testnetOptions = do
         { cardanoTestnetMagic = testnetMagic
         , cardanoSlotLength = slotLength
         , cardanoEpochLength = epochLength
-        , cardanoMaxSupply = maxLovelaceLovelaceSupply
+        , cardanoMaxSupply = sgMaxLovelaceSupply
         , cardanoActiveSlotsCoeff
         , cardanoNodeEra
         } = testnetOptions
@@ -449,7 +449,7 @@ defaultShelleyGenesis startTime testnetOptions = do
   Api.shelleyGenesisDefaults
         { Api.sgActiveSlotsCoeff = unsafeBoundedRational activeSlotsCoeff
         , Api.sgEpochLength = EpochSize $ fromIntegral epochLength
-        , Api.sgMaxLovelaceSupply = maxLovelaceLovelaceSupply
+        , Api.sgMaxLovelaceSupply
         , Api.sgNetworkMagic = fromIntegral testnetMagic
         , Api.sgProtocolParams = protocolParamsWithPVer
         -- using default from shelley genesis k = 2160

--- a/cardano-testnet/src/Testnet/Start/Byron.hs
+++ b/cardano-testnet/src/Testnet/Start/Byron.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE TypeApplications #-}
 
 {-# OPTIONS_GHC -Wno-unused-local-binds -Wno-unused-matches #-}
+{-# LANGUAGE NumericUnderscores #-}
 
 module Testnet.Start.Byron
   ( createByronGenesis
@@ -34,7 +35,7 @@ byronDefaultGenesisOptions = ByronGenesisOptions
   -- TODO: createByronGenesis should have a check that errors
   -- if totalBalance can be evenly split between numBftNodes
   -- with no remainder. Having a remainder results in rounding errors.
-  , byronTotalBalance = 8000000000000001
+  , byronTotalBalance = 8_000_000_001 -- 8 billions. Should be smaller than 'cardanoMaxSupply' in Testnet.Start.Types
   }
 
 -- TODO: We should not abuse the byron testnet options for genesis creation.

--- a/cardano-testnet/src/Testnet/Start/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Start/Cardano.hs
@@ -333,7 +333,7 @@ cardanoTestnet
     forM_ (zip [1..] portNumbers) $ \(i, portNumber) -> do
       let iStr = printf "%03d" (i - 1)
       H.renameFile (tmpAbsPath </> "byron-gen-command" </> "delegate-keys." <> iStr <> ".key") (tmpAbsPath </> poolKeyDir i </> "byron-delegate.key")
-      H.renameFile (tmpAbsPath </> "byron-gen-command" </> "delegation-cert." <> iStr <> ".json") (tmpAbsPath </> poolKeyDir i </>"byron-delegation.cert")
+      H.renameFile (tmpAbsPath </> "byron-gen-command" </> "delegation-cert." <> iStr <> ".json") (tmpAbsPath </> poolKeyDir i </> "byron-delegation.cert")
       H.writeFile (tmpAbsPath </> poolKeyDir i </> "port") (show portNumber)
 
     -- Make topology files

--- a/cardano-testnet/src/Testnet/Start/Types.hs
+++ b/cardano-testnet/src/Testnet/Start/Types.hs
@@ -43,7 +43,7 @@ data CardanoTestnetOptions = CardanoTestnetOptions
   , cardanoSlotLength :: Double -- ^ Slot length, in seconds
   , cardanoTestnetMagic :: Int
   , cardanoActiveSlotsCoeff :: Double
-  , cardanoMaxSupply :: Word64 -- ^ The amount of ADA you are starting your testnet with
+  , cardanoMaxSupply :: Word64 -- ^ The amount of ADA you are starting your testnet with (forwarded to shelley genesis)
   , cardanoEnableP2P :: Bool
   , cardanoNodeLoggingFormat :: NodeLoggingFormat
   , cardanoNumDReps :: Int -- ^ The number of DReps to generate at creation
@@ -57,7 +57,7 @@ cardanoDefaultTestnetOptions = CardanoTestnetOptions
   , cardanoSlotLength = 0.1
   , cardanoTestnetMagic = 42
   , cardanoActiveSlotsCoeff = 0.05
-  , cardanoMaxSupply = 10_020_000_000
+  , cardanoMaxSupply = 100_020_000_000 -- 100 billions. This amount should be bigger than the 'byronTotalBalance' in Testnet.Start.Byron
   , cardanoEnableP2P = False
   , cardanoNodeLoggingFormat = NodeLoggingFormatAsJson
   , cardanoNumDReps = 3


### PR DESCRIPTION
# Description

Avoid this [hacky rewrite](https://github.com/IntersectMBO/cardano-node/blob/master/cardano-testnet/src/Testnet/Components/Configuration.hs#L164) that was necessary for the [treasury growth test](https://github.com/IntersectMBO/cardano-node/blob/master/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/TreasuryGrowth.hs) to pass (without the rewrite the treasury was negative).

# How to trust this PR

The treasury growth test now passes without the genesis' rewrite (try it with `PARALLEL_TESTNETS=1 DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/Treasury Growth/"'`)

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] CI passes. See note on CI.
- [X] Self-reviewed the diff