### PR TITLE
Integrate with a future version of ouroboros-network (0.16)

### DIFF
--- a/bench/locli/locli.cabal
+++ b/bench/locli/locli.cabal
@@ -121,7 +121,7 @@ library
                       , optparse-generic
                       , ouroboros-consensus
                       -- for Data.SOP.Strict:
-                      , ouroboros-network ^>= 0.13
+                      , ouroboros-network ^>= 0.14
                       , ouroboros-network-api
                       , process
                       , quiet

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2024-03-26T06:28:59Z
-  , cardano-haskell-packages 2024-04-05T07:51:28Z
+  , cardano-haskell-packages 2024-04-11T09:29:53Z
 
 packages:
   cardano-node
@@ -59,3 +59,18 @@ package plutus-scripts-bench
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
 
 -- `smtp-mail` should depend on `crypton-connection` rather than `connection`!
+
+source-repository-package
+  type: git
+  location: https://github.com/IntersectMBO/ouroboros-network
+  --sha256: sha256-q0m77ON0fcswZt0wevI+r9Zq+hphlsW9jUWY1iFuW5o=
+  tag: 94cd5e7197c9d450ecdd538dd9790b8ed4c2110c
+  subdir: ouroboros-network-api
+          ouroboros-network
+
+source-repository-package
+  type: git
+  location: https://github.com/IntersectMBO/ouroboros-consensus
+  --sha256: sha256-3/9vv3CH54AMxyvxzTndratjPZ0b/mb3BZDPbtnFPDg=
+  tag: 95c7341818db01c9e51c98346cdbcb305bcec465
+  subdir: ouroboros-consensus-diffusion

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -185,10 +185,10 @@ library
                       , optparse-applicative-fork >= 0.18.1
                       , ouroboros-consensus ^>= 0.17
                       , ouroboros-consensus-cardano ^>= 0.15
-                      , ouroboros-consensus-diffusion ^>= 0.13
+                      , ouroboros-consensus-diffusion ^>= 0.15
                       , ouroboros-consensus-protocol
                       , ouroboros-network-api ^>= 0.7.1
-                      , ouroboros-network ^>= 0.13
+                      , ouroboros-network ^>= 0.14
                       , ouroboros-network-framework
                       , ouroboros-network-protocols ^>= 0.8
                       , prettyprinter

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -374,8 +374,9 @@ handleSimpleNode blockType runP p2pMode tracers nc onKernel = do
 
   dbPath <- canonDbPath nc
 
-  let diffusionArguments :: Diffusion.Arguments Socket      RemoteAddress
-                                                LocalSocket LocalAddress
+  publicPeerSelectionVar <- Diffusion.makePublicPeerSelectionStateVar
+  let diffusionArguments :: Diffusion.Arguments IO Socket      RemoteAddress
+                                                   LocalSocket LocalAddress
       diffusionArguments =
         Diffusion.Arguments {
             Diffusion.daIPv4Address  =
@@ -395,6 +396,7 @@ handleSimpleNode blockType runP p2pMode tracers nc onKernel = do
                 Nothing                         -> Nothing
           , Diffusion.daAcceptedConnectionsLimit = ncAcceptedConnectionsLimit nc
           , Diffusion.daMode = ncDiffusionMode nc
+          , Diffusion.daPublicPeerSelectionVar = publicPeerSelectionVar
           }
 
   ipv4 <- traverse getSocketOrSocketInfoAddr publicIPv4SocketOrAddr

--- a/cardano-node/src/Cardano/Node/Tracing/Consistency.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Consistency.hs
@@ -62,7 +62,7 @@ import qualified Ouroboros.Network.NodeToClient as NtC
 import           Ouroboros.Network.NodeToNode (ErrorPolicyTrace (..), RemoteAddress, WithAddr (..))
 import qualified Ouroboros.Network.NodeToNode as NtN
 import           Ouroboros.Network.PeerSelection.Governor (DebugPeerSelection (..),
-                   PeerSelectionCounters (..), TracePeerSelection (..))
+                   PeerSelectionCounters, TracePeerSelection (..))
 import           Ouroboros.Network.PeerSelection.LedgerPeers (TraceLedgerPeers)
 import           Ouroboros.Network.PeerSelection.PeerStateActions (PeerSelectionActionsTrace (..))
 import           Ouroboros.Network.PeerSelection.RootPeersDNS.LocalRootPeers

--- a/cardano-node/src/Cardano/Node/Tracing/Documentation.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Documentation.hs
@@ -71,7 +71,7 @@ import qualified Ouroboros.Network.NodeToClient as NtC
 import           Ouroboros.Network.NodeToNode (ErrorPolicyTrace (..), RemoteAddress, WithAddr (..))
 import qualified Ouroboros.Network.NodeToNode as NtN
 import           Ouroboros.Network.PeerSelection.Governor (DebugPeerSelection (..),
-                   PeerSelectionCounters (..), TracePeerSelection (..))
+                   PeerSelectionCounters, TracePeerSelection (..))
 import           Ouroboros.Network.PeerSelection.LedgerPeers (TraceLedgerPeers)
 import           Ouroboros.Network.PeerSelection.PeerStateActions (PeerSelectionActionsTrace (..))
 import           Ouroboros.Network.PeerSelection.RootPeersDNS.LocalRootPeers

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
@@ -539,6 +539,11 @@ mkDiffusionTracersExtra configReflection trBase trForward mbTrEKG _trDataPoint t
       ["Net", "PeerSelection"]
     configureTracers configReflection trConfig [peerSelectionCountersTr]
 
+    !churnCountersTr  <-  mkCardanoTracer
+      trBase trForward mbTrEKG
+      ["Net", "Churn"]
+    configureTracers configReflection trConfig [churnCountersTr]
+
     !peerSelectionActionsTr  <-  mkCardanoTracer
       trBase trForward mbTrEKG
       ["Net", "PeerSelection", "Actions"]
@@ -602,6 +607,8 @@ mkDiffusionTracersExtra configReflection trBase trForward mbTrEKG _trDataPoint t
                  traceWith debugPeerSelectionResponderTr
              , P2P.dtTracePeerSelectionCounters = Tracer $
                  traceWith peerSelectionCountersTr
+             , P2P.dtTraceChurnCounters = Tracer $
+                 traceWith churnCountersTr
              , P2P.dtPeerSelectionActionsTracer = Tracer $
                  traceWith peerSelectionActionsTr
              , P2P.dtConnectionManagerTracer = Tracer $

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/P2P.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/P2P.hs
@@ -26,20 +26,19 @@ import           Ouroboros.Network.InboundGovernor (InboundGovernorTrace (..))
 import qualified Ouroboros.Network.InboundGovernor as InboundGovernor
 import           Ouroboros.Network.InboundGovernor.State (InboundGovernorCounters (..))
 import qualified Ouroboros.Network.NodeToNode as NtN
-import           Ouroboros.Network.PeerSelection.Governor (DebugPeerSelection (..),
-                   DebugPeerSelectionState (..), PeerSelectionCounters (..),
-                   PeerSelectionState (..), PeerSelectionTargets (..), TracePeerSelection (..))
+import           Ouroboros.Network.PeerSelection.Governor (ChurnCounters (..), DebugPeerSelection (..),
+                   DebugPeerSelectionState (..), PeerSelectionCounters , PeerSelectionView (..),
+                   PeerSelectionState (..), PeerSelectionTargets (..),
+                   TracePeerSelection (..), peerSelectionStateToCounters)
 import           Ouroboros.Network.PeerSelection.PeerStateActions (PeerSelectionActionsTrace (..))
 import           Ouroboros.Network.PeerSelection.RelayAccessPoint (RelayAccessPoint)
 import           Ouroboros.Network.PeerSelection.RootPeersDNS.LocalRootPeers
                    (TraceLocalRootPeers (..))
 import           Ouroboros.Network.PeerSelection.RootPeersDNS.PublicRootPeers
                    (TracePublicRootPeers (..))
-import qualified Ouroboros.Network.PeerSelection.State.EstablishedPeers as EstablishedPeers
 import qualified Ouroboros.Network.PeerSelection.State.KnownPeers as KnownPeers
-import           Ouroboros.Network.PeerSelection.State.LocalRootPeers (HotValency (..),
-                   WarmValency (..))
 import           Ouroboros.Network.PeerSelection.Types ()
+import           Ouroboros.Network.Protocol.PeerSharing.Type (PeerSharingAmount (..))
 import           Ouroboros.Network.RethrowPolicy (ErrorCommand (..))
 import           Ouroboros.Network.Server2 (ServerTrace (..))
 import           Ouroboros.Network.Snocket (LocalAddress (..))
@@ -272,10 +271,11 @@ instance LogFormatting (TracePeerSelection SockAddr) where
              , "actualKnown" .= actualKnown
              , "selectedPeers" .= toJSONList (toList sp)
              ]
-  forMachine _dtal (TracePeerShareRequests targetKnown actualKnown aps sps) =
+  forMachine _dtal (TracePeerShareRequests targetKnown actualKnown (PeerSharingAmount numRequested) aps sps) =
     mconcat [ "kind" .= String "PeerShareRequests"
              , "targetKnown" .= targetKnown
              , "actualKnown" .= actualKnown
+             , "numRequested" .= numRequested
              , "availablePeers" .= toJSONList (toList aps)
              , "selectedPeers" .= toJSONList (toList sps)
              ]
@@ -509,6 +509,17 @@ instance LogFormatting (TracePeerSelection SockAddr) where
     mconcat [ "kind" .= String "OutboundGovernorCriticalFailure"
             , "reason" .= show err
             ]
+  forMachine _dtal (TraceChurnAction duration action counter) =
+    mconcat [ "kind" .= String "ChurnAction"
+            , "action" .= show action
+            , "counter" .= counter
+            , "duration" .= duration
+            ]
+  forMachine _dtal (TraceChurnTimeout action counter) =
+    mconcat [ "kind" .= String "ChurnTimeout"
+            , "action" .= show action
+            , "counter" .= counter
+            ]
   forMachine _dtal (TraceDebugState mtime ds) =
     mconcat [ "kind" .= String "DebugState"
             , "monotonicTime" .= show mtime
@@ -534,6 +545,12 @@ instance LogFormatting (TracePeerSelection SockAddr) where
             ]
 
   forHuman = pack . show
+
+  asMetrics (TraceChurnAction duration action _) =
+    [ DoubleM ("Net.PeerSelection.Churn." <> pack (show action) <> ".duration")
+              (realToFrac duration)
+    ]
+  asMetrics _ = []
 
 instance MetaTrace (TracePeerSelection SockAddr) where
     namespaceFor TraceLocalRootPeersChanged {} =
@@ -644,6 +661,10 @@ instance MetaTrace (TracePeerSelection SockAddr) where
       Namespace [] ["BootstrapPeersFlagChangedWhilstInSensitiveState"]
     namespaceFor TraceOutboundGovernorCriticalFailure {} =
       Namespace [] ["OutboundGovernorCriticalFailure"]
+    namespaceFor TraceChurnAction {} =
+      Namespace [] ["ChurnAction"]
+    namespaceFor TraceChurnTimeout {} =
+      Namespace [] ["ChurnTimeout"]
     namespaceFor TraceDebugState {} =
       Namespace [] ["DebugState"]
 
@@ -678,6 +699,8 @@ instance MetaTrace (TracePeerSelection SockAddr) where
     severityFor (Namespace [] ["ChurnMode"]) _ = Just Info
     severityFor (Namespace [] ["KnownInboundConnection"]) _ = Just Info
     severityFor (Namespace [] ["OutboundGovernorCriticalFailure"]) _ = Just Error
+    severityFor (Namespace [] ["ChurnAction"]) _ = Just Info
+    severityFor (Namespace [] ["ChurnTimeout"]) _ = Just Notice
     severityFor (Namespace [] ["DebugState"]) _ = Just Info
     severityFor _ _ = Nothing
 
@@ -779,17 +802,13 @@ instance MetaTrace (TracePeerSelection SockAddr) where
 --------------------------------------------------------------------------------
 
 instance LogFormatting (DebugPeerSelection SockAddr) where
-  forMachine DNormal (TraceGovernorState blockedAt wakeupAfter
-                   PeerSelectionState { targets, knownPeers, establishedPeers, activePeers }) =
+  forMachine dtal@DNormal (TraceGovernorState blockedAt wakeupAfter
+                   st@PeerSelectionState { targets }) =
     mconcat [ "kind" .= String "DebugPeerSelection"
              , "blockedAt" .= String (pack $ show blockedAt)
              , "wakeupAfter" .= String (pack $ show wakeupAfter)
              , "targets" .= peerSelectionTargetsToObject targets
-             , "numberOfPeers" .=
-                 Object (mconcat [ "known" .= KnownPeers.size knownPeers
-                                  , "established" .= EstablishedPeers.size establishedPeers
-                                  , "active" .= Set.size activePeers
-                                  ])
+             , "counters" .= forMachine dtal (peerSelectionStateToCounters st)
              ]
   forMachine _ (TraceGovernorState blockedAt wakeupAfter ev) =
     mconcat [ "kind" .= String "DebugPeerSelection"
@@ -838,43 +857,123 @@ instance MetaTrace (DebugPeerSelection SockAddr) where
 --------------------------------------------------------------------------------
 
 instance LogFormatting PeerSelectionCounters where
-  forMachine _dtal ev =
+  forMachine _dtal PeerSelectionCounters {..} =
     mconcat [ "kind" .= String "PeerSelectionCounters"
-            , "coldPeers" .= coldPeers ev
-            , "warmPeers" .= warmPeers ev
-            , "hotPeers" .= hotPeers ev
-            , "coldBigLedgerPeers" .= coldBigLedgerPeers ev
-            , "warmBigLedgerPeers" .= warmBigLedgerPeers ev
-            , "hotBigLedgerPeers" .= hotBigLedgerPeers ev
-            , "localRoots" .= toJSON (localRoots ev)
+
+            , "knownPeers" .= numberOfKnownPeers
+            , "rootPeers" .= numberOfRootPeers
+            , "coldPeersPromotions" .= numberOfColdPeersPromotions
+            , "establishedPeers" .= numberOfEstablishedPeers
+            , "warmPeersDemotions" .= numberOfWarmPeersDemotions
+            , "warmPeersPromotions" .= numberOfWarmPeersPromotions
+            , "activePeers" .= numberOfActivePeers
+            , "activePeersDemotions" .= numberOfActivePeersDemotions
+
+            , "knownBigLedgerPeers" .= numberOfKnownBigLedgerPeers
+            , "coldBigLedgerPeersPromotions" .= numberOfColdBigLedgerPeersPromotions
+            , "establishedBigLedgerPeers" .= numberOfEstablishedBigLedgerPeers
+            , "warmBigLedgerPeersDemotions" .= numberOfWarmBigLedgerPeersDemotions
+            , "warmBigLedgerPeersPromotions" .= numberOfWarmBigLedgerPeersPromotions
+            , "activeBigLedgerPeers" .= numberOfActiveBigLedgerPeers
+            , "activeBigLedgerPeersDemotions" .= numberOfActiveBigLedgerPeersDemotions
+
+            , "knownLocalRootPeers" .= numberOfKnownLocalRootPeers
+            , "establishedLocalRootPeers" .= numberOfEstablishedLocalRootPeers
+            , "warmLocalRootPeersPromotions" .= numberOfWarmLocalRootPeersPromotions
+            , "activeLocalRootPeers" .= numberOfActiveLocalRootPeers
+            , "activeLocalRootPeersDemotions" .= numberOfActiveLocalRootPeersDemotions
+
+            , "knownSharedPeers" .= numberOfKnownSharedPeers
+            , "coldSharedPeersPromotions" .= numberOfColdSharedPeersPromotions
+            , "establishedSharedPeers" .= numberOfEstablishedSharedPeers
+            , "warmSharedPeersDemotions" .= numberOfWarmSharedPeersDemotions
+            , "warmSharedPeersPromotions" .= numberOfWarmSharedPeersPromotions
+            , "activeSharedPeers" .= numberOfActiveSharedPeers
+            , "activeSharedPeersDemotions" .= numberOfActiveSharedPeersDemotions
+
+            , "knownBootstrapPeers" .= numberOfKnownBootstrapPeers
+            , "coldBootstrapPeersPromotions" .= numberOfColdBootstrapPeersPromotions
+            , "establishedBootstrapPeers" .= numberOfEstablishedBootstrapPeers
+            , "warmBootstrapPeersDemotions" .= numberOfWarmBootstrapPeersDemotions
+            , "warmBootstrapPeersPromotions" .= numberOfWarmBootstrapPeersPromotions
+            , "activeBootstrapPeers" .= numberOfActiveBootstrapPeers
+            , "ActiveBootstrapPeersDemotions" .= numberOfActiveBootstrapPeersDemotions
             ]
   forHuman = pack . show
-  asMetrics PeerSelectionCounters {..} =
-    [ IntM
-        "Net.PeerSelection.Cold"
-        (fromIntegral coldPeers)
-    , IntM
-        "Net.PeerSelection.Warm"
-        (fromIntegral warmPeers)
-    , IntM
-        "Net.PeerSelection.Hot"
-        (fromIntegral hotPeers)
-    , IntM
-        "Net.PeerSelection.ColdBigLedgerPeers"
-        (fromIntegral coldBigLedgerPeers)
-    , IntM
-        "Net.PeerSelection.WarmBigLedgerPeers"
-        (fromIntegral warmBigLedgerPeers)
-    , IntM
-        "Net.PeerSelection.HotBigLedgerPeers"
-        (fromIntegral hotBigLedgerPeers)
-    , IntM
-        "Net.PeerSelection.WarmLocalRoots"
-        (fromIntegral $ getWarmValency $ foldl' (\a (_, b) -> a + b) 0 localRoots)
-    , IntM
-        "Net.PeerSelection.HotLocalRoots"
-        (fromIntegral $ getHotValency $ foldl' (\a (b, _) -> a + b) 0 localRoots)
-    ]
+  asMetrics psc =
+    case psc of
+      PeerSelectionCountersHWC {..} ->
+        -- Deprecated metrics; they will be removed in a future version.
+        [ IntM
+            "Net.PeerSelection.Cold"
+            (fromIntegral numberOfColdPeers)
+        , IntM
+            "Net.PeerSelection.Warm"
+            (fromIntegral numberOfWarmPeers)
+        , IntM
+            "Net.PeerSelection.Hot"
+            (fromIntegral numberOfHotPeers)
+        , IntM
+            "Net.PeerSelection.ColdBigLedgerPeers"
+            (fromIntegral numberOfColdBigLedgerPeers)
+        , IntM
+            "Net.PeerSelection.WarmBigLedgerPeers"
+            (fromIntegral numberOfWarmBigLedgerPeers)
+        , IntM
+            "Net.PeerSelection.HotBigLedgerPeers"
+            (fromIntegral numberOfHotBigLedgerPeers)
+
+        , IntM
+            "Net.PeerSelection.WarmLocalRoots"
+            (fromIntegral $ numberOfActiveLocalRootPeers psc)
+        , IntM
+            "Net.PeerSelection.HotLocalRoots"
+            (fromIntegral $ numberOfEstablishedLocalRootPeers psc
+                          - numberOfActiveLocalRootPeers psc)
+        ]
+    ++
+    case psc of
+      PeerSelectionCounters {..} ->
+        [ IntM "Net.PeerSelection.RootPeers" (fromIntegral numberOfRootPeers)
+
+        , IntM "Net.PeerSelection.KnownPeers" (fromIntegral numberOfKnownPeers)
+        , IntM "Net.PeerSelection.ColdPeersPromotions" (fromIntegral numberOfColdPeersPromotions)
+        , IntM "Net.PeerSelection.EstablishedPeers" (fromIntegral numberOfEstablishedPeers)
+        , IntM "Net.PeerSelection.WarmPeersDemotions" (fromIntegral numberOfWarmPeersDemotions)
+        , IntM "Net.PeerSelection.WarmPeersPromotions" (fromIntegral numberOfWarmPeersPromotions)
+        , IntM "Net.PeerSelection.ActivePeers" (fromIntegral numberOfActivePeers)
+        , IntM "Net.PeerSelection.ActivePeersDemotions" (fromIntegral numberOfActivePeersDemotions)
+
+        , IntM "Net.PeerSelection.KnownBigLedgerPeers" (fromIntegral numberOfKnownBigLedgerPeers)
+        , IntM "Net.PeerSelection.ColdBigLedgerPeersPromotions" (fromIntegral numberOfColdBigLedgerPeersPromotions)
+        , IntM "Net.PeerSelection.EstablishedBigLedgerPeers" (fromIntegral numberOfEstablishedBigLedgerPeers)
+        , IntM "Net.PeerSelection.WarmBigLedgerPeersDemotions" (fromIntegral numberOfWarmBigLedgerPeersDemotions)
+        , IntM "Net.PeerSelection.WarmBigLedgerPeersPromotions" (fromIntegral numberOfWarmBigLedgerPeersPromotions)
+        , IntM "Net.PeerSelection.ActiveBigLedgerPeers" (fromIntegral numberOfActiveBigLedgerPeers)
+        , IntM "Net.PeerSelection.ActiveBigLedgerPeersDemotions" (fromIntegral numberOfActiveBigLedgerPeersDemotions)
+
+        , IntM "Net.PeerSelection.KnownLocalRootPeers" (fromIntegral numberOfKnownLocalRootPeers)
+        , IntM "Net.PeerSelection.EstablishedLocalRootPeers" (fromIntegral numberOfEstablishedLocalRootPeers)
+        , IntM "Net.PeerSelection.WarmLocalRootPeersPromotions" (fromIntegral numberOfWarmLocalRootPeersPromotions)
+        , IntM "Net.PeerSelection.ActiveLocalRootPeers" (fromIntegral numberOfActiveLocalRootPeers)
+        , IntM "Net.PeerSelection.ActiveLocalRootPeersDemotions" (fromIntegral numberOfActiveLocalRootPeersDemotions)
+
+        , IntM "Net.PeerSelection.KnownSharedPeers" (fromIntegral numberOfKnownSharedPeers)
+        , IntM "Net.PeerSelection.ColdSharedPeersPromotions" (fromIntegral numberOfColdSharedPeersPromotions)
+        , IntM "Net.PeerSelection.EstablishedSharedPeers" (fromIntegral numberOfEstablishedSharedPeers)
+        , IntM "Net.PeerSelection.WarmSharedPeersDemotions" (fromIntegral numberOfWarmSharedPeersDemotions)
+        , IntM "Net.PeerSelection.WarmSharedPeersPromotions" (fromIntegral numberOfWarmSharedPeersPromotions)
+        , IntM "Net.PeerSelection.ActiveSharedPeers" (fromIntegral numberOfActiveSharedPeers)
+        , IntM "Net.PeerSelection.ActiveSharedPeersDemotions" (fromIntegral numberOfActiveSharedPeersDemotions)
+
+        , IntM "Net.PeerSelection.KnownBootstrapPeers" (fromIntegral numberOfKnownBootstrapPeers)
+        , IntM "Net.PeerSelection.ColdBootstrapPeersPromotions" (fromIntegral numberOfColdBootstrapPeersPromotions)
+        , IntM "Net.PeerSelection.EstablishedBootstrapPeers" (fromIntegral numberOfEstablishedBootstrapPeers)
+        , IntM "Net.PeerSelection.WarmBootstrapPeersDemotions" (fromIntegral numberOfWarmBootstrapPeersDemotions)
+        , IntM "Net.PeerSelection.WarmBootstrapPeersPromotions" (fromIntegral numberOfWarmBootstrapPeersPromotions)
+        , IntM "Net.PeerSelection.ActiveBootstrapPeers" (fromIntegral numberOfActiveBootstrapPeers)
+        , IntM "Net.PeerSelection.ActiveBootstrapPeersDemotions" (fromIntegral numberOfActiveBootstrapPeersDemotions)
+        ]
 
 instance MetaTrace PeerSelectionCounters where
     namespaceFor PeerSelectionCounters {} = Namespace [] ["Counters"]
@@ -883,7 +982,7 @@ instance MetaTrace PeerSelectionCounters where
     severityFor _ _ = Nothing
 
     documentFor (Namespace _ ["Counters"]) = Just
-      "Counters for cold, warm and hot peers"
+      "Counters of selected peers"
     documentFor _ = Nothing
 
     metricsDocFor (Namespace _ ["Counters"]) =
@@ -899,6 +998,54 @@ instance MetaTrace PeerSelectionCounters where
 
     allNamespaces =[
       Namespace [] ["Counters"]
+      ]
+
+
+--------------------------------------------------------------------------------
+-- ChurnCounters Tracer
+--------------------------------------------------------------------------------
+
+
+instance LogFormatting ChurnCounters where
+  forMachine _dtal (ChurnCounter action c) =
+    mconcat [ "kind" .= String "ChurnCounter" 
+            , "action" .= String (pack $ show action)
+            , "counter" .= c
+            ]
+  asMetrics (ChurnCounter action c) =
+    [ IntM
+        ("Net.Churn." <> (pack $ show action))
+        (fromIntegral c)
+    ]
+
+instance MetaTrace ChurnCounters where
+    namespaceFor ChurnCounter {} = Namespace [] ["ChurnCounters"]
+
+    severityFor (Namespace _ ["ChurnCounters"]) _ = Just Info
+    severityFor _ _ = Nothing
+
+    documentFor (Namespace _ ["ChurnCounters"]) = Just
+      "churn counters"
+    documentFor _ = Nothing
+
+    metricsDocFor (Namespace _ ["Counters"]) =
+     [ ("Net.Churn.DecreasedActivePeers", "number of decreased active peers")
+     , ("Net.Churn.IncreasedActivePeers", "number of increased active peers")
+     , ("Net.Churn.DecreasedActiveBigLedgerPeers", "number of decreased active big ledger peers")
+     , ("Net.Churn.IncreasedActiveBigLedgerPeers", "number of increased active big ledger peers")
+     , ("Net.Churn.DecreasedEstablishedPeers", "number of decreased established peers")
+     , ("Net.Churn.IncreasedEstablishedPeers", "number of increased established peers")
+     , ("Net.Churn.IncreasedEstablishedBigLedgerPeers", "number of increased established big ledger peers")
+     , ("Net.Churn.DecreasedEstablishedBigLedgerPeers", "number of decreased established big ledger peers")
+     , ("Net.Churn.DecreasedKnownPeers", "number of decreased known peers")
+     , ("Net.Churn.IncreasedKnownPeers", "number of increased known peers")
+     , ("Net.Churn.DecreasedKnownBigLedgerPeers", "number of decreased known big ledger peers")
+     , ("Net.Churn.IncreasedKnownBigLedgerPeers", "number of increased known big ledger peers")
+     ]
+    metricsDocFor _ = []
+
+    allNamespaces =[
+      Namespace [] ["ChurnCounters"]
       ]
 
 

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PackageImports #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
@@ -93,7 +94,8 @@ import           Ouroboros.Network.InboundGovernor (InboundGovernorTrace (..))
 import           Ouroboros.Network.InboundGovernor.State (InboundGovernorCounters (..))
 import           Ouroboros.Network.NodeToClient (LocalAddress)
 import           Ouroboros.Network.NodeToNode (RemoteAddress)
-import           Ouroboros.Network.PeerSelection.Governor (PeerSelectionCounters (..))
+import           Ouroboros.Network.PeerSelection.Governor (PeerSelectionCounters, PeerSelectionView (..), ChurnCounters (..))
+import qualified Ouroboros.Network.PeerSelection.Governor as Governor
 import           Ouroboros.Network.Point (fromWithOrigin)
 import           Ouroboros.Network.Protocol.LocalStateQuery.Type (ShowQuery)
 import           Ouroboros.Network.TxSubmission.Inbound
@@ -363,8 +365,14 @@ mkTracers blockConfig tOpts@(TracingOnLegacy trSel) tr nodeKern ekgDirect enable
                tracerOnOff (tracePublicRootPeers trSel)
                             verb "PublicRootPeers" tr
            , P2P.dtTracePeerSelectionTracer =
-               tracerOnOff (tracePeerSelection trSel)
-                            verb "PeerSelection" tr
+                  tracerOnOff (tracePeerSelection trSel)
+                               verb "PeerSelection" tr
+               <> tracePeerSelectionTracerMetrics
+                    (tracePeerSelection trSel)
+                    ekgDirect
+           , P2P.dtTraceChurnCounters =
+               traceChurnCountersMetrics
+                 ekgDirect
            , P2P.dtDebugPeerSelectionInitiatorTracer =
                tracerOnOff (traceDebugPeerSelectionInitiatorTracer trSel)
                             verb "DebugPeerSelection" tr
@@ -1447,6 +1455,26 @@ traceConnectionManagerTraceMetrics (OnOff True) (Just ekgDirect) = cmtTracer
       _ -> return ()
 
 
+tracePeerSelectionTracerMetrics
+    :: forall peeraddr.
+       OnOff TracePeerSelection
+    -> Maybe EKGDirect
+    -> Tracer IO (Governor.TracePeerSelection peeraddr)
+tracePeerSelectionTracerMetrics _             Nothing          = nullTracer
+tracePeerSelectionTracerMetrics (OnOff False) _                = nullTracer
+tracePeerSelectionTracerMetrics (OnOff True)  (Just ekgDirect) = pstTracer
+  where
+    pstTracer :: Tracer IO (Governor.TracePeerSelection peeraddr)
+    pstTracer = Tracer $ \a -> do
+      case a of
+        Governor.TraceChurnAction duration action _ ->
+          sendEKGDirectDouble
+            ekgDirect
+            ("cardano.node.metrics.peerSelection.churn." <> Text.pack (show action) <> ".duration")
+            (realToFrac duration)
+        _ -> pure ()
+
+
 tracePeerSelectionCountersMetrics
     :: OnOff TracePeerSelectionCounters
     -> Maybe EKGDirect
@@ -1456,13 +1484,68 @@ tracePeerSelectionCountersMetrics (OnOff False) _                = nullTracer
 tracePeerSelectionCountersMetrics (OnOff True)  (Just ekgDirect) = pscTracer
   where
     pscTracer :: Tracer IO PeerSelectionCounters
-    pscTracer = Tracer $ \(PeerSelectionCounters cold warm hot coldBigLedgerPeers warmBigLedgerPeers hotBigLedgerPeers _) -> do
-      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.cold" cold
-      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.warm" warm
-      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.hot"  hot
-      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.coldBigLedgerPeers" coldBigLedgerPeers
-      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.warmBigLedgerPeers" warmBigLedgerPeers
-      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.hotBigLedgerPeers" hotBigLedgerPeers
+    pscTracer = Tracer $ \psc -> do
+      let PeerSelectionCountersHWC {..} = psc
+      -- Deprecated counters; they will be removed in a future version
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.cold" numberOfColdPeers
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.warm" numberOfWarmPeers
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.hot"  numberOfHotPeers
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.coldBigLedgerPeers" numberOfColdBigLedgerPeers
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.warmBigLedgerPeers" numberOfWarmBigLedgerPeers
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.hotBigLedgerPeers" numberOfHotBigLedgerPeers
+
+      let PeerSelectionCounters {..} = psc
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.RootPeers" numberOfRootPeers
+
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.KnownPeers" numberOfKnownPeers
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.ColdPeersPromotions" numberOfColdPeersPromotions
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.EstablishedPeers" numberOfEstablishedPeers
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.WarmPeersDemotions" numberOfWarmPeersDemotions
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.WarmPeersPromotions" numberOfWarmPeersPromotions
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.ActivePeers" numberOfActivePeers
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.ActivePeersDemotions" numberOfActivePeersDemotions
+
+
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.KnownBigLedgerPeers" numberOfKnownBigLedgerPeers
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.ColdBigLedgerPeersPromotions" numberOfColdBigLedgerPeersPromotions
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.EstablishedBigLedgerPeers" numberOfEstablishedBigLedgerPeers
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.WarmBigLedgerPeersDemotions" numberOfWarmBigLedgerPeersDemotions
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.WarmBigLedgerPeersPromotions" numberOfWarmBigLedgerPeersPromotions
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.ActiveBigLedgerPeers" numberOfActiveBigLedgerPeers
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.ActiveBigLedgerPeersDemotions" numberOfActiveBigLedgerPeersDemotions
+
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.KnownLocalRootPeers" numberOfKnownLocalRootPeers
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.EstablishedLocalRootPeers" numberOfEstablishedLocalRootPeers
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.WarmLocalRootPeersPromotions" numberOfWarmLocalRootPeersPromotions
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.ActiveLocalRootPeers" numberOfActiveLocalRootPeers
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.ActiveLocalRootPeersDemotions" numberOfActiveLocalRootPeersDemotions
+
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.KnownSharedPeers" numberOfKnownSharedPeers
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.ColdSharedPeersPromotions" numberOfColdSharedPeersPromotions
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.EstablishedSharedPeers" numberOfEstablishedSharedPeers
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.WarmSharedPeersDemotions" numberOfWarmSharedPeersDemotions
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.WarmSharedPeersPromotions" numberOfWarmSharedPeersPromotions
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.ActiveSharedPeers" numberOfActiveSharedPeers
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.ActiveSharedPeersDemotions" numberOfActiveSharedPeersDemotions
+
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.KnownBootstrapPeers" numberOfKnownBootstrapPeers
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.ColdBootstrapPeersPromotions" numberOfColdBootstrapPeersPromotions
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.EstablishedBootstrapPeers" numberOfEstablishedBootstrapPeers
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.WarmBootstrapPeersDemotions" numberOfWarmBootstrapPeersDemotions
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.WarmBootstrapPeersPromotions" numberOfWarmBootstrapPeersPromotions
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.ActiveBootstrapPeers" numberOfActiveBootstrapPeers
+      sendEKGDirectInt ekgDirect "cardano.node.metrics.peerSelection.ActiveBootstrapPeersDemotions" numberOfActiveBootstrapPeersDemotions
+
+
+traceChurnCountersMetrics
+    :: Maybe EKGDirect
+    -> Tracer IO ChurnCounters
+traceChurnCountersMetrics Nothing = nullTracer
+traceChurnCountersMetrics (Just ekgDirect) = churnTracer
+  where
+    churnTracer :: Tracer IO ChurnCounters
+    churnTracer = Tracer $ \(ChurnCounter action c) ->
+      sendEKGDirectInt ekgDirect ("cardano.node.metrics.peerSelection.churn." <> Text.pack (show action)) c
 
 
 traceInboundGovernorCountersMetrics

--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -49,7 +49,7 @@ library
                       , network
                       , optparse-applicative-fork
                       , ouroboros-consensus-cardano
-                      , ouroboros-network ^>= 0.13
+                      , ouroboros-network ^>= 0.14
                       , ouroboros-network-protocols
                       , prometheus >= 2.2.4
                       , servant

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -65,7 +65,7 @@ library
                       , network
                       , network-mux
                       , optparse-applicative-fork
-                      , ouroboros-network ^>= 0.13
+                      , ouroboros-network ^>= 0.14
                       , ouroboros-network-api
                       , prettyprinter
                       , process

--- a/cardano-tracer/cardano-tracer.cabal
+++ b/cardano-tracer/cardano-tracer.cabal
@@ -152,7 +152,7 @@ library
                       , filepath
                       , mime-mail
                       , optparse-applicative
-                      , ouroboros-network ^>= 0.13
+                      , ouroboros-network ^>= 0.14
                       , ouroboros-network-api
                       , ouroboros-network-framework
                       , signal

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1712304473,
-        "narHash": "sha256-AXf+FiTVt4Jte0lQ1rb1tvUNfl+xgvJHbE4zktu3bbQ=",
+        "lastModified": 1712829844,
+        "narHash": "sha256-TAyL7qpO2rlCVr3+jABtZjvAO2rsLcRtEzcryydf1sI=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "465a71bd629a80522fed1fd643f8bf4dd5f9ab6f",
+        "rev": "1b790b980d78bc45883dd51fa68d458fcdc795ae",
         "type": "github"
       },
       "original": {

--- a/trace-dispatcher/trace-dispatcher.cabal
+++ b/trace-dispatcher/trace-dispatcher.cabal
@@ -60,7 +60,7 @@ library
                       , hostname
                       , network
                       , optparse-applicative-fork
-                      , ouroboros-network ^>= 0.13
+                      , ouroboros-network ^>= 0.14
                       , ouroboros-network-api
                       , ouroboros-network-framework
                       , serialise


### PR DESCRIPTION
# Description

Integrate recent version of `ouroboros-network` (IntersectMBO/ouroboros-newtork#4871) with `cardano-node`

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
