### PR TITLE
Remove consensus internal options from cli flags

### DIFF
--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -3,6 +3,12 @@
 ## Next version
 
 - Use p2p network stack by default, warn when using the legacy network stack.
+- Deprecate some CLI flags corresponding to low-level consensus options. They are 
+  still accepted but a warning is emitted on startup on stderr suggesting to set 
+  them in the configuration file instead:
+  - `--mempool-capacity-override` and `--no-mempool-capacity-override` can be set in the configuration file via the key `MempoolCapacityBytesOverride`.
+  - `--snapshot-interval` can be set in the configuration file via the key `SnapshotInterval`.
+  - `--num-of-disk-snapshots` can be set in the configuration file via the key `NumOfDiskSnapshots`.
 
 ## 8.2.1 -- August 2023
 

--- a/cardano-node/src/Cardano/Node/Parsers.hs
+++ b/cardano-node/src/Cardano/Node/Parsers.hs
@@ -51,8 +51,10 @@ nodeRunParser = do
   -- Filepaths
   topFp <- lastOption parseTopologyFile
   dbFp <- lastOption parseDbPath
+  validate <- lastOption parseValidateDB
   socketFp <- lastOption $ parseSocketPath "Path to a cardano-node socket"
   traceForwardSocket <- lastOption parseTracerSocketMode
+  nodeConfigFp <- lastOption parseConfigFile
 
   -- Protocol files
   byronCertFile   <- optional parseByronDelegationCert
@@ -68,15 +70,13 @@ nodeRunParser = do
   nIPv6Address <- lastOption parseHostIPv6Addr
   nPortNumber  <- lastOption parsePort
 
-  -- NodeConfiguration filepath
-  nodeConfigFp <- lastOption parseConfigFile
-  numOfDiskSnapshots <- lastOption parseNumOfDiskSnapshots
-  snapshotInterval   <- lastOption parseSnapshotInterval
-
-  validate <- lastOption parseValidateDB
+  -- Shutdown
   shutdownIPC <- lastOption parseShutdownIPC
   shutdownOnLimit <- lastOption parseShutdownOn
 
+  -- Hidden options (to be removed eventually)
+  numOfDiskSnapshots <- lastOption parseNumOfDiskSnapshots
+  snapshotInterval   <- lastOption parseSnapshotInterval
   maybeMempoolCapacityOverride <- lastOption parseMempoolCapacityOverride
 
   pure $ PartialNodeConfiguration
@@ -215,13 +215,13 @@ parseMempoolCapacityOverride = parseOverride <|> parseNoOverride
       Opt.option (auto @Word32)
         (  long "mempool-capacity-override"
         <> metavar "BYTES"
-        <> help "The number of bytes"
+        <> help "[DEPRECATED: Set it in config file with key MempoolCapacityBytesOverride] The number of bytes"
         )
     parseNoOverride :: Parser MempoolCapacityBytesOverride
     parseNoOverride =
       flag' NoMempoolCapacityBytesOverride
         (  long "no-mempool-capacity-override"
-        <> help "The port number"
+        <> help "[DEPRECATED: Set it in config file] Don't override mempool capacity"
         )
 
 parseDbPath :: Parser FilePath
@@ -336,7 +336,7 @@ parseNumOfDiskSnapshots = fmap RequestedNumOfDiskSnapshots parseNum
   parseNum = Opt.option auto
     ( long "num-of-disk-snapshots"
         <> metavar "NUMOFDISKSNAPSHOTS"
-        <> help "Number of ledger snapshots stored on disk."
+        <> help "[DEPRECATED: Set it in config file with key NumOfDiskSnapshots] Number of ledger snapshots stored on disk."
     )
 
 -- TODO revisit because it sucks
@@ -346,7 +346,7 @@ parseSnapshotInterval = fmap (RequestedSnapshotInterval . secondsToDiffTime) par
   parseDifftime = Opt.option auto
     ( long "snapshot-interval"
         <> metavar "SNAPSHOTINTERVAL"
-        <> help "Snapshot Interval (in seconds)"
+        <> help "[DEPRECATED: Set it in config file with key SnapshotInterval] Snapshot Interval (in seconds)"
     )
 
 -- | Produce just the brief help header for a given CLI option parser,

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
@@ -422,7 +422,7 @@ instance ( LogFormatting (Header blk)
       "Added request to queue to reprocess blocks postponed by LoE."
   forHuman ChainDB.PoppedReprocessLoEBlocksFromQueue =
       "Poppped request from queue to reprocess blocks postponed by LoE."
-  forHuman ChainDB.ChainSelectionLoEDebug {} =
+  forHuman ChainDB.ChainSelectionLoEDebug{} =
       "ChainDB LoE debug event"
   forMachine dtal (ChainDB.IgnoreBlockOlderThanK pt) =
       mconcat [ "kind" .= String "IgnoreBlockOlderThanK"


### PR DESCRIPTION
# Description

Some of the options presented as cli flags seem to be consensus internal or low-level options. This PR adds warnings when they are set via cli flags in preparation for future removal, they can still be configured in the JSON/YAML configuration.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [X] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff
