### PR TITLE
Doc: Remove old references to Docker Hub

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,11 +67,11 @@ The download includes cardano-node.exe and a .dll. To run the node with cardano-
 Docker image
 ============
 
-You can pull the docker image with the latest version of cardano-node from `here <https://hub.docker.com/r/inputoutput/cardano-node>`_.
+You can pull the docker image with the latest version of cardano-node from `here <https://github.com/IntersectMBO/cardano-node/pkgs/container/cardano-node>`_.
 
 .. code-block:: console
 
-    docker pull inputoutput/cardano-node
+    docker pull ghcr.io/intersectmbo/cardano-node:8.9.1
 
 **********************
 Using ``cardano-node``


### PR DESCRIPTION
# Description

These images were moved to ghcr.io

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
