### PR TITLE
NodeVersion tracer for providing metrics

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -32,7 +32,7 @@ packages:
   trace-forward
 
 program-options
-  ghc-options: -Werror
+--  ghc-options: -Werror
 
 test-show-details: direct
 

--- a/cabal.project
+++ b/cabal.project
@@ -32,7 +32,7 @@ packages:
   trace-forward
 
 program-options
---  ghc-options: -Werror
+  ghc-options: -Werror
 
 test-show-details: direct
 

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -113,6 +113,7 @@ library
                         Cardano.Node.Tracing.Tracers.KESInfo
                         Cardano.Node.Tracing.Tracers.NodeToClient
                         Cardano.Node.Tracing.Tracers.NodeToNode
+                        Cardano.Node.Tracing.Tracers.NodeVersion
                         Cardano.Node.Tracing.Tracers.NonP2P
                         Cardano.Node.Tracing.Tracers.P2P
                         Cardano.Node.Tracing.Tracers.Peer

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -288,8 +288,12 @@ handleNodeWithTracers cmdPc nc0 p networkMagic blockType runP = do
             >>= mapM_ (traceWith $ startupTracer tracers)
 
           traceWith (nodeVersionTracer tracers) getNodeVersion
+
+          blockForging <- snd (Api.protocolInfo runP)
           traceWith (startupTracer tracers)
-                    (BlockForgingUpdate NotEffective)
+                    (BlockForgingUpdate (if null blockForging
+                                          then DisabledBlockForging
+                                          else EnabledBlockForging))
 
           -- We ignore peer logging thread if it dies, but it will be killed
           -- when 'handleSimpleNode' terminates.

--- a/cardano-node/src/Cardano/Node/Tracing.hs
+++ b/cardano-node/src/Cardano/Node/Tracing.hs
@@ -16,6 +16,8 @@ import           Cardano.Node.Tracing.StateRep (NodeState)
 import           Cardano.Node.Tracing.Tracers.ConsensusStartupException
                    (ConsensusStartupException (..))
 import           Cardano.Node.Tracing.Tracers.Peer (PeerT)
+import           Cardano.Node.Tracing.Tracers.NodeVersion (NodeVersionTrace)
+
 import qualified Ouroboros.Consensus.Network.NodeToClient as NodeToClient
 import qualified Ouroboros.Consensus.Network.NodeToNode as NodeToNode
 import qualified Ouroboros.Consensus.Node.Tracers as Consensus
@@ -48,6 +50,7 @@ data Tracers peer localPeer blk p2p = Tracers
   , startupTracer         :: !(Tracer IO (StartupTrace blk))
   , shutdownTracer        :: !(Tracer IO ShutdownTrace)
   , nodeInfoTracer        :: !(Tracer IO NodeInfo)
+  , nodeVersionTracer     :: !(Tracer IO NodeVersionTrace)
   , nodeStartupInfoTracer :: !(Tracer IO NodeStartupInfo)
   , nodeStateTracer       :: !(Tracer IO NodeState)
   , resourcesTracer       :: !(Tracer IO ResourceStats)

--- a/cardano-node/src/Cardano/Node/Tracing/Consistency.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Consistency.hs
@@ -27,6 +27,8 @@ import           Cardano.Node.Tracing.Tracers.Diffusion ()
 import           Cardano.Node.Tracing.Tracers.KESInfo ()
 import           Cardano.Node.Tracing.Tracers.NodeToClient ()
 import           Cardano.Node.Tracing.Tracers.NodeToNode ()
+import           Cardano.Node.Tracing.Tracers.NodeVersion (NodeVersionTrace)
+
 import           Cardano.Node.Tracing.Tracers.NonP2P ()
 import           Cardano.Node.Tracing.Tracers.P2P ()
 import           Cardano.Node.Tracing.Tracers.Peer
@@ -130,6 +132,9 @@ getAllNamespaces =
                         (allNamespaces :: [Namespace (StartupTrace blk)])
         shutdownNS = map (nsGetTuple . nsReplacePrefix ["Shutdown"])
                         (allNamespaces :: [Namespace ShutdownTrace])
