### PR TITLE
Add test for DRep Activity mechanism

### DIFF
--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -193,6 +193,7 @@ test-suite cardano-testnet-test
                         Cardano.Testnet.Test.LedgerEvents.Gov.ProposeNewConstitution
                         Cardano.Testnet.Test.LedgerEvents.Gov.ProposeNewConstitutionSPO
                         Cardano.Testnet.Test.LedgerEvents.Gov.TreasuryWithdrawal
+                        Cardano.Testnet.Test.LedgerEvents.Gov.DRepActivity
                         Cardano.Testnet.Test.LedgerEvents.SanityCheck
                         Cardano.Testnet.Test.LedgerEvents.TreasuryGrowth
 
@@ -218,6 +219,7 @@ test-suite cardano-testnet-test
                       , cardano-testnet
                       , containers
                       , directory
+                      , exceptions
                       , filepath
                       , hedgehog
                       , hedgehog-extras

--- a/cardano-testnet/src/Testnet/Components/Configuration.hs
+++ b/cardano-testnet/src/Testnet/Components/Configuration.hs
@@ -121,7 +121,9 @@ createSPOGenesisAndFiles (NumPools numPoolNodes) (NumDReps numDelReps) era shell
   let genesisShelleyDirAbs = takeDirectory inputGenesisShelleyFp
   genesisShelleyDir <- H.createDirectoryIfMissing genesisShelleyDirAbs
   let testnetMagic = sgNetworkMagic shelleyGenesis
-      numStakeDelegators = 3 :: Int
+      -- At least there should be a delegator per DRep
+      -- otherwise some won't be representing anybody
+      numStakeDelegators = max 3 numDelReps :: Int
       startTime = sgSystemStart shelleyGenesis
 
  -- TODO: Remove this rewrite.

--- a/cardano-testnet/src/Testnet/Components/DReps.hs
+++ b/cardano-testnet/src/Testnet/Components/DReps.hs
@@ -10,6 +10,7 @@ module Testnet.Components.DReps
   , signTx
   , submitTx
   , failToSubmitTx
+  , retrieveTransactionId
   ) where
 
 import           Cardano.Api (AnyCardanoEra (..), FileDirection (In), ShelleyBasedEra (..),
@@ -304,3 +305,24 @@ failToSubmitTx execConfig cEra signedTx = GHC.withFrozenCallStack $ do
   case exitCode of
     ExitSuccess -> H.failMessage GHC.callStack "Transaction submission was expected to fail but it succeeded"
     _ -> return ()
+
+-- | Retrieves the transaction ID (governance action ID) from a signed
+-- transaction file using @cardano-cli@.
+--
+-- This function takes the following parameters:
+--
+-- * 'execConfig': Specifies the CLI execution configuration.
+-- * 'signedTx': Signed transaction to be submitted, obtained using 'signTx'.
+--
+-- Returns the transaction ID (governance action ID) as a 'String'.
+retrieveTransactionId
+  :: (MonadTest m, MonadCatch m, MonadIO m)
+  => H.ExecConfig
+  -> File SignedTx In
+  -> m String
+retrieveTransactionId execConfig signedTxBody = do
+  txidOutput <- H.execCli' execConfig
+    [ "transaction", "txid"
+    , "--tx-file", unFile signedTxBody
+    ]
+  return $ mconcat $ lines txidOutput

--- a/cardano-testnet/src/Testnet/Components/DReps.hs
+++ b/cardano-testnet/src/Testnet/Components/DReps.hs
@@ -1,12 +1,10 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Testnet.Components.DReps
-  ( SomeKeyPair(..)
-  , VoteFile
+  ( VoteFile
   , generateDRepKeyPair
   , generateRegistrationCertificate
   , createCertificatePublicationTxBody
@@ -46,8 +44,8 @@ import           System.FilePath ((</>))
 import           Testnet.Components.Query (EpochStateView, findLargestUtxoForPaymentKey,
                    getCurrentEpochNo, getMinDRepDeposit, waitUntilEpoch)
 import qualified Testnet.Process.Run as H
-import           Testnet.Runtime (PaymentKeyInfo (paymentKeyInfoAddr, paymentKeyInfoPair),
-                   PaymentKeyPair (..), StakingKeyPair (StakingKeyPair, stakingSKey))
+import           Testnet.Runtime (KeyPair(..), PaymentKeyInfo (paymentKeyInfoAddr, paymentKeyInfoPair),
+                   PaymentKeyPair (..), StakingKeyPair (..), SomeKeyPair (..))
 import           Testnet.Start.Types (anyEraToString)
 
 import           Hedgehog (MonadTest, evalMaybe)
@@ -200,23 +198,6 @@ createVotingTxBody execConfig epochStateView sbe work prefix votes wallet = do
 -- Transaction signing
 
 data SignedTx
-
-class KeyPair a where
-  secretKey :: a -> FilePath
-
-instance KeyPair PaymentKeyPair where
-  secretKey :: PaymentKeyPair -> FilePath
-  secretKey = paymentSKey
-
-instance KeyPair StakingKeyPair where
-  secretKey :: StakingKeyPair -> FilePath
-  secretKey = stakingSKey
-
-data SomeKeyPair = forall a . KeyPair a => SomeKeyPair a
-
-instance KeyPair SomeKeyPair where
-  secretKey :: SomeKeyPair -> FilePath
-  secretKey (SomeKeyPair x) = secretKey x
 
 -- | Calls @cardano-cli@ to signs a transaction body using the specified key pairs.
 --

--- a/cardano-testnet/src/Testnet/Components/DReps.hs
+++ b/cardano-testnet/src/Testnet/Components/DReps.hs
@@ -461,7 +461,7 @@ delegateToDRep execConfig epochStateView configurationFile socketPath sbe work p
   submitTx execConfig cEra repRegSignedRegTx1
 
   -- Wait two epochs
-  (EpochNo epochAfterProp) <- getCurrentEpochNo epochStateView sbe
+  (EpochNo epochAfterProp) <- getCurrentEpochNo epochStateView
   void $ waitUntilEpoch (File configurationFile) (File socketPath) (EpochNo (epochAfterProp + 2))
 
 -- | This function obtains the identifier for the last enacted parameter update proposal

--- a/cardano-testnet/src/Testnet/Components/DReps.hs
+++ b/cardano-testnet/src/Testnet/Components/DReps.hs
@@ -55,18 +55,12 @@ import qualified Hedgehog.Extras as H
 
 -- | Generates a key pair for a decentralized representative (DRep) using @cardano-cli@.
 --
--- The function takes three parameters:
---
--- * 'execConfig': Specifies the CLI execution configuration.
--- * 'work': Base directory path where keys will be stored.
--- * 'prefix': Name for the subfolder that will be created under 'work' folder to store the output keys.
---
 -- Returns the generated 'PaymentKeyPair' containing paths to the verification and
 -- signing key files.
 generateDRepKeyPair :: (MonadTest m, MonadCatch m, MonadIO m, HasCallStack)
-  => H.ExecConfig
-  -> FilePath
-  -> String
+  => H.ExecConfig -- ^ Specifies the CLI execution configuration.
+  -> FilePath -- ^ Base directory path where keys will be stored.
+  -> String -- ^ Name for the subfolder that will be created under 'work' folder to store the output keys.
   -> m PaymentKeyPair
 generateDRepKeyPair execConfig work prefix = do
   baseDir <- H.createDirectoryIfMissing $ work </> prefix
@@ -86,25 +80,17 @@ data Certificate
 -- | Generates a registration certificate for a decentralized representative (DRep)
 -- using @cardano-cli@.
 --
--- The function takes five parameters:
---
--- * 'execConfig': Specifies the CLI execution configuration.
--- * 'work': Base directory path where the certificate file will be stored.
--- * 'prefix': Prefix for the output certificate file name. The extension will be @.regcert@.
--- * 'drepKeyPair': Payment key pair associated with the DRep. Can be generated using
---                  'generateDRepKeyPair'.
--- * 'depositAmount': Deposit amount required for DRep registration. The right amount
---                    can be obtained using 'getMinDRepDeposit'.
---
 -- Returns the generated @File DRepRegistrationCertificate In@ file path to the
 -- registration certificate.
 generateRegistrationCertificate
   :: (MonadTest m, MonadCatch m, MonadIO m, HasCallStack)
-  => H.ExecConfig
-  -> FilePath
-  -> String
-  -> PaymentKeyPair
-  -> Integer
+  => H.ExecConfig -- ^ Specifies the CLI execution configuration.
+  -> FilePath -- ^ Base directory path where the certificate file will be stored.
+  -> String -- ^ Prefix for the output certificate file name. The extension will be @.regcert@.
+  -> PaymentKeyPair -- ^ Payment key pair associated with the DRep. Can be generated using
+                    -- 'generateDRepKeyPair'.
+  -> Integer -- ^ Deposit amount required for DRep registration. The right amount
+             -- can be obtained using 'getMinDRepDeposit'.
   -> m (File Certificate In)
 generateRegistrationCertificate execConfig work prefix drepKeyPair depositAmount = do
   let dRepRegistrationCertificate = File (work </> prefix <> ".regcert")
@@ -121,28 +107,18 @@ data TxBody
 
 -- | Composes a certificate publication transaction body (without signing) using @cardano-cli@.
 --
--- This function takes seven parameters:
---
--- * 'execConfig': Specifies the CLI execution configuration.
--- * 'epochStateView': Current epoch state view for transaction building. It can be obtained
---                     using the 'getEpochStateView' function.
--- * 'sbe': The Shelley-based era (e.g., 'ShelleyBasedEraShelley') in which the transaction will be constructed.
--- * 'work': Base directory path where the transaction body file will be stored.
--- * 'prefix': Prefix for the output transaction body file name. The extension will be @.txbody@.
--- * 'certificate': The file name of the certificate.
--- * 'wallet': Payment key information associated with the transaction,
---             as returned by 'cardanoTestnetDefault'.
---
 -- Returns the generated @File TxBody In@ file path to the transaction body.
 createCertificatePublicationTxBody
   :: (H.MonadAssertion m, MonadTest m, MonadCatch m, MonadIO m)
-  => H.ExecConfig
-  -> EpochStateView
-  -> ShelleyBasedEra era
-  -> FilePath
-  -> String
-  -> File Certificate In
-  -> PaymentKeyInfo
+  => H.ExecConfig -- ^ Specifies the CLI execution configuration.
+  -> EpochStateView -- ^ Current epoch state view for transaction building. It can be obtained
+                    -- using the 'getEpochStateView' function.
+  -> ShelleyBasedEra era -- ^ The Shelley-based era (e.g., 'ShelleyBasedEraShelley') in which the transaction will be constructed.
+  -> FilePath -- ^ Base directory path where the transaction body file will be stored.
+  -> String -- ^ Prefix for the output transaction body file name. The extension will be @.txbody@.
+  -> File Certificate In -- ^ The file name of the certificate.
+  -> PaymentKeyInfo -- ^ Payment key information associated with the transaction,
+                    -- as returned by 'cardanoTestnetDefault'.
   -> m (File TxBody In)
 createCertificatePublicationTxBody execConfig epochStateView sbe work prefix cert wallet = do
   let dRepRegistrationTxBody = File (work </> prefix <> ".txbody")
@@ -163,28 +139,19 @@ data VoteFile
 -- | Generates decentralized representative (DRep) voting files (without signing)
 -- using @cardano-cli@.
 --
--- This function takes the following parameters:
---
--- * 'execConfig': Specifies the CLI execution configuration.
--- * 'work': Base directory path where the voting files and directories will be
---           stored.
--- * 'prefix': Name for the subfolder that will be created under 'work' to store
---             the output voting files.
--- * 'governanceActionTxId': Transaction ID string of the governance action.
--- * 'governanceActionIndex': Index of the governance action.
--- * 'allVotes': List of tuples where each tuple contains a 'PaymentKeyPair'
---               representing the DRep key pair and a 'String' representing the
---               vote type (i.e: "yes", "no", or "abstain").
---
 -- Returns a list of generated @File VoteFile In@ representing the paths to
 -- the generated voting files.
 generateVoteFiles :: (MonadTest m, MonadIO m, MonadCatch m)
-  => H.ExecConfig
-  -> FilePath
-  -> String
-  -> String
-  -> Word32
-  -> [(PaymentKeyPair, [Char])]
+  => H.ExecConfig -- ^ Specifies the CLI execution configuration.
+  -> FilePath -- ^ Base directory path where the voting files and directories will be
+              -- stored.
+  -> String -- ^ Name for the subfolder that will be created under 'work' to store
+            -- the output voting files.
+  -> String -- ^ Transaction ID string of the governance action.
+  -> Word32 -- ^ Index of the governance action.
+  -> [(PaymentKeyPair, [Char])] -- ^ List of tuples where each tuple contains a 'PaymentKeyPair'
+                                -- representing the DRep key pair and a 'String' representing the
+                                -- vote type (i.e: "yes", "no", or "abstain").
   -> m [File VoteFile In]
 generateVoteFiles execConfig work prefix governanceActionTxId governanceActionIndex allVotes = do
   baseDir <- H.createDirectoryIfMissing $ work </> prefix
@@ -203,29 +170,19 @@ generateVoteFiles execConfig work prefix governanceActionTxId governanceActionIn
 -- | Composes a decentralized representative (DRep) voting transaction body
 -- (without signing) using @cardano-cli@.
 --
--- This function takes seven parameters:
---
--- * 'execConfig': Specifies the CLI execution configuration.
--- * 'epochStateView': Current epoch state view for transaction building. It can be obtained
---                     using the 'getEpochStateView' function.
--- * 'sbe': The Shelley-based era (e.g., 'ShelleyBasedEraShelley') in which the transaction will be constructed.
--- * 'work': Base directory path where the transaction body file will be stored.
--- * 'prefix': Prefix for the output transaction body file name. The extension will be @.txbody@.
--- * 'votes': List of voting files (@File VoteFile In@) to include in the transaction,
---            obtained using 'generateVoteFiles'.
--- * 'wallet': Payment key information associated with the transaction,
---             as returned by 'cardanoTestnetDefault'.
---
 -- Returns the generated @File TxBody In@ file path to the transaction body.
 createVotingTxBody
   :: (H.MonadAssertion m, MonadTest m, MonadCatch m, MonadIO m)
-  => H.ExecConfig
-  -> EpochStateView
-  -> ShelleyBasedEra era
-  -> FilePath
-  -> String
-  -> [File VoteFile In]
-  -> PaymentKeyInfo
+  => H.ExecConfig -- ^ Specifies the CLI execution configuration.
+  -> EpochStateView -- ^ Current epoch state view for transaction building. It can be obtained
+                    -- using the 'getEpochStateView' function.
+  -> ShelleyBasedEra era -- ^ The Shelley-based era (e.g., 'ShelleyBasedEraShelley') in which the transaction will be constructed.
+  -> FilePath -- ^ Base directory path where the transaction body file will be stored.
+  -> String -- ^ Prefix for the output transaction body file name. The extension will be @.txbody@.
+  -> [File VoteFile In] -- ^ List of voting files (@File VoteFile In@) to include in the transaction,
+                        -- obtained using 'generateVoteFiles'.
+  -> PaymentKeyInfo -- ^ Payment key information associated with the transaction,
+                    -- as returned by 'cardanoTestnetDefault'.
   -> m (File TxBody In)
 createVotingTxBody execConfig epochStateView sbe work prefix votes wallet = do
   let dRepVotingTxBody = File (work </> prefix <> ".txbody")
@@ -265,21 +222,14 @@ instance KeyPair SomeKeyPair where
 --
 -- This function takes five parameters:
 --
--- * 'execConfig': Specifies the CLI execution configuration.
--- * 'cEra': Specifies the current Cardano era.
--- * 'work': Base directory path where the signed transaction file will be stored.
--- * 'prefix': Prefix for the output signed transaction file name. The extension will be @.tx@.
--- * 'txBody': Transaction body to be signed, obtained using 'createCertificatePublicationTxBody' or similar.
--- * 'signatoryKeyPairs': List of payment key pairs used for signing the transaction.
---
 -- Returns the generated @File SignedTx In@ file path to the signed transaction file.
 signTx :: (MonadTest m, MonadCatch m, MonadIO m, KeyPair k)
-  => H.ExecConfig
-  -> AnyCardanoEra
-  -> FilePath
-  -> String
-  -> File TxBody In
-  -> [k]
+  => H.ExecConfig -- ^ Specifies the CLI execution configuration.
+  -> AnyCardanoEra -- ^ Specifies the current Cardano era.
+  -> FilePath -- ^ Base directory path where the signed transaction file will be stored.
+  -> String -- ^ Prefix for the output signed transaction file name. The extension will be @.tx@.
+  -> File TxBody In -- ^ Transaction body to be signed, obtained using 'createCertificatePublicationTxBody' or similar.
+  -> [k] -- ^ List of payment key pairs used for signing the transaction.
   -> m (File SignedTx In)
 signTx execConfig cEra work prefix txBody signatoryKeyPairs = do
   let signedTx = File (work </> prefix <> ".tx")
@@ -292,17 +242,11 @@ signTx execConfig cEra work prefix txBody signatoryKeyPairs = do
   return signedTx
 
 -- | Submits a signed transaction using @cardano-cli@.
---
--- This function takes two parameters:
---
--- * 'execConfig': Specifies the CLI execution configuration.
--- * 'cEra': Specifies the current Cardano era.
--- * 'signedTx': Signed transaction to be submitted, obtained using 'signTx'.
 submitTx
   :: (MonadTest m, MonadCatch m, MonadIO m)
-  => H.ExecConfig
-  -> AnyCardanoEra
-  -> File SignedTx In
+  => H.ExecConfig -- ^ Specifies the CLI execution configuration.
+  -> AnyCardanoEra -- ^ Specifies the current Cardano era.
+  -> File SignedTx In -- ^ Signed transaction to be submitted, obtained using 'signTx'.
   -> m ()
 submitTx execConfig cEra signedTx =
   void $ H.execCli' execConfig
@@ -312,20 +256,14 @@ submitTx execConfig cEra signedTx =
 
 -- | Attempts to submit a transaction that is expected to fail using @cardano-cli@.
 --
--- This function takes two parameters:
---
--- * 'execConfig': Specifies the CLI execution configuration.
--- * 'cEra': Specifies the current Cardano era.
--- * 'signedTx': Signed transaction to be submitted, obtained using 'signTx'.
---
 -- If the submission fails (the expected behavior), the function succeeds.
 -- If the submission succeeds unexpectedly, it raises a failure message that is
 -- meant to be caught by @Hedgehog@.
 failToSubmitTx
   :: (MonadTest m, MonadCatch m, MonadIO m)
-  => H.ExecConfig
-  -> AnyCardanoEra
-  -> File SignedTx In
+  => H.ExecConfig -- ^ Specifies the CLI execution configuration.
+  -> AnyCardanoEra -- ^ Specifies the current Cardano era.
+  -> File SignedTx In -- ^ Signed transaction to be submitted, obtained using 'signTx'.
   -> m ()
 failToSubmitTx execConfig cEra signedTx = GHC.withFrozenCallStack $ do
   (exitCode, _, _) <- H.execFlexAny' execConfig "cardano-cli" "CARDANO_CLI"
@@ -339,16 +277,11 @@ failToSubmitTx execConfig cEra signedTx = GHC.withFrozenCallStack $ do
 -- | Retrieves the transaction ID (governance action ID) from a signed
 -- transaction file using @cardano-cli@.
 --
--- This function takes the following parameters:
---
--- * 'execConfig': Specifies the CLI execution configuration.
--- * 'signedTx': Signed transaction to be submitted, obtained using 'signTx'.
---
 -- Returns the transaction ID (governance action ID) as a 'String'.
 retrieveTransactionId
   :: (MonadTest m, MonadCatch m, MonadIO m)
-  => H.ExecConfig
-  -> File SignedTx In
+  => H.ExecConfig -- ^ Specifies the CLI execution configuration.
+  -> File SignedTx In -- ^ Signed transaction to be submitted, obtained using 'signTx'.
   -> m String
 retrieveTransactionId execConfig signedTxBody = do
   txidOutput <- H.execCli' execConfig
@@ -360,27 +293,16 @@ retrieveTransactionId execConfig signedTxBody = do
 -- | Register a Delegate Representative (DRep) using @cardano-cli@,
 -- generating a fresh key pair in the process.
 --
--- This function takes the following parameters:
---
--- * 'execConfig': Specifies the CLI execution configuration.
--- * 'epochStateView': Current epoch state view for transaction building. It can be obtained
---                     using the 'getEpochStateView' function.
--- * 'configurationFile': Path to the node configuration file as returned by 'cardanoTestnetDefault'.
--- * 'socketPath': Path to the cardano-node unix socket file.
--- * 'sbe': The conway era onwards witness for the era in which the transaction will be constructed.
--- * 'work': Base directory path where the signed transaction file will be stored.
--- * 'prefix': Name for the subfolder that will be created under 'work' folder to store the output keys.
--- * 'wallet': Payment key information associated with the transaction,
---             as returned by 'cardanoTestnetDefault'.
---
 -- Returns the key pair for the DRep as a 'PaymentKeyPair'.
 registerDRep :: (MonadCatch m, MonadIO m, MonadTest m, H.MonadAssertion m)
-  => H.ExecConfig
-  -> EpochStateView
-  -> ConwayEraOnwards ConwayEra
-  -> FilePath
-  -> FilePath
-  -> PaymentKeyInfo
+  => H.ExecConfig -- ^ Specifies the CLI execution configuration.
+  -> EpochStateView -- ^ Current epoch state view for transaction building. It can be obtained
+                    -- using the 'getEpochStateView' function.
+  -> ConwayEraOnwards ConwayEra -- ^ The conway era onwards witness for the era in which the transaction will be constructed.
+  -> FilePath -- ^ Base directory path where the signed transaction file will be stored.
+  -> FilePath -- ^ Name for the subfolder that will be created under 'work' folder to store the output keys.
+  -> PaymentKeyInfo -- ^ Payment key information associated with the transaction,
+                    -- as returned by 'cardanoTestnetDefault'.
   -> m PaymentKeyPair
 registerDRep execConfig epochStateView ceo work prefix wallet = do
   let sbe = conwayEraOnwardsToShelleyBasedEra ceo
@@ -403,32 +325,18 @@ registerDRep execConfig epochStateView ceo work prefix wallet = do
 
 -- | Delegate to a Delegate Representative (DRep) by creating and submitting
 -- a vote delegation certificate transaction using @cardano-cli@.
---
--- This function takes the following parameters:
---
--- * 'execConfig': Specifies the CLI execution configuration.
--- * 'epochStateView': Current epoch state view for transaction building. It can be obtained
---                     using the 'getEpochStateView' function.
--- * 'configurationFile': Path to the node configuration file as returned by 'cardanoTestnetDefault'.
--- * 'socketPath': Path to the cardano-node unix socket file.
--- * 'sbe': The Shelley-based era (e.g., 'ConwayEra') in which the transaction will be constructed.
--- * 'work': Base directory path where generated files will be stored.
--- * 'prefix': Name for the subfolder that will be created under 'work' folder.
--- * 'payingWallet': Wallet that will pay for the transaction.
--- * 'skeyPair': Staking key pair used for delegation.
--- * 'drepKeyPair': Delegate Representative (DRep) key pair ('PaymentKeyPair') to which delegate.
 delegateToDRep
   :: (MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m)
-  => H.ExecConfig
-  -> EpochStateView
-  -> FilePath
-  -> FilePath
-  -> ShelleyBasedEra ConwayEra
-  -> FilePath
-  -> String
-  -> PaymentKeyInfo
-  -> StakingKeyPair
-  -> PaymentKeyPair
+  => H.ExecConfig -- ^ Specifies the CLI execution configuration.
+  -> EpochStateView -- ^ Current epoch state view for transaction building. It can be obtained
+  -> FilePath -- ^ Path to the node configuration file as returned by 'cardanoTestnetDefault'.
+  -> FilePath -- ^ Path to the cardano-node unix socket file.
+  -> ShelleyBasedEra ConwayEra -- ^ The Shelley-based era (e.g., 'ConwayEra') in which the transaction will be constructed.
+  -> FilePath -- ^ Base directory path where generated files will be stored.
+  -> String -- ^ Name for the subfolder that will be created under 'work' folder.
+  -> PaymentKeyInfo -- ^ Wallet that will pay for the transaction.
+  -> StakingKeyPair -- ^ Staking key pair used for delegation.
+  -> PaymentKeyPair -- ^ Delegate Representative (DRep) key pair ('PaymentKeyPair') to which delegate.
   -> m ()
 delegateToDRep execConfig epochStateView configurationFile socketPath sbe work prefix
                payingWallet skeyPair@(StakingKeyPair vKeyFile _sKeyFile)
@@ -467,14 +375,12 @@ delegateToDRep execConfig epochStateView configurationFile socketPath sbe work p
 -- | This function obtains the identifier for the last enacted parameter update proposal
 -- if any.
 --
--- This function takes the following parameter:
---
--- * 'execConfig': Specifies the CLI execution configuration.
---
 -- If no previous proposal was enacted, the function returns 'Nothing'.
 -- If there was a previous enacted proposal, the function returns a tuple with its transaction
 -- identifier (as a 'String') and the action index (as a 'Word32').
-getLastPParamUpdateActionId :: (MonadTest m, MonadCatch m, MonadIO m) => H.ExecConfig -> m (Maybe (String, Word32))
+getLastPParamUpdateActionId :: (MonadTest m, MonadCatch m, MonadIO m)
+  => H.ExecConfig -- ^ Specifies the CLI execution configuration.
+  -> m (Maybe (String, Word32))
 getLastPParamUpdateActionId execConfig = do
   govStateString <- H.execCli' execConfig
     [ "conway", "query", "gov-state"

--- a/cardano-testnet/src/Testnet/Components/Query.hs
+++ b/cardano-testnet/src/Testnet/Components/Query.hs
@@ -302,7 +302,12 @@ checkDRepState sbe configurationFile socketPath execConfig f = withFrozenCallSta
                   [ "checkDRepState: foldEpochState returned Nothing: "
                   , "This is probably an error related to foldEpochState." ]
       H.failure
-    Right (_, Just val) ->
+    Right (ConditionNotMet, Just _) -> do
+      H.note_ $ unlines
+                  [ "checkDRepState: foldEpochState returned Just and ConditionNotMet: "
+                  , "This is probably an error related to foldEpochState." ]
+      H.failure
+    Right (ConditionMet, Just val) ->
       return val
 
 -- | Obtain governance state from node (CLI query)

--- a/cardano-testnet/src/Testnet/Components/Query.hs
+++ b/cardano-testnet/src/Testnet/Components/Query.hs
@@ -345,12 +345,7 @@ getMinDRepDeposit execConfig ceo = withFrozenCallStack $ do
 -- | Obtain current epoch number using 'getEpochState'
 getCurrentEpochNo :: (MonadTest m, MonadAssertion m, MonadIO m)
   => EpochStateView
-  -> ShelleyBasedEra ConwayEra
   -> m EpochNo
-getCurrentEpochNo epochStateView sbe = do
-  AnyNewEpochState actualEra newEpochState <- getEpochState epochStateView
-  case testEquality sbe actualEra of
-    Just Refl -> return $ shelleyBasedEraConstraints sbe newEpochState
-                            ^. L.nesELL
-    Nothing ->
-      error $ "Eras mismatch! expected: " <> show sbe <> ", actual: " <> show actualEra
+getCurrentEpochNo epochStateView = do
+  AnyNewEpochState _ newEpochState <- getEpochState epochStateView
+  return $ newEpochState ^. L.nesELL

--- a/cardano-testnet/src/Testnet/Defaults.hs
+++ b/cardano-testnet/src/Testnet/Defaults.hs
@@ -16,6 +16,7 @@ module Testnet.Defaults
   , defaultConwayGenesis
   , defaultDRepVkeyFp
   , defaultDRepSkeyFp
+  , defaultDRepKeyPair
   , defaultShelleyGenesis
   , defaultGenesisFilepath
   , defaultYamlHardforkViaConfig
@@ -70,6 +71,7 @@ import           Numeric.Natural
 import           System.FilePath ((</>))
 
 import           Test.Cardano.Ledger.Core.Rational
+import           Testnet.Runtime (PaymentKeyPair (PaymentKeyPair))
 import           Testnet.Start.Types
 
 {- HLINT ignore "Use underscore" -}
@@ -507,6 +509,10 @@ defaultDRepSkeyFp
   :: Int -- ^ The DRep's index (starts at 1)
   -> FilePath
 defaultDRepSkeyFp n = "drep-keys" </> ("drep" <> show n) </> "drep.skey"
+
+-- | The relative path to DRep key pairs in directories created by cardano-testnet
+defaultDRepKeyPair :: Int -> PaymentKeyPair
+defaultDRepKeyPair n = PaymentKeyPair (defaultDRepVkeyFp n) (defaultDRepSkeyFp n)
 
 -- TODO: We should not hardcode a script like this. We need to move
 -- plutus-example from plutus apps to cardano-node-testnet. This will

--- a/cardano-testnet/src/Testnet/Defaults.hs
+++ b/cardano-testnet/src/Testnet/Defaults.hs
@@ -23,6 +23,7 @@ module Testnet.Defaults
   , defaultMainnetTopology
   , plutusV3NonSpendingScript
   , plutusV3SpendingScript
+  , defaultDelegatorStakeKeyPair
   ) where
 
 import           Cardano.Api (AnyCardanoEra (..), CardanoEra (..), pshow)
@@ -71,7 +72,7 @@ import           Numeric.Natural
 import           System.FilePath ((</>))
 
 import           Test.Cardano.Ledger.Core.Rational
-import           Testnet.Runtime (PaymentKeyPair (PaymentKeyPair))
+import           Testnet.Runtime (PaymentKeyPair (PaymentKeyPair), StakingKeyPair (StakingKeyPair))
 import           Testnet.Start.Types
 
 {- HLINT ignore "Use underscore" -}
@@ -513,6 +514,22 @@ defaultDRepSkeyFp n = "drep-keys" </> ("drep" <> show n) </> "drep.skey"
 -- | The relative path to DRep key pairs in directories created by cardano-testnet
 defaultDRepKeyPair :: Int -> PaymentKeyPair
 defaultDRepKeyPair n = PaymentKeyPair (defaultDRepVkeyFp n) (defaultDRepSkeyFp n)
+
+-- | The relative path to stake delegator stake keys in directories created by cardano-testnet
+defaultDelegatorStakeVkeyFp
+  :: Int -- ^ The Stake delegator index (starts at 1)
+  -> FilePath
+defaultDelegatorStakeVkeyFp n = "stake-delegators" </> ("delegator" <> show n) </> "staking.vkey"
+
+-- | The relative path to stake delegator stake secret keys in directories created by cardano-testnet
+defaultDelegatorStakeSkeyFp
+  :: Int -- ^ The Stake delegator index (starts at 1)
+  -> FilePath
+defaultDelegatorStakeSkeyFp n = "stake-delegators" </> ("delegator" <> show n) </> "staking.skey"
+
+-- | The relative path to stake delegator key pairs in directories created by cardano-testnet
+defaultDelegatorStakeKeyPair :: Int -> StakingKeyPair
+defaultDelegatorStakeKeyPair n = StakingKeyPair (defaultDelegatorStakeVkeyFp n) (defaultDelegatorStakeSkeyFp n)
 
 -- TODO: We should not hardcode a script like this. We need to move
 -- plutus-example from plutus apps to cardano-node-testnet. This will

--- a/cardano-testnet/src/Testnet/Runtime.hs
+++ b/cardano-testnet/src/Testnet/Runtime.hs
@@ -6,6 +6,8 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE InstanceSigs #-}
 
 module Testnet.Runtime
   ( LeadershipSlot(..)
@@ -18,6 +20,8 @@ module Testnet.Runtime
   , PoolNode(..)
   , PoolNodeKeys(..)
   , Delegator(..)
+  , KeyPair(..)
+  , SomeKeyPair(..)
   , allNodes
   , poolSprockets
   , poolNodeStdout
@@ -134,6 +138,22 @@ data LeadershipSlot = LeadershipSlot
   , slotTime    :: Text
   } deriving (Eq, Show, Generic, FromJSON)
 
+class KeyPair a where
+  secretKey :: a -> FilePath
+
+instance KeyPair PaymentKeyPair where
+  secretKey :: PaymentKeyPair -> FilePath
+  secretKey = paymentSKey
+
+instance KeyPair StakingKeyPair where
+  secretKey :: StakingKeyPair -> FilePath
+  secretKey = stakingSKey
+
+data SomeKeyPair = forall a . KeyPair a => SomeKeyPair a
+
+instance KeyPair SomeKeyPair where
+  secretKey :: SomeKeyPair -> FilePath
+  secretKey (SomeKeyPair x) = secretKey x
 
 poolNodeStdout :: PoolNode -> FilePath
 poolNodeStdout = nodeStdout . poolRuntime

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/DRepActivity.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/DRepActivity.hs
@@ -260,7 +260,7 @@ makeActivityChangeProposal execConfig epochStateView configurationFile socketPat
                       , P.signingKeyFile = stakeSKeyFp
                       }
 
-  proposalAnchorFile <- H.note $ baseDir </> "sample-proposFal-anchor"
+  proposalAnchorFile <- H.note $ baseDir </> "sample-proposal-anchor"
   H.writeFile proposalAnchorFile "dummy anchor data"
 
   proposalAnchorDataHash <- H.execCli' execConfig
@@ -270,7 +270,7 @@ makeActivityChangeProposal execConfig epochStateView configurationFile socketPat
 
   minDRepDeposit <- getMinDRepDeposit execConfig ceo
 
-  proposalFile <- H.note $ baseDir </> "sample-proposFal-anchor"
+  proposalFile <- H.note $ baseDir </> "sample-proposal-anchor"
 
   void $ H.execCli' execConfig $
     [ "conway", "governance", "action", "create-protocol-parameters-update"

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/DRepActivity.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/DRepActivity.hs
@@ -123,7 +123,7 @@ hprop_check_drep_activity = H.integrationWorkspace "test-activity" $ \tempAbsBas
                                     (fromIntegral $ 4 + proposalNum) Nothing 3
      | (proposalNum, wallet) <- zip [1..(4 :: Int)] (cycle [wallet0, wallet1, wallet2])]
 
-  (EpochNo epochAfterTimeout) <- getCurrentEpochNo epochStateView sbe
+  (EpochNo epochAfterTimeout) <- getCurrentEpochNo epochStateView
   H.note_ $ "Epoch after which we are going to test timeout: " <> show epochAfterTimeout
 
   -- Last proposal (set activity to something else again and it should pass, because of inactivity)
@@ -158,7 +158,7 @@ activityChangeProposalTest execConfig epochStateView configurationFile socketPat
       propVotes = zip (concatMap (uncurry replicate) votes) [1..]
   annotateShow propVotes
 
-  (EpochNo epochBeforeProp) <- getCurrentEpochNo epochStateView sbe
+  (EpochNo epochBeforeProp) <- getCurrentEpochNo epochStateView
   H.note_ $ "Epoch before \"" <> prefix <> "\" prop: " <> show epochBeforeProp
 
   thisProposal@(governanceActionTxId, governanceActionIndex) <-
@@ -168,7 +168,7 @@ activityChangeProposalTest execConfig epochStateView configurationFile socketPat
   voteChangeProposal execConfig epochStateView sbe baseDir "vote"
                      governanceActionTxId governanceActionIndex propVotes wallet
 
-  (EpochNo epochAfterProp) <- getCurrentEpochNo epochStateView sbe
+  (EpochNo epochAfterProp) <- getCurrentEpochNo epochStateView
   H.note_ $ "Epoch after \"" <> prefix <> "\" prop: " <> show epochAfterProp
 
   void $ waitUntilEpoch (File configurationFile) (File socketPath) (EpochNo (epochAfterProp + epochsToWait))

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/DRepActivity.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/DRepActivity.hs
@@ -1,0 +1,301 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Cardano.Testnet.Test.LedgerEvents.Gov.DRepActivity
+  ( hprop_check_drep_activity
+  ) where
+
+import           Cardano.Api as Api
+import           Cardano.Api.Error (displayError)
+import           Cardano.Api.Ledger (DRepState (drepExpiry))
+
+import           Cardano.Testnet
+
+import           Prelude
+
+import           Control.Monad
+import           Control.Monad.Catch (MonadCatch)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Lens as AL
+import           Data.ByteString.Lazy.Char8 (pack)
+import qualified Data.Map as Map
+import           Data.String
+import qualified Data.Text as Text
+import           Data.Word (Word32)
+import           GHC.Stack (callStack)
+import           Lens.Micro ((^?))
+import           System.FilePath ((</>))
+
+import           Testnet.Components.DReps (createVotingTxBody, generateVoteFiles,
+                   retrieveTransactionId, signTx, submitTx)
+import           Testnet.Components.Query (EpochStateView, checkDRepState,
+                   findLargestUtxoForPaymentKey, getCurrentEpochNo, getEpochStateView,
+                   getMinDRepDeposit)
+import           Testnet.Defaults
+import qualified Testnet.Process.Cli as P
+import qualified Testnet.Process.Run as H
+import qualified Testnet.Property.Utils as H
+import           Testnet.Runtime
+
+import           Hedgehog
+import qualified Hedgehog.Extras as H
+import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
+
+-- | Execute me with:
+-- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/DRep Activity/"'@
+hprop_check_drep_activity :: Property
+hprop_check_drep_activity = H.integrationWorkspace "test-activity" $ \tempAbsBasePath' -> do
+    -- Start a local test net
+  conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
+  let tempAbsPath' = unTmpAbsPath tempAbsPath
+      tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
+
+  work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
+
+  let sbe = ShelleyBasedEraConway
+      era = toCardanoEra sbe
+      cEra = AnyCardanoEra era
+      fastTestnetOptions = cardanoDefaultTestnetOptions
+        { cardanoEpochLength = 100
+        , cardanoNodeEra = cEra
+        , cardanoNumDReps = 10
+        }
+
+  TestnetRuntime
+    { testnetMagic
+    , poolNodes
+    , wallets=wallet0:wallet1:wallet2:_
+    , configurationFile
+    }
+    <- cardanoTestnetDefault fastTestnetOptions conf
+
+  poolNode1 <- H.headM poolNodes
+  poolSprocket1 <- H.noteShow $ nodeSprocket $ poolRuntime poolNode1
+  execConfig <- H.mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
+
+  let socketName' = IO.sprocketName poolSprocket1
+      socketBase = IO.sprocketBase poolSprocket1 -- /tmp
+      socketPath = socketBase </> socketName'
+
+  epochStateView <- getEpochStateView (File configurationFile) (File socketPath)
+
+  H.note_ $ "Sprocket: " <> show poolSprocket1
+  H.note_ $ "Abs path: " <> tempAbsBasePath'
+  H.note_ $ "Socketpath: " <> socketPath
+  H.note_ $ "Foldblocks config file: " <> configurationFile
+
+  gov <- H.createDirectoryIfMissing $ work </> "governance"
+
+  -- First proposal (set activity to something feasible in the test)
+  dRepActivityBeforeFirstProp <- getDRepActivityValue execConfig
+  dRepActivityBeforeFirstProp === 100 -- This is the default value
+
+  let firstPropVotes :: [(String, Int)]
+      firstPropVotes = zip (concatMap (uncurry replicate) [(6, "yes"), (4, "no")]) [1..]
+  annotateShow firstPropVotes
+
+  fgaInfo@(firstGovernanceActionTxId, firstGovernanceActionIndex) <-
+    makeActivityChangeProposal execConfig epochStateView (File configurationFile) (File socketPath)
+                               sbe gov "proposal1" Nothing 4 wallet0
+
+  voteChangeProposal execConfig epochStateView sbe gov "vote1"
+                     firstGovernanceActionTxId firstGovernanceActionIndex firstPropVotes wallet0
+
+  (EpochNo epochAfterFirstProp) <- getCurrentEpochNo epochStateView sbe
+  H.note_ $ "Epoch after first prop: " <> show epochAfterFirstProp
+
+  void $ waitUntilEpoch (File configurationFile) (File socketPath) (EpochNo (epochAfterFirstProp + 2))
+  dRepActivityAfterFirstProp <- getDRepActivityValue execConfig
+
+  dRepActivityAfterFirstProp === 4 -- This is what we just set, should work
+
+  result1 <- checkDRepState sbe (File configurationFile) (File socketPath) execConfig
+                            (Just . map (drepExpiry . snd) . Map.toList)
+  H.note_ $ "DRep expiration dates: " <> show result1
+
+  -- Second proposal (set activity to something else and it should fail, because of percentage being under 51)
+  let secondPropVotes :: [(String, Int)]
+      secondPropVotes = zip (concatMap (uncurry replicate) [(4, "yes")]) [1..]
+  annotateShow secondPropVotes
+
+  (secondGovernanceActionTxId, secondGovernanceActionIndex) <-
+    makeActivityChangeProposal execConfig epochStateView (File configurationFile) (File socketPath)
+                               sbe gov "proposal2" (Just fgaInfo) 7 wallet1
+
+  voteChangeProposal execConfig epochStateView sbe gov "vote2"
+                     secondGovernanceActionTxId secondGovernanceActionIndex secondPropVotes wallet1
+
+  (EpochNo epochAfterSecondProp) <- getCurrentEpochNo epochStateView sbe
+  H.note_ $ "Epoch after second prop: " <> show epochAfterSecondProp
+
+  void $ waitUntilEpoch (File configurationFile) (File socketPath) (EpochNo (epochAfterSecondProp + 5))
+  dRepActivityAfterSecondProp <- getDRepActivityValue execConfig
+
+  dRepActivityAfterSecondProp === 4 -- This is what we set in first prop, second prop should fail
+
+  result2 <- checkDRepState sbe (File configurationFile) (File socketPath) execConfig
+                            (Just . map (drepExpiry . snd) . Map.toList)
+  H.note_ $ "DRep expiration dates: " <> show result2
+
+  -- Third proposal (set activity to something else again and it should pass, because of inactivity)
+  let thirdPropVotes :: [(String, Int)]
+      thirdPropVotes = zip (concatMap (uncurry replicate) [(4, "yes")]) [1..]
+  annotateShow thirdPropVotes
+
+  (thirdGovernanceActionTxId, thirdGovernanceActionIndex) <-
+    makeActivityChangeProposal execConfig epochStateView (File configurationFile) (File socketPath)
+                               sbe gov "proposal3" (Just fgaInfo) 8 wallet2
+
+  voteChangeProposal execConfig epochStateView sbe gov "vote3"
+                     thirdGovernanceActionTxId thirdGovernanceActionIndex thirdPropVotes wallet2
+
+  (EpochNo epochAfterThirdProp) <- getCurrentEpochNo epochStateView sbe
+  H.note_ $ "Epoch after third prop: " <> show epochAfterThirdProp
+
+  void $ waitUntilEpoch (File configurationFile) (File socketPath) (EpochNo (epochAfterThirdProp + 2))
+  dRepActivityAfterThirdProp <- getDRepActivityValue execConfig
+
+  dRepActivityAfterThirdProp === 8 -- Because 6 out of 10 were inactive, third prop should pass
+
+  result3 <- checkDRepState sbe (File configurationFile) (File socketPath) execConfig
+                            (Just . map (drepExpiry . snd) . Map.toList)
+  H.note_ $ "DRep expiration dates: " <> show result3
+
+
+makeActivityChangeProposal
+  :: (H.MonadAssertion m, MonadTest m, MonadCatch m, MonadIO m, Foldable f)
+  => H.ExecConfig
+  -> EpochStateView
+  -> NodeConfigFile 'In
+  -> SocketPath
+  -> ShelleyBasedEra ConwayEra
+  -> FilePath
+  -> String
+  -> f (String, Word32)
+  -> Word32
+  -> PaymentKeyInfo
+  -> m (String, Word32)
+makeActivityChangeProposal execConfig epochStateView configurationFile socketPath
+                           sbe work prefix prevGovActionInfo drepActivity wallet = do
+
+  let era = toCardanoEra sbe
+      cEra = AnyCardanoEra era
+
+  baseDir <- H.createDirectoryIfMissing $ work </> prefix
+
+  let stakeVkeyFp = baseDir </> "stake.vkey"
+      stakeSKeyFp = baseDir </> "stake.skey"
+
+
+  _ <- P.cliStakeAddressKeyGen baseDir
+         $ P.KeyNames { P.verificationKeyFile = stakeVkeyFp
+                      , P.signingKeyFile = stakeSKeyFp
+                      }
+
+  proposalAnchorFile <- H.note $ baseDir </> "sample-proposFal-anchor"
+  H.writeFile proposalAnchorFile "dummy anchor data"
+
+  proposalAnchorDataHash <- H.execCli' execConfig
+    [ "conway", "governance"
+    , "hash", "anchor-data", "--file-text", proposalAnchorFile
+    ]
+
+  minDRepDeposit <- getMinDRepDeposit execConfig
+
+  proposalFile <- H.note $ baseDir </> "sample-proposFal-anchor"
+
+  void $ H.execCli' execConfig $
+    [ "conway", "governance", "action", "create-protocol-parameters-update"
+    , "--testnet"
+    , "--governance-action-deposit", show @Integer minDRepDeposit
+    , "--deposit-return-stake-verification-key-file", stakeVkeyFp
+    ] ++ concatMap (\(prevGovernanceActionTxId, prevGovernanceActionIndex) ->
+                      [ "--prev-governance-action-tx-id", prevGovernanceActionTxId
+                      , "--prev-governance-action-index", show prevGovernanceActionIndex
+                      ]) prevGovActionInfo ++
+    [ "--drep-activity", show drepActivity
+    , "--anchor-url", "https://tinyurl.com/3wrwb2as"
+    , "--anchor-data-hash", proposalAnchorDataHash
+    , "--out-file", proposalFile
+    ]
+
+  proposalBody <- H.note $ baseDir </> "tx.body"
+  txIn <- findLargestUtxoForPaymentKey epochStateView sbe wallet
+
+  void $ H.execCli' execConfig
+    [ "conway", "transaction", "build"
+    , "--change-address", Text.unpack $ paymentKeyInfoAddr wallet
+    , "--tx-in", Text.unpack $ renderTxIn txIn
+    , "--proposal-file", proposalFile
+    , "--out-file", proposalBody
+    ]
+
+  signedProposalTx <- signTx execConfig cEra baseDir "signed-proposal"
+                             (File proposalBody) [paymentKeyInfoPair wallet]
+
+  submitTx execConfig cEra signedProposalTx
+
+  governanceActionTxId <- retrieveTransactionId execConfig signedProposalTx
+
+  !propSubmittedResult <- findCondition (maybeExtractGovernanceActionIndex sbe (fromString governanceActionTxId))
+                                        (unFile configurationFile)
+                                        (unFile socketPath)
+                                        (EpochNo 30)
+
+  governanceActionIndex <- case propSubmittedResult of
+                             Left e ->
+                               H.failMessage callStack
+                                 $ "findCondition failed with: " <> displayError e
+                             Right Nothing ->
+                               H.failMessage callStack "Couldn't find proposal."
+                             Right (Just a) -> return a
+
+  return (governanceActionTxId, governanceActionIndex)
+
+voteChangeProposal :: (MonadTest m, MonadIO m, MonadCatch m, H.MonadAssertion m)
+  => H.ExecConfig
+  -> EpochStateView
+  -> ShelleyBasedEra ConwayEra
+  -> FilePath
+  -> FilePath
+  -> String
+  -> Word32
+  -> [([Char], Int)]
+  -> PaymentKeyInfo
+  -> m ()
+voteChangeProposal execConfig epochStateView sbe work prefix governanceActionTxId governanceActionIndex votes wallet = do
+  baseDir <- H.createDirectoryIfMissing $ work </> prefix
+
+  let era = toCardanoEra sbe
+      cEra = AnyCardanoEra era
+
+  voteFiles <- generateVoteFiles execConfig baseDir "vote-files"
+                                 governanceActionTxId governanceActionIndex
+                                 [(defaultDRepKeyPair idx, vote) | (vote, idx) <- votes]
+
+  voteTxBodyFp <- createVotingTxBody execConfig epochStateView sbe baseDir "vote-tx-body"
+                                     voteFiles wallet
+
+  voteTxFp <- signTx execConfig cEra baseDir "signed-vote-tx" voteTxBodyFp
+                     (paymentKeyInfoPair wallet:[defaultDRepKeyPair n | (_, n) <- votes])
+  submitTx execConfig cEra voteTxFp
+
+
+getDRepActivityValue :: (MonadTest m, MonadCatch m, MonadIO m) => H.ExecConfig -> m Integer
+getDRepActivityValue execConfig = do
+  govStateString <- H.execCli' execConfig
+    [ "conway", "query", "gov-state"
+    , "--volatile-tip"
+    ]
+
+  govStateJSON <- H.nothingFail (Aeson.decode (pack govStateString) :: Maybe Aeson.Value)
+  let mDRepActivityValue :: Maybe Integer
+      mDRepActivityValue = govStateJSON
+                             ^? AL.key "currentPParams"
+                              . AL.key "dRepActivity"
+                              . AL._Integer
+  evalMaybe mDRepActivityValue

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/DRepActivity.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/DRepActivity.hs
@@ -28,7 +28,7 @@ import qualified Data.Map as Map
 import           Data.String
 import qualified Data.Text as Text
 import           Data.Word (Word32, Word64)
-import           GHC.Stack (callStack)
+import           GHC.Stack (HasCallStack, callStack)
 import           Lens.Micro ((^.))
 import           System.FilePath ((</>))
 
@@ -52,7 +52,7 @@ import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/DRep Activity/"'@
 hprop_check_drep_activity :: Property
 hprop_check_drep_activity = H.integrationWorkspace "test-activity" $ \tempAbsBasePath' -> do
-    -- Start a local test net
+  -- Start a local test net
   conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
       tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
@@ -149,7 +149,7 @@ hprop_check_drep_activity = H.integrationWorkspace "test-activity" $ \tempAbsBas
                                     maxEpochsToWaitAfterProposal
 
 activityChangeProposalTest
-  :: (MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m, Foldable t)
+  :: (HasCallStack, MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m, Foldable t)
   => H.ExecConfig
   -> EpochStateView
   -> FilePath
@@ -230,7 +230,7 @@ activityChangeProposalTest execConfig epochStateView configurationFile socketPat
 
 
 makeActivityChangeProposal
-  :: (H.MonadAssertion m, MonadTest m, MonadCatch m, MonadIO m)
+  :: (HasCallStack, H.MonadAssertion m, MonadTest m, MonadCatch m, MonadIO m)
   => H.ExecConfig
   -> EpochStateView
   -> NodeConfigFile 'In
@@ -320,7 +320,7 @@ makeActivityChangeProposal execConfig epochStateView configurationFile socketPat
 
   return (governanceActionTxId, governanceActionIndex)
 
-voteChangeProposal :: (MonadTest m, MonadIO m, MonadCatch m, H.MonadAssertion m)
+voteChangeProposal :: (HasCallStack, MonadTest m, MonadIO m, MonadCatch m, H.MonadAssertion m)
   => H.ExecConfig
   -> EpochStateView
   -> ShelleyBasedEra ConwayEra

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/DRepDeposits.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/DRepDeposits.hs
@@ -98,7 +98,7 @@ hprop_ledger_events_drep_deposits = H.integrationWorkspace "drep-deposits" $ \te
 
   -- DRep 2 (enough deposit)
 
-  void $ registerDRep execConfig epochStateView sbe work "drep2" wallet1
+  void $ registerDRep execConfig epochStateView ceo work "drep2" wallet1
 
   checkDRepState sbe (File configurationFile) (File socketPath) execConfig
     (\m -> if map L.drepDeposit (Map.elems m) == [L.Coin minDRepDeposit] then Just () else Nothing)

--- a/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
+++ b/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
@@ -14,6 +14,7 @@ import qualified Cardano.Testnet.Test.Cli.KesPeriodInfo
 import qualified Cardano.Testnet.Test.Cli.Queries
 import qualified Cardano.Testnet.Test.Cli.QuerySlotNumber
 import qualified Cardano.Testnet.Test.FoldBlocks
+import qualified Cardano.Testnet.Test.LedgerEvents.Gov.DRepActivity
 import qualified Cardano.Testnet.Test.LedgerEvents.Gov.DRepDeposits
 import qualified Cardano.Testnet.Test.LedgerEvents.Gov.ProposeNewConstitution
 import qualified Cardano.Testnet.Test.LedgerEvents.Gov.ProposeNewConstitutionSPO as LedgerEvents
@@ -48,6 +49,7 @@ tests = do
             -- TODO: Replace foldBlocks with checkLedgerStateCondition
             , T.testGroup "Governance"
                 [ H.ignoreOnMacAndWindows "ProposeAndRatifyNewConstitution" Cardano.Testnet.Test.LedgerEvents.Gov.ProposeNewConstitution.hprop_ledger_events_propose_new_constitution
+                , H.ignoreOnWindows "DRep Activity" Cardano.Testnet.Test.LedgerEvents.Gov.DRepActivity.hprop_check_drep_activity
                 , H.ignoreOnWindows "DRep Deposits" Cardano.Testnet.Test.LedgerEvents.Gov.DRepDeposits.hprop_ledger_events_drep_deposits
                   -- FIXME Those tests are flaky
                   -- , H.ignoreOnWindows "InfoAction" LedgerEvents.hprop_ledger_events_info_action


### PR DESCRIPTION
# Description

This PR adds a test for DRep activity mechanism (which addresses [this issue](https://github.com/IntersectMBO/cardano-node/issues/5599)), that ensures that stake associated to DReps that are not actively participating in governance are not counted towards the minimum participation required for approving proposals.

We test it by:
- Creating a testnet with a single default DRep (which expires in 100 epochs)
- Have that DRep set the `drepActivity` param to `6`
- Register two new DReps (which are affected immediately by the new `drepActivity` param)
- Distribute the stake evenly among all the DReps
- Carry out some voting activity while they expire (this is to ensure the number of dormant epochs is low)
- Carry out a new proposal after the expiration time and vote `yes` only with the default DRep
- Check that only the proposal after the expiration passes due to inactivity

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff
