### PR TITLE
Add tests watchdog

### DIFF
--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -92,6 +92,7 @@ library
                         Testnet.Components.DReps
                         Testnet.Components.SPO
                         Testnet.Components.Query
+                        Testnet.Components.TestWatchdog
                         Testnet.Defaults
                         Testnet.Filepath
                         Testnet.EpochStateProcessing
@@ -212,7 +213,6 @@ test-suite cardano-testnet-test
                       , cardano-testnet
                       , containers
                       , directory
-                      , exceptions
                       , filepath
                       , hedgehog
                       , hedgehog-extras

--- a/cardano-testnet/src/Testnet/Components/TestWatchdog.hs
+++ b/cardano-testnet/src/Testnet/Components/TestWatchdog.hs
@@ -35,13 +35,13 @@ import qualified Hedgehog.Extras as H
 
 -- | Configuration for the watchdog.
 newtype WatchdogConfig = WatchdogConfig
-  { watchdogTimeout :: Int -- ^ Timeout in µs after which watchdog will kill the test case
+  { watchdogTimeout :: Int -- ^ Timeout in seconds after which watchdog will kill the test case
   }
 
 -- | Default watchdog config with 10 minutes timeout.
 defaultWatchdogConfig :: WatchdogConfig
 defaultWatchdogConfig = WatchdogConfig
-  { watchdogTimeout = 600_000_000
+  { watchdogTimeout = 600
   }
 
 -- | A watchdog
@@ -73,7 +73,7 @@ runWatchdog w@Watchdog{watchedThreadId, startTime, kickChan} = liftIO $ do
       pure ()
     Just (Kick timeout) -> do
       -- got a kick, wait for another period
-      threadDelay timeout
+      threadDelay $ timeout * 1_000_000
       runWatchdog w
     Nothing -> do
       -- we are out of scheduled timeouts, kill the monitored thread
@@ -82,7 +82,7 @@ runWatchdog w@Watchdog{watchedThreadId, startTime, kickChan} = liftIO $ do
 
 -- | Watchdog command
 data WatchdogCommand
-  = Kick !Int -- ^ Add another delay
+  = Kick !Int -- ^ Add another delay in seconds
   | PoisonPill -- ^ Stop the watchdog
 
 -- | Enqueue a kick for the watchdog. It will extend the timeout by another one defined in the watchdog

--- a/cardano-testnet/src/Testnet/Components/TestWatchdog.hs
+++ b/cardano-testnet/src/Testnet/Components/TestWatchdog.hs
@@ -1,0 +1,137 @@
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | This module provides a test watchdog - an utility monitoring test cases and killing them if they don't
+-- finish in time. To wrap an 'H.Integration' test case in a watchdog just use
+-- @
+-- runWithWatchdog watchdogConfig $ \watchdog -> do
+--   -- body of your test case
+-- @
+module Testnet.Components.TestWatchdog
+  ( runWithWatchdog_
+  , runWithWatchdog
+  , runWithDefaultWatchdog_
+  , runWithDefaultWatchdog
+  , Watchdog
+  , kickWatchdog
+  , poisonWatchdog
+  ) where
+
+import           Control.Concurrent (myThreadId, threadDelay, throwTo)
+import           Control.Concurrent.STM (atomically)
+import           Control.Concurrent.STM.TChan (TChan, newTChanIO, tryReadTChan, writeTChan)
+import           Control.Exception.Safe (Exception)
+import           Control.Monad.IO.Class
+import           Data.Time (NominalDiffTime, UTCTime, diffUTCTime, getCurrentTime,
+                   nominalDiffTimeToSeconds)
+import           GHC.Conc (ThreadId)
+import           GHC.Stack
+
+import qualified Hedgehog.Extras as H
+
+-- | Configuration for the watchdog.
+newtype WatchdogConfig = WatchdogConfig
+  { watchdogTimeout :: Int -- ^ Timeout in µs after which watchdog will kill the test case
+  }
+
+-- | Default watchdog config with 10 minutes timeout.
+defaultWatchdogConfig :: WatchdogConfig
+defaultWatchdogConfig = WatchdogConfig
+  { watchdogTimeout = 600_000_000
+  }
+
+-- | A watchdog
+data Watchdog = Watchdog
+  { watchdogConfig :: !WatchdogConfig
+  , watchedThreadId :: !ThreadId -- ^ monitored thread id
+  , startTime :: !UTCTime -- ^ watchdog creation time
+  , kickChan :: TChan WatchdogCommand -- ^ a queue of watchdog commands
+  }
+
+-- | Create a new watchdog
+makeWatchdog :: MonadIO m
+             => WatchdogConfig
+             -> ThreadId -- ^ thread id which will get killed after timeouts expire
+             -> m Watchdog
+makeWatchdog config watchedThreadId' = liftIO $ do
+  watchdog <- Watchdog config watchedThreadId' <$> getCurrentTime <*> newTChanIO
+  kickWatchdog watchdog
+  pure watchdog
+
+-- | Run watchdog in a loop
+runWatchdog :: MonadIO m
+            => Watchdog
+            -> m ()
+runWatchdog w@Watchdog{watchedThreadId, startTime, kickChan} = liftIO $ do
+  atomically (tryReadTChan kickChan) >>= \case
+    Just PoisonPill ->
+      -- deactivate watchdog
+      pure ()
+    Just (Kick timeout) -> do
+      -- got a kick, wait for another period
+      threadDelay timeout
+      runWatchdog w
+    Nothing -> do
+      -- we are out of scheduled timeouts, kill the monitored thread
+      currentTime <- getCurrentTime
+      throwTo watchedThreadId . WatchdogException $ diffUTCTime currentTime startTime
+
+-- | Watchdog command
+data WatchdogCommand
+  = Kick !Int -- ^ Add another delay
+  | PoisonPill -- ^ Stop the watchdog
+
+-- | Enqueue a kick for the watchdog. It will extend the timeout by another one defined in the watchdog
+-- configuration.
+kickWatchdog :: MonadIO m => Watchdog -> m ()
+kickWatchdog Watchdog{watchdogConfig=WatchdogConfig{watchdogTimeout}, kickChan} = liftIO $
+  atomically $ writeTChan kickChan (Kick watchdogTimeout)
+
+-- | Enqueue a poison pill for the watchdog. It will stop the watchdog after all timeouts.
+poisonWatchdog :: MonadIO m => Watchdog -> m ()
+poisonWatchdog Watchdog{kickChan} = liftIO $
+  atomically $ writeTChan kickChan PoisonPill
+
+
+-- | Execute a test case with a watchdog.
+runWithWatchdog :: HasCallStack
+                => WatchdogConfig -- ^ configuration
+                -> (HasCallStack => Watchdog -> H.Integration a) -- ^ a test case to be wrapped in watchdog
+                -> H.Integration a
+runWithWatchdog config testCase = do
+  watchedThreadId <- liftIO myThreadId
+  watchdog <- makeWatchdog config watchedThreadId
+  H.withAsync (runWatchdog watchdog) $
+    \_ -> testCase watchdog
+
+-- | Execuate a test case with a watchdog.
+runWithWatchdog_ :: HasCallStack
+                => WatchdogConfig -- ^ configuration
+                -> (HasCallStack => H.Integration a) -- ^ a test case to be wrapped in watchdog
+                -> H.Integration a
+runWithWatchdog_ config testCase = runWithWatchdog config (const testCase)
+
+-- | Execute a test case with watchdog with default config.
+runWithDefaultWatchdog :: HasCallStack
+                       => (HasCallStack => Watchdog -> H.Integration a) -- ^ a test case to be wrapped in watchdog
+                       -> H.Integration a
+runWithDefaultWatchdog = runWithWatchdog defaultWatchdogConfig
+
+-- | Execute a test case with watchdog with default config.
+runWithDefaultWatchdog_ :: HasCallStack
+                        => (HasCallStack => H.Integration a) -- ^ a test case to be wrapped in watchdog
+                        -> H.Integration a
+runWithDefaultWatchdog_ testCase = runWithDefaultWatchdog (const testCase)
+
+-- | An exception thrown to the test case thread.
+newtype WatchdogException = WatchdogException { timeElapsed :: NominalDiffTime }
+
+instance Show WatchdogException where
+  show WatchdogException{timeElapsed} =
+    "WatchdogException: Test watchdog killed test case thread after " <> show @Int (round $ nominalDiffTimeToSeconds timeElapsed) <> " seconds."
+
+instance Exception WatchdogException

--- a/cardano-testnet/src/Testnet/EpochStateProcessing.hs
+++ b/cardano-testnet/src/Testnet/EpochStateProcessing.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TypeFamilies #-}
+
 module Testnet.EpochStateProcessing
   ( maybeExtractGovernanceActionIndex
   , findCondition
@@ -19,36 +19,44 @@ import qualified Cardano.Ledger.Shelley.LedgerState as L
 
 import           Prelude
 
-import           Control.Monad.Catch (MonadCatch)
-import           Control.Monad.State.Strict (StateT, withStateT)
-import           Data.Bifunctor (Bifunctor (second))
+import           Control.Monad.State.Strict (MonadState (put), StateT)
 import           Data.Data ((:~:) (..))
 import qualified Data.Map as Map
 import           Data.Type.Equality (TestEquality (..))
 import           Data.Word (Word32)
+import           GHC.Stack
 import           Lens.Micro ((^.))
 
-findCondition :: (MonadIO m, MonadCatch m)
+import           Hedgehog
+
+findCondition
+  :: HasCallStack
+  => MonadTest m
+  => MonadIO m
   => (AnyNewEpochState -> Maybe a)
   -> FilePath
   -> FilePath
   -> EpochNo -- ^ The termination epoch: the condition must be found *before* this epoch
   -> m (Either FoldBlocksError (Maybe a))
-findCondition epochStateFoldFunc configurationFile socketPath maxEpochNo = do
-  eResult <- runExceptT $ foldEpochState (File configurationFile)
-                                         (File socketPath)
-                                         FullValidation
-                                         maxEpochNo
-                                         Nothing
-                                         (\epochState _ _ -> go epochStateFoldFunc epochState)
-  return $ second (\case (ConditionMet, Just x) -> Just x
-                         _                      -> Nothing)
-                  eResult
+findCondition epochStateFoldFunc configurationFile socketPath maxEpochNo = withFrozenCallStack $ evalIO . runExceptT $ do
+  result <-
+    foldEpochState
+      (File configurationFile)
+      (File socketPath)
+      FullValidation
+      maxEpochNo
+      Nothing
+      (\epochState _ _ -> go epochStateFoldFunc epochState)
+  pure $ case result of
+    (ConditionMet, Just x) -> Just x
+    _                      -> Nothing
+
   where
     go :: (AnyNewEpochState -> Maybe a) -> AnyNewEpochState -> StateT (Maybe a) IO LedgerStateCondition
-    go f epochState = case f epochState of
-                        Just x -> withStateT (const (Just x)) $ return ConditionMet
-                        Nothing -> return ConditionNotMet
+    go f epochState = do
+      case f epochState of
+        Just x -> put (Just x) >> pure ConditionMet
+        Nothing -> pure ConditionNotMet
 
 maybeExtractGovernanceActionIndex :: ShelleyBasedEra ConwayEra -- ^ The era in which the test runs
   -> Api.TxId

--- a/cardano-testnet/src/Testnet/Property/Assert.hs
+++ b/cardano-testnet/src/Testnet/Property/Assert.hs
@@ -56,7 +56,7 @@ newlineBytes :: Word8
 newlineBytes = 10
 
 readJsonLines :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> m [Value]
-readJsonLines fp = mapMaybe (Aeson.decode @Value) . LBS.split newlineBytes <$> H.evalIO (LBS.readFile fp)
+readJsonLines fp = withFrozenCallStack $ mapMaybe (Aeson.decode @Value) . LBS.split newlineBytes <$> H.evalIO (LBS.readFile fp)
 
 fileJsonGrep :: FilePath -> (Value -> Bool) -> IO Bool
 fileJsonGrep fp f = do

--- a/cardano-testnet/src/Testnet/Start/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Start/Cardano.hs
@@ -91,7 +91,9 @@ startTimeOffsetSeconds = if OS.isWin32 then 90 else 15
 
 -- | Like 'cardanoTestnet', but using defaults for all configuration files.
 -- See 'cardanoTestnet' for additional documentation.
-cardanoTestnetDefault :: ()
+cardanoTestnetDefault
+  :: ()
+  => HasCallStack
   => CardanoTestnetOptions
   -> Conf
   -> H.Integration TestnetRuntime
@@ -350,7 +352,7 @@ cardanoTestnet
       let nodeName = mkNodeName i
           keyDir = tmpAbsPath </> poolKeyDir i
       H.note_ $ "Node name: " <> nodeName
-      eRuntime <- lift . lift . runExceptT $
+      eRuntime <- runExceptT $
         startNode (TmpAbsolutePath tmpAbsPath) nodeName testnetIpv4Address port testnetMagic
           [ "run"
           , "--config", configurationFile

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/LeadershipSchedule.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/LeadershipSchedule.hs
@@ -37,6 +37,7 @@ import qualified System.Info as SYS
 
 import           Testnet.Components.Configuration
 import           Testnet.Components.SPO
+import           Testnet.Components.TestWatchdog
 import           Testnet.Process.Cli
 import qualified Testnet.Process.Run as H
 import           Testnet.Process.Run
@@ -54,7 +55,7 @@ import qualified Hedgehog.Extras.Test.File as H
 -- | Execute me with:
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/leadership-schedule/"'@
 hprop_leadershipSchedule :: Property
-hprop_leadershipSchedule = H.integrationRetryWorkspace 2 "babbage-leadership-schedule" $ \tempAbsBasePath' -> do
+hprop_leadershipSchedule = H.integrationRetryWorkspace 2 "babbage-leadership-schedule" $ \tempAbsBasePath' -> runWithDefaultWatchdog_ $ do
   H.note_ SYS.os
   conf@Conf { tempAbsPath=tempAbsPath@(TmpAbsolutePath work) } <- mkConf tempAbsBasePath'
   let tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
@@ -242,7 +243,7 @@ hprop_leadershipSchedule = H.integrationRetryWorkspace 2 "babbage-leadership-sch
   jsonBS <- createConfigJson tempAbsPath (cardanoNodeEra cTestnetOptions)
   H.lbsWriteFile configurationFile jsonBS
   [newNodePort] <- requestAvailablePortNumbers 1
-  eRuntime <- lift . lift . runExceptT $ startNode (TmpAbsolutePath work) "test-spo" "127.0.0.1" newNodePort testnetMagic
+  eRuntime <- runExceptT $ startNode (TmpAbsolutePath work) "test-spo" "127.0.0.1" newNodePort testnetMagic
         [ "run"
         , "--config", configurationFile
         , "--topology", topologyFile

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/StakeSnapshot.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/StakeSnapshot.hs
@@ -21,6 +21,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KM
 import qualified System.Info as SYS
 
+import           Testnet.Components.TestWatchdog
 import           Testnet.Process.Cli (execCliStdoutToJson)
 import qualified Testnet.Process.Run as H
 import qualified Testnet.Property.Utils as H
@@ -32,7 +33,7 @@ import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
 import qualified Hedgehog.Extras.Test.Base as H
 
 hprop_stakeSnapshot :: Property
-hprop_stakeSnapshot = H.integrationRetryWorkspace 2 "babbage-stake-snapshot" $ \tempAbsBasePath' -> do
+hprop_stakeSnapshot = H.integrationRetryWorkspace 2 "babbage-stake-snapshot" $ \tempAbsBasePath' -> runWithDefaultWatchdog_ $ do
   H.note_ SYS.os
   conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/Transaction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/Transaction.hs
@@ -29,6 +29,7 @@ import           System.FilePath ((</>))
 import qualified System.Info as SYS
 
 import           Testnet.Components.SPO
+import           Testnet.Components.TestWatchdog
 import qualified Testnet.Process.Run as H
 import           Testnet.Process.Run
 import qualified Testnet.Property.Utils as H
@@ -40,7 +41,7 @@ import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
 hprop_transaction :: Property
-hprop_transaction = H.integrationRetryWorkspace 0 "babbage-transaction" $ \tempAbsBasePath' -> do
+hprop_transaction = H.integrationRetryWorkspace 0 "babbage-transaction" $ \tempAbsBasePath' -> runWithDefaultWatchdog_ $ do
   H.note_ SYS.os
   conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/DRepRetirement.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/DRepRetirement.hs
@@ -21,6 +21,7 @@ import qualified Data.Text as Text
 import           System.FilePath ((</>))
 
 import           Testnet.Components.Query
+import           Testnet.Components.TestWatchdog
 import           Testnet.Defaults
 import qualified Testnet.Process.Cli as P
 import qualified Testnet.Process.Run as H
@@ -39,7 +40,7 @@ sbe = ShelleyBasedEraConway
 -- Execute this test with:
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/DRepRetirement/"'@
 hprop_drep_retirement :: Property
-hprop_drep_retirement = H.integrationRetryWorkspace 2 "drep-retirement" $ \tempAbsBasePath' -> do
+hprop_drep_retirement = H.integrationRetryWorkspace 2 "drep-retirement" $ \tempAbsBasePath' -> runWithDefaultWatchdog_ $ do
   -- Start a local test net
   conf@Conf { tempAbsPath } <- H.noteShowM $ mkConf tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/Plutus.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/Plutus.hs
@@ -29,6 +29,7 @@ import qualified System.Info as SYS
 
 import           Testnet.Components.Configuration
 import           Testnet.Components.SPO
+import           Testnet.Components.TestWatchdog
 import           Testnet.Defaults
 import qualified Testnet.Process.Run as H
 import           Testnet.Process.Run
@@ -48,7 +49,7 @@ import qualified Hedgehog.Extras as H
 -- Voting NO
 -- Proposing NO
 hprop_plutus_v3 :: Property
-hprop_plutus_v3 = H.integrationWorkspace "all-plutus-script-purposes" $ \tempAbsBasePath' -> do
+hprop_plutus_v3 = H.integrationWorkspace "all-plutus-script-purposes" $ \tempAbsBasePath' -> runWithDefaultWatchdog_ $ do
   H.note_ SYS.os
   conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/StakeSnapshot.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/StakeSnapshot.hs
@@ -18,6 +18,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KM
 import qualified System.Info as SYS
 
+import           Testnet.Components.TestWatchdog
 import           Testnet.Process.Cli (execCliStdoutToJson)
 import qualified Testnet.Process.Run as H
 import qualified Testnet.Property.Utils as H
@@ -29,7 +30,7 @@ import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
 import qualified Hedgehog.Extras.Test.Base as H
 
 hprop_stakeSnapshot :: Property
-hprop_stakeSnapshot = H.integrationRetryWorkspace 2 "conway-stake-snapshot" $ \tempAbsBasePath' -> do
+hprop_stakeSnapshot = H.integrationRetryWorkspace 2 "conway-stake-snapshot" $ \tempAbsBasePath' -> runWithDefaultWatchdog_ $ do
   H.note_ SYS.os
   conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/KesPeriodInfo.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/KesPeriodInfo.hs
@@ -32,6 +32,7 @@ import qualified System.Info as SYS
 
 import           Testnet.Components.Configuration
 import           Testnet.Components.SPO
+import           Testnet.Components.TestWatchdog
 import           Testnet.Process.Cli
 import qualified Testnet.Process.Run as H
 import           Testnet.Process.Run
@@ -46,7 +47,7 @@ import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
 hprop_kes_period_info :: Property
-hprop_kes_period_info = H.integrationRetryWorkspace 2 "kes-period-info" $ \tempAbsBasePath' -> do
+hprop_kes_period_info = H.integrationRetryWorkspace 2 "kes-period-info" $ \tempAbsBasePath' -> runWithDefaultWatchdog_ $ do
   H.note_ SYS.os
   conf@Conf { tempAbsPath=tempAbsPath@(TmpAbsolutePath work) }
     -- TODO: Move yaml filepath specification into individual node options
@@ -237,7 +238,7 @@ hprop_kes_period_info = H.integrationRetryWorkspace 2 "kes-period-info" $ \tempA
   jsonBS <- createConfigJson tempAbsPath (cardanoNodeEra cTestnetOptions)
   H.lbsWriteFile configurationFile jsonBS
   [newNodePortNumber] <- requestAvailablePortNumbers 1
-  eRuntime <- lift . lift . runExceptT $ startNode tempAbsPath "test-spo" "127.0.0.1" newNodePortNumber testnetMagic
+  eRuntime <- runExceptT $ startNode tempAbsPath "test-spo" "127.0.0.1" newNodePortNumber testnetMagic
         [ "run"
         , "--config", configurationFile
         , "--topology", topologyFile

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Queries.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Queries.hs
@@ -25,6 +25,7 @@ import           GHC.Stack (HasCallStack)
 import           System.FilePath ((</>))
 
 import           Testnet.Components.Query (checkDRepsNumber)
+import           Testnet.Components.TestWatchdog
 import qualified Testnet.Process.Cli as H
 import qualified Testnet.Process.Run as H
 import qualified Testnet.Property.Utils as H
@@ -42,7 +43,7 @@ import qualified Hedgehog.Extras.Test.Golden as H
 -- If you want to recreate golden files, run the comment with
 -- RECREATE_GOLDEN_FILES=1 as its prefix
 hprop_cli_queries :: Property
-hprop_cli_queries = H.integrationWorkspace "cli-queries" $ \tempAbsBasePath' -> do
+hprop_cli_queries = H.integrationWorkspace "cli-queries" $ \tempAbsBasePath' -> runWithDefaultWatchdog_ $ do
   conf@Conf { tempAbsPath=tempAbsPath@(TmpAbsolutePath work) }
     <- mkConf tempAbsBasePath'
   let tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/QuerySlotNumber.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/QuerySlotNumber.hs
@@ -24,6 +24,7 @@ import qualified Data.Time.Clock as DT
 import qualified Data.Time.Format as DT
 import qualified System.Info as SYS
 
+import           Testnet.Components.TestWatchdog
 import qualified Testnet.Process.Run as H
 import           Testnet.Process.Run
 import qualified Testnet.Property.Utils as H
@@ -36,7 +37,7 @@ import qualified Hedgehog.Internal.Property as H
 
 -- | Tests @query slot-number@ cardano-cli command that it returns correct slot numbers for provided utc time
 hprop_querySlotNumber :: Property
-hprop_querySlotNumber = H.integrationRetryWorkspace 2 "query-slot-number" $ \tempAbsBasePath' -> do
+hprop_querySlotNumber = H.integrationRetryWorkspace 2 "query-slot-number" $ \tempAbsBasePath' -> runWithDefaultWatchdog_ $ do
   H.note_ SYS.os
   conf <- mkConf tempAbsBasePath'
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/FoldBlocks.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/FoldBlocks.hs
@@ -21,6 +21,7 @@ import           Control.Monad
 import qualified System.Directory as IO
 import           System.FilePath ((</>))
 
+import           Testnet.Components.TestWatchdog
 import qualified Testnet.Property.Utils as H
 import           Testnet.Runtime
 
@@ -39,7 +40,7 @@ instance Show FoldBlocksException where
 -- events and block, and on reception writes this to the `lock` `MVar`
 -- that main thread blocks on.
 prop_foldBlocks :: H.Property
-prop_foldBlocks = H.integrationRetryWorkspace 2 "foldblocks" $ \tempAbsBasePath' -> do
+prop_foldBlocks = H.integrationRetryWorkspace 2 "foldblocks" $ \tempAbsBasePath' -> runWithDefaultWatchdog_ $ do
   -- Start testnet
   conf <- TN.mkConf tempAbsBasePath'
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/DRepDeposits.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/DRepDeposits.hs
@@ -22,6 +22,7 @@ import           System.FilePath ((</>))
 import           Testnet.Components.DReps (createDRepRegistrationTxBody, failToSubmitTx,
                    generateDRepKeyPair, generateRegistrationCertificate, signTx, submitTx)
 import           Testnet.Components.Query (checkDRepState, getEpochStateView, getMinDRepDeposit)
+import           Testnet.Components.TestWatchdog
 import qualified Testnet.Process.Run as H
 import qualified Testnet.Property.Utils as H
 import           Testnet.Runtime (PaymentKeyInfo (paymentKeyInfoPair), PoolNode (poolRuntime),
@@ -35,7 +36,7 @@ import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
 -- | Execute me with:
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/DRep Deposits/"'@
 hprop_ledger_events_drep_deposits :: Property
-hprop_ledger_events_drep_deposits = H.integrationWorkspace "drep-deposits" $ \tempAbsBasePath' -> do
+hprop_ledger_events_drep_deposits = H.integrationWorkspace "drep-deposits" $ \tempAbsBasePath' -> runWithDefaultWatchdog_ $ do
 
   -- Start a local test net
   conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/InfoAction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/InfoAction.hs
@@ -32,6 +32,7 @@ import           GHC.Stack
 import           System.FilePath ((</>))
 
 import           Testnet.Components.Query
+import           Testnet.Components.TestWatchdog
 import           Testnet.Defaults
 import qualified Testnet.Process.Cli as P
 import qualified Testnet.Process.Run as H
@@ -45,7 +46,7 @@ import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
 -- | Execute me with:
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/InfoAction/'@
 hprop_ledger_events_info_action :: Property
-hprop_ledger_events_info_action = H.integrationRetryWorkspace 0 "info-hash" $ \tempAbsBasePath' -> do
+hprop_ledger_events_info_action = H.integrationRetryWorkspace 0 "info-hash" $ \tempAbsBasePath' -> runWithDefaultWatchdog_ $ do
 
   -- Start a local test net
   conf@Conf { tempAbsPath } <- H.noteShowM $ mkConf tempAbsBasePath'

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SubmitApi/Babbage/Transaction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SubmitApi/Babbage/Transaction.hs
@@ -36,6 +36,7 @@ import qualified System.Info as SYS
 import           Text.Regex (mkRegex, subRegex)
 
 import           Testnet.Components.SPO
+import           Testnet.Components.TestWatchdog
 import qualified Testnet.Process.Run as H
 import           Testnet.Process.Run
 import qualified Testnet.Property.Utils as H
@@ -49,7 +50,7 @@ import qualified Hedgehog.Extras.Test.File as H
 import qualified Hedgehog.Extras.Test.Golden as H
 
 hprop_transaction :: Property
-hprop_transaction = H.integrationRetryWorkspace 0 "submit-api-babbage-transaction" $ \tempAbsBasePath' -> do
+hprop_transaction = H.integrationRetryWorkspace 0 "submit-api-babbage-transaction" $ \tempAbsBasePath' -> runWithDefaultWatchdog_ $ do
   H.note_ SYS.os
   conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath


### PR DESCRIPTION
# Description

This is a workaround for test hangs, which induces early failure after configured time when the test case is unable to complete. This should help with debugging in https://github.com/IntersectMBO/cardano-node/issues/5762. Triggering of the test failure has an advantage, that it stores the failed test workspace in the github action artifacts, which are available for inspection.

Sample triggered failures: 
 - https://github.com/IntersectMBO/cardano-node/actions/runs/8693586858/job/23840655664?pr=5784#step:14:4567

The test case will report where the hang occurred if it happened in a function that:
 * is wrapped in `evalIO` - `liftIO` does not convert an exception to the test failure
 * is wrapped in `withFrozenCallStack`
 * has `HasCallStack` constraint

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
