### PR TITLE
Remove orphan ToJSON instances that were moved to ledger

### DIFF
--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -248,6 +248,8 @@ test-suite cardano-node-test
                       , cardano-crypto-wrapper
                       , cardano-api:{cardano-api, internal}
                       , cardano-ledger-core
+                      , cardano-ledger-allegra
+                      , cardano-ledger-alonzo
                       , cardano-node
                       , cardano-slotting
                       , directory
@@ -276,5 +278,6 @@ test-suite cardano-node-test
                         Test.Cardano.Node.POM
                         Test.Cardano.Tracing.NewTracing.Consistency
                         Test.Cardano.Tracing.OrphanInstances.HardFork
+                        Test.Cardano.Tracing.OrphanInstances.Shelley
 
   ghc-options:          -threaded -rtsopts "-with-rtsopts=-N -T"

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -149,8 +149,8 @@ library
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
                       , cardano-git-rev ^>=0.2.2
-                      , cardano-ledger-alonzo
-                      , cardano-ledger-allegra
+                      , cardano-ledger-alonzo >=1.7.1
+                      , cardano-ledger-allegra >=1.4.1
                       , cardano-ledger-api
                       , cardano-ledger-babbage
                       , cardano-ledger-byron

--- a/cardano-node/test/Test/Cardano/Tracing/OrphanInstances/Shelley.hs
+++ b/cardano-node/test/Test/Cardano/Tracing/OrphanInstances/Shelley.hs
@@ -1,0 +1,107 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Test the JSON encoding of instances in Cardano.Tracing.OrphanInstances.Shelley
+--
+-- The golden files are stored in the path given by 'addPrefix'.
+--
+-- If a new test is added and no golden file exists for it it will be created.
+-- This new file needs to be commited.
+--
+-- For now we added a couple of representative examples, however the tests are
+-- not exhaustive.
+--
+-- The examples can be best viewed using a tool like 'jq'.
+module Test.Cardano.Tracing.OrphanInstances.Shelley (tests) where
+
+import           Cardano.Ledger.Allegra.Scripts (ValidityInterval (..))
+import           Cardano.Ledger.Alonzo.Rules (FailureDescription (..), TagMismatchDescription (..))
+import           Cardano.Ledger.Alonzo.Tx (IsValid (..))
+import           Cardano.Ledger.BaseTypes (SlotNo (..), StrictMaybe (..))
+import           Cardano.Tracing.OrphanInstances.Shelley ()
+
+import qualified Data.Aeson as Aeson
+import           Data.ByteString.Lazy.Char8 (unpack)
+import qualified Data.List.NonEmpty as NE
+
+import           Hedgehog (Property)
+import qualified Hedgehog as H
+import qualified Hedgehog.Extras.Test.Base as H.Base
+import qualified Hedgehog.Extras.Test.Golden as H.Golden
+import           Hedgehog.Internal.Property (PropertyName (PropertyName))
+
+tests :: IO Bool
+tests = H.checkSequential
+      $ H.Group "Shelley JSON instances"
+        [ test
+            (  validityInterval
+            , "validityInterval.json")
+        , test
+            (  isValid
+            , "isValid.json")
+        , test
+            (  failureDescription
+            , "failureDescription.json")
+        , test
+            (  tagMismatchDescription
+            , "tagMismatchDescription.json")
+        ]
+  where
+    test (actualValue, goldenBaseName) =
+        (PropertyName goldenBaseName, goldenTestJSON actualValue goldenBaseName)
+
+--------------------------------------------------------------------------------
+-- Examples
+--------------------------------------------------------------------------------
+
+validityInterval :: [ValidityInterval]
+validityInterval =
+  [ ValidityInterval
+      { invalidBefore = SNothing
+      , invalidHereafter = SNothing
+      }
+  , ValidityInterval
+      { invalidBefore = SJust (SlotNo 12345)
+      , invalidHereafter = SNothing
+      }
+  , ValidityInterval
+      { invalidBefore = SNothing
+      , invalidHereafter = SJust (SlotNo 12354)
+      }
+  , ValidityInterval
+      { invalidBefore = SJust (SlotNo 12345)
+      , invalidHereafter = SJust (SlotNo 12354)
+      }
+  ]
+
+isValid :: [IsValid]
+isValid =
+  [ IsValid True
+  , IsValid False
+  ]
+
+failureDescription :: [FailureDescription]
+failureDescription =
+  [ PlutusFailure "A description" "A reconstruction"
+  ]
+
+tagMismatchDescription :: [TagMismatchDescription]
+tagMismatchDescription =
+  [ PassedUnexpectedly
+  , FailedUnexpectedly (NE.fromList failureDescription)
+  ]
+
+--------------------------------------------------------------------------------
+-- Helper functions
+--------------------------------------------------------------------------------
+
+goldenTestJSON :: Aeson.ToJSON a => a -> FilePath -> Property
+goldenTestJSON valueToEncode goldenFileBaseName =
+    H.withTests 1 $ H.withShrinks 0 $ H.property $ do
+      goldenFp    <- H.Base.note $ addPrefix goldenFileBaseName
+      let actualValue = unpack $ Aeson.encode valueToEncode
+      H.Golden.diffVsGoldenFile actualValue goldenFp
+
+-- | NB: this function is only used in 'goldenTestJSON' but it is defined at the
+-- top level so that we can refer to it in the documentation of this module.
+addPrefix :: FilePath -> FilePath
+addPrefix fname = "test/Test/Cardano/Tracing/OrphanInstances/data/" <> fname

--- a/cardano-node/test/Test/Cardano/Tracing/OrphanInstances/data/failureDescription.json
+++ b/cardano-node/test/Test/Cardano/Tracing/OrphanInstances/data/failureDescription.json
@@ -1,0 +1,1 @@
+[{"description":"A description","error":"PlutusFailure","kind":"FailureDescription"}]

--- a/cardano-node/test/Test/Cardano/Tracing/OrphanInstances/data/isValid.json
+++ b/cardano-node/test/Test/Cardano/Tracing/OrphanInstances/data/isValid.json
@@ -1,0 +1,1 @@
+[true,false]

--- a/cardano-node/test/Test/Cardano/Tracing/OrphanInstances/data/tagMismatchDescription.json
+++ b/cardano-node/test/Test/Cardano/Tracing/OrphanInstances/data/tagMismatchDescription.json
@@ -1,0 +1,1 @@
+[{"error":"PassedUnexpectedly","kind":"TagMismatchDescription"},{"error":"FailedUnexpectedly","kind":"TagMismatchDescription","reconstruction":[{"description":"A description","error":"PlutusFailure","kind":"FailureDescription"}]}]

--- a/cardano-node/test/Test/Cardano/Tracing/OrphanInstances/data/validityInterval.json
+++ b/cardano-node/test/Test/Cardano/Tracing/OrphanInstances/data/validityInterval.json
@@ -1,0 +1,1 @@
+[{},{"invalidBefore":12345},{"invalidHereafter":12354},{"invalidBefore":12345,"invalidHereafter":12354}]

--- a/cardano-node/test/cardano-node-test.hs
+++ b/cardano-node/test/cardano-node-test.hs
@@ -14,6 +14,7 @@ import qualified Test.Cardano.Node.FilePermissions
 import qualified Test.Cardano.Node.Json
 import qualified Test.Cardano.Node.POM
 import qualified Test.Cardano.Tracing.OrphanInstances.HardFork
+import qualified Test.Cardano.Tracing.OrphanInstances.Shelley
 import qualified Test.Cardano.Tracing.NewTracing.Consistency
 
 import qualified Cardano.Crypto.Init as Crypto
@@ -35,5 +36,6 @@ main = do
       , Test.Cardano.Node.Json.tests
       , Test.Cardano.Node.POM.tests
       , Test.Cardano.Tracing.OrphanInstances.HardFork.tests
+      , Test.Cardano.Tracing.OrphanInstances.Shelley.tests
       , Test.Cardano.Tracing.NewTracing.Consistency.tests
       ]


### PR DESCRIPTION
# Description

These instances were added to ledger in IntersectMBO/cardano-ledger#4250. This PR shouldn't be merged until node is updated to use the corresponding versions of the ledger packages.

The golden tests pass with the current instances. They can be used to validate the new instances and should then be discarded (in #5776) because they will no longer be testing code that's in node.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