+        nodeVersionNS = map (nsGetTuple . nsReplacePrefix ["Version"])
+                        (allNamespaces :: [Namespace NodeVersionTrace])
+
         chainDBNS = map (nsGetTuple . nsReplacePrefix ["ChainDB"])
                         (allNamespaces :: [Namespace (ChainDB.TraceEvent blk)])
         replayBlockNS = map (nsGetTuple . nsReplacePrefix ["ChainDB", "ReplayBlock"])
@@ -366,6 +371,7 @@ getAllNamespaces =
             <> resourcesNS
             <> startupNS
             <> shutdownNS
+            <> nodeVersionNS
             <> chainDBNS
             <> replayBlockNS
 -- Consensus

--- a/cardano-node/src/Cardano/Node/Tracing/Documentation.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Documentation.hs
@@ -35,6 +35,8 @@ import           Cardano.Node.Tracing.Tracers.ForgingThreadStats (ForgeThreadSta
 import           Cardano.Node.Tracing.Tracers.KESInfo ()
 import           Cardano.Node.Tracing.Tracers.NodeToClient ()
 import           Cardano.Node.Tracing.Tracers.NodeToNode ()
+import           Cardano.Node.Tracing.Tracers.NodeVersion (NodeVersionTrace)
+
 import           Cardano.Node.Tracing.Tracers.NonP2P ()
 import           Cardano.Node.Tracing.Tracers.P2P ()
 import           Cardano.Node.Tracing.Tracers.Peer
@@ -191,6 +193,12 @@ docTracersFirstPhase condConfigFileName = do
     configureTracers configReflection trConfig [nodeStartupInfoDp]
     nodeStartupInfoDpDoc <- documentTracer
                       (nodeStartupInfoDp :: Trace IO NodeStartupInfo)
+
+    nodeVersionTr <- mkCardanoTracer
+                      trBase trForward mbTrEKG
+                      ["Version"]
+    configureTracers configReflection trConfig  [nodeVersionTr]
+    nodeVersionDoc <- documentTracer (nodeVersionTr :: Trace IO NodeVersionTrace)
 
     -- State tracer
     stateTr   <- mkCardanoTracer
@@ -677,6 +685,7 @@ docTracersFirstPhase condConfigFileName = do
             <> resourcesTrDoc
             <> startupTrDoc
             <> shutdownTrDoc
+            <> nodeVersionDoc
             <> peersTrDoc
             <> chainDBTrDoc
             <> replayBlockTrDoc

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
@@ -33,6 +33,8 @@ import           Cardano.Node.Tracing.Tracers.ForgingThreadStats (forgeThreadSta
 import           Cardano.Node.Tracing.Tracers.KESInfo
 import           Cardano.Node.Tracing.Tracers.NodeToClient ()
 import           Cardano.Node.Tracing.Tracers.NodeToNode ()
+import           Cardano.Node.Tracing.Tracers.NodeVersion (getNodeVersion)
+
 import           Cardano.Node.Tracing.Tracers.NonP2P ()
 import           Cardano.Node.Tracing.Tracers.P2P ()
 import           Cardano.Node.Tracing.Tracers.Peer ()
@@ -125,6 +127,10 @@ mkDispatchTracers nodeKernel trBase trForward mbTrEKG trDataPoint trConfig enabl
     !chainDBTr <- mkCardanoTracer' trBase trForward mbTrEKG ["ChainDB"]
                                     withAddedToCurrentChainEmptyLimited
     configureTracers configReflection trConfig [chainDBTr]
+
+    !nodeVersionTr <- mkCardanoTracer trBase trForward mbTrEKG ["Version"]
+    configureTracers configReflection trConfig  [nodeVersionTr]
+
     -- Filter out replayed blocks for this tracer
     let chainDBTr' = filterTrace
                       (\case (_, ChainDB.TraceLedgerReplayEvent
@@ -170,6 +176,8 @@ mkDispatchTracers nodeKernel trBase trForward mbTrEKG trDataPoint trConfig enabl
 
     traceEffectiveConfiguration trBase trForward trConfig
 
+    traceWith nodeVersionTr getNodeVersion
+
     pure Tracers
       {
         chainDBTracer = Tracer (traceWith chainDBTr')
@@ -188,6 +196,7 @@ mkDispatchTracers nodeKernel trBase trForward mbTrEKG trDataPoint trConfig enabl
       , nodeStartupInfoTracer = Tracer (traceWith nodeStartupInfoDP)
       , nodeStateTracer = Tracer (traceWith stateTr)
                           <> Tracer (traceWith nodeStateDP)
+      , nodeVersionTracer = Tracer (traceWith nodeVersionTr)
       , resourcesTracer = Tracer (traceWith resourcesTr)
       , peersTracer     = Tracer (traceWith peersTr)
                           <> Tracer (traceNodePeers nodePeersDP)

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/NodeVersion.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/NodeVersion.hs
@@ -1,0 +1,138 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+
+module Cardano.Node.Tracing.Tracers.NodeVersion
+(
+    NodeVersionTrace (..)
+  , getNodeVersion
+  , getCardanoBuildInfo
+)
+ where
+
+import           Data.Aeson (toJSON, (.=))
+import           Data.Text (Text, pack)
+
+import           Data.Version (Version (..), showVersion)
+import           System.Info (arch, compilerName, compilerVersion, os)
+
+
+import           Cardano.Git.Rev (gitRev)
+import           Cardano.Logging
+
+
+import           Paths_cardano_node (version)
+
+
+
+-- | Node version information
+
+data NodeVersionTrace = NodeVersionTrace
+  { applicationName    :: Text
+  , applicationVersion :: Version
+  , osName             :: Text
+  , architecture       :: Text
+  , compilerName       :: Text
+  , compilerVersion    :: Version
+  , gitRevision        :: Text
+  } deriving (Eq, Show)
+
+-- | Get the node version information
+
+getNodeVersion :: NodeVersionTrace
+getNodeVersion =
+  let applicationName = "cardano-node"
+      applicationVersion = version
+      osName = pack os
+      architecture = pack arch
+      compilerName = pack System.Info.compilerName
+      compilerVersion = System.Info.compilerVersion
+
+      gitRevision = $(gitRev)
+  in NodeVersionTrace {..}
+
+
+instance MetaTrace NodeVersionTrace where
+  namespaceFor NodeVersionTrace {}  =
+    Namespace [] ["NodeVersion"]
+  severityFor (Namespace _ ["NodeVersion"]) _ = Just Info
+  severityFor _ _ = Nothing
+
+  documentFor (Namespace _ ["NodeVersion"]) = Just "Node version information"
+
+  documentFor _ = Nothing
+
+  metricsDocFor (Namespace _ ["NodeVersion"]) =
+    [("cardano_version_major", "Cardano node version information")
+    ,("cardano_version_minor", "Cardano node version information")
+    ,("cardano_version_patch", "Cardano node version information")
+    ,("haskell_compiler_major", "Cardano compiler version information")
+    ,("haskell_compiler_minor", "Cardano compiler version information")
+    --,("haskell_compiler_patch", "Cardano compiler version information")
+    ,("cardano_build_info", "Cardano node build info")
+    ]
+  metricsDocFor _ = []
+
+  allNamespaces = [Namespace [] ["NodeVersion"]]
+
+instance LogFormatting NodeVersionTrace where
+  forHuman NodeVersionTrace {..} = mconcat
+    [ "cardano-node ", pack (showVersion applicationVersion)
+    , " git rev ", gitRevision
+    , " - ", pack os, "-", pack arch
+    , " - ", compilerName, "-", pack (showVersion compilerVersion)
+    ]
+
+  forMachine _dtal NodeVersionTrace {..} = mconcat
+
+    [ "applicationName" .= applicationName
+    , "applicationVersion" .= toJSON applicationVersion
+    , "gitRevision" .= gitRevision
+    , "osName" .= osName
+    , "architecture" .= architecture
+    , "compilerName" .= compilerName
+    , "compilerVersion" .= toJSON compilerVersion
+    ]
+
+  asMetrics nvt@NodeVersionTrace {..} =
+    [ IntM "cardano_version_major" (fromIntegral (getMajor applicationVersion))
+    , IntM "cardano_version_minor" (fromIntegral (getMinor applicationVersion))
+    , IntM "cardano_version_patch" (fromIntegral (getPatch applicationVersion))
+    , IntM "haskell_compiler_major" (fromIntegral (getMajor compilerVersion))
+    , IntM "haskell_compiler_minor" (fromIntegral (getMinor compilerVersion))
+    --, IntM "haskell_compiler_patch" (fromIntegral (getPatch compilerVersion))
+    , PrometheusM "cardano_build_info" (getCardanoBuildInfo nvt)
+    ]
+
+getCardanoBuildInfo :: NodeVersionTrace -> [(Text,Text)]
+getCardanoBuildInfo NodeVersionTrace {..} =
+  [ ("version_major", pack (show (getMajor applicationVersion)))
+  , ("version_minor", pack (show (getMinor applicationVersion)))
+  , ("version_patch", pack (show (getPatch applicationVersion)))
+  , ("version", pack (showVersion applicationVersion))
+  , ("revision", gitRevision)
+  , ("compiler_name", compilerName)
+  , ("compiler_version", pack (showVersion compilerVersion))
+  , ("compiler_version_major", pack (show (getMajor compilerVersion)))
+  , ("compiler_version_minor", pack (show (getMinor compilerVersion)))
+  -- , ("compiler_version_patch", pack (show (getPatch compilerVersion)))
+  , ("architecture", architecture)
+  , ("os_name", osName)
+  ]
+
+getMajor :: Version -> Int
+getMajor (Version (x:_) _) = x
+getMajor _ = 0
+
+getMinor :: Version -> Int
+getMinor (Version (_:x:_) _) = x
+getMinor _ = 0
+
+getPatch :: Version -> Int
+getPatch (Version (_:_:x:_) _) = x
+getPatch _ = 0
+
+
+

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
@@ -25,7 +25,9 @@ import           Cardano.Logging
 import           Cardano.Node.Configuration.POM (NodeConfiguration, ncProtocol)
 import           Cardano.Node.Configuration.Socket
 import           Cardano.Node.Protocol (SomeConsensusProtocol (..))
+
 import           Cardano.Node.Startup
+
 import           Cardano.Slotting.Slot (EpochSize (..))
 import qualified Ouroboros.Consensus.BlockchainTime.WallClock.Types as WCT
 import           Ouroboros.Consensus.Byron.Ledger.Conversions (fromByronEpochSlots,
@@ -54,6 +56,7 @@ import           Data.Text (Text, pack)
 import           Data.Time (getCurrentTime)
 import           Data.Time.Clock.POSIX (POSIXTime, utcTimeToPOSIXSeconds)
 import           Data.Version (showVersion)
+
 import           Network.Socket (SockAddr)
 
 import           Paths_cardano_node (version)

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -706,7 +706,7 @@ sendEKGDirectPrometheusLabel ekgDirect name labels = do
     presentPrometheusM =
       label . map pair
       where
-        label pairs = "{" <> Text.intercalate "," pairs <> "} 1"
+        label pairs = "{" <> Text.intercalate "," pairs <> "}"
         pair (k, v) = k <> "=\"" <> v <> "\""
 
 --------------------------------------------------------------------------------

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -139,7 +139,6 @@ import qualified System.Metrics.Gauge as Gauge
 import qualified System.Metrics.Label as Label
 import qualified System.Remote.Monitoring as EKG
 
-import           Debug.Trace (trace)
 
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
 -- needs different instances on ghc8 and on ghc9
@@ -378,16 +377,16 @@ mkTracers blockConfig tOpts@(TracingOnLegacy trSel) tr nodeKern ekgDirect enable
               _ -> pure ()
         Nothing -> pure ()
    traceVersionMetric :: Maybe EKGDirect -> NodeVersionTrace -> IO ()
-   traceVersionMetric mbEKGDirect ev = trace "traceVersionMetric" $ do
+   traceVersionMetric mbEKGDirect ev = do
       case mbEKGDirect of
         Just ekgDirect' ->
           case ev of
-              NodeVersionTrace {} -> trace "traceVersionMetric sending" $
+              NodeVersionTrace {} ->
                   sendEKGDirectPrometheusLabel
                     ekgDirect'
                     "cardano.node.metrics.cardano_build_info"
                     (getCardanoBuildInfo ev)
-        Nothing -> trace "no ekg direct" $ pure ()
+        Nothing -> pure ()
 
    diffusionTracers = Diffusion.Tracers
      { Diffusion.dtMuxTracer                     = muxTracer

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -369,7 +369,7 @@ mkTracers blockConfig tOpts@(TracingOnLegacy trSel) tr nodeKern ekgDirect enable
       case mbEKGDirect of
         Just ekgDirect' ->
           case ev of
-              BlockForgingUpdate b -> sendEKGDirectInt ekgDirect' "forging_enabled"
+              BlockForgingUpdate b -> sendEKGDirectInt ekgDirect' "cardano.node.metrics.forging_enabled"
                                         (case b of
                                             EnabledBlockForging -> 1 :: Int
                                             DisabledBlockForging -> 0 :: Int

--- a/nix/workbench/service/tracing.nix
+++ b/nix/workbench/service/tracing.nix
@@ -86,6 +86,7 @@ let
       "TxSubmission.Remote".severity = "Notice";
       "TxSubmission.TxInbound".severity = "Debug";
       "TxSubmission.TxOutbound".severity = "Notice";
+      "Version.NodeVersion".severity = "Info";
       };
   };
 

--- a/trace-dispatcher/CHANGELOG.md
+++ b/trace-dispatcher/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for trace-dispatcher
 
+## 2.5.7
+
+* With a prometheus metric with key label pairs. The value will always be "1"
+
 ## 2.5.2 -- Dec 2023
 
 * ForHuman Color, Increased Consistency Checks, and Non-empty Inner Workspace Validation

--- a/trace-dispatcher/src/Cardano/Logging/Types.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Types.hs
@@ -188,6 +188,15 @@ data Metric
   -- | A counter metric.
   -- Text is used to name the metric
     | CounterM Text (Maybe Int)
+  -- | A prometheus metric with key label pairs.
+  -- Text is used to name the metric
+  -- [(Text, Text)] is used to represent the key label pairs
+  -- The value of the metric will always be "1"
+  -- e.g. if you have a prometheus metric with the name "prometheus_metric"
+  -- and the key label pairs [("key1", "value1"), ("key2", "value2")]
+  -- the metric will be represented as "prometheus_metric{key1=\"value1\",key2=\"value2\"} 1"
+
+    | PrometheusM Text [(Text, Text)]
   deriving (Show, Eq)
 
 
@@ -195,6 +204,8 @@ getMetricName :: Metric -> Text
 getMetricName (IntM name _) = name
 getMetricName (DoubleM name _) = name
 getMetricName (CounterM name _) = name
+getMetricName (PrometheusM name _) = name
+
 
 -- | A helper function for creating an empty |Object|.
 emptyObject :: HM.HashMap Text a

--- a/trace-dispatcher/trace-dispatcher.cabal
+++ b/trace-dispatcher/trace-dispatcher.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   trace-dispatcher
-version:                2.5.6
+version:                2.5.7
 synopsis:               Tracers for Cardano
 description:            Package for development of simple and efficient tracers
                         based on the arrow based contra-tracer package


### PR DESCRIPTION
This adds a new trace message, which adds new metrics. Here is an example of what it provides:
```
cardano_build_info {
, version = "8.10.0"
, version_major="8"
, version_minor="10"
, version_patch="0"
, revision="fd7eb00d1697b0c6eb7f3e3d0ad6e94fcc5caa63"
, compiler_name="ghc"
, compiler_version="8.10"
, compiler_version_major="8"
, compiler_version_minor="10"
, architecture="x86_64"
, os_name="linux" 
} 1 
```
*NB* in the actual Prometheus output, this is 1 line only; newlines have been inserted here for readability only.

Additionally, it provided an alternative representation of the same data as trace messages for both machines and humans. Here are examples of how the data will be represented:

Machine Trace Message:
{"at":"2024-04-08T12:30:08.89384608Z","ns":"Version.NodeVersion","data":{"applicationName":"cardano-node","applicationVersion":"8.10.0","architecture":"x86_64","compilerName":"ghc","compilerVersion":"8.10","gitRevision":"f3fabe88bfc83f5e9c2a9d7af2293857cd8212c3","osName":"linux"},"sev":"Info","thread":"5","host":"deusXmachina"}

Human Trace Message:
[2024-04-08 13:46:26.5169Z][deusXmachina:Version.NodeVersion](Info,5) cardano-node 8.10.0 git rev f3fabe88bfc83f5e9c2a9d7af2293857cd8212c3 - linux-x86_64 - ghc-8.10
