### PR TITLE
'can_forge_blocks' metric

### DIFF
--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -235,6 +235,13 @@ handleNodeWithTracers cmdPc nc0 p networkMagic blockType runP = do
           mapM_ (traceWith $ startupTracer tracers) startupInfo
           traceNodeStartupInfo (nodeStartupInfoTracer tracers) startupInfo
 
+          -- sends initial BlockForgingUpdate
+          blockForging <- snd (Api.protocolInfo runP)
+          traceWith (startupTracer tracers)
+                    (BlockForgingUpdate (if null blockForging
+                                          then EnabledBlockForging
+                                          else DisabledBlockForging))
+
           handleSimpleNode blockType runP p2pMode tracers nc
             (\nk -> do
                 setNodeKernel nodeKernelData nk
@@ -271,6 +278,13 @@ handleNodeWithTracers cmdPc nc0 p networkMagic blockType runP = do
 
           getStartupInfo nc p fp
             >>= mapM_ (traceWith $ startupTracer tracers)
+
+          blockForging <- snd (Api.protocolInfo runP)
+          traceWith (startupTracer tracers)
+                    (BlockForgingUpdate (if null blockForging
+                                          then EnabledBlockForging
+                                          else DisabledBlockForging))
+
 
           -- We ignore peer logging thread if it dies, but it will be killed
           -- when 'handleSimpleNode' terminates.

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
@@ -276,7 +276,7 @@ instance ( Show (BlockNodeToNodeVersion blk)
                ]
 
   asMetrics (BlockForgingUpdate b) =
-    [ IntM "isForging"
+    [ IntM "can_forge_blocks"
       (case  b of
         EnabledBlockForging -> 1
         DisabledBlockForging -> 0
@@ -405,7 +405,8 @@ instance MetaTrace  (StartupTrace blk) where
   documentFor _ns = Nothing
 
   metricsDocFor (Namespace _ ["BlockForgingUpdate"]) =
-    [("isForging","Is this node forging blocks 0 = no, 1 = yes")]
+    [("can_forge_blocks","Can this node forging blocks (is it provided with block forging credentials) 0 = no, 1 = yes")]
+
   metricsDocFor _ = []
 
   allNamespaces =

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
@@ -275,6 +275,15 @@ instance ( Show (BlockNodeToNodeVersion blk)
                , "nodeStartTime" .= biNodeStartTime
                ]
 
+  asMetrics (BlockForgingUpdate b) =
+    [ IntM "isForging"
+      (case  b of
+        EnabledBlockForging -> 1
+        DisabledBlockForging -> 0
+        NotEffective -> 0
+      )]
+  asMetrics _ = []
+
 instance MetaTrace  (StartupTrace blk) where
   namespaceFor StartupInfo {}  =
     Namespace [] ["Info"]
@@ -394,6 +403,10 @@ instance MetaTrace  (StartupTrace blk) where
     , "\n_niIpProducers_: shows the list of ip subscription addresses."
     ]
   documentFor _ns = Nothing
+
+  metricsDocFor (Namespace _ ["BlockForgingUpdate"]) =
+    [("isForging","Is this node forging blocks 0 = no, 1 = yes")]
+  metricsDocFor _ = []
 
   allNamespaces =
     [ Namespace [] ["Info"]

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -354,7 +354,7 @@ mkTracers blockConfig tOpts@(TracingOnLegacy trSel) tr nodeKern ekgDirect enable
       case mbEKGDirect of
         Just ekgDirect' ->
           case ev of
-              BlockForgingUpdate b -> sendEKGDirectInt ekgDirect' "isForge"
+              BlockForgingUpdate b -> sendEKGDirectInt ekgDirect' "can_forge_blocks"
                                         (case b of
                                             EnabledBlockForging -> 1 :: Int
                                             DisabledBlockForging -> 0 :: Int


### PR DESCRIPTION
I have prepared a pull request to add a new Prometheus metric called 'can_forge_blocks'. This metric indicates whether a blockchain node has the capability to forge new blocks on the network.

The metric will be a boolean type, where a value of 1 signifies that the node can forge blocks, and 0 indicates otherwise.

This addition will provide valuable insights into the operational status and capabilities of our blockchain nodes, aiding in monitoring and decision-making processes.