### PR TITLE
Replace CLI queries in testnet test cases with EpochStateView usage

### DIFF
--- a/cardano-testnet/src/Testnet/Components/DReps.hs
+++ b/cardano-testnet/src/Testnet/Components/DReps.hs
@@ -292,7 +292,7 @@ registerDRep execConfig epochStateView ceo work prefix wallet = do
       era = toCardanoEra sbe
       cEra = AnyCardanoEra era
 
-  minDRepDeposit <- getMinDRepDeposit execConfig ceo
+  minDRepDeposit <- getMinDRepDeposit epochStateView ceo
 
   baseDir <- H.createDirectoryIfMissing $ work </> prefix
   drepKeyPair <- generateDRepKeyPair execConfig baseDir "keys"

--- a/cardano-testnet/src/Testnet/Components/Query.hs
+++ b/cardano-testnet/src/Testnet/Components/Query.hs
@@ -11,7 +11,7 @@ module Testnet.Components.Query
   , getEpochState
   , getMinDRepDeposit
   , getGovState
-  , queryTip
+  , getEpochNo
   , waitUntilEpoch
   , waitForEpochs
   , getEpochStateView
@@ -27,16 +27,17 @@ import           Cardano.Api as Api
 import           Cardano.Api.Ledger (Credential, DRepState, KeyRole (DRepRole), StandardCrypto)
 import           Cardano.Api.Shelley (ShelleyLedgerEra, fromShelleyTxIn, fromShelleyTxOut)
 
-import           Cardano.CLI.Types.Output
+import qualified Cardano.Ledger.Api as L
 import           Cardano.Ledger.BaseTypes (EpochInterval, addEpochInterval)
+import qualified Cardano.Ledger.Coin as L
+import qualified Cardano.Ledger.Conway.Governance as L
+import qualified Cardano.Ledger.Conway.PParams as L
 import qualified Cardano.Ledger.Shelley.LedgerState as L
 import qualified Cardano.Ledger.UTxO as L
 
 import           Control.Exception.Safe (MonadCatch)
 import           Control.Monad.Trans.Resource
 import           Control.Monad.Trans.State.Strict (put)
-import           Data.Aeson as A
-import           Data.Aeson.Lens (_Integral, key)
 import           Data.Bifunctor (bimap)
 import           Data.IORef
 import           Data.List (sortOn)
@@ -50,18 +51,15 @@ import qualified Data.Text as T
 import           Data.Type.Equality
 import           GHC.Exts (IsList (..))
 import           GHC.Stack
-import           Lens.Micro ((^.), (^?))
+import           Lens.Micro (to, (^.))
 
-import qualified Testnet.Process.Cli as H
 import           Testnet.Property.Assert
 import           Testnet.Property.Utils (runInBackground)
 import           Testnet.Runtime
-import           Testnet.Start.Types (eraToString)
 
 import qualified Hedgehog as H
 import           Hedgehog.Extras (MonadAssertion)
 import qualified Hedgehog.Extras as H
-import           Hedgehog.Extras.Test.Process (ExecConfig)
 import           Hedgehog.Internal.Property (MonadTest)
 
 -- | Block and wait for the desired epoch.
@@ -89,27 +87,22 @@ waitUntilEpoch nodeConfigFile socketPath desiredEpoch = withFrozenCallStack $ do
 -- | Wait for the number of epochs
 waitForEpochs
   :: MonadTest m
-  => MonadCatch m
+  => MonadAssertion m
   => MonadIO m
-  => ExecConfig
-  -> NodeConfigFile In
-  -> SocketPath
+  => EpochStateView
+  -> ShelleyBasedEra era
   -> EpochInterval  -- ^ Number of epochs to wait
   -> m EpochNo -- ^ The epoch number reached
-waitForEpochs execConfig nodeConfigFile socketPath interval = withFrozenCallStack $ do
-  currentEpoch <- H.nothingFailM $ mEpoch <$> queryTip execConfig
-  waitUntilEpoch nodeConfigFile socketPath $ addEpochInterval currentEpoch interval
-
--- | Query the tip of the blockchain
-queryTip
-  :: (MonadCatch m, MonadIO m, MonadTest m, HasCallStack)
-  => ExecConfig
-  -> m QueryTipLocalStateOutput
-queryTip execConfig = withFrozenCallStack $
-  H.execCliStdoutToJson execConfig [ "query", "tip" ]
+waitForEpochs epochStateView@EpochStateView{nodeConfigPath, socketPath} sbe interval = withFrozenCallStack $ do
+  currentEpoch <- getEpochNo epochStateView sbe
+  waitUntilEpoch nodeConfigPath socketPath $ addEpochInterval currentEpoch interval
 
 -- | A read-only mutable pointer to an epoch state, updated automatically
-newtype EpochStateView = EpochStateView (IORef (Maybe AnyNewEpochState))
+data EpochStateView = EpochStateView
+  { nodeConfigPath :: !(NodeConfigFile In)
+  , socketPath :: !SocketPath
+  , epochStateView :: !(IORef (Maybe AnyNewEpochState))
+  }
 
 -- | Get epoch state from the view. If the state isn't available, retry waiting up to 15 seconds. Fails when
 -- the state is not available after 15 seconds.
@@ -118,10 +111,10 @@ getEpochState :: MonadTest m
               => MonadIO m
               => EpochStateView
               -> m AnyNewEpochState
-getEpochState (EpochStateView esv) =
+getEpochState EpochStateView{epochStateView} =
   withFrozenCallStack $
     H.byDurationM 0.5 15 "EpochStateView has not been initialized within 15 seconds" $
-      H.evalIO (readIORef esv) >>= maybe H.failure pure
+      H.evalIO (readIORef epochStateView) >>= maybe H.failure pure
 
 
 -- | Create a background thread listening for new epoch states. New epoch states are available to access
@@ -140,7 +133,7 @@ getEpochStateView nodeConfigFile socketPath = withFrozenCallStack $ do
     $ \epochState _slotNb _blockNb -> do
         liftIO $ writeIORef epochStateView (Just epochState)
         pure ConditionNotMet
-  pure . EpochStateView $ epochStateView
+  pure $ EpochStateView nodeConfigFile socketPath epochStateView
 
 -- | Retrieve all UTxOs map from the epoch state view.
 findAllUtxos
@@ -234,18 +227,18 @@ findLargestUtxoForPaymentKey epochStateView sbe address =
 -- this number is not attained before two epochs, the test is failed.
 checkDRepsNumber
   :: HasCallStack
-  => MonadCatch m
+  => MonadAssertion m
   => MonadIO m
   => MonadTest m
-  => ShelleyBasedEra ConwayEra -- ^ The era in which the test runs
-  -> NodeConfigFile 'In
-  -> SocketPath
-  -> H.ExecConfig
+  => EpochStateView
+  -> ShelleyBasedEra ConwayEra -- ^ The era in which the test runs
   -> Int
   -> m ()
-checkDRepsNumber sbe configurationFile socketPath execConfig expectedDRepsNb = withFrozenCallStack $
-  checkDRepState sbe configurationFile socketPath execConfig
-    (\m -> if length m == expectedDRepsNb then Just () else Nothing)
+checkDRepsNumber epochStateView sbe expectedDRepsNumber = withFrozenCallStack $
+  checkDRepState epochStateView sbe $ \dreps ->
+    if length dreps == expectedDRepsNumber
+       then Just ()
+       else Nothing
 
 -- | @checkDRepState sbe configurationFile socketPath execConfig f@
 -- This functions helps check properties about the DRep state.
@@ -254,23 +247,20 @@ checkDRepsNumber sbe configurationFile socketPath execConfig expectedDRepsNb = w
 -- If @f@ returns 'Just', the contents of the 'Just' are returned.
 checkDRepState
   :: HasCallStack
-  => MonadCatch m
+  => MonadAssertion m
   => MonadIO m
   => MonadTest m
-  => ShelleyBasedEra ConwayEra -- ^ The era in which the test runs
-  -> NodeConfigFile In
-  -> SocketPath
-  -> H.ExecConfig
+  => EpochStateView
+  -> ShelleyBasedEra ConwayEra -- ^ The era in which the test runs
   -> (Map (Credential 'DRepRole StandardCrypto)
           (DRepState StandardCrypto)
       -> Maybe a) -- ^ A function that checks whether the DRep state is correct or up to date
                   -- and potentially inspects it.
   -> m a
-checkDRepState sbe configurationFile socketPath execConfig f = withFrozenCallStack $ do
-  QueryTipLocalStateOutput{mEpoch} <- queryTip execConfig
-  currentEpoch <- H.evalMaybe mEpoch
+checkDRepState epochStateView@EpochStateView{nodeConfigPath, socketPath} sbe f = withFrozenCallStack $ do
+  currentEpoch <- getEpochNo epochStateView sbe
   let terminationEpoch = succ . succ $ currentEpoch
-  result <- H.evalIO . runExceptT $ foldEpochState configurationFile socketPath QuickValidation terminationEpoch Nothing
+  result <- H.evalIO . runExceptT $ foldEpochState nodeConfigPath socketPath QuickValidation terminationEpoch Nothing
       $ \(AnyNewEpochState actualEra newEpochState) _slotNb _blockNb -> do
         case testEquality sbe actualEra of
           Just Refl -> do
@@ -313,39 +303,41 @@ checkDRepState sbe configurationFile socketPath execConfig f = withFrozenCallSta
 -- | Obtain governance state from node (CLI query)
 getGovState
   :: HasCallStack
-  => MonadCatch m
+  => MonadAssertion m
   => MonadIO m
   => MonadTest m
-  => H.ExecConfig
+  => EpochStateView
   -> ConwayEraOnwards era
-  -> m A.Value -- ^ The governance state
-getGovState execConfig ceo = withFrozenCallStack $ do
-  let eraName = eraToString $ toCardanoEra ceo
-  H.execCliStdoutToJson execConfig
-      [ eraName, "query", "gov-state" , "--volatile-tip" ]
-
+  -> m (L.ConwayGovState (ShelleyLedgerEra era)) -- ^ The governance state
+getGovState epochStateView ceo = withFrozenCallStack $ do
+  AnyNewEpochState sbe' newEpochState <- getEpochState epochStateView
+  let sbe = conwayEraOnwardsToShelleyBasedEra ceo
+  Refl <- H.leftFail $ assertErasEqual sbe sbe'
+  pure $ conwayEraOnwardsConstraints ceo $ newEpochState ^. L.newEpochStateGovStateL
 
 -- | Obtain minimum deposit amount for DRep registration from node
 getMinDRepDeposit
   :: HasCallStack
-  => MonadCatch m
+  => MonadAssertion m
   => MonadIO m
   => MonadTest m
-  => H.ExecConfig
-  -> ConwayEraOnwards era
-  -> m Integer
-getMinDRepDeposit execConfig ceo = withFrozenCallStack $ do
-  govState <- getGovState execConfig ceo
-  let mMinDRepDeposit :: Maybe Integer
-      mMinDRepDeposit = govState ^? key "currentPParams"
-                                  . key "dRepDeposit"
-                                  . _Integral
-  H.evalMaybe mMinDRepDeposit
-
--- | Obtain current epoch number using 'getEpochState'
-getCurrentEpochNo :: (MonadTest m, MonadAssertion m, MonadIO m)
   => EpochStateView
+  -> ConwayEraOnwards era
+  -> m Integer -- ^ The governance state
+getMinDRepDeposit epochStateView ceo = withFrozenCallStack $ do
+  govState <- getGovState epochStateView ceo
+  pure $ conwayEraOnwardsConstraints ceo $ govState ^. L.cgsCurPParamsL . L.ppDRepDepositL . to L.unCoin
+
+-- | Return current epoch number
+getEpochNo
+  :: HasCallStack
+  => MonadAssertion m
+  => MonadIO m
+  => MonadTest m
+  => EpochStateView
+  -> ShelleyBasedEra era
   -> m EpochNo
-getCurrentEpochNo epochStateView = do
-  AnyNewEpochState _ newEpochState <- getEpochState epochStateView
-  return $ newEpochState ^. L.nesELL
+getEpochNo epochStateView sbe = withFrozenCallStack $ do
+  AnyNewEpochState sbe' newEpochState <- getEpochState epochStateView
+  Refl <- H.leftFail $ assertErasEqual sbe sbe'
+  pure $ newEpochState ^. L.nesELL

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/DRepRetirement.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/DRepRetirement.hs
@@ -11,7 +11,6 @@ module Cardano.Testnet.Test.Cli.Conway.DRepRetirement
   ) where
 
 import           Cardano.Api
-import qualified Cardano.Api as Api
 
 import           Cardano.Testnet
 
@@ -89,10 +88,7 @@ hprop_drep_retirement = H.integrationRetryWorkspace 2 "drep-retirement" $ \tempA
                       , P.signingKeyFile = stakeSKeyFp
                       }
   let sizeBefore = 3
-      configFile' = Api.File configurationFile
-      socketPath' = Api.File socketPath
-
-  checkDRepsNumber sbe configFile' socketPath' execConfig sizeBefore
+  checkDRepsNumber epochStateView sbe sizeBefore
 
   -- Deregister first DRep
   let dreprRetirementCertFile = gov </> "drep-keys" <> "drep1.retirementcert"
@@ -140,5 +136,5 @@ hprop_drep_retirement = H.integrationRetryWorkspace 2 "drep-retirement" $ \tempA
 
   -- The important bit is that we pass (sizeBefore - 1) as the last argument,
   -- to witness that the number of dreps indeed decreased.
-  checkDRepsNumber sbe configFile' socketPath' execConfig (sizeBefore - 1)
+  checkDRepsNumber epochStateView sbe (sizeBefore - 1)
   H.success

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Queries.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Queries.hs
@@ -11,7 +11,6 @@ module Cardano.Testnet.Test.Cli.Queries
   ) where
 
 import           Cardano.Api
-import qualified Cardano.Api as Api
 
 import           Cardano.CLI.Types.Output (QueryTipLocalStateOutput)
 import           Cardano.Testnet
@@ -24,7 +23,7 @@ import qualified Data.Vector as Vector
 import           GHC.Stack (HasCallStack)
 import           System.FilePath ((</>))
 
-import           Testnet.Components.Query (checkDRepsNumber)
+import           Testnet.Components.Query
 import           Testnet.Components.TestWatchdog
 import qualified Testnet.Process.Cli as H
 import qualified Testnet.Process.Run as H
@@ -72,13 +71,15 @@ hprop_cli_queries = H.integrationWorkspace "cli-queries" $ \tempAbsBasePath' -> 
       socketBase = IO.sprocketBase poolSprocket1 -- /tmp
       socketPath = socketBase </> socketName'
 
+  epochStateView <- getEpochStateView (File configurationFile) (File socketPath)
+
   H.note_ $ "Sprocket: " <> show poolSprocket1
   H.note_ $ "Abs path: " <> tempAbsBasePath'
   H.note_ $ "Socketpath: " <> socketPath
   H.note_ $ "Foldblocks config file: " <> configurationFile
 
   -- TODO: we could wait less: waiting 1 block should suffice.
-  checkDRepsNumber sbe (Api.File configurationFile) (Api.File socketPath) execConfig 3
+  checkDRepsNumber epochStateView sbe 3
 
   -- protocol-parameters to stdout
   protocolParametersOut <- H.execCli' execConfig

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/DRepActivity.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/DRepActivity.hs
@@ -113,8 +113,10 @@ hprop_check_drep_activity = H.integrationWorkspace "test-activity" $ \tempAbsBas
   delegateToDRep execConfig epochStateView configurationFile socketPath sbe work "drep3-delegation"
                  wallet1 (defaultDelegatorStakeKeyPair 3) drep3
 
-  expirationDates <- checkDRepState sbe (File configurationFile) (File socketPath) execConfig
-                                    (\m -> if length m == 3 then Just $ Map.map drepExpiry m else Nothing)
+  expirationDates <- checkDRepState epochStateView sbe $ \m ->
+    if length m == 3
+       then Just $ Map.map drepExpiry m
+       else Nothing
   H.note_ $ "Expiration dates for the registered DReps: " ++ show expirationDates
 
   -- This proposal should fail because there is 2 DReps that don't vote (out of 3)
@@ -268,7 +270,7 @@ makeActivityChangeProposal execConfig epochStateView configurationFile socketPat
     , "hash", "anchor-data", "--file-text", proposalAnchorFile
     ]
 
-  minDRepDeposit <- getMinDRepDeposit execConfig ceo
+  minDRepDeposit <- getMinDRepDeposit epochStateView ceo
 
   proposalFile <- H.note $ baseDir </> "sample-proposal-anchor"
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/DRepDeposits.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/DRepDeposits.hs
@@ -80,7 +80,7 @@ hprop_ledger_events_drep_deposits = H.integrationWorkspace "drep-deposits" $ \te
 
   gov <- H.createDirectoryIfMissing $ work </> "governance"
 
-  minDRepDeposit <- getMinDRepDeposit execConfig ceo
+  minDRepDeposit <- getMinDRepDeposit epochStateView ceo
 
   -- DRep 1 (not enough deposit)
 
@@ -100,7 +100,9 @@ hprop_ledger_events_drep_deposits = H.integrationWorkspace "drep-deposits" $ \te
 
   void $ registerDRep execConfig epochStateView ceo work "drep2" wallet1
 
-  checkDRepState sbe (File configurationFile) (File socketPath) execConfig
-    (\m -> if map L.drepDeposit (Map.elems m) == [L.Coin minDRepDeposit] then Just () else Nothing)
+  checkDRepState epochStateView sbe $ \m ->
+    if map L.drepDeposit (Map.elems m) == [L.Coin minDRepDeposit]
+       then Just ()
+       else Nothing
 
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/ProposeNewConstitution.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/ProposeNewConstitution.hs
@@ -27,7 +27,6 @@ import           Data.Maybe
 import           Data.Maybe.Strict
 import           Data.String
 import qualified Data.Text as Text
-import           Data.Word
 import           GHC.Exts (IsList (..))
 import           GHC.Stack (callStack)
 import           Lens.Micro

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/ProposeNewConstitutionSPO.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/ProposeNewConstitutionSPO.hs
@@ -163,7 +163,7 @@ hprop_ledger_events_propose_new_constitution_spo = H.integrationWorkspace "propo
     , "--tx-file", txbodySignedFp
     ]
 
-  currentEpoch <- getEpochNo epochStateView sbe
+  currentEpoch <- getCurrentEpochNo epochStateView
   -- Proposal should be there already, so don't wait a lot:
   let terminationEpoch = succ . succ $ currentEpoch
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/ProposeNewConstitutionSPO.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/ProposeNewConstitutionSPO.hs
@@ -14,8 +14,6 @@ import           Cardano.Api
 import qualified Cardano.Api as Api
 import           Cardano.Api.Ledger
 
-import           Cardano.CLI.Types.Output (QueryTipLocalStateOutput (QueryTipLocalStateOutput),
-                   mEpoch)
 import qualified Cardano.Ledger.Conway.Governance as L
 import qualified Cardano.Ledger.Shelley.LedgerState as L
 import           Cardano.Testnet
@@ -120,7 +118,7 @@ hprop_ledger_events_propose_new_constitution_spo = H.integrationWorkspace "propo
       spoColdSkeyFp :: Int -> FilePath
       spoColdSkeyFp n = tempAbsPath' </> "pools-keys" </> "pool" <> show n </> "cold.skey"
 
-  minDRepDeposit <- getMinDRepDeposit execConfig ceo
+  minDRepDeposit <- getMinDRepDeposit epochStateView ceo
 
   -- Create constitution proposal
   H.noteM_ $ H.execCli' execConfig
@@ -165,8 +163,7 @@ hprop_ledger_events_propose_new_constitution_spo = H.integrationWorkspace "propo
     , "--tx-file", txbodySignedFp
     ]
 
-  QueryTipLocalStateOutput{mEpoch} <- queryTip execConfig
-  currentEpoch <- H.evalMaybe mEpoch
+  currentEpoch <- getEpochNo epochStateView sbe
   -- Proposal should be there already, so don't wait a lot:
   let terminationEpoch = succ . succ $ currentEpoch
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/TreasuryWithdrawal.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/TreasuryWithdrawal.hs
@@ -171,7 +171,7 @@ hprop_ledger_events_treasury_withdrawal = H.integrationRetryWorkspace 1  "treasu
   txbodySignedFp <- H.note $ work </> "tx.body.signed"
 
   -- wait for an epoch before using wallet0 again
-  void $ waitForEpochs epochStateView sbe (EpochInterval 1)
+  void $ waitForEpochs epochStateView (EpochInterval 1)
 
   txin3 <- findLargestUtxoForPaymentKey epochStateView sbe wallet0
 
@@ -202,7 +202,7 @@ hprop_ledger_events_treasury_withdrawal = H.integrationRetryWorkspace 1  "treasu
     , "--tx-file", txbodySignedFp
     ]
 
-  currentEpoch <- getEpochNo epochStateView sbe
+  currentEpoch <- getCurrentEpochNo epochStateView
   let terminationEpoch = succ . succ $ currentEpoch
   L.GovActionIx governanceActionIndex <- fmap L.gaidGovActionIx . H.nothingFailM $
     getTreasuryWithdrawalProposal (File configurationFile) (File socketPath) terminationEpoch
@@ -255,7 +255,7 @@ hprop_ledger_events_treasury_withdrawal = H.integrationRetryWorkspace 1  "treasu
   -- }}}
 
   withdrawals <- H.nothingFailM $
-    getEpochNo epochStateView sbe >>=
+    getCurrentEpochNo epochStateView >>=
       getAnyWithdrawals (File configurationFile) (File socketPath) . (`L.addEpochInterval` EpochInterval 5)
 
   H.noteShow_ withdrawals

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/TreasuryWithdrawal.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/TreasuryWithdrawal.hs
@@ -18,7 +18,6 @@ import           Cardano.Api.Ledger (EpochInterval (EpochInterval), KeyRole (Sta
                    StandardCrypto)
 import           Cardano.Api.ReexposeLedger (Coin, Credential)
 
-import           Cardano.CLI.Types.Output (QueryTipLocalStateOutput (..))
 import qualified Cardano.Ledger.BaseTypes as L
 import qualified Cardano.Ledger.Coin as L
 import qualified Cardano.Ledger.Conway.Governance as L
@@ -154,7 +153,7 @@ hprop_ledger_events_treasury_withdrawal = H.integrationRetryWorkspace 1  "treasu
 
   -- {{{ Create treasury withdrawal
   let withdrawalAmount = 3_300_777 :: Integer
-  govActionDeposit <- getMinDRepDeposit execConfig ceo
+  govActionDeposit <- getMinDRepDeposit epochStateView ceo
   void $ H.execCli' execConfig
     [ eraName, "governance", "action", "create-treasury-withdrawal"
     , "--testnet"
@@ -172,7 +171,7 @@ hprop_ledger_events_treasury_withdrawal = H.integrationRetryWorkspace 1  "treasu
   txbodySignedFp <- H.note $ work </> "tx.body.signed"
 
   -- wait for an epoch before using wallet0 again
-  void $ waitForEpochs execConfig (File configurationFile) (File socketPath) (EpochInterval 1)
+  void $ waitForEpochs epochStateView sbe (EpochInterval 1)
 
   txin3 <- findLargestUtxoForPaymentKey epochStateView sbe wallet0
 
@@ -203,7 +202,7 @@ hprop_ledger_events_treasury_withdrawal = H.integrationRetryWorkspace 1  "treasu
     , "--tx-file", txbodySignedFp
     ]
 
-  currentEpoch <- H.nothingFailM $ mEpoch <$> queryTip execConfig
+  currentEpoch <- getEpochNo epochStateView sbe
   let terminationEpoch = succ . succ $ currentEpoch
   L.GovActionIx governanceActionIndex <- fmap L.gaidGovActionIx . H.nothingFailM $
     getTreasuryWithdrawalProposal (File configurationFile) (File socketPath) terminationEpoch
@@ -256,7 +255,7 @@ hprop_ledger_events_treasury_withdrawal = H.integrationRetryWorkspace 1  "treasu
   -- }}}
 
   withdrawals <- H.nothingFailM $
-    H.nothingFailM (mEpoch <$> queryTip execConfig) >>=
+    getEpochNo epochStateView sbe >>=
       getAnyWithdrawals (File configurationFile) (File socketPath) . (`L.addEpochInterval` EpochInterval 5)
 
   H.noteShow_ withdrawals


### PR DESCRIPTION
# Description
Follow-up from: https://github.com/IntersectMBO/cardano-node/pull/5611#discussion_r1574800184
Replace CLI queries in testnet test cases with `EpochStateView` usage.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
