### PR TITLE
Set NumThreads to 1 in cardano-testnet-test

### DIFF
--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -74,7 +74,7 @@ library
                       , scientific
                       , si-timers
                       , stm
-                      , tasty
+                      , tasty ^>= 1.5
                       , tasty-expected-failure
                       , tasty-hedgehog
                       , text
@@ -152,7 +152,7 @@ test-suite cardano-testnet-golden
                       , hedgehog-extras
                       , process
                       , regex-compat
-                      , tasty
+                      , tasty ^>= 1.5
                       , tasty-hedgehog
                       , text
 
@@ -220,7 +220,7 @@ test-suite cardano-testnet-test
                       , mtl
                       , process
                       , regex-compat
-                      , tasty
+                      , tasty ^>= 1.5
                       , text
                       , time
                       , transformers

--- a/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
+++ b/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
@@ -24,6 +24,8 @@ import qualified Cardano.Testnet.Test.SubmitApi.Babbage.Transaction
 import           Prelude
 
 import qualified System.Environment as E
+import qualified System.Exit as IO
+import qualified System.IO as IO
 import           System.IO (BufferMode (LineBuffering), hSetBuffering, hSetEncoding, stdout, utf8)
 
 import qualified Testnet.Property.Run as H
@@ -31,40 +33,41 @@ import qualified Testnet.Property.Run as H
 import qualified Test.Tasty as T
 import           Test.Tasty (TestTree)
 import qualified Test.Tasty.Ingredients as T
+import qualified Test.Tasty.Options as T
+import qualified Test.Tasty.Runners as T
 
 tests :: IO TestTree
 tests = do
-  testGroup <- runTestGroup <$> shouldRunInParallel
-  pure $ testGroup "test/Spec.hs"
-    [ testGroup "Spec"
-        [ testGroup "Ledger Events"
+  pure $ T.testGroup "test/Spec.hs"
+    [ T.testGroup "Spec"
+        [ T.testGroup "Ledger Events"
             [ H.ignoreOnWindows "Sanity Check" LedgerEvents.hprop_ledger_events_sanity_check
             , H.ignoreOnWindows "Treasury Growth" LedgerEvents.prop_check_if_treasury_is_growing
             -- TODO: Replace foldBlocks with checkLedgerStateCondition
-            , testGroup "Governance"
+            , T.testGroup "Governance"
                 [ H.ignoreOnMacAndWindows "ProposeAndRatifyNewConstitution" Cardano.Testnet.Test.LedgerEvents.Gov.ProposeNewConstitution.hprop_ledger_events_propose_new_constitution
                   -- FIXME Those tests are flaky
                   -- , H.ignoreOnWindows "InfoAction" LedgerEvents.hprop_ledger_events_info_action
                 , H.ignoreOnWindows "ProposeNewConstitutionSPO" LedgerEvents.hprop_ledger_events_propose_new_constitution_spo
                 , H.ignoreOnWindows "DRepRetirement" DRepRetirement.hprop_drep_retirement
                 ]
-            , testGroup "Plutus"
+            , T.testGroup "Plutus"
                 [ H.ignoreOnWindows "PlutusV3" Cardano.Testnet.Test.Cli.Conway.Plutus.hprop_plutus_v3]
             ]
-        , testGroup "CLI"
+        , T.testGroup "CLI"
           [ H.ignoreOnWindows "Shutdown" Cardano.Testnet.Test.Node.Shutdown.hprop_shutdown
           -- ShutdownOnSigint fails on Mac with
           -- "Log file: /private/tmp/tmp.JqcjW7sLKS/kes-period-info-2-test-30c2d0d8eb042a37/logs/test-spo.stdout.log had no logs indicating the relevant node has minted blocks."
           , H.ignoreOnMacAndWindows "ShutdownOnSigint" Cardano.Testnet.Test.Node.Shutdown.hprop_shutdownOnSigint
           -- ShutdownOnSlotSynced FAILS Still. The node times out and it seems the "shutdown-on-slot-synced" flag does nothing
           -- , H.ignoreOnWindows "ShutdownOnSlotSynced" Cardano.Testnet.Test.Node.Shutdown.hprop_shutdownOnSlotSynced
-          , testGroup "Babbage"
+          , T.testGroup "Babbage"
               [ H.ignoreOnMacAndWindows "leadership-schedule" Cardano.Testnet.Test.Cli.Babbage.LeadershipSchedule.hprop_leadershipSchedule -- FAILS
               , H.ignoreOnWindows "stake-snapshot" Cardano.Testnet.Test.Cli.Babbage.StakeSnapshot.hprop_stakeSnapshot
               , H.ignoreOnWindows "transaction" Cardano.Testnet.Test.Cli.Babbage.Transaction.hprop_transaction
               ]
           -- TODO: Conway -  Re-enable when create-staked is working in conway again
-          --, testGroup "Conway"
+          --, T.testGroup "Conway"
           --  [ H.ignoreOnWindows "stake-snapshot" Cardano.Testnet.Test.Cli.Conway.StakeSnapshot.hprop_stakeSnapshot
           --  ]
             -- Ignored on Windows due to <stdout>: commitBuffer: invalid argument (invalid character)
@@ -75,27 +78,27 @@ tests = do
           , H.ignoreOnWindows "CliQueries" Cardano.Testnet.Test.Cli.Queries.hprop_cli_queries
           ]
         ]
-    , testGroup "SubmitApi"
-        [ testGroup "Babbage"
+    , T.testGroup "SubmitApi"
+        [ T.testGroup "Babbage"
             [ H.ignoreOnWindows "transaction" Cardano.Testnet.Test.SubmitApi.Babbage.Transaction.hprop_transaction
             ]
         ]
     ]
 
-shouldRunInParallel :: IO Bool
-shouldRunInParallel = (== Just "1") <$> E.lookupEnv "PARALLEL_TESTNETS"
+defaultMainWithIngredientsAndOptions :: [T.Ingredient] -> T.OptionSet -> T.TestTree -> IO ()
+defaultMainWithIngredientsAndOptions ins opts testTree = do
+  T.installSignalHandlers
+  parsedOpts <- T.parseOptions ins testTree
+  let opts' = opts <> parsedOpts
 
--- FIXME Right now when running tests concurrently it makes them flaky
-runTestGroup
-  :: Bool -- ^ True to run in parallel
-  -> T.TestName
-  -> [TestTree]
-  -> TestTree
-runTestGroup True name = T.testGroup name
-runTestGroup False name = T.sequentialTestGroup name T.AllFinish
-
-ingredients :: [T.Ingredient]
-ingredients = T.defaultIngredients
+  case T.tryIngredients ins opts' testTree of
+    Nothing -> do
+      IO.hPutStrLn IO.stderr
+        "No ingredients agreed to run. Something is wrong either with your ingredient set or the options."
+      IO.exitFailure
+    Just act -> do
+      ok <- act
+      if ok then IO.exitSuccess else IO.exitFailure
 
 main :: IO ()
 main = do
@@ -105,4 +108,6 @@ main = do
   hSetEncoding stdout utf8
   args <- E.getArgs
 
-  E.withArgs args $ tests >>= T.defaultMainWithIngredients ingredients
+  let opts = T.singleOption $ T.NumThreads 1
+
+  E.withArgs args $ tests >>= defaultMainWithIngredientsAndOptions T.defaultIngredients opts


### PR DESCRIPTION
# Description

Make tests single-threaded by setting `NumThreads 1`.  This has the advantage that `--list-tests` still work.

This replaces https://github.com/IntersectMBO/cardano-node/pull/5744 because that PR fails in CI for an as yet unknown reason.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
