### PR TITLE
Replace `foldBlocks` test with `foldEpochState` test

### DIFF
--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -184,7 +184,7 @@ test-suite cardano-testnet-test
                         Cardano.Testnet.Test.Cli.KesPeriodInfo
                         Cardano.Testnet.Test.Cli.Query
                         Cardano.Testnet.Test.Cli.QuerySlotNumber
-                        Cardano.Testnet.Test.FoldBlocks
+                        Cardano.Testnet.Test.FoldEpochState
                         Cardano.Testnet.Test.Misc
 
                         Cardano.Testnet.Test.Gov.DRepActivity

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/FoldEpochState.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/FoldEpochState.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Cardano.Testnet.Test.FoldEpochState where
+
+import           Cardano.Api hiding (cardanoEra)
+import qualified Cardano.Api as Api
+
+import           Cardano.Testnet as TN
+
+import           Prelude
+
+import           Control.Concurrent.Async ()
+import           Control.Monad.Trans.State.Strict
+import qualified System.Directory as IO
+import           System.FilePath ((</>))
+
+import qualified Testnet.Property.Util as H
+import           Testnet.Runtime
+
+import           Hedgehog ((===))
+import qualified Hedgehog as H
+import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as H
+import qualified Hedgehog.Extras.Test as H
+
+prop_foldEpochState :: H.Property
+prop_foldEpochState = H.integrationWorkspace "foldEpochState" $ \tempAbsBasePath' -> do
+  conf <- TN.mkConf tempAbsBasePath'
+
+  let tempAbsPath' = unTmpAbsPath $ tempAbsPath conf
+      era = BabbageEra
+      options = cardanoDefaultTestnetOptions
+        { cardanoNodeEra = AnyCardanoEra era
+        }
+
+  runtime@TestnetRuntime{configurationFile} <- cardanoTestnetDefault options conf
+
+  socketPathAbs <- do
+    socketPath' <- H.sprocketArgumentName <$> H.headM (poolSprockets runtime)
+    H.noteIO (IO.canonicalizePath $ tempAbsPath' </> socketPath')
+
+  let handler :: ()
+        => AnyNewEpochState
+        -> SlotNo
+        -> BlockNo
+        -> StateT [(SlotNo, BlockNo)] IO LedgerStateCondition
+      handler _ slotNo blockNo = do
+        modify ((slotNo, blockNo):)
+        s <- get
+        if length s >= 10
+          then pure ConditionMet
+          else pure ConditionNotMet
+
+  (_, nums) <- H.leftFailM $ H.evalIO $ runExceptT $
+    Api.foldEpochState (File configurationFile) (Api.File socketPathAbs) Api.QuickValidation (EpochNo maxBound) [] handler
+
+  length nums === 10

--- a/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
+++ b/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
@@ -12,7 +12,7 @@ import qualified Cardano.Testnet.Test.Cli.Conway.Plutus
 import qualified Cardano.Testnet.Test.Cli.KesPeriodInfo
 import qualified Cardano.Testnet.Test.Cli.Query
 import qualified Cardano.Testnet.Test.Cli.QuerySlotNumber
-import qualified Cardano.Testnet.Test.FoldBlocks
+import qualified Cardano.Testnet.Test.FoldEpochState
 import qualified Cardano.Testnet.Test.Gov.DRepDeposit as Gov
 import qualified Cardano.Testnet.Test.Gov.DRepRetirement as Gov
 import qualified Cardano.Testnet.Test.Gov.ProposeNewConstitution as Gov
@@ -81,7 +81,7 @@ tests = do
             -- as a result of the kes-period-info output to stdout.
           , H.ignoreOnWindows "kes-period-info" Cardano.Testnet.Test.Cli.KesPeriodInfo.hprop_kes_period_info
           , H.ignoreOnWindows "query-slot-number" Cardano.Testnet.Test.Cli.QuerySlotNumber.hprop_querySlotNumber
-          , H.ignoreOnWindows "foldBlocks receives ledger state" Cardano.Testnet.Test.FoldBlocks.prop_foldBlocks
+          , H.ignoreOnWindows "foldEpochState receives ledger state" Cardano.Testnet.Test.FoldEpochState.prop_foldEpochState
           , H.ignoreOnWindows "CliQueries" Cardano.Testnet.Test.Cli.Query.hprop_cli_queries
           ]
         ]


### PR DESCRIPTION
# Description

We are no longer supporting `foldBlocks` so testing `foldEpochState` instead.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
