### PR TITLE
Updating the broken documentation link for building the node

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Obtaining ``cardano-node``
 Building from source
 ====================
 
-Documentation for building the node can be found `here <https://docs.cardano.org/getting-started/installing-the-cardano-node>`_.
+Documentation for building the node can be found `here <https://docs.cardano.org/development-guidelines/installing-the-cardano-node>`_.
 
 Executables
 ===========


### PR DESCRIPTION
# Description

The documentation link is broken for building the cardano node. Here is the updated link - [link](https://docs.cardano.org/development-guidelines/installing-the-cardano-node)