### PR TITLE
Automated drep (Scenario 2)

### DIFF
--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -67,6 +67,7 @@ library
                       , mtl
                       , network
                       , network-mux
+                      , monad-control
                       , optparse-applicative-fork
                       , ouroboros-network ^>= 0.16
                       , ouroboros-network-api
@@ -231,6 +232,7 @@ test-suite cardano-testnet-test
                       , http-conduit
                       , lens-aeson
                       , microlens
+                      , monad-control
                       , mtl
                       , process
                       , regex-compat

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -200,6 +200,7 @@ test-suite cardano-testnet-test
                         Cardano.Testnet.Test.Misc
                         Cardano.Testnet.Test.Gov.DRepActivity
                         Cardano.Testnet.Test.Gov.PredefinedAbstainDRep
+                        Cardano.Testnet.Test.Gov.PredefinedNoConfidenceDRep
                         Cardano.Testnet.Test.Node.Shutdown
                         Cardano.Testnet.Test.SanityCheck
                         Cardano.Testnet.Test.SubmitApi.Babbage.Transaction

--- a/cardano-testnet/src/Testnet/Process/Cli/DRep.hs
+++ b/cardano-testnet/src/Testnet/Process/Cli/DRep.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}

--- a/cardano-testnet/src/Testnet/Process/Cli/SPO.hs
+++ b/cardano-testnet/src/Testnet/Process/Cli/SPO.hs
@@ -427,7 +427,7 @@ generateVoteFiles ceo execConfig work prefix governanceActionTxId governanceActi
   forM (zip [(1 :: Integer)..] allVotes) $ \(idx, (spoKeys, vote)) -> do
     let path = File (baseDir </> "vote-spo-" <> show idx)
     void $ execCli' execConfig
-      [ eraToString $ toCardanoEra ceo , "governance", "vote", "create"
+      [ eraToString $ toCardanoEra ceo, "governance", "vote", "create"
       , "--" ++ vote
       , "--governance-action-tx-id", governanceActionTxId
       , "--governance-action-index", show @Word32 governanceActionIndex

--- a/cardano-testnet/src/Testnet/Process/Cli/SPO.hs
+++ b/cardano-testnet/src/Testnet/Process/Cli/SPO.hs
@@ -408,7 +408,7 @@ registerSingleSpo identifier tap@(TmpAbsolutePath tempAbsPath') nodeConfigFile s
 -- Returns a list of generated @File VoteFile In@ representing the paths to
 -- the generated voting files.
 -- TODO: unify with DRep.generateVoteFiles
-generateVoteFiles :: (MonadTest m, MonadIO m, MonadCatch m)
+generateVoteFiles :: (MonadTest m, MonadIO m, MonadCatch m, HasCallStack)
   => ConwayEraOnwards era -- ^ The conway era onwards witness for the era in which the
                           -- transaction will be constructed.
   -> H.ExecConfig -- ^ Specifies the CLI execution configuration.

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/InfoAction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/InfoAction.hs
@@ -56,8 +56,8 @@ hprop_ledger_events_info_action = integrationRetryWorkspace 0 "info-hash" $ \tem
   work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
 
   let ceo = ConwayEraOnwardsConway
-      era = toCardanoEra sbe
       sbe = conwayEraOnwardsToShelleyBasedEra ceo
+      era = toCardanoEra sbe
       fastTestnetOptions = cardanoDefaultTestnetOptions
         { cardanoEpochLength = 200
         , cardanoNodeEra = AnyCardanoEra era

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
@@ -325,11 +325,10 @@ type DefaultSPOVote = (String, Int)
 -- | Create and issue votes for (or against) a government proposal with default
 -- Delegate Representative (DReps created by 'cardanoTestnetDefault') and
 -- default Stake Pool Operatorsusing using @cardano-cli@.
-voteChangeProposal :: (MonadTest m, MonadIO m, MonadCatch m, H.MonadAssertion m)
+voteChangeProposal :: (Typeable era, MonadTest m, MonadIO m, MonadCatch m, H.MonadAssertion m)
   => H.ExecConfig -- ^ Specifies the CLI execution configuration.
   -> EpochStateView -- ^ Current epoch state view for transaction building. It can be obtained
-                    -- using the 'getEpochStateView' function.
-  -> ConwayEraOnwards ConwayEra -- ^ The @ConwayEraOnwards@ witness for the Conway era.
+  -> ConwayEraOnwards era -- ^ The @ConwayEraOnwards@ witness for the current era.
   -> FilePath -- ^ Base directory path where the subdirectory with the intermediate files will be created.
   -> String -- ^ Name for the subdirectory that will be created for storing the intermediate files.
   -> String -- ^ Transaction id of the governance action to vote.

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
@@ -28,6 +28,7 @@ import           Prelude
 
 import           Control.Monad (void)
 import           Control.Monad.Catch (MonadCatch)
+import           Control.Monad.Trans.Control (MonadBaseControl)
 import           Data.Data (Typeable)
 import           Data.String (fromString)
 import qualified Data.Text as Text
@@ -184,7 +185,7 @@ delegateToAutomaticDRep execConfig epochStateView sbe work prefix flag payingWal
   void $ waitForEpochs epochStateView (EpochInterval 1)
 
 desiredPoolNumberProposalTest
-  :: (HasCallStack, MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m, Foldable t)
+  :: (HasCallStack, MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m, MonadBaseControl IO m, Foldable t)
   => H.ExecConfig -- ^ Specifies the CLI execution configuration.
   -> EpochStateView -- ^ Current epoch state view for transaction building. It can be obtained
   -> ConwayEraOnwards ConwayEra -- ^ The ConwaysEraOnwards witness for the Conway era
@@ -317,7 +318,7 @@ type DefaultSPOVote = (String, Int)
 -- | Create and issue votes for (or against) a government proposal with default
 -- Delegate Representative (DReps created by 'cardanoTestnetDefault') and
 -- default Stake Pool Operatorsusing using @cardano-cli@.
-voteChangeProposal :: (Typeable era, MonadTest m, MonadIO m, MonadCatch m, H.MonadAssertion m)
+voteChangeProposal :: (Typeable era, MonadTest m, MonadIO m, MonadCatch m, H.MonadAssertion m, MonadBaseControl IO m)
   => H.ExecConfig -- ^ Specifies the CLI execution configuration.
   -> EpochStateView -- ^ Current epoch state view for transaction building. It can be obtained
   -> ConwayEraOnwards era -- ^ The @ConwayEraOnwards@ witness for the current era.

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
@@ -149,7 +149,7 @@ delegateToAlwaysAbstain
 delegateToAlwaysAbstain execConfig epochStateView sbe work prefix =
   delegateToAutomaticDRep execConfig epochStateView sbe work prefix "--always-abstain"
 
--- | Delegates to a staking key pair with the delegation preference set to automatic.
+-- | Delegates a staking key pair to an automatic DRep.
 delegateToAutomaticDRep
   :: (HasCallStack, MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m, Typeable era)
   => H.ExecConfig -- ^ Specifies the CLI execution configuration.
@@ -158,7 +158,7 @@ delegateToAutomaticDRep
   -> ShelleyBasedEra era -- ^ The Shelley-based era (e.g., 'ConwayEra') in which the transaction will be constructed.
   -> FilePath -- ^ Base directory path where generated files will be stored.
   -> String -- ^ Name for the subfolder that will be created under 'work' folder.
-  -> String -- ^ Additional command-line arguments for the delegation.
+  -> String -- ^ Additional command-line argument for the delegation.
   -> PaymentKeyInfo -- ^ Wallet that will pay for the transaction.
   -> KeyPair StakingKey -- ^ Staking key pair used for delegation.
   -> m ()

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
@@ -6,7 +6,8 @@
 {-# LANGUAGE TypeApplications #-}
 
 module Cardano.Testnet.Test.Gov.PredefinedAbstainDRep
-  ( hprop_check_predefined_abstain_drep
+  ( AutomaticDRepFlag(..)
+  , hprop_check_predefined_abstain_drep
   , delegateToAutomaticDRep
   , desiredPoolNumberProposalTest
   , getDesiredPoolNumberValue
@@ -122,11 +123,11 @@ hprop_check_predefined_abstain_drep = H.integrationWorkspace "test-activity" $ \
   void $ desiredPoolNumberProposalTest execConfig epochStateView ceo gov "firstProposal"
                                        wallet0 Nothing [(1, "yes")] newNumberOfDesiredPools 3 (Just initialDesiredNumberOfPools) 10
 
-  -- Take the last two stake delegators and delegate them to "Abstain".
-  delegateToAlwaysAbstain execConfig epochStateView sbe gov "delegateToAbstain1"
-                          wallet1 (defaultDelegatorStakeKeyPair 2)
-  delegateToAlwaysAbstain execConfig epochStateView sbe gov "delegateToAbstain2"
-                          wallet2 (defaultDelegatorStakeKeyPair 3)
+  -- Take the last two stake delegators and delegate them to "AlwaysAbstainDRep".
+  delegateToAutomaticDRep execConfig epochStateView sbe gov "delegateToAbstain1"
+                          AlwaysAbstainDRep wallet1 (defaultDelegatorStakeKeyPair 2)
+  delegateToAutomaticDRep execConfig epochStateView sbe gov "delegateToAbstain2"
+                          AlwaysAbstainDRep wallet2 (defaultDelegatorStakeKeyPair 3)
 
   -- Do some other proposal and vote yes with first DRep only
   -- and assert the new proposal passes now.
@@ -134,22 +135,10 @@ hprop_check_predefined_abstain_drep = H.integrationWorkspace "test-activity" $ \
   void $ desiredPoolNumberProposalTest execConfig epochStateView ceo gov "secondProposal"
                                        wallet0 Nothing [(1, "yes")] newNumberOfDesiredPools2 0 (Just newNumberOfDesiredPools2) 10
 
--- | Delegates a staking key pair to the "always abstain" automated DRep
-delegateToAlwaysAbstain
-  :: (HasCallStack, MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m, Typeable era)
-  => H.ExecConfig -- ^ Specifies the CLI execution configuration.
-  -> EpochStateView -- ^ Current epoch state view for transaction building. It can be obtained
-                    -- using the 'getEpochStateView' function.
-  -> ShelleyBasedEra era -- ^ The Shelley-based era (e.g., 'ConwayEra') in which the transaction will be constructed.
-  -> FilePath -- ^ Base directory path where generated files will be stored.
-  -> String -- ^ Name for the subfolder that will be created under 'work' folder.
-  -> PaymentKeyInfo -- ^ Wallet that will pay for the transaction.
-  -> KeyPair StakingKey -- ^ Staking key pair used for delegation.
-  -> m ()
-delegateToAlwaysAbstain execConfig epochStateView sbe work prefix =
-  delegateToAutomaticDRep execConfig epochStateView sbe work prefix "--always-abstain"
+-- | Which automatic DRep to delegate to
+data AutomaticDRepFlag = AlwaysAbstainDRep
+                       | NoConfidenceDRep
 
--- | Delegates a staking key pair to an automatic DRep.
 delegateToAutomaticDRep
   :: (HasCallStack, MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m, Typeable era)
   => H.ExecConfig -- ^ Specifies the CLI execution configuration.
@@ -158,13 +147,11 @@ delegateToAutomaticDRep
   -> ShelleyBasedEra era -- ^ The Shelley-based era (e.g., 'ConwayEra') in which the transaction will be constructed.
   -> FilePath -- ^ Base directory path where generated files will be stored.
   -> String -- ^ Name for the subfolder that will be created under 'work' folder.
-  -> String -- ^ Additional command-line argument for the delegation.
+  -> AutomaticDRepFlag -- ^ Which type of automatic DRep to delegate to.
   -> PaymentKeyInfo -- ^ Wallet that will pay for the transaction.
   -> KeyPair StakingKey -- ^ Staking key pair used for delegation.
   -> m ()
-delegateToAutomaticDRep execConfig epochStateView sbe work prefix
-                        flag payingWallet skeyPair@(KeyPair vKeyFile _sKeyFile) = do
-
+delegateToAutomaticDRep execConfig epochStateView sbe work prefix flag payingWallet skeyPair@(KeyPair vKeyFile _sKeyFile) = do
   let era = toCardanoEra sbe
       cEra = AnyCardanoEra era
 
@@ -174,7 +161,9 @@ delegateToAutomaticDRep execConfig epochStateView sbe work prefix
   let voteDelegationCertificatePath = baseDir </> "delegation-certificate.delegcert"
   void $ H.execCli' execConfig
     [ anyEraToString cEra, "stake-address", "vote-delegation-certificate"
-    , flag
+    , case flag of
+        AlwaysAbstainDRep -> "--always-abstain"
+        NoConfidenceDRep -> "--always-no-confidence"
     , "--stake-verification-key-file", unFile vKeyFile
     , "--out-file", voteDelegationCertificatePath
     ]

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE TypeApplications #-}
 
 module Cardano.Testnet.Test.Gov.PredefinedAbstainDRep
-  ( AutomaticDRepFlag(..)
+  ( AutomaticDRepType(..)
   , hprop_check_predefined_abstain_drep
   , delegateToAutomaticDRep
   , desiredPoolNumberProposalTest
@@ -136,7 +136,7 @@ hprop_check_predefined_abstain_drep = H.integrationWorkspace "test-activity" $ \
                                        wallet0 Nothing [(1, "yes")] newNumberOfDesiredPools2 0 (Just newNumberOfDesiredPools2) 10
 
 -- | Which automatic DRep to delegate to
-data AutomaticDRepFlag = AlwaysAbstainDRep
+data AutomaticDRepType = AlwaysAbstainDRep
                        | NoConfidenceDRep
 
 delegateToAutomaticDRep
@@ -147,7 +147,7 @@ delegateToAutomaticDRep
   -> ShelleyBasedEra era -- ^ The Shelley-based era (e.g., 'ConwayEra') in which the transaction will be constructed.
   -> FilePath -- ^ Base directory path where generated files will be stored.
   -> String -- ^ Name for the subfolder that will be created under 'work' folder.
-  -> AutomaticDRepFlag -- ^ Which type of automatic DRep to delegate to.
+  -> AutomaticDRepType -- ^ Which type of automatic DRep to delegate to.
   -> PaymentKeyInfo -- ^ Wallet that will pay for the transaction.
   -> KeyPair StakingKey -- ^ Staking key pair used for delegation.
   -> m ()

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
@@ -134,6 +134,7 @@ hprop_check_predefined_abstain_drep = H.integrationWorkspace "test-activity" $ \
   void $ desiredPoolNumberProposalTest execConfig epochStateView ceo gov "secondProposal"
                                        wallet0 Nothing [(1, "yes")] newNumberOfDesiredPools2 0 (Just newNumberOfDesiredPools2) 10
 
+-- | Delegates a staking key pair to the "always abstain" automated DRep
 delegateToAlwaysAbstain
   :: (HasCallStack, MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m, Typeable era)
   => H.ExecConfig -- ^ Specifies the CLI execution configuration.
@@ -148,16 +149,18 @@ delegateToAlwaysAbstain
 delegateToAlwaysAbstain execConfig epochStateView sbe work prefix =
   delegateToAutomaticDRep execConfig epochStateView sbe work prefix "--always-abstain"
 
+-- | Delegates to a staking key pair with the delegation preference set to automatic.
 delegateToAutomaticDRep
   :: (HasCallStack, MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m, Typeable era)
-  => H.ExecConfig
-  -> EpochStateView
-  -> ShelleyBasedEra era
-  -> FilePath
-  -> String
-  -> String
-  -> PaymentKeyInfo
-  -> KeyPair StakingKey
+  => H.ExecConfig -- ^ Specifies the CLI execution configuration.
+  -> EpochStateView -- ^ Current epoch state view for transaction building. It can be obtained
+                    -- using the 'getEpochStateView' function.
+  -> ShelleyBasedEra era -- ^ The Shelley-based era (e.g., 'ConwayEra') in which the transaction will be constructed.
+  -> FilePath -- ^ Base directory path where generated files will be stored.
+  -> String -- ^ Name for the subfolder that will be created under 'work' folder.
+  -> String -- ^ Additional command-line arguments for the delegation.
+  -> PaymentKeyInfo -- ^ Wallet that will pay for the transaction.
+  -> KeyPair StakingKey -- ^ Staking key pair used for delegation.
   -> m ()
 delegateToAutomaticDRep execConfig epochStateView sbe work prefix
                         flag payingWallet skeyPair@(KeyPair vKeyFile _sKeyFile) = do

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedNoConfidenceDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedNoConfidenceDRep.hs
@@ -27,6 +27,7 @@ import qualified Data.Map as Map
 import           Data.String (fromString)
 import qualified Data.Text as Text
 import           Data.Word (Word32)
+import           GHC.Stack (HasCallStack)
 import           Lens.Micro ((^.))
 import           System.FilePath ((</>))
 
@@ -263,7 +264,7 @@ makeUpdateConstitutionalCommitteeProposal execConfig epochStateView ceo work pre
   return (governanceActionTxId, governanceActionIndex)
 
 delegateToAlwaysNoConfidence
-  :: (MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m, Typeable era)
+  :: (MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m, Typeable era, HasCallStack)
   => H.ExecConfig
   -> EpochStateView
   -> ShelleyBasedEra era
@@ -276,7 +277,7 @@ delegateToAlwaysNoConfidence execConfig epochStateView sbe work prefix =
   delegateToAutomaticDRep execConfig epochStateView sbe work prefix "--always-no-confidence"
 
 testNoConfidenceProposal
-  :: (MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m, Foldable t)
+  :: (MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m, Foldable t, HasCallStack)
   => H.ExecConfig
   -> EpochStateView
   -> ConwayEraOnwards ConwayEra

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedNoConfidenceDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedNoConfidenceDRep.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Testnet.Test.Gov.PredefinedNoConfidenceDRep
+  ( hprop_check_predefined_no_confidence_drep
+  ) where
+
+import           Cardano.Api as Api
+
+import           Cardano.Testnet
+
+import           Prelude
+
+import           System.FilePath ((</>))
+
+import           Testnet.Components.Query (getEpochStateView)
+import qualified Testnet.Process.Run as H
+import qualified Testnet.Property.Util as H
+import           Testnet.Types (PoolNode (..), TestnetRuntime (..), nodeSocketPath)
+
+import           Hedgehog
+import qualified Hedgehog.Extras as H
+
+-- | Execute me with:
+-- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/Predefined No Confidence DRep/"'@
+hprop_check_predefined_no_confidence_drep :: Property
+hprop_check_predefined_no_confidence_drep = H.integrationWorkspace "test-activity" $ \tempAbsBasePath' -> do
+  -- Start a local test net
+  conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
+  let tempAbsPath' = unTmpAbsPath tempAbsPath
+      tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
+
+  work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
+
+  -- Create default testnet with 3 DReps and 3 stake holders delegated, one to each DRep.
+  let ceo = ConwayEraOnwardsConway
+      sbe = conwayEraOnwardsToShelleyBasedEra ceo
+      era = toCardanoEra sbe
+      cEra = AnyCardanoEra era
+      fastTestnetOptions = cardanoDefaultTestnetOptions
+        { cardanoEpochLength = 100
+        , cardanoNodeEra = cEra
+        , cardanoNumDReps = 3
+        }
+
+  _testnetRuntime@TestnetRuntime
+    { testnetMagic
+    , poolNodes
+    , wallets=_wallet0:_wallet1:_wallet2:_
+    , configurationFile
+    }
+    <- cardanoTestnetDefault fastTestnetOptions conf
+
+  PoolNode{poolRuntime} <- H.headM poolNodes
+  poolSprocket1 <- H.noteShow $ nodeSprocket poolRuntime
+  _execConfig <- H.mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
+  let socketPath = nodeSocketPath poolRuntime
+
+  _epochStateView <- getEpochStateView configurationFile socketPath
+
+  H.note_ $ "Sprocket: " <> show poolSprocket1
+  H.note_ $ "Abs path: " <> tempAbsBasePath'
+  H.note_ $ "Socketpath: " <> unFile socketPath
+  H.note_ $ "Foldblocks config file: " <> unFile configurationFile
+
+  _gov <- H.createDirectoryIfMissing $ work </> "governance"
+
+  -- ToDo: Do some proposal and vote yes with all the DReps.
+  -- ToDo: ASSERT: that proposal passes.
+  -- ToDo: Take the last two stake delegators and delegate them to "No Confidence".
+  -- ToDo: This can be done using cardano-cli conway stake-address vote-delegation-certificate --always-no-confidence
+  -- ToDo: Do some other proposal and vote yes with all the DReps.
+  -- ToDo: ASSERT: the new proposal does NOT pass.
+  -- ToDo: Create a no confidence proposal.
+  -- ToDo: This can be done using cardano-cli conway governance action create-no-confidence
+  -- ToDo: Vote no to the no confidence proposal with all DReps.
+  -- ToDo: ASSERT: the no confidence proposal passes.
+
+  success

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedNoConfidenceDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedNoConfidenceDRep.hs
@@ -69,7 +69,7 @@ hprop_check_predefined_no_confidence_drep = H.integrationWorkspace "test-activit
         , cardanoNumDReps = 3
         }
 
-  _testnetRuntime@TestnetRuntime
+  TestnetRuntime
     { testnetMagic
     , poolNodes
     , wallets=wallet0:wallet1:wallet2:_

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedNoConfidenceDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedNoConfidenceDRep.hs
@@ -9,9 +9,11 @@ module Cardano.Testnet.Test.Gov.PredefinedNoConfidenceDRep
   ) where
 
 import           Cardano.Api as Api
-import           Cardano.Api.IO.Base (Socket)
-import           Cardano.Api.Ledger (EpochInterval (..))
+import           Cardano.Api.Ledger (EpochInterval (..), StrictMaybe (..))
+import qualified Cardano.Api.Ledger as L
 
+import qualified Cardano.Ledger.Conway.Governance as L
+import qualified Cardano.Ledger.Shelley.LedgerState as L
 import           Cardano.Testnet
 import           Cardano.Testnet.Test.Gov.PredefinedAbstainDRep (delegateToAutomaticDRep,
                    desiredPoolNumberProposalTest, getDesiredPoolNumberValue, voteChangeProposal)
@@ -20,15 +22,12 @@ import           Prelude
 
 import           Control.Monad (void)
 import           Control.Monad.Catch (MonadCatch)
-import qualified Data.Aeson as Aeson
-import qualified Data.Aeson.Lens as AL
-import qualified Data.ByteString.Lazy.Char8 as LBS
 import           Data.Data (Typeable)
+import qualified Data.Map as Map
 import           Data.String (fromString)
-import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Word (Word32)
-import           Lens.Micro ((^?))
+import           Lens.Micro ((^.))
 import           System.FilePath ((</>))
 
 import           Testnet.Components.Query (EpochStateView, findLargestUtxoForPaymentKey,
@@ -88,6 +87,10 @@ hprop_check_predefined_no_confidence_drep = H.integrationWorkspace "test-activit
 
   gov <- H.createDirectoryIfMissing $ work </> "governance"
 
+  -- Create constitutional committee and check it exists
+  constitutionalAction <- updateConstitutionalCommittee execConfig epochStateView ceo work
+                                                        "committeeUpdate" wallet0 Nothing [(3, "yes")]
+
   -- Do some proposal and vote yes with all the DReps
   -- and assert that proposal passes.
   initialDesiredNumberOfPools <- getDesiredPoolNumberValue epochStateView ceo
@@ -95,25 +98,169 @@ hprop_check_predefined_no_confidence_drep = H.integrationWorkspace "test-activit
   let newNumberOfDesiredPools = fromIntegral (initialDesiredNumberOfPools + 1)
 
   firstProposalInfo <- desiredPoolNumberProposalTest execConfig epochStateView ceo gov "firstProposal"
-                                                     wallet0 Nothing [(3, "yes")] newNumberOfDesiredPools 0 (Just newNumberOfDesiredPools) 10
+                                                     wallet1 Nothing [(3, "yes")] newNumberOfDesiredPools 0 (Just newNumberOfDesiredPools) 10
 
   -- Take the last two stake delegators and delegate them to "No Confidence".
-  delegateToAlwaysNoConfidence execConfig epochStateView sbe gov "delegateToAbstain1"
-                               wallet1 (defaultDelegatorStakeKeyPair 2)
-  delegateToAlwaysNoConfidence execConfig epochStateView sbe gov "delegateToAbstain2"
-                               wallet1 (defaultDelegatorStakeKeyPair 3)
+  delegateToAlwaysNoConfidence execConfig epochStateView sbe gov "delegateToNoConfidence1"
+                               wallet2 (defaultDelegatorStakeKeyPair 2)
+  delegateToAlwaysNoConfidence execConfig epochStateView sbe gov "delegateToNoConfidence2"
+                               wallet2 (defaultDelegatorStakeKeyPair 3)
 
   -- Do some other proposal and vote yes with all the DReps
-  -- and assert the new proposal does NOT pass
+  -- and assert the new proposal does NOT pass.
   let newNumberOfDesiredPools2 = fromIntegral (newNumberOfDesiredPools + 1)
 
   void $ desiredPoolNumberProposalTest execConfig epochStateView ceo gov "secondProposal"
-                                       wallet2 (Just firstProposalInfo) [(3, "yes")] newNumberOfDesiredPools2 3 (Just newNumberOfDesiredPools) 10
+                                       wallet0 (Just firstProposalInfo) [(3, "yes")] newNumberOfDesiredPools2 3 (Just newNumberOfDesiredPools) 10
 
   -- Create a no confidence proposal and vote "no" to the proposal with all DReps.
   -- Assert the no confidence proposal passes.
-  void $ testNoConfidenceProposal execConfig epochStateView configurationFile socketPath ceo work "noConfidenceProposal"
-                                  wallet0 firstProposalInfo [(3, "no")] 3
+  void $ testNoConfidenceProposal execConfig epochStateView ceo gov "noConfidenceProposal"
+                                  wallet1 constitutionalAction [(3, "no")]
+
+filterCommittee :: AnyNewEpochState -> Maybe [(L.Credential L.ColdCommitteeRole L.StandardCrypto, EpochNo)]
+filterCommittee (AnyNewEpochState sbe newEpochState) =
+  caseShelleyToBabbageOrConwayEraOnwards
+    (const $ error "filterNoCommittee: Only conway era supported")
+    (const $ do
+      let rState = L.extractDRepPulsingState $ newEpochState ^. L.newEpochStateGovStateL . L.drepPulsingStateGovStateL
+          ensCommittee = rState ^. L.rsEnactStateL . L.ensCommitteeL
+      case ensCommittee of
+        SNothing -> Nothing
+        SJust x | Map.null (L.committeeMembers x) -> Nothing
+                | otherwise -> Just $ Map.toList $ L.committeeMembers x
+    )
+    sbe
+
+updateConstitutionalCommittee
+  :: (MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m, Foldable t)
+  => H.ExecConfig
+  -> EpochStateView
+  -> ConwayEraOnwards ConwayEra
+  -> FilePath
+  -> FilePath
+  -> PaymentKeyInfo
+  -> Maybe (String, Word32)
+  -> t (Int, String)
+  -> m (String, Word32)
+updateConstitutionalCommittee execConfig epochStateView ceo work prefix
+                              wallet previousProposalInfo votes = do
+  baseDir <- H.createDirectoryIfMissing $ work </> prefix
+
+  let propVotes :: [(String, Int)]
+      propVotes = zip (concatMap (uncurry replicate) votes) [1..]
+  annotateShow propVotes
+
+  let coldVKeyFile = baseDir </> "cold-key.vkey"
+      coldSKeyFile = baseDir </> "cold-key.skey"
+
+  void $ H.execCli' execConfig
+      [ "conway", "governance", "committee", "key-gen-cold"
+      , "--cold-verification-key-file", coldVKeyFile
+      , "--cold-signing-key-file", coldSKeyFile
+      ]
+
+  coldKeyHash <- Text.unpack . Text.strip . Text.pack <$> H.execCli' execConfig
+    [ "conway", "governance", "committee", "key-hash"
+    , "--verification-key-file", coldVKeyFile
+    ]
+
+  thisProposal@(governanceActionTxId, governanceActionIndex) <-
+    makeUpdateConstitutionalCommitteeProposal execConfig epochStateView ceo baseDir "proposal"
+                                              previousProposalInfo [coldKeyHash] wallet
+
+  voteChangeProposal execConfig epochStateView ceo baseDir "vote"
+                     governanceActionTxId governanceActionIndex propVotes (zip (repeat "yes") [1..3]) wallet
+
+  (EpochNo epochAfterProp) <- getCurrentEpochNo epochStateView
+  H.note_ $ "Epoch after \"" <> prefix <> "\" prop: " <> show epochAfterProp
+
+  committee <- H.nothingFailM $ watchEpochStateView epochStateView (return . filterCommittee) (EpochInterval 1)
+
+  H.note_ $ show committee
+
+  return thisProposal
+
+makeUpdateConstitutionalCommitteeProposal
+  :: (H.MonadAssertion m, MonadTest m, MonadCatch m, MonadIO m, Foldable f)
+  => H.ExecConfig
+  -> EpochStateView
+  -> ConwayEraOnwards ConwayEra
+  -> FilePath
+  -> String
+  -> Maybe (String, Word32)
+  -> f String
+  -> PaymentKeyInfo
+  -> m (String, Word32)
+makeUpdateConstitutionalCommitteeProposal execConfig epochStateView ceo work prefix
+                                          prevGovActionInfo coldKeyHashes wallet = do
+
+  let sbe = conwayEraOnwardsToShelleyBasedEra ceo
+      era = toCardanoEra sbe
+      cEra = AnyCardanoEra era
+
+  baseDir <- H.createDirectoryIfMissing $ work </> prefix
+
+  let stakeVkeyFp = baseDir </> "stake.vkey"
+      stakeSKeyFp = baseDir </> "stake.skey"
+
+  P.cliStakeAddressKeyGen
+    $ KeyPair { verificationKey = File stakeVkeyFp
+              , signingKey = File stakeSKeyFp
+              }
+
+  proposalAnchorFile <- H.note $ baseDir </> "sample-proposal-anchor"
+  H.writeFile proposalAnchorFile "dummy anchor data"
+
+  proposalAnchorDataHash <- H.execCli' execConfig
+    [ "conway", "governance"
+    , "hash", "anchor-data", "--file-text", proposalAnchorFile
+    ]
+
+  minDRepDeposit <- getMinDRepDeposit epochStateView ceo
+
+  proposalFile <- H.note $ baseDir </> "sample-proposal-file"
+
+  void $ H.execCli' execConfig $
+    [ "conway", "governance", "action", "update-committee"
+    , "--testnet"
+    , "--governance-action-deposit", show @Integer minDRepDeposit
+    , "--deposit-return-stake-verification-key-file", stakeVkeyFp
+    ] ++ concatMap (\(prevGovernanceActionTxId, prevGovernanceActionIndex) ->
+                      [ "--prev-governance-action-tx-id", prevGovernanceActionTxId
+                      , "--prev-governance-action-index", show prevGovernanceActionIndex
+                      ]) prevGovActionInfo ++
+    [ "--anchor-url", "https://tinyurl.com/3wrwb2as"
+    , "--anchor-data-hash", proposalAnchorDataHash
+    ] ++ concatMap (\keyHash ->
+                    [ "--add-cc-cold-verification-key-hash", keyHash
+                    , "--epoch", show (100 :: Int)
+                    ]) coldKeyHashes ++
+    [ "--threshold", "0"
+    , "--out-file", proposalFile
+    ]
+
+  proposalBody <- H.note $ baseDir </> "tx.body"
+  txIn <- findLargestUtxoForPaymentKey epochStateView sbe wallet
+
+  void $ H.execCli' execConfig
+    [ "conway", "transaction", "build"
+    , "--change-address", Text.unpack $ paymentKeyInfoAddr wallet
+    , "--tx-in", Text.unpack $ renderTxIn txIn
+    , "--proposal-file", proposalFile
+    , "--out-file", proposalBody
+    ]
+
+  signedProposalTx <- signTx execConfig cEra baseDir "signed-proposal"
+                             (File proposalBody) [SomeKeyPair $ paymentKeyInfoPair wallet]
+
+  submitTx execConfig cEra signedProposalTx
+
+  governanceActionTxId <- retrieveTransactionId execConfig signedProposalTx
+
+  governanceActionIndex <- H.nothingFailM $ watchEpochStateView epochStateView (return . maybeExtractGovernanceActionIndex (fromString governanceActionTxId)) (EpochInterval 1)
+
+  return (governanceActionTxId, governanceActionIndex)
 
 delegateToAlwaysNoConfidence
   :: (MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m, Typeable era)
@@ -132,20 +279,15 @@ testNoConfidenceProposal
   :: (MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m, Foldable t)
   => H.ExecConfig
   -> EpochStateView
-  -> NodeConfigFile 'In
-  -> File Socket 'InOut
   -> ConwayEraOnwards ConwayEra
   -> FilePath
   -> FilePath
   -> PaymentKeyInfo
   -> (String, Word32)
   -> t (Int, String)
-  -> Integer
   -> m (String, Word32)
-testNoConfidenceProposal execConfig epochStateView configurationFile socketPath ceo work prefix
-                         wallet previousProposalInfo votes epochsToWait = do
-
-  let sbe = conwayEraOnwardsToShelleyBasedEra ceo
+testNoConfidenceProposal execConfig epochStateView ceo work prefix
+                         wallet previousProposalInfo votes = do
   baseDir <- H.createDirectoryIfMissing $ work </> prefix
 
   let propVotes :: [(String, Int)]
@@ -156,51 +298,18 @@ testNoConfidenceProposal execConfig epochStateView configurationFile socketPath 
     makeNoConfidenceProposal execConfig epochStateView ceo baseDir
                              "proposal" previousProposalInfo wallet
 
-  voteChangeProposal execConfig epochStateView sbe baseDir "vote"
-                     governanceActionTxId governanceActionIndex propVotes wallet
+  voteChangeProposal execConfig epochStateView ceo baseDir "vote"
+                     governanceActionTxId governanceActionIndex propVotes (zip (repeat "yes") [1..3]) wallet
 
-  -- Wait two epochs
   (EpochNo epochAfterProp) <- getCurrentEpochNo epochStateView
   H.note_ $ "Epoch after \"" <> prefix <> "\" prop: " <> show epochAfterProp
-  void $ waitUntilEpoch configurationFile socketPath (EpochNo (epochAfterProp + fromIntegral epochsToWait))
 
-  -- We check that no confidence proposal passes
-  obtainedProposalId <- getLastEnactedCommitteeActionId execConfig
-  obtainedProposalId === thisProposal
+  committee <- H.nothingFailM $ watchEpochStateView epochStateView (return . filterCommittee) (EpochInterval 1)
+
+  H.note_ $ show committee
 
   return thisProposal
 
-getLastEnactedCommitteeActionId :: (MonadTest m, MonadCatch m, MonadIO m) => H.ExecConfig -> m (String, Word32)
-getLastEnactedCommitteeActionId execConfig = do
-  govStateString <- H.execCli' execConfig
-    [ "conway", "query", "gov-state"
-    , "--volatile-tip"
-    ]
-
-  govStateJSON <- H.nothingFail (Aeson.decode (LBS.pack govStateString) :: Maybe Aeson.Value)
-
-  let mLastCommitteeAction :: Maybe Aeson.Value
-      mLastCommitteeAction = govStateJSON
-                               ^? AL.key "nextRatifyState"
-                                . AL.key "nextEnactState"
-                                . AL.key "prevGovActionIds"
-                                . AL.key "Committee"
-
-  lastCommitteeAction <- evalMaybe mLastCommitteeAction
-
-  let mLastCommitteeActionIx :: Maybe Integer
-      mLastCommitteeActionIx = lastCommitteeAction ^? AL.key "govActionIx"
-                                                    . AL._Integer
-
-  lastCommitteeActionIx <- fromIntegral <$> evalMaybe mLastCommitteeActionIx
-
-  let mLastCommitteeActionTxId :: Maybe Text
-      mLastCommitteeActionTxId = lastCommitteeAction ^? AL.key "txId"
-                                                      . AL._String
-
-  lastCommitteeActionTxId <- Text.unpack <$> evalMaybe mLastCommitteeActionTxId
-
-  return (lastCommitteeActionTxId, lastCommitteeActionIx)
 
 makeNoConfidenceProposal
   :: (H.MonadAssertion m, MonadTest m, MonadCatch m, MonadIO m)
@@ -214,7 +323,6 @@ makeNoConfidenceProposal
   -> m (String, Word32)
 makeNoConfidenceProposal execConfig epochStateView
                          ceo work prefix (prevGovernanceActionTxId, prevGovernanceActionIndex) wallet = do
-
   let sbe = conwayEraOnwardsToShelleyBasedEra ceo
       era = toCardanoEra sbe
       cEra = AnyCardanoEra era

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedNoConfidenceDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedNoConfidenceDRep.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -23,6 +24,7 @@ import           Prelude
 
 import           Control.Monad (void)
 import           Control.Monad.Catch (MonadCatch)
+import           Control.Monad.Trans.Control (MonadBaseControl)
 import qualified Data.Map as Map
 import           Data.String (fromString)
 import qualified Data.Text as Text
@@ -134,7 +136,7 @@ filterCommittee (AnyNewEpochState sbe newEpochState) =
     sbe
 
 updateConstitutionalCommittee
-  :: (MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m, Foldable t)
+  :: (MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m, MonadBaseControl IO m, Foldable t, HasCallStack)
   => H.ExecConfig
   -> EpochStateView
   -> ConwayEraOnwards ConwayEra
@@ -266,7 +268,7 @@ makeUpdateConstitutionalCommitteeProposal execConfig epochStateView ceo work pre
 -- Run a no confidence motion and check the result. Vote "yes" with 3 SPOs. Check the no
 -- confidence motion passes.
 testNoConfidenceProposal
-  :: (MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m, Foldable t, HasCallStack)
+  :: (MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m, MonadBaseControl IO m, Foldable t, HasCallStack)
   => H.ExecConfig -- ^ Specifies the CLI execution configuration.
   -> EpochStateView -- ^ Current epoch state view for transaction building. It can be obtained
                     -- using the 'getEpochStateView' function.
@@ -302,9 +304,8 @@ testNoConfidenceProposal execConfig epochStateView ceo work prefix
 
   return thisProposal
 
-
 makeNoConfidenceProposal
-  :: (H.MonadAssertion m, MonadTest m, MonadCatch m, MonadIO m)
+  :: (H.MonadAssertion m, MonadTest m, MonadCatch m, MonadIO m, HasCallStack)
   => H.ExecConfig
   -> EpochStateView
   -> ConwayEraOnwards ConwayEra

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedNoConfidenceDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedNoConfidenceDRep.hs
@@ -15,7 +15,7 @@ import qualified Cardano.Api.Ledger as L
 import qualified Cardano.Ledger.Conway.Governance as L
 import qualified Cardano.Ledger.Shelley.LedgerState as L
 import           Cardano.Testnet
-import           Cardano.Testnet.Test.Gov.PredefinedAbstainDRep (AutomaticDRepFlag (..),
+import           Cardano.Testnet.Test.Gov.PredefinedAbstainDRep (AutomaticDRepType (..),
                    delegateToAutomaticDRep, desiredPoolNumberProposalTest,
                    getDesiredPoolNumberValue, voteChangeProposal)
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedNoConfidenceDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedNoConfidenceDRep.hs
@@ -2,23 +2,44 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Cardano.Testnet.Test.Gov.PredefinedNoConfidenceDRep
   ( hprop_check_predefined_no_confidence_drep
   ) where
 
 import           Cardano.Api as Api
+import           Cardano.Api.IO.Base (Socket)
+import           Cardano.Api.Ledger (EpochInterval (..))
 
 import           Cardano.Testnet
+import           Cardano.Testnet.Test.Gov.PredefinedAbstainDRep (delegateToAutomaticDRep,
+                   desiredPoolNumberProposalTest, getDesiredPoolNumberValue, voteChangeProposal)
 
 import           Prelude
 
+import           Control.Monad (void)
+import           Control.Monad.Catch (MonadCatch)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Lens as AL
+import qualified Data.ByteString.Lazy.Char8 as LBS
+import           Data.Data (Typeable)
+import           Data.String (fromString)
+import           Data.Text (Text)
+import qualified Data.Text as Text
+import           Data.Word (Word32)
+import           Lens.Micro ((^?))
 import           System.FilePath ((</>))
 
-import           Testnet.Components.Query (getEpochStateView)
+import           Testnet.Components.Query (EpochStateView, findLargestUtxoForPaymentKey,
+                   getCurrentEpochNo, getEpochStateView, getMinDRepDeposit, watchEpochStateView)
+import           Testnet.Defaults (defaultDelegatorStakeKeyPair)
+import qualified Testnet.Process.Cli.Keys as P
+import           Testnet.Process.Cli.Transaction (retrieveTransactionId, signTx, submitTx)
 import qualified Testnet.Process.Run as H
 import qualified Testnet.Property.Util as H
-import           Testnet.Types (PoolNode (..), TestnetRuntime (..), nodeSocketPath)
+import           Testnet.Types (KeyPair (..), PaymentKeyInfo (..), PoolNode (..),
+                   SomeKeyPair (SomeKeyPair), StakingKey, TestnetRuntime (..), nodeSocketPath)
 
 import           Hedgehog
 import qualified Hedgehog.Extras as H
@@ -48,34 +69,208 @@ hprop_check_predefined_no_confidence_drep = H.integrationWorkspace "test-activit
   _testnetRuntime@TestnetRuntime
     { testnetMagic
     , poolNodes
-    , wallets=_wallet0:_wallet1:_wallet2:_
+    , wallets=wallet0:wallet1:wallet2:_
     , configurationFile
     }
     <- cardanoTestnetDefault fastTestnetOptions conf
 
   PoolNode{poolRuntime} <- H.headM poolNodes
   poolSprocket1 <- H.noteShow $ nodeSprocket poolRuntime
-  _execConfig <- H.mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
+  execConfig <- H.mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
   let socketPath = nodeSocketPath poolRuntime
 
-  _epochStateView <- getEpochStateView configurationFile socketPath
+  epochStateView <- getEpochStateView configurationFile socketPath
 
   H.note_ $ "Sprocket: " <> show poolSprocket1
   H.note_ $ "Abs path: " <> tempAbsBasePath'
   H.note_ $ "Socketpath: " <> unFile socketPath
   H.note_ $ "Foldblocks config file: " <> unFile configurationFile
 
-  _gov <- H.createDirectoryIfMissing $ work </> "governance"
+  gov <- H.createDirectoryIfMissing $ work </> "governance"
 
-  -- ToDo: Do some proposal and vote yes with all the DReps.
-  -- ToDo: ASSERT: that proposal passes.
-  -- ToDo: Take the last two stake delegators and delegate them to "No Confidence".
-  -- ToDo: This can be done using cardano-cli conway stake-address vote-delegation-certificate --always-no-confidence
-  -- ToDo: Do some other proposal and vote yes with all the DReps.
-  -- ToDo: ASSERT: the new proposal does NOT pass.
-  -- ToDo: Create a no confidence proposal.
-  -- ToDo: This can be done using cardano-cli conway governance action create-no-confidence
-  -- ToDo: Vote no to the no confidence proposal with all DReps.
-  -- ToDo: ASSERT: the no confidence proposal passes.
+  -- Do some proposal and vote yes with all the DReps
+  -- and assert that proposal passes.
+  initialDesiredNumberOfPools <- getDesiredPoolNumberValue epochStateView ceo
 
-  success
+  let newNumberOfDesiredPools = fromIntegral (initialDesiredNumberOfPools + 1)
+
+  firstProposalInfo <- desiredPoolNumberProposalTest execConfig epochStateView ceo gov "firstProposal"
+                                                     wallet0 Nothing [(3, "yes")] newNumberOfDesiredPools 0 (Just newNumberOfDesiredPools) 10
+
+  -- Take the last two stake delegators and delegate them to "No Confidence".
+  delegateToAlwaysNoConfidence execConfig epochStateView sbe gov "delegateToAbstain1"
+                               wallet1 (defaultDelegatorStakeKeyPair 2)
+  delegateToAlwaysNoConfidence execConfig epochStateView sbe gov "delegateToAbstain2"
+                               wallet1 (defaultDelegatorStakeKeyPair 3)
+
+  -- Do some other proposal and vote yes with all the DReps
+  -- and assert the new proposal does NOT pass
+  let newNumberOfDesiredPools2 = fromIntegral (newNumberOfDesiredPools + 1)
+
+  void $ desiredPoolNumberProposalTest execConfig epochStateView ceo gov "secondProposal"
+                                       wallet2 (Just firstProposalInfo) [(3, "yes")] newNumberOfDesiredPools2 3 (Just newNumberOfDesiredPools) 10
+
+  -- Create a no confidence proposal and vote "no" to the proposal with all DReps.
+  -- Assert the no confidence proposal passes.
+  void $ testNoConfidenceProposal execConfig epochStateView configurationFile socketPath ceo work "noConfidenceProposal"
+                                  wallet0 firstProposalInfo [(3, "no")] 3
+
+delegateToAlwaysNoConfidence
+  :: (MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m, Typeable era)
+  => H.ExecConfig
+  -> EpochStateView
+  -> ShelleyBasedEra era
+  -> FilePath
+  -> String
+  -> PaymentKeyInfo
+  -> KeyPair StakingKey
+  -> m ()
+delegateToAlwaysNoConfidence execConfig epochStateView sbe work prefix =
+  delegateToAutomaticDRep execConfig epochStateView sbe work prefix "--always-no-confidence"
+
+testNoConfidenceProposal
+  :: (MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m, Foldable t)
+  => H.ExecConfig
+  -> EpochStateView
+  -> NodeConfigFile 'In
+  -> File Socket 'InOut
+  -> ConwayEraOnwards ConwayEra
+  -> FilePath
+  -> FilePath
+  -> PaymentKeyInfo
+  -> (String, Word32)
+  -> t (Int, String)
+  -> Integer
+  -> m (String, Word32)
+testNoConfidenceProposal execConfig epochStateView configurationFile socketPath ceo work prefix
+                         wallet previousProposalInfo votes epochsToWait = do
+
+  let sbe = conwayEraOnwardsToShelleyBasedEra ceo
+  baseDir <- H.createDirectoryIfMissing $ work </> prefix
+
+  let propVotes :: [(String, Int)]
+      propVotes = zip (concatMap (uncurry replicate) votes) [1..]
+  annotateShow propVotes
+
+  thisProposal@(governanceActionTxId, governanceActionIndex) <-
+    makeNoConfidenceProposal execConfig epochStateView ceo baseDir
+                             "proposal" previousProposalInfo wallet
+
+  voteChangeProposal execConfig epochStateView sbe baseDir "vote"
+                     governanceActionTxId governanceActionIndex propVotes wallet
+
+  -- Wait two epochs
+  (EpochNo epochAfterProp) <- getCurrentEpochNo epochStateView
+  H.note_ $ "Epoch after \"" <> prefix <> "\" prop: " <> show epochAfterProp
+  void $ waitUntilEpoch configurationFile socketPath (EpochNo (epochAfterProp + fromIntegral epochsToWait))
+
+  -- We check that no confidence proposal passes
+  obtainedProposalId <- getLastEnactedCommitteeActionId execConfig
+  obtainedProposalId === thisProposal
+
+  return thisProposal
+
+getLastEnactedCommitteeActionId :: (MonadTest m, MonadCatch m, MonadIO m) => H.ExecConfig -> m (String, Word32)
+getLastEnactedCommitteeActionId execConfig = do
+  govStateString <- H.execCli' execConfig
+    [ "conway", "query", "gov-state"
+    , "--volatile-tip"
+    ]
+
+  govStateJSON <- H.nothingFail (Aeson.decode (LBS.pack govStateString) :: Maybe Aeson.Value)
+
+  let mLastCommitteeAction :: Maybe Aeson.Value
+      mLastCommitteeAction = govStateJSON
+                               ^? AL.key "nextRatifyState"
+                                . AL.key "nextEnactState"
+                                . AL.key "prevGovActionIds"
+                                . AL.key "Committee"
+
+  lastCommitteeAction <- evalMaybe mLastCommitteeAction
+
+  let mLastCommitteeActionIx :: Maybe Integer
+      mLastCommitteeActionIx = lastCommitteeAction ^? AL.key "govActionIx"
+                                                    . AL._Integer
+
+  lastCommitteeActionIx <- fromIntegral <$> evalMaybe mLastCommitteeActionIx
+
+  let mLastCommitteeActionTxId :: Maybe Text
+      mLastCommitteeActionTxId = lastCommitteeAction ^? AL.key "txId"
+                                                      . AL._String
+
+  lastCommitteeActionTxId <- Text.unpack <$> evalMaybe mLastCommitteeActionTxId
+
+  return (lastCommitteeActionTxId, lastCommitteeActionIx)
+
+makeNoConfidenceProposal
+  :: (H.MonadAssertion m, MonadTest m, MonadCatch m, MonadIO m)
+  => H.ExecConfig
+  -> EpochStateView
+  -> ConwayEraOnwards ConwayEra
+  -> FilePath
+  -> String
+  -> (String, Word32)
+  -> PaymentKeyInfo
+  -> m (String, Word32)
+makeNoConfidenceProposal execConfig epochStateView
+                         ceo work prefix (prevGovernanceActionTxId, prevGovernanceActionIndex) wallet = do
+
+  let sbe = conwayEraOnwardsToShelleyBasedEra ceo
+      era = toCardanoEra sbe
+      cEra = AnyCardanoEra era
+
+  baseDir <- H.createDirectoryIfMissing $ work </> prefix
+
+  let stakeVkeyFp = baseDir </> "stake.vkey"
+      stakeSKeyFp = baseDir </> "stake.skey"
+
+  _ <- P.cliStakeAddressKeyGen
+         $ KeyPair { verificationKey = File stakeVkeyFp
+                   , signingKey = File stakeSKeyFp
+                   }
+
+  proposalAnchorFile <- H.note $ baseDir </> "sample-proposal-anchor"
+  H.writeFile proposalAnchorFile "dummy anchor data"
+
+  proposalAnchorDataHash <- H.execCli' execConfig
+    [ "conway", "governance"
+    , "hash", "anchor-data", "--file-text", proposalAnchorFile
+    ]
+
+  minDRepDeposit <- getMinDRepDeposit epochStateView ceo
+
+  proposalFile <- H.note $ baseDir </> "sample-proposal-file"
+
+  void $ H.execCli' execConfig
+    [ "conway", "governance", "action", "create-no-confidence"
+    , "--testnet"
+    , "--governance-action-deposit", show @Integer minDRepDeposit
+    , "--deposit-return-stake-verification-key-file", stakeVkeyFp
+    , "--prev-governance-action-tx-id", prevGovernanceActionTxId
+    , "--prev-governance-action-index", show prevGovernanceActionIndex
+    , "--anchor-url", "https://tinyurl.com/3wrwb2as"
+    , "--anchor-data-hash", proposalAnchorDataHash
+    , "--out-file", proposalFile
+    ]
+
+  proposalBody <- H.note $ baseDir </> "tx.body"
+  txIn <- findLargestUtxoForPaymentKey epochStateView sbe wallet
+
+  void $ H.execCli' execConfig
+    [ "conway", "transaction", "build"
+    , "--change-address", Text.unpack $ paymentKeyInfoAddr wallet
+    , "--tx-in", Text.unpack $ renderTxIn txIn
+    , "--proposal-file", proposalFile
+    , "--out-file", proposalBody
+    ]
+
+  signedProposalTx <- signTx execConfig cEra baseDir "signed-proposal"
+                             (File proposalBody) [SomeKeyPair $ paymentKeyInfoPair wallet]
+
+  submitTx execConfig cEra signedProposalTx
+
+  governanceActionTxId <- retrieveTransactionId execConfig signedProposalTx
+
+  governanceActionIndex <- H.nothingFailM $ watchEpochStateView epochStateView (return . maybeExtractGovernanceActionIndex (fromString governanceActionTxId)) (EpochInterval 1)
+
+  return (governanceActionTxId, governanceActionIndex)

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedNoConfidenceDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedNoConfidenceDRep.hs
@@ -263,7 +263,7 @@ makeUpdateConstitutionalCommitteeProposal execConfig epochStateView ceo work pre
 
   return (governanceActionTxId, governanceActionIndex)
 
--- | Delegate to a staking key pair with the delegation preference set to always no confidence.
+-- | Delegate a staking key pair to the automated no confidence DRep.
 delegateToAlwaysNoConfidence
   :: (MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m, Typeable era, HasCallStack)
   => H.ExecConfig -- ^ Specifies the CLI execution configuration.
@@ -278,16 +278,20 @@ delegateToAlwaysNoConfidence
 delegateToAlwaysNoConfidence execConfig epochStateView sbe work prefix =
   delegateToAutomaticDRep execConfig epochStateView sbe work prefix "--always-no-confidence"
 
+-- Run a no confidence motion and check the result. Vote "yes" with 3 SPOs. Check the no
+-- confidence motion passes.
 testNoConfidenceProposal
   :: (MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m, Foldable t, HasCallStack)
-  => H.ExecConfig
-  -> EpochStateView
-  -> ConwayEraOnwards ConwayEra
-  -> FilePath
-  -> FilePath
-  -> PaymentKeyInfo
-  -> (String, Word32)
-  -> t (Int, String)
+  => H.ExecConfig -- ^ Specifies the CLI execution configuration.
+  -> EpochStateView -- ^ Current epoch state view for transaction building. It can be obtained
+                    -- using the 'getEpochStateView' function.
+  -> ConwayEraOnwards ConwayEra -- ^ The Shelley based era witness for ConwayEra onwards.
+  -> FilePath -- ^ Base directory path where generated files will be stored.
+  -> String -- ^ Name for the subfolder that will be created under 'work' folder.
+  -> PaymentKeyInfo -- ^ Wallet that will pay for the transaction.
+  -> (String, Word32) -- ^ Tuple containing the preivous proposal transaction id and index.
+  -> t (Int, String) -- ^ Model of DRep votes for proposal, list of pairs with an amount
+                     -- of votes and the and type of vote (i.e: "yes", "no", or "abstain").
   -> m (String, Word32)
 testNoConfidenceProposal execConfig epochStateView ceo work prefix
                          wallet previousProposalInfo votes = do

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedNoConfidenceDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedNoConfidenceDRep.hs
@@ -263,15 +263,17 @@ makeUpdateConstitutionalCommitteeProposal execConfig epochStateView ceo work pre
 
   return (governanceActionTxId, governanceActionIndex)
 
+-- | Delegate to a staking key pair with the delegation preference set to always no confidence.
 delegateToAlwaysNoConfidence
   :: (MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m, Typeable era, HasCallStack)
-  => H.ExecConfig
-  -> EpochStateView
-  -> ShelleyBasedEra era
-  -> FilePath
-  -> String
-  -> PaymentKeyInfo
-  -> KeyPair StakingKey
+  => H.ExecConfig -- ^ Specifies the CLI execution configuration.
+  -> EpochStateView -- ^ Current epoch state view for transaction building. It can be obtained
+                    -- using the 'getEpochStateView' function.
+  -> ShelleyBasedEra era -- ^ The Shelley based era witness for ConwayEra
+  -> FilePath -- ^ Base directory path where generated files will be stored.
+  -> String -- ^ Name for the subfolder that will be created under 'work' folder.
+  -> PaymentKeyInfo -- ^ Wallet that will pay for the transaction.
+  -> KeyPair StakingKey -- ^ Staking key pair used for delegation.
   -> m ()
 delegateToAlwaysNoConfidence execConfig epochStateView sbe work prefix =
   delegateToAutomaticDRep execConfig epochStateView sbe work prefix "--always-no-confidence"

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedNoConfidenceDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedNoConfidenceDRep.hs
@@ -183,7 +183,7 @@ updateConstitutionalCommittee execConfig epochStateView ceo work prefix
   return thisProposal
 
 makeUpdateConstitutionalCommitteeProposal
-  :: (H.MonadAssertion m, MonadTest m, MonadCatch m, MonadIO m, Foldable f)
+  :: (HasCallStack, H.MonadAssertion m, MonadTest m, MonadCatch m, MonadIO m, Foldable f)
   => H.ExecConfig
   -> EpochStateView
   -> ConwayEraOnwards ConwayEra

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedNoConfidenceDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedNoConfidenceDRep.hs
@@ -35,6 +35,7 @@ import           System.FilePath ((</>))
 
 import           Testnet.Components.Query (EpochStateView, findLargestUtxoForPaymentKey,
                    getCurrentEpochNo, getEpochStateView, getMinDRepDeposit, watchEpochStateView)
+import           Testnet.Components.TestWatchdog (runWithDefaultWatchdog_)
 import           Testnet.Defaults (defaultDelegatorStakeKeyPair)
 import qualified Testnet.Process.Cli.Keys as P
 import           Testnet.Process.Cli.Transaction (retrieveTransactionId, signTx, submitTx)
@@ -49,7 +50,7 @@ import qualified Hedgehog.Extras as H
 -- | Execute me with:
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/Predefined No Confidence DRep/"'@
 hprop_check_predefined_no_confidence_drep :: Property
-hprop_check_predefined_no_confidence_drep = H.integrationWorkspace "test-activity" $ \tempAbsBasePath' -> do
+hprop_check_predefined_no_confidence_drep = H.integrationWorkspace "test-activity" $ \tempAbsBasePath' -> runWithDefaultWatchdog_ $ do
   -- Start a local test net
   conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedNoConfidenceDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedNoConfidenceDRep.hs
@@ -109,7 +109,7 @@ hprop_check_predefined_no_confidence_drep = H.integrationWorkspace "test-activit
 
   -- Do some other proposal and vote yes with all the DReps
   -- and assert the new proposal does NOT pass.
-  let newNumberOfDesiredPools2 = fromIntegral (newNumberOfDesiredPools + 1)
+  let newNumberOfDesiredPools2 = newNumberOfDesiredPools + 1
 
   void $ desiredPoolNumberProposalTest execConfig epochStateView ceo gov "secondProposal"
                                        wallet0 (Just firstProposalInfo) [(3, "yes")] newNumberOfDesiredPools2 3 (Just newNumberOfDesiredPools) 10

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedNoConfidenceDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedNoConfidenceDRep.hs
@@ -96,7 +96,7 @@ hprop_check_predefined_no_confidence_drep = H.integrationWorkspace "test-activit
   -- and assert that proposal passes.
   initialDesiredNumberOfPools <- getDesiredPoolNumberValue epochStateView ceo
 
-  let newNumberOfDesiredPools = fromIntegral (initialDesiredNumberOfPools + 1)
+  let newNumberOfDesiredPools = initialDesiredNumberOfPools + 1
 
   firstProposalInfo <- desiredPoolNumberProposalTest execConfig epochStateView ceo gov "firstProposal"
                                                      wallet1 Nothing [(3, "yes")] newNumberOfDesiredPools 0 (Just newNumberOfDesiredPools) 10

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitution.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitution.hs
@@ -231,8 +231,7 @@ filterRatificationState c guardRailScriptHash (AnyNewEpochState sbe newEpochStat
           constitution = rState ^. Ledger.rsEnactStateL . Ledger.ensConstitutionL
           constitutionAnchorHash = Ledger.anchorDataHash $ Ledger.constitutionAnchor constitution
           L.ScriptHash constitutionScriptHash = fromMaybe (error "filterRatificationState: consitution does not have a guardrail script")
-                                                $ strictMaybeToMaybe $ constitution ^. Ledger.constitutionScriptL
+                                                  $ strictMaybeToMaybe $ constitution ^. Ledger.constitutionScriptL
       Text.pack c == renderSafeHashAsHex constitutionAnchorHash && L.hashToTextAsHex constitutionScriptHash == Text.pack guardRailScriptHash
-
     )
     sbe

--- a/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
+++ b/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
@@ -39,6 +39,7 @@ import           Test.Tasty (TestTree)
 import qualified Test.Tasty.Ingredients as T
 import qualified Test.Tasty.Options as T
 import qualified Test.Tasty.Runners as T
+import qualified Cardano.Testnet.Test.Gov.PredefinedNoConfidenceDRep as Gov
 
 tests :: IO TestTree
 tests = do
@@ -53,6 +54,7 @@ tests = do
                 -- TODO: Disabled because proposals for parameter changes are not working
                 -- , ignoreOnWindows "DRep Activity" Gov.hprop_check_drep_activity
                 -- , ignoreOnWindows "Predefined Abstain DRep" Gov.hprop_check_predefined_abstain_drep
+                , ignoreOnWindows "Predefined No Confidence DRep" Gov.hprop_check_predefined_no_confidence_drep
                 , ignoreOnMacAndWindows "Committee Motion Of No Confidence"  Gov.hprop_gov_no_confidence
                 , ignoreOnWindows "DRep Deposits" Gov.hprop_ledger_events_drep_deposits
                   -- FIXME Those tests are flaky

--- a/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
+++ b/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
@@ -17,6 +17,7 @@ import qualified Cardano.Testnet.Test.Gov.CommitteeAddNew as Gov
 import qualified Cardano.Testnet.Test.Gov.DRepDeposit as Gov
 import qualified Cardano.Testnet.Test.Gov.DRepRetirement as Gov
 import qualified Cardano.Testnet.Test.Gov.NoConfidence as Gov
+import qualified Cardano.Testnet.Test.Gov.PredefinedNoConfidenceDRep as Gov
 import qualified Cardano.Testnet.Test.Gov.ProposeNewConstitution as Gov
 import qualified Cardano.Testnet.Test.Gov.ProposeNewConstitutionSPO as Gov
 import qualified Cardano.Testnet.Test.Gov.TreasuryGrowth as Gov
@@ -39,7 +40,6 @@ import           Test.Tasty (TestTree)
 import qualified Test.Tasty.Ingredients as T
 import qualified Test.Tasty.Options as T
 import qualified Test.Tasty.Runners as T
-import qualified Cardano.Testnet.Test.Gov.PredefinedNoConfidenceDRep as Gov
 
 tests :: IO TestTree
 tests = do

--- a/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
+++ b/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
@@ -54,8 +54,8 @@ tests = do
                 -- TODO: Disabled because proposals for parameter changes are not working
                 -- , ignoreOnWindows "DRep Activity" Gov.hprop_check_drep_activity
                 -- , ignoreOnWindows "Predefined Abstain DRep" Gov.hprop_check_predefined_abstain_drep
-                , ignoreOnWindows "Predefined No Confidence DRep" Gov.hprop_check_predefined_no_confidence_drep
-                , ignoreOnMacAndWindows "Committee Motion Of No Confidence"  Gov.hprop_gov_no_confidence
+                -- , ignoreOnWindows "Predefined No Confidence DRep" Gov.hprop_check_predefined_no_confidence_drep
+                , ignoreOnMacAndWindows "Committee Motion Of No Confidence" Gov.hprop_gov_no_confidence
                 , ignoreOnWindows "DRep Deposits" Gov.hprop_ledger_events_drep_deposits
                   -- FIXME Those tests are flaky
                   -- , ignoreOnWindows "InfoAction" LedgerEvents.hprop_ledger_events_info_action


### PR DESCRIPTION
# Description

This PR aims to address this issue: https://github.com/IntersectMBO/cardano-node/issues/5600
With that aim, it adds two scenarios for automated DReps. This PR contains the second scenario:

## Scenario 2

- Create default testnet with 3 DReps and 3 stake holders delegated, one to each DRep.
- Do some proposal and vote `yes` with all the DReps.
- **Check** that proposal passes.
- Take the last two stake delegators and delegate them to "No Confidence".
- Do some other proposal and vote `yes` with all the DReps.
- **Check** the new proposal does **NOT** pass.
- Create a no confidence proposal.
- Vote `no` to the no confidence proposal with all DReps.
- **Check** the no confidence proposal passes.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff
