### PR TITLE
Automated drep (Scenario 1)

### DIFF
--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -198,6 +198,8 @@ test-suite cardano-testnet-test
                         Cardano.Testnet.Test.Gov.TreasuryGrowth
                         Cardano.Testnet.Test.Gov.TreasuryWithdrawal
                         Cardano.Testnet.Test.Misc
+                        Cardano.Testnet.Test.Gov.DRepActivity
+                        Cardano.Testnet.Test.Gov.PredefinedAbstainDRep
                         Cardano.Testnet.Test.Node.Shutdown
                         Cardano.Testnet.Test.SanityCheck
                         Cardano.Testnet.Test.SubmitApi.Babbage.Transaction

--- a/cardano-testnet/src/Cardano/Testnet.hs
+++ b/cardano-testnet/src/Cardano/Testnet.hs
@@ -27,7 +27,6 @@ module Cardano.Testnet (
 
   -- * EpochState processsing helper functions
   maybeExtractGovernanceActionIndex,
-  findCondition,
 
   -- * Processes
   procChairman,

--- a/cardano-testnet/src/Testnet/Components/Query.hs
+++ b/cardano-testnet/src/Testnet/Components/Query.hs
@@ -24,6 +24,7 @@ module Testnet.Components.Query
   , findLargestUtxoWithAddress
   , findLargestUtxoForPaymentKey
   , assertNewEpochState
+  , watchEpochStateView
   ) where
 
 import           Cardano.Api as Api

--- a/cardano-testnet/src/Testnet/Components/Query.hs
+++ b/cardano-testnet/src/Testnet/Components/Query.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE NumericUnderscores #-}
-{-# LANGUAGE FlexibleContexts #-}
 
 module Testnet.Components.Query
   ( EpochStateView
@@ -32,7 +32,6 @@ import           Cardano.Api.Ledger (Credential, DRepState, EpochInterval (..), 
 import           Cardano.Api.Shelley (ShelleyLedgerEra, fromShelleyTxIn, fromShelleyTxOut)
 
 import qualified Cardano.Ledger.Api as L
-import           Cardano.Ledger.BaseTypes (addEpochInterval)
 import qualified Cardano.Ledger.Coin as L
 import qualified Cardano.Ledger.Conway.Governance as L
 import qualified Cardano.Ledger.Conway.PParams as L
@@ -40,6 +39,7 @@ import qualified Cardano.Ledger.Shelley.LedgerState as L
 import qualified Cardano.Ledger.UTxO as L
 
 import           Control.Exception.Safe (MonadCatch)
+import           Control.Monad (void)
 import           Control.Monad.Trans.Resource
 import           Control.Monad.Trans.State.Strict (put)
 import           Data.Bifunctor (bimap)
@@ -99,9 +99,9 @@ waitForEpochs
   => EpochStateView
   -> EpochInterval  -- ^ Number of epochs to wait
   -> m EpochNo -- ^ The epoch number reached
-waitForEpochs epochStateView@EpochStateView{nodeConfigPath, socketPath} interval = withFrozenCallStack $ do
-  currentEpoch <- getCurrentEpochNo epochStateView
-  waitUntilEpoch nodeConfigPath socketPath $ addEpochInterval currentEpoch interval
+waitForEpochs epochStateView interval = withFrozenCallStack $ do
+  void $ watchEpochStateView epochStateView (const $ pure Nothing) interval
+  getCurrentEpochNo epochStateView
 
 -- | A read-only mutable pointer to an epoch state, updated automatically
 data EpochStateView = EpochStateView

--- a/cardano-testnet/src/Testnet/Components/Query.hs
+++ b/cardano-testnet/src/Testnet/Components/Query.hs
@@ -424,5 +424,5 @@ watchEpochStateView epochStateView f (EpochInterval maxWait) = withFrozenCallSta
             if currentEpoch > timeout
               then pure Nothing
               else do
-                H.threadDelay 100_000
+                H.threadDelay 10_000
                 go (EpochNo timeout)

--- a/cardano-testnet/src/Testnet/EpochStateProcessing.hs
+++ b/cardano-testnet/src/Testnet/EpochStateProcessing.hs
@@ -4,7 +4,6 @@
 
 module Testnet.EpochStateProcessing
   ( maybeExtractGovernanceActionIndex
-  , findCondition
   ) where
 
 import           Cardano.Api
@@ -17,42 +16,12 @@ import qualified Cardano.Ledger.Shelley.LedgerState as L
 
 import           Prelude
 
-import           Control.Monad.State.Strict (MonadState (put), StateT)
 import qualified Data.Map as Map
 import           Data.Word (Word32)
 import           GHC.Stack
 import           Lens.Micro ((^.))
 
-import           Hedgehog
 
-findCondition
-  :: HasCallStack
-  => MonadTest m
-  => MonadIO m
-  => (AnyNewEpochState -> Maybe a)
-  -> NodeConfigFile In
-  -> SocketPath
-  -> EpochNo -- ^ The termination epoch: the condition must be found *before* this epoch
-  -> m (Either FoldBlocksError (Maybe a))
-findCondition epochStateFoldFunc configurationFile socketPath maxEpochNo = withFrozenCallStack $ evalIO . runExceptT $ do
-  result <-
-    foldEpochState
-      configurationFile
-      socketPath
-      FullValidation
-      maxEpochNo
-      Nothing
-      (\epochState _ _ -> go epochStateFoldFunc epochState)
-  pure $ case result of
-    (ConditionMet, Just x) -> Just x
-    _                      -> Nothing
-
-  where
-    go :: (AnyNewEpochState -> Maybe a) -> AnyNewEpochState -> StateT (Maybe a) IO LedgerStateCondition
-    go f epochState = do
-      case f epochState of
-        Just x -> put (Just x) >> pure ConditionMet
-        Nothing -> pure ConditionNotMet
 
 maybeExtractGovernanceActionIndex
   :: HasCallStack

--- a/cardano-testnet/src/Testnet/EpochStateProcessing.hs
+++ b/cardano-testnet/src/Testnet/EpochStateProcessing.hs
@@ -1,16 +1,14 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Testnet.EpochStateProcessing
   ( maybeExtractGovernanceActionIndex
   , findCondition
-  , watchEpochStateView
   ) where
 
 import           Cardano.Api
-import           Cardano.Api.Ledger (EpochInterval (..), GovActionId (..))
+import           Cardano.Api.Ledger (GovActionId (..))
 import qualified Cardano.Api.Ledger as L
 
 import qualified Cardano.Ledger.Conway.Governance as L
@@ -25,11 +23,7 @@ import           Data.Word (Word32)
 import           GHC.Stack
 import           Lens.Micro ((^.))
 
-import           Testnet.Components.Query (EpochStateView, getEpochState)
-
 import           Hedgehog
-import           Hedgehog.Extras (MonadAssertion)
-import qualified Hedgehog.Extras as H
 
 findCondition
   :: HasCallStack
@@ -77,32 +71,4 @@ maybeExtractGovernanceActionIndex txid (AnyNewEpochState sbe newEpochState) =
     compareWithTxId (TxId ti1) Nothing (GovActionId (L.TxId ti2) (L.GovActionIx gai)) _
       | ti1 == L.extractHash ti2 = Just gai
     compareWithTxId _ x _ _ = x
-
--- | Watch the epoch state view until the guard function returns 'Just' or the timeout epoch is reached.
--- Wait for at most @maxWait@ epochs.
--- The function will return the result of the guard function if it is met, otherwise it will return @Nothing@.
-watchEpochStateView
-  :: forall m a. (HasCallStack, MonadIO m, MonadTest m, MonadAssertion m)
-  => EpochStateView -- ^ The info to access the epoch state
-  -> (AnyNewEpochState -> m (Maybe a)) -- ^ The guard function (@Just@ if the condition is met, @Nothing@ otherwise)
-  -> EpochInterval -- ^ The maximum number of epochs to wait
-  -> m (Maybe a)
-watchEpochStateView epochStateView f (EpochInterval maxWait) = withFrozenCallStack $ do
-  AnyNewEpochState _ newEpochState <- getEpochState epochStateView
-  let EpochNo currentEpoch = L.nesEL newEpochState
-  go (EpochNo $ currentEpoch + fromIntegral maxWait)
-    where
-      go :: EpochNo -> m (Maybe a)
-      go (EpochNo timeout) = do
-        epochState@(AnyNewEpochState _ newEpochState') <- getEpochState epochStateView
-        let EpochNo currentEpoch = L.nesEL newEpochState'
-        condition <- f epochState
-        case condition of
-          Just result -> pure (Just result)
-          Nothing -> do
-            if currentEpoch > timeout
-              then pure Nothing
-              else do
-                H.threadDelay 100_000
-                go (EpochNo timeout)
 

--- a/cardano-testnet/src/Testnet/EpochStateProcessing.hs
+++ b/cardano-testnet/src/Testnet/EpochStateProcessing.hs
@@ -1,27 +1,39 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Testnet.EpochStateProcessing
   ( maybeExtractGovernanceActionIndex
+  , waitForGovActionVotes
   ) where
 
 import           Cardano.Api
-import           Cardano.Api.Ledger (GovActionId (..))
+import           Cardano.Api.Ledger (EpochInterval, GovActionId (..))
 import qualified Cardano.Api.Ledger as L
+import           Cardano.Api.Shelley (ShelleyLedgerEra)
 
 import qualified Cardano.Ledger.Conway.Governance as L
 import qualified Cardano.Ledger.Shelley.API as L
+import           Cardano.Ledger.Shelley.LedgerState (newEpochStateGovStateL)
 import qualified Cardano.Ledger.Shelley.LedgerState as L
 
 import           Prelude
 
+import           Data.Data ((:~:) (..))
 import qualified Data.Map as Map
 import           Data.Word (Word32)
+import           GHC.Exts (IsList (toList), toList)
 import           GHC.Stack
-import           Lens.Micro ((^.))
+import           Lens.Micro (to, (^.))
 
+import           Testnet.Components.Query (EpochStateView, watchEpochStateView)
+import           Testnet.Property.Assert (assertErasEqual)
 
+import           Hedgehog (MonadTest)
+import           Hedgehog.Extras (MonadAssertion)
+import qualified Hedgehog.Extras as H
 
 maybeExtractGovernanceActionIndex
   :: HasCallStack
@@ -41,3 +53,33 @@ maybeExtractGovernanceActionIndex txid (AnyNewEpochState sbe newEpochState) =
       | ti1 == L.extractHash ti2 = Just gai
     compareWithTxId _ x _ _ = x
 
+-- | Wait for the last gov action proposal in the list to have DRep or SPO votes.
+waitForGovActionVotes
+  :: forall m era.
+     (MonadAssertion m, MonadTest m, MonadIO m, HasCallStack)
+  => EpochStateView -- ^ Current epoch state view. It can be obtained using the 'getEpochStateView' function.
+  -> ConwayEraOnwards era -- ^ The ConwayEraOnwards witness for current era.
+  -> EpochInterval -- ^ The maximum wait time in epochs.
+  -> m ()
+waitForGovActionVotes epochStateView ceo maxWait = withFrozenCallStack $ do
+  mResult <- watchEpochStateView epochStateView getFromEpochState maxWait
+  case mResult of
+    Just () -> pure ()
+    Nothing -> H.failMessage callStack "waitForGovActionVotes: No votes appeared before timeout."
+  where
+    getFromEpochState :: HasCallStack
+      => AnyNewEpochState -> m (Maybe ())
+    getFromEpochState (AnyNewEpochState actualEra newEpochState) = do
+      let sbe = conwayEraOnwardsToShelleyBasedEra ceo
+      Refl <- H.leftFail $ assertErasEqual sbe actualEra
+      let govState :: L.ConwayGovState (ShelleyLedgerEra era) = conwayEraOnwardsConstraints ceo $ newEpochState ^. newEpochStateGovStateL
+          proposals = govState ^. L.cgsProposalsL . L.pPropsL . to toList
+      if null proposals
+        then pure Nothing
+        else do
+          let lastProposal = last proposals
+              gaDRepVotes = lastProposal ^. L.gasDRepVotesL . to toList
+              gaSpoVotes = lastProposal ^. L.gasStakePoolVotesL . to toList
+          if null gaDRepVotes && null gaSpoVotes
+          then pure Nothing
+          else pure $ Just ()

--- a/cardano-testnet/src/Testnet/Process/Cli/DRep.hs
+++ b/cardano-testnet/src/Testnet/Process/Cli/DRep.hs
@@ -16,6 +16,7 @@ module Testnet.Process.Cli.DRep
   ) where
 
 import           Cardano.Api hiding (Certificate, TxBody)
+import           Cardano.Api.Ledger (EpochInterval (EpochInterval))
 
 import           Prelude
 
@@ -248,8 +249,7 @@ delegateToDRep
   => MonadCatch m
   => H.ExecConfig -- ^ Specifies the CLI execution configuration.
   -> EpochStateView -- ^ Current epoch state view for transaction building. It can be obtained
-  -> NodeConfigFile In -- ^ Path to the node configuration file as returned by 'cardanoTestnetDefault'.
-  -> SocketPath  -- ^ Path to the cardano-node unix socket file.
+                    -- using the 'getEpochStateView' function.
   -> ShelleyBasedEra ConwayEra -- ^ The Shelley-based era (e.g., 'ConwayEra') in which the transaction will be constructed.
   -> FilePath -- ^ Base directory path where generated files will be stored.
   -> String -- ^ Name for the subfolder that will be created under 'work' folder.
@@ -257,7 +257,7 @@ delegateToDRep
   -> KeyPair StakingKey -- ^ Staking key pair used for delegation.
   -> KeyPair PaymentKey -- ^ Delegate Representative (DRep) key pair ('PaymentKeyPair') to which delegate.
   -> m ()
-delegateToDRep execConfig epochStateView configurationFile' socketPath sbe work prefix
+delegateToDRep execConfig epochStateView sbe work prefix
                payingWallet skeyPair@KeyPair{verificationKey=File vKeyFile}
                KeyPair{verificationKey=File drepVKey}  = do
 
@@ -288,8 +288,7 @@ delegateToDRep execConfig epochStateView configurationFile' socketPath sbe work 
   submitTx execConfig cEra repRegSignedRegTx1
 
   -- Wait two epochs
-  (EpochNo epochAfterProp) <- getCurrentEpochNo epochStateView
-  void $ waitUntilEpoch configurationFile' socketPath (EpochNo (epochAfterProp + 2))
+  void $ waitForEpochs epochStateView (EpochInterval 2)
 
 -- | This function obtains the identifier for the last enacted parameter update proposal
 -- if any.

--- a/cardano-testnet/src/Testnet/Process/Cli/DRep.hs
+++ b/cardano-testnet/src/Testnet/Process/Cli/DRep.hs
@@ -287,8 +287,8 @@ delegateToDRep execConfig epochStateView sbe work prefix
   -- Submit transaction
   submitTx execConfig cEra repRegSignedRegTx1
 
-  -- Wait two epochs
-  void $ waitForEpochs epochStateView (EpochInterval 2)
+  -- Wait one epoch
+  void $ waitForEpochs epochStateView (EpochInterval 1)
 
 -- | This function obtains the identifier for the last enacted parameter update proposal
 -- if any.

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/CommitteeAddNew.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/CommitteeAddNew.hs
@@ -37,6 +37,7 @@ import           Testnet.Components.Configuration
 import           Testnet.Components.Query
 import           Testnet.Components.TestWatchdog
 import           Testnet.Defaults
+import           Testnet.EpochStateProcessing (waitForGovActionVotes)
 import qualified Testnet.Process.Cli.DRep as DRep
 import           Testnet.Process.Cli.Keys
 import qualified Testnet.Process.Cli.SPO as SPO
@@ -205,7 +206,7 @@ hprop_constitutional_committee_add_new = integrationWorkspace "constitutional-co
 
   submitTx execConfig cEra voteTxFp
 
-  _ <- waitForEpochs epochStateView (L.EpochInterval 1)
+  waitForGovActionVotes epochStateView ceo (L.EpochInterval 1)
 
   govState <- getGovState epochStateView ceo
   govActionState <- H.headM $ govState ^. L.cgsProposalsL . L.pPropsL . to toList

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/CommitteeAddNew.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/CommitteeAddNew.hs
@@ -73,7 +73,7 @@ hprop_constitutional_committee_add_new = integrationWorkspace "constitutional-co
       cEra = AnyCardanoEra era
       eraName = eraToString era
       fastTestnetOptions = cardanoDefaultTestnetOptions
-        { cardanoEpochLength = 100
+        { cardanoEpochLength = 200
         , cardanoNodeEra = cEra
         , cardanoNumDReps = nDrepVotes
         }

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepActivity.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepActivity.hs
@@ -200,7 +200,7 @@ activityChangeProposalTest execConfig epochStateView configurationFile socketPat
   (EpochNo epochAfterProp) <- getCurrentEpochNo epochStateView
   H.note_ $ "Epoch after \"" <> prefix <> "\" prop: " <> show epochAfterProp
 
-  waitAndCheckNewEpochState epochStateView configurationFile socketPath sbe minWait mExpected maxWait
+  waitAndCheckNewEpochState epochStateView configurationFile socketPath ceo minWait mExpected maxWait
                             (nesEpochStateL . epochStateGovStateL . curPParamsGovStateL . ppDRepActivityL)
 
   return thisProposal

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepActivity.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepActivity.hs
@@ -109,11 +109,11 @@ hprop_check_drep_activity = integrationWorkspace "test-activity" $ \tempAbsBaseP
 
   -- Now we register two new DReps
   drep2 <- registerDRep execConfig epochStateView ceo work "drep2" wallet1
-  delegateToDRep execConfig epochStateView configurationFile socketPath sbe work "drep2-delegation"
+  delegateToDRep execConfig epochStateView sbe work "drep2-delegation"
                  wallet2 (defaultDelegatorStakeKeyPair 2) drep2
 
   drep3 <- registerDRep execConfig epochStateView ceo work "drep3" wallet0
-  delegateToDRep execConfig epochStateView configurationFile socketPath sbe work "drep3-delegation"
+  delegateToDRep execConfig epochStateView sbe work "drep3-delegation"
                  wallet1 (defaultDelegatorStakeKeyPair 3) drep3
 
   expirationDates <- checkDRepState epochStateView sbe $ \m ->

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepActivity.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepActivity.hs
@@ -56,6 +56,7 @@ hprop_check_drep_activity = integrationWorkspace "test-activity" $ \tempAbsBaseP
 
   work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
 
+  -- Create default testnet with 3 DReps and 3 stake holders delegated, one to each DRep.
   let ceo = ConwayEraOnwardsConway
       sbe = conwayEraOnwardsToShelleyBasedEra ceo
       era = toCardanoEra sbe

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/InfoAction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/InfoAction.hs
@@ -13,6 +13,7 @@ module Cardano.Testnet.Test.Gov.InfoAction
 
 import           Cardano.Api as Api
 import           Cardano.Api.Error (displayError)
+import           Cardano.Api.Ledger (EpochInterval (EpochInterval))
 import           Cardano.Api.Shelley
 
 import           Cardano.Ledger.Conway.Governance (RatifyState (..))
@@ -144,18 +145,7 @@ hprop_ledger_events_info_action = integrationRetryWorkspace 0 "info-hash" $ \tem
     , "--tx-file", txbodySignedFp
     ]
 
-  !propSubmittedResult <- findCondition (maybeExtractGovernanceActionIndex (fromString txidString))
-                                        configurationFile
-                                        socketPath
-                                        (EpochNo 10)
-
-  governanceActionIndex <- case propSubmittedResult of
-                             Left e ->
-                               H.failMessage callStack
-                                 $ "findCondition failed with: " <> displayError e
-                             Right Nothing ->
-                               H.failMessage callStack "Couldn't find proposal."
-                             Right (Just a) -> return a
+  governanceActionIndex <- H.nothingFailM $ watchEpochStateView epochStateView (return . maybeExtractGovernanceActionIndex (fromString txidString)) (EpochInterval 1)
 
   let voteFp :: Int -> FilePath
       voteFp n = work </> gov </> "vote-" <> show n

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/InfoAction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/InfoAction.hs
@@ -59,7 +59,7 @@ hprop_ledger_events_info_action = integrationRetryWorkspace 0 "info-hash" $ \tem
       era = toCardanoEra sbe
       sbe = conwayEraOnwardsToShelleyBasedEra ceo
       fastTestnetOptions = cardanoDefaultTestnetOptions
-        { cardanoEpochLength = 100
+        { cardanoEpochLength = 200
         , cardanoNodeEra = AnyCardanoEra era
         }
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs
@@ -156,7 +156,7 @@ hprop_gov_no_confidence = integrationWorkspace "no-confidence" $ \tempAbsBasePat
 
   minActDeposit <- getMinGovActionDeposit epochStateView ceo
 
-  void $ H.execCli' execConfig $
+  void $ H.execCli' execConfig
     [ eraToString era, "governance", "action", "create-no-confidence"
     , "--testnet"
     , "--governance-action-deposit", show @Integer minActDeposit

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -10,7 +9,6 @@ module Cardano.Testnet.Test.Gov.NoConfidence
   ) where
 
 import           Cardano.Api as Api
-import           Cardano.Api.Error
 import           Cardano.Api.Ledger
 import           Cardano.Api.Shelley
 
@@ -29,7 +27,6 @@ import qualified Data.Map.Strict as Map
 import           Data.Maybe.Strict
 import           Data.String
 import qualified Data.Text as Text
-import           GHC.Stack
 import           Lens.Micro
 import           System.FilePath ((</>))
 
@@ -132,9 +129,10 @@ hprop_gov_no_confidence = integrationWorkspace "no-confidence" $ \tempAbsBasePat
   H.note_ $ "Abs path: " <> tempAbsBasePath'
   H.note_ $ "Socketpath: " <> socketPath
 
-  mCommitteePresent
-    <- H.leftFailM $ findCondition (committeeIsPresent True) configurationFile (File socketPath) (EpochNo 3)
-  H.nothingFail mCommitteePresent
+  epochStateView <- getEpochStateView configurationFile (File socketPath)
+
+  H.nothingFailM $ watchEpochStateView epochStateView (return . committeeIsPresent True) (EpochInterval 3)
+
 
   -- Step 2. Propose motion of no confidence. DRep and SPO voting thresholds must be met.
 
@@ -156,7 +154,6 @@ hprop_gov_no_confidence = integrationWorkspace "no-confidence" $ \tempAbsBasePat
   cliStakeAddressKeyGen
     $ KeyPair (File stakeVkeyFp) (File stakeSKeyFp)
 
-  epochStateView <- getEpochStateView configurationFile (File socketPath)
   minActDeposit <- getMinGovActionDeposit epochStateView ceo
 
   void $ H.execCli' execConfig $
@@ -193,18 +190,7 @@ hprop_gov_no_confidence = integrationWorkspace "no-confidence" $ \tempAbsBasePat
 
   governanceActionTxId <- retrieveTransactionId execConfig signedProposalTx
 
-  !propSubmittedResult <- findCondition (maybeExtractGovernanceActionIndex (fromString governanceActionTxId))
-                                        configurationFile
-                                        (File socketPath)
-                                        (EpochNo 10)
-
-  governanceActionIndex <- case propSubmittedResult of
-                             Left e ->
-                               H.failMessage callStack
-                                 $ "findCondition failed with: " <> displayError e
-                             Right Nothing ->
-                               H.failMessage callStack "Couldn't find proposal."
-                             Right (Just a) -> return a
+  governanceActionIndex <- H.nothingFailM $ watchEpochStateView epochStateView (return . maybeExtractGovernanceActionIndex (fromString governanceActionTxId)) (EpochInterval 10)
 
   let spoVotes :: [(String, Int)]
       spoVotes =  [("yes", 1), ("yes", 2), ("yes", 3)]
@@ -236,9 +222,7 @@ hprop_gov_no_confidence = integrationWorkspace "no-confidence" $ \tempAbsBasePat
   -- Step 4. We confirm the no confidence motion has been ratified by checking
   -- for an empty constitutional committee.
 
-  mCommitteeEmpty
-    <- H.leftFailM $ findCondition (committeeIsPresent False) configurationFile (File socketPath) (EpochNo 5)
-  H.nothingFail mCommitteeEmpty
+  H.nothingFailM $ watchEpochStateView epochStateView (return . committeeIsPresent False) (EpochInterval 10)
 
 -- | Checks if the committee is empty or not.
 committeeIsPresent :: Bool -> AnyNewEpochState -> Maybe ()

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
@@ -102,7 +102,7 @@ hprop_check_predefined_abstain_drep = H.integrationWorkspace "test-activity" $ \
 
   initialDesiredNumberOfPools <- getDesiredPoolNumberValue execConfig
 
-  let newNumberOfDesiredPools = fromIntegral (initialDesiredNumberOfPools + 1)
+  let newNumberOfDesiredPools = initialDesiredNumberOfPools + 1
 
   -- Do some proposal and vote yes with the first DRep only
   -- and assert that proposal does NOT pass.
@@ -117,7 +117,7 @@ hprop_check_predefined_abstain_drep = H.integrationWorkspace "test-activity" $ \
 
   -- Do some other proposal and vote yes with first DRep only
   -- and assert the new proposal passes now.
-  let newNumberOfDesiredPools2 = fromIntegral (newNumberOfDesiredPools + 1)
+  let newNumberOfDesiredPools2 = newNumberOfDesiredPools + 1
   void $ desiredPoolNumberProposalTest execConfig epochStateView configurationFile socketPath ceo gov "secondProposal"
                                        wallet0 Nothing [(1, "yes")] newNumberOfDesiredPools2 newNumberOfDesiredPools2 2
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
@@ -188,7 +188,7 @@ desiredPoolNumberProposalTest execConfig epochStateView configurationFile socket
 
   baseDir <- H.createDirectoryIfMissing $ work </> prefix
 
-  let propVotes :: [(String, Int)]
+  let propVotes :: [DefaultDRepVote]
       propVotes = zip (concatMap (uncurry replicate) votes) [1..]
   annotateShow propVotes
 
@@ -299,18 +299,26 @@ makeDesiredPoolNumberChangeProposal execConfig epochStateView configurationFile 
 
   return (governanceActionTxId, governanceActionIndex)
 
+-- A pair of a vote string (i.e: "yes", "no", or "abstain") and the number of
+-- a default DRep (from the ones created by 'cardanoTestnetDefault')
+type DefaultDRepVote = (String, Int)
+
+-- | Create and issue votes for (or against) a government proposal with default
+-- Delegate Representative (DReps created by 'cardanoTestnetDefault') using @cardano-cli@.
 voteChangeProposal :: (MonadTest m, MonadIO m, MonadCatch m, H.MonadAssertion m)
-  => H.ExecConfig
-  -> EpochStateView
-  -> ShelleyBasedEra ConwayEra
-  -> FilePath
-  -> FilePath
-  -> String
-  -> Word32
-  -> [([Char], Int)]
-  -> PaymentKeyInfo
+  => H.ExecConfig -- ^ Specifies the CLI execution configuration.
+  -> EpochStateView -- ^ Current epoch state view for transaction building. It can be obtained
+                    -- using the 'getEpochStateView' function.
+  -> ShelleyBasedEra ConwayEra -- ^ The Shelley-based witness for ConwayEra (i.e: ShelleyBasedEraConway).
+  -> FilePath -- ^ Base directory path where the subdirectory with the intermediate files will be created.
+  -> String -- ^ Name for the subdirectory that will be created for storing the intermediate files.
+  -> String -- ^ Transaction id of the governance action to vote.
+  -> Word32 -- ^ Index of the governance action to vote in the transaction.
+  -> [DefaultDRepVote] -- ^ List of votes to issue as pairs of the vote and the number of DRep that votes it.
+  -> PaymentKeyInfo -- ^ Wallet that will pay for the transactions
   -> m ()
-voteChangeProposal execConfig epochStateView sbe work prefix governanceActionTxId governanceActionIndex votes wallet = do
+voteChangeProposal execConfig epochStateView sbe work prefix
+                   governanceActionTxId governanceActionIndex votes wallet = do
   baseDir <- H.createDirectoryIfMissing $ work </> prefix
 
   let era = toCardanoEra sbe

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
@@ -51,14 +51,19 @@ import           Hedgehog
 import qualified Hedgehog.Extras as H
 import Testnet.Components.TestWatchdog (runWithDefaultWatchdog_)
 
--- | This test creates a default testnet with three DReps and one stake holder delegated to each.
--- We then do a proposal for an arbitrary parameter change (in this case to the
--- @desiredNumberOfPools@ parameter) to check that it fails, when the first DRep votes "yes" and the
--- last two vote "no". Later we chack that if we change the stake holders under the DReps that vote
--- "no" to delegate to the automate "always abstain" DRep, the same kind of proposal passes.
+-- | This test creates a default testnet with three DReps delegated to by three
+-- separate stake holders (one per DRep). We then do a proposal for an arbitrary
+-- parameter change (in this case to the @desiredNumberOfPools@ parameter) to check
+-- that it fails, when the first DRep votes "yes" and the last two vote "no". Later
+-- we chack that if we change the stake holders under the DReps that vote "no" to
+-- delegate to the automate "always abstain" DRep, the same kind of proposal passes.
+-- If the proposal passes, it means that the stake was counted as abstaining,
+-- because the threshold of minimum participation is 50%, if the stake was not counted as
+-- abstaining, the "yes" votes would not have been enough, since they only account
+-- for the 33% of the total active stake.
 --
--- This test is meant to ensure that delegating to "always abstain" has the desired effect of
--- counting as abstaining for the stake delegated.
+-- This test is meant to ensure that delegating to "always abstain" has the desired
+-- effect of counting as abstaining for the stake delegated.
 --
 -- Execute me with:
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/Predefined Abstain DRep/"'@

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
@@ -46,7 +46,16 @@ import           Testnet.Types (KeyPair (..),
 import           Hedgehog
 import qualified Hedgehog.Extras as H
 
--- | Execute me with:
+-- | This test creates a default testnet with three DReps and one stake holder delegated to each.
+-- We then do a proposal for an arbitrary parameter change (in this case to the
+-- @desiredNumberOfPools@ parameter) to check that it fails, when the first DRep votes "yes" and the
+-- last two vote "no". Later we chack that if we change the stake holders under the DReps that vote
+-- "no" to delegate to the automate "always abstain" DRep, the same kind of proposal passes.
+-- 
+-- This test is meant to ensure that delegating to "always abstain" has the desired effect of
+-- counting as abstaining for the stake delegated.
+--
+-- Execute me with:
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/Predefined Abstain DRep/"'@
 hprop_check_predefined_abstain_drep :: Property
 hprop_check_predefined_abstain_drep = H.integrationWorkspace "test-activity" $ \tempAbsBasePath' -> do

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
@@ -14,10 +14,12 @@ import           Cardano.Api as Api
 import           Cardano.Api.Eon.ShelleyBasedEra (ShelleyLedgerEra)
 import           Cardano.Api.Error (displayError)
 import           Cardano.Api.IO.Base (Socket)
+import           Cardano.Api.Ledger (EpochInterval (EpochInterval))
 
 import           Cardano.Ledger.Conway.Core (ppNOptL)
 import           Cardano.Ledger.Conway.Governance (ConwayGovState, cgsCurPParamsL)
 import           Cardano.Ledger.Core (EraPParams)
+import           Cardano.Ledger.Shelley.LedgerState (epochStateGovStateL, nesEpochStateL)
 import           Cardano.Testnet
 
 import           Prelude
@@ -32,7 +34,8 @@ import           Lens.Micro ((^.))
 import           System.FilePath ((</>))
 
 import           Testnet.Components.Query (EpochStateView, findLargestUtxoForPaymentKey,
-                   getCurrentEpochNo, getEpochStateView, getGovState, getMinDRepDeposit)
+                   getCurrentEpochNo, getEpochStateView, getGovState, getMinDRepDeposit,
+                   waitAndCheckNewEpochState)
 import           Testnet.Defaults (defaultDRepKeyPair, defaultDelegatorStakeKeyPair)
 import           Testnet.Process.Cli.DRep (createCertificatePublicationTxBody, createVotingTxBody,
                    generateVoteFiles)
@@ -109,7 +112,7 @@ hprop_check_predefined_abstain_drep = H.integrationWorkspace "test-activity" $ \
   -- Do some proposal and vote yes with the first DRep only
   -- and assert that proposal does NOT pass.
   void $ desiredPoolNumberProposalTest execConfig epochStateView configurationFile socketPath ceo gov "firstProposal"
-                                       wallet0 Nothing [(1, "yes")] newNumberOfDesiredPools initialDesiredNumberOfPools 2
+                                       wallet0 Nothing [(1, "yes")] newNumberOfDesiredPools 3 (Just initialDesiredNumberOfPools) 10
 
   -- Take the last two stake delegators and delegate them to "Abstain".
   delegateToAlwaysAbstain execConfig epochStateView configurationFile socketPath sbe gov "delegateToAbstain1"
@@ -121,7 +124,7 @@ hprop_check_predefined_abstain_drep = H.integrationWorkspace "test-activity" $ \
   -- and assert the new proposal passes now.
   let newNumberOfDesiredPools2 = newNumberOfDesiredPools + 1
   void $ desiredPoolNumberProposalTest execConfig epochStateView configurationFile socketPath ceo gov "secondProposal"
-                                       wallet0 Nothing [(1, "yes")] newNumberOfDesiredPools2 newNumberOfDesiredPools2 2
+                                       wallet0 Nothing [(1, "yes")] newNumberOfDesiredPools2 0 (Just newNumberOfDesiredPools2) 10
 
 delegateToAlwaysAbstain
   :: (HasCallStack, MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m)
@@ -184,11 +187,12 @@ desiredPoolNumberProposalTest
   -> t (Int, String) -- ^ Model of votes to issue as a list of pairs of amount of each vote
                      -- together with the vote (i.e: "yes", "no", "abstain")
   -> Integer -- ^ What to change the @desiredPoolNumber@ to
-  -> Integer -- ^ What the expected result is of the change
-  -> Integer -- ^ How many epochs to wait before checking the result
+  -> Integer -- ^ Minimum number of epochs to wait before checking the result
+  -> Maybe Integer -- ^ What the expected result is of the change (if anything)
+  -> Integer -- ^ Maximum number of epochs to wait while waiting for the result
   -> m (String, Word32)
 desiredPoolNumberProposalTest execConfig epochStateView configurationFile socketPath ceo work prefix
-                              wallet previousProposalInfo votes change expected epochsToWait = do
+                              wallet previousProposalInfo votes change minWait mExpected maxWait = do
   let sbe = conwayEraOnwardsToShelleyBasedEra ceo
 
   baseDir <- H.createDirectoryIfMissing $ work </> prefix
@@ -207,10 +211,10 @@ desiredPoolNumberProposalTest execConfig epochStateView configurationFile socket
   (EpochNo epochAfterProp) <- getCurrentEpochNo epochStateView
   H.note_ $ "Epoch after \"" <> prefix <> "\" prop: " <> show epochAfterProp
 
-  void $ waitUntilEpoch configurationFile socketPath (EpochNo (epochAfterProp + fromIntegral epochsToWait))
-  desiredPoolNumberAfterProp <- getDesiredPoolNumberValue epochStateView ceo
-
-  desiredPoolNumberAfterProp === expected
+  waitAndCheckNewEpochState epochStateView configurationFile socketPath ceo
+                            (EpochInterval (fromIntegral minWait)) (fromIntegral <$> mExpected)
+                            (EpochInterval (fromIntegral maxWait))
+                            (nesEpochStateL . epochStateGovStateL . cgsCurPParamsL . ppNOptL)
 
   return thisProposal
 
@@ -291,10 +295,12 @@ makeDesiredPoolNumberChangeProposal execConfig epochStateView configurationFile 
 
   governanceActionTxId <- retrieveTransactionId execConfig signedProposalTx
 
+  (EpochNo curEpoch) <- getCurrentEpochNo epochStateView
+
   !propSubmittedResult <- findCondition (maybeExtractGovernanceActionIndex (fromString governanceActionTxId))
                                         configurationFile
                                         socketPath
-                                        (EpochNo 30)
+                                        (EpochNo $ curEpoch + 10)
 
   governanceActionIndex <- case propSubmittedResult of
                              Left e ->

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Testnet.Test.Gov.PredefinedAbstainDRep
+  ( hprop_check_predefined_abstain_drep
+  ) where
+
+import           Cardano.Api as Api
+
+import           Cardano.Testnet
+
+import           Prelude
+
+import           System.FilePath ((</>))
+
+import           Testnet.Components.Query (getEpochStateView)
+import qualified Testnet.Process.Run as H
+import qualified Testnet.Property.Util as H
+import           Testnet.Runtime
+import           Testnet.Types (PoolNode (..), TestnetRuntime (..), nodeSocketPath)
+
+import           Hedgehog
+import qualified Hedgehog.Extras as H
+
+-- | Execute me with:
+-- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/Predefined Abstain DRep/"'@
+hprop_check_predefined_abstain_drep :: Property
+hprop_check_predefined_abstain_drep = H.integrationWorkspace "test-activity" $ \tempAbsBasePath' -> do
+    -- Start a local test net
+  conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
+  let tempAbsPath' = unTmpAbsPath tempAbsPath
+      tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
+  work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
+
+  let ceo = ConwayEraOnwardsConway
+      sbe = conwayEraOnwardsToShelleyBasedEra ceo
+      era = toCardanoEra sbe
+      cEra = AnyCardanoEra era
+      fastTestnetOptions = cardanoDefaultTestnetOptions
+        { cardanoEpochLength = 100
+        , cardanoNodeEra = cEra
+        , cardanoNumDReps = 1
+        }
+
+  testnetRuntime@TestnetRuntime
+    { testnetMagic
+    , poolNodes
+    , wallets=_wallet0:_wallet1:_wallet2:_
+    , configurationFile
+    }
+    <- cardanoTestnetDefault fastTestnetOptions conf
+
+  PoolNode{poolRuntime} <- H.headM poolNodes
+  poolSprocket1 <- H.noteShow $ nodeSprocket poolRuntime
+  _execConfig <- H.mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
+  let socketPath = nodeSocketPath poolRuntime
+
+  _epochStateView <- getEpochStateView configurationFile socketPath
+
+  startLedgerNewEpochStateLogging testnetRuntime tempAbsPath'
+
+  H.note_ $ "Sprocket: " <> show poolSprocket1
+  H.note_ $ "Abs path: " <> tempAbsBasePath'
+  H.note_ $ "Socketpath: " <> unFile socketPath
+  H.note_ $ "Foldblocks config file: " <> unFile configurationFile
+
+  _gov <- H.createDirectoryIfMissing $ work </> "governance"
+
+  -- ToDo: Do some proposal and vote yes with the first DRep only.
+  -- ToDo: ASSERT: Check that proposal does NOT pass.
+  -- ToDo: Take the last two stake delegators and delegate them to "Abstain".
+  -- ToDo: This can be done using cardano-cli conway stake-address vote-delegation-certificate --always-abstain
+  -- ToDo: Do some other proposal and vote yes with first DRep only.
+  -- ToDo: ASSERT: Check the new proposal passes now.
+
+  success

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
@@ -355,8 +355,8 @@ voteChangeProposal execConfig epochStateView sbe work prefix
 -- The @desiredPoolNumberValue@ or (@k@ in the spec) is the protocol parameter
 -- that defines what is the optimal number of SPOs. It is a tradeoff between
 -- decentralization and efficiency and the spec suggest it should be between 100 an 1000.
--- Changing this parameter will inderectly affect how easy it is to saturate a pool in order to
--- incentivize that the number of SPOs states close to the parameter value.
+-- Changing this parameter will indirectly affect how easy it is to saturate a pool in order to
+-- incentivize that the number of SPOs stays close to the parameter value.
 getDesiredPoolNumberValue :: (EraPParams (ShelleyLedgerEra era), H.MonadAssertion m, MonadTest m, MonadIO m)
   => EpochStateView
   -> ConwayEraOnwards era

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
@@ -327,6 +327,12 @@ voteChangeProposal execConfig epochStateView sbe work prefix governanceActionTxI
                      (SomeKeyPair (paymentKeyInfoPair wallet):[SomeKeyPair $ defaultDRepKeyPair n | (_, n) <- votes])
   submitTx execConfig cEra voteTxFp
 
+-- | Obtains the @desiredPoolNumberValue@ from the protocol parameters.
+-- The @desiredPoolNumberValue@ or (@k@ in the spec) is the protocol parameter
+-- that defines what is the optimal number of SPOs. It is a tradeoff between
+-- decentralization and efficiency and the spec suggest it should be between 100 an 1000.
+-- Changing this parameter will inderectly affect how easy it is to saturate a pool in order to
+-- incentivize that the number of SPOs states close to the parameter value.
 getDesiredPoolNumberValue :: (MonadTest m, MonadCatch m, MonadIO m) => H.ExecConfig -> m Integer
 getDesiredPoolNumberValue execConfig = do
   govStateString <- H.execCli' execConfig

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
@@ -1,25 +1,47 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Cardano.Testnet.Test.Gov.PredefinedAbstainDRep
   ( hprop_check_predefined_abstain_drep
   ) where
 
 import           Cardano.Api as Api
+import           Cardano.Api.Error (displayError)
+import           Cardano.Api.IO.Base (Socket)
 
 import           Cardano.Testnet
 
 import           Prelude
 
+import           Control.Monad (void)
+import           Control.Monad.Catch (MonadCatch)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Lens as AL
+import           Data.ByteString.Lazy.Char8 (pack)
+import           Data.String (fromString)
+import qualified Data.Text as Text
+import           Data.Word (Word32)
+import           GHC.Stack (callStack)
+import           Lens.Micro ((^?))
 import           System.FilePath ((</>))
 
-import           Testnet.Components.Query (getEpochStateView)
+import           Testnet.Components.Query (EpochStateView, findLargestUtxoForPaymentKey,
+                   getCurrentEpochNo, getEpochStateView, getMinDRepDeposit)
+import           Testnet.Defaults (defaultDRepKeyPair, defaultDelegatorStakeKeyPair)
+import           Testnet.Process.Cli.DRep (createCertificatePublicationTxBody, createVotingTxBody,
+                   generateVoteFiles)
+import qualified Testnet.Process.Cli.Keys as P
+import           Testnet.Process.Cli.Transaction (retrieveTransactionId, signTx, submitTx)
 import qualified Testnet.Process.Run as H
 import qualified Testnet.Property.Util as H
 import           Testnet.Runtime
-import           Testnet.Types (PoolNode (..), TestnetRuntime (..), nodeSocketPath)
+import           Testnet.Types (KeyPair (..),
+                   PaymentKeyInfo (paymentKeyInfoAddr, paymentKeyInfoPair), PoolNode (..),
+                   SomeKeyPair (SomeKeyPair), StakingKey, TestnetRuntime (..), nodeSocketPath)
 
 import           Hedgehog
 import qualified Hedgehog.Extras as H
@@ -28,12 +50,13 @@ import qualified Hedgehog.Extras as H
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/Predefined Abstain DRep/"'@
 hprop_check_predefined_abstain_drep :: Property
 hprop_check_predefined_abstain_drep = H.integrationWorkspace "test-activity" $ \tempAbsBasePath' -> do
-    -- Start a local test net
+  -- Start a local test net
   conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
       tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
   work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
 
+  -- Create default testnet with 3 DReps and 3 stake holders delegated, one to each DRep.
   let ceo = ConwayEraOnwardsConway
       sbe = conwayEraOnwardsToShelleyBasedEra ceo
       era = toCardanoEra sbe
@@ -41,23 +64,23 @@ hprop_check_predefined_abstain_drep = H.integrationWorkspace "test-activity" $ \
       fastTestnetOptions = cardanoDefaultTestnetOptions
         { cardanoEpochLength = 100
         , cardanoNodeEra = cEra
-        , cardanoNumDReps = 1
+        , cardanoNumDReps = 3
         }
 
   testnetRuntime@TestnetRuntime
     { testnetMagic
     , poolNodes
-    , wallets=_wallet0:_wallet1:_wallet2:_
+    , wallets=wallet0:wallet1:wallet2:_
     , configurationFile
     }
     <- cardanoTestnetDefault fastTestnetOptions conf
 
   PoolNode{poolRuntime} <- H.headM poolNodes
   poolSprocket1 <- H.noteShow $ nodeSprocket poolRuntime
-  _execConfig <- H.mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
+  execConfig <- H.mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
   let socketPath = nodeSocketPath poolRuntime
 
-  _epochStateView <- getEpochStateView configurationFile socketPath
+  epochStateView <- getEpochStateView configurationFile socketPath
 
   startLedgerNewEpochStateLogging testnetRuntime tempAbsPath'
 
@@ -66,13 +89,246 @@ hprop_check_predefined_abstain_drep = H.integrationWorkspace "test-activity" $ \
   H.note_ $ "Socketpath: " <> unFile socketPath
   H.note_ $ "Foldblocks config file: " <> unFile configurationFile
 
-  _gov <- H.createDirectoryIfMissing $ work </> "governance"
+  gov <- H.createDirectoryIfMissing $ work </> "governance"
 
-  -- ToDo: Do some proposal and vote yes with the first DRep only.
-  -- ToDo: ASSERT: Check that proposal does NOT pass.
-  -- ToDo: Take the last two stake delegators and delegate them to "Abstain".
-  -- ToDo: This can be done using cardano-cli conway stake-address vote-delegation-certificate --always-abstain
-  -- ToDo: Do some other proposal and vote yes with first DRep only.
-  -- ToDo: ASSERT: Check the new proposal passes now.
+  initialDesiredNumberOfPools <- getDesiredPoolNumberValue execConfig
 
-  success
+  let newNumberOfDesiredPools = fromIntegral (initialDesiredNumberOfPools + 1)
+
+  -- Do some proposal and vote yes with the first DRep only
+  -- and assert that proposal does NOT pass.
+  void $ desiredPoolNumberProposalTest execConfig epochStateView configurationFile socketPath ceo gov "firstProposal"
+                                       wallet0 Nothing [(1, "yes")] newNumberOfDesiredPools initialDesiredNumberOfPools 2
+
+  -- Take the last two stake delegators and delegate them to "Abstain".
+  delegateToAlwaysAbstain execConfig epochStateView configurationFile socketPath sbe gov "delegateToAbstain1"
+                          wallet1 (defaultDelegatorStakeKeyPair 2)
+  delegateToAlwaysAbstain execConfig epochStateView configurationFile socketPath sbe gov "delegateToAbstain2"
+                          wallet2 (defaultDelegatorStakeKeyPair 3)
+
+  -- Do some other proposal and vote yes with first DRep only
+  -- and assert the new proposal passes now.
+  let newNumberOfDesiredPools2 = fromIntegral (newNumberOfDesiredPools + 1)
+  void $ desiredPoolNumberProposalTest execConfig epochStateView configurationFile socketPath ceo gov "secondProposal"
+                                       wallet0 Nothing [(1, "yes")] newNumberOfDesiredPools2 newNumberOfDesiredPools2 2
+
+delegateToAlwaysAbstain
+  :: (MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m)
+  => H.ExecConfig
+  -> EpochStateView
+  -> NodeConfigFile 'In
+  -> File Socket 'InOut
+  -> ShelleyBasedEra ConwayEra
+  -> FilePath
+  -> String
+  -> PaymentKeyInfo
+  -> KeyPair StakingKey
+  -> m ()
+delegateToAlwaysAbstain execConfig epochStateView configurationFile socketPath sbe work prefix
+                        payingWallet skeyPair@(KeyPair vKeyFile _sKeyFile) = do
+
+  let era = toCardanoEra sbe
+      cEra = AnyCardanoEra era
+
+  baseDir <- H.createDirectoryIfMissing $ work </> prefix
+
+  -- Create vote delegation certificate
+  let voteDelegationCertificatePath = baseDir </> "delegation-certificate.delegcert"
+  void $ H.execCli' execConfig
+    [ "conway", "stake-address", "vote-delegation-certificate"
+    , "--always-abstain"
+    , "--stake-verification-key-file", unFile vKeyFile
+    , "--out-file", voteDelegationCertificatePath
+    ]
+
+  -- Compose transaction to publish delegation certificate
+  repRegTxBody1 <- createCertificatePublicationTxBody execConfig epochStateView sbe baseDir "del-cert-txbody"
+                                                      (File voteDelegationCertificatePath) payingWallet
+
+  -- Sign transaction
+  repRegSignedRegTx1 <- signTx execConfig cEra baseDir "signed-reg-tx"
+                               repRegTxBody1 [ SomeKeyPair (paymentKeyInfoPair payingWallet)
+                                             , SomeKeyPair skeyPair]
+
+  -- Submit transaction
+  submitTx execConfig cEra repRegSignedRegTx1
+
+  -- Wait two epochs
+  (EpochNo epochAfterProp) <- getCurrentEpochNo epochStateView
+  void $ waitUntilEpoch configurationFile socketPath (EpochNo (epochAfterProp + 2))
+
+desiredPoolNumberProposalTest
+  :: (MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m, Foldable t)
+  => H.ExecConfig
+  -> EpochStateView
+  -> NodeConfigFile 'In
+  -> File Socket 'InOut
+  -> ConwayEraOnwards ConwayEra
+  -> FilePath
+  -> FilePath
+  -> PaymentKeyInfo
+  -> Maybe (String, Word32)
+  -> t (Int, String)
+  -> Integer
+  -> Integer
+  -> Integer
+  -> m (String, Word32)
+desiredPoolNumberProposalTest execConfig epochStateView configurationFile socketPath ceo work prefix
+                              wallet previousProposalInfo votes change expected epochsToWait = do
+  let sbe = conwayEraOnwardsToShelleyBasedEra ceo
+
+  baseDir <- H.createDirectoryIfMissing $ work </> prefix
+
+  let propVotes :: [(String, Int)]
+      propVotes = zip (concatMap (uncurry replicate) votes) [1..]
+  annotateShow propVotes
+
+  thisProposal@(governanceActionTxId, governanceActionIndex) <-
+    makeDesiredPoolNumberChangeProposal execConfig epochStateView configurationFile socketPath
+                                            ceo baseDir "proposal" previousProposalInfo (fromIntegral change) wallet
+
+  voteChangeProposal execConfig epochStateView sbe baseDir "vote"
+                     governanceActionTxId governanceActionIndex propVotes wallet
+
+  (EpochNo epochAfterProp) <- getCurrentEpochNo epochStateView
+  H.note_ $ "Epoch after \"" <> prefix <> "\" prop: " <> show epochAfterProp
+
+  void $ waitUntilEpoch configurationFile socketPath (EpochNo (epochAfterProp + fromIntegral epochsToWait))
+  desiredPoolNumberAfterProp <- getDesiredPoolNumberValue execConfig
+
+  desiredPoolNumberAfterProp === expected
+
+  return thisProposal
+
+makeDesiredPoolNumberChangeProposal
+  :: (H.MonadAssertion m, MonadTest m, MonadCatch m, MonadIO m)
+  => H.ExecConfig
+  -> EpochStateView
+  -> NodeConfigFile 'In
+  -> SocketPath
+  -> ConwayEraOnwards ConwayEra
+  -> FilePath
+  -> String
+  -> Maybe (String, Word32)
+  -> Word32
+  -> PaymentKeyInfo
+  -> m (String, Word32)
+makeDesiredPoolNumberChangeProposal execConfig epochStateView configurationFile socketPath
+                                    ceo work prefix prevGovActionInfo desiredPoolNumber wallet = do
+
+  let sbe = conwayEraOnwardsToShelleyBasedEra ceo
+      era = toCardanoEra sbe
+      cEra = AnyCardanoEra era
+
+  baseDir <- H.createDirectoryIfMissing $ work </> prefix
+
+  let stakeVkeyFp = baseDir </> "stake.vkey"
+      stakeSKeyFp = baseDir </> "stake.skey"
+
+  P.cliStakeAddressKeyGen
+    $ KeyPair { verificationKey = File stakeVkeyFp
+              , signingKey = File stakeSKeyFp
+              }
+
+  proposalAnchorFile <- H.note $ baseDir </> "sample-proposal-anchor"
+  H.writeFile proposalAnchorFile "dummy anchor data"
+
+  proposalAnchorDataHash <- H.execCli' execConfig
+    [ "conway", "governance"
+    , "hash", "anchor-data", "--file-text", proposalAnchorFile
+    ]
+
+  minDRepDeposit <- getMinDRepDeposit epochStateView ceo
+
+  proposalFile <- H.note $ baseDir </> "sample-proposal-file"
+
+  void $ H.execCli' execConfig $
+    [ "conway", "governance", "action", "create-protocol-parameters-update"
+    , "--testnet"
+    , "--governance-action-deposit", show @Integer minDRepDeposit
+    , "--deposit-return-stake-verification-key-file", stakeVkeyFp
+    ] ++ concatMap (\(prevGovernanceActionTxId, prevGovernanceActionIndex) ->
+                      [ "--prev-governance-action-tx-id", prevGovernanceActionTxId
+                      , "--prev-governance-action-index", show prevGovernanceActionIndex
+                      ]) prevGovActionInfo ++
+    [ "--number-of-pools", show desiredPoolNumber
+    , "--anchor-url", "https://tinyurl.com/3wrwb2as"
+    , "--anchor-data-hash", proposalAnchorDataHash
+    , "--out-file", proposalFile
+    ]
+
+  proposalBody <- H.note $ baseDir </> "tx.body"
+  txIn <- findLargestUtxoForPaymentKey epochStateView sbe wallet
+
+  void $ H.execCli' execConfig
+    [ "conway", "transaction", "build"
+    , "--change-address", Text.unpack $ paymentKeyInfoAddr wallet
+    , "--tx-in", Text.unpack $ renderTxIn txIn
+    , "--proposal-file", proposalFile
+    , "--out-file", proposalBody
+    ]
+
+  signedProposalTx <- signTx execConfig cEra baseDir "signed-proposal"
+                             (File proposalBody) [SomeKeyPair $ paymentKeyInfoPair wallet]
+
+  submitTx execConfig cEra signedProposalTx
+
+  governanceActionTxId <- retrieveTransactionId execConfig signedProposalTx
+
+  !propSubmittedResult <- findCondition (maybeExtractGovernanceActionIndex (fromString governanceActionTxId))
+                                        configurationFile
+                                        socketPath
+                                        (EpochNo 30)
+
+  governanceActionIndex <- case propSubmittedResult of
+                             Left e ->
+                               H.failMessage callStack
+                                 $ "findCondition failed with: " <> displayError e
+                             Right Nothing ->
+                               H.failMessage callStack "Couldn't find proposal."
+                             Right (Just a) -> return a
+
+  return (governanceActionTxId, governanceActionIndex)
+
+voteChangeProposal :: (MonadTest m, MonadIO m, MonadCatch m, H.MonadAssertion m)
+  => H.ExecConfig
+  -> EpochStateView
+  -> ShelleyBasedEra ConwayEra
+  -> FilePath
+  -> FilePath
+  -> String
+  -> Word32
+  -> [([Char], Int)]
+  -> PaymentKeyInfo
+  -> m ()
+voteChangeProposal execConfig epochStateView sbe work prefix governanceActionTxId governanceActionIndex votes wallet = do
+  baseDir <- H.createDirectoryIfMissing $ work </> prefix
+
+  let era = toCardanoEra sbe
+      cEra = AnyCardanoEra era
+
+  voteFiles <- generateVoteFiles execConfig baseDir "vote-files"
+                                 governanceActionTxId governanceActionIndex
+                                 [(defaultDRepKeyPair idx, vote) | (vote, idx) <- votes]
+
+  voteTxBodyFp <- createVotingTxBody execConfig epochStateView sbe baseDir "vote-tx-body"
+                                     voteFiles wallet
+
+  voteTxFp <- signTx execConfig cEra baseDir "signed-vote-tx" voteTxBodyFp
+                     (SomeKeyPair (paymentKeyInfoPair wallet):[SomeKeyPair $ defaultDRepKeyPair n | (_, n) <- votes])
+  submitTx execConfig cEra voteTxFp
+
+getDesiredPoolNumberValue :: (MonadTest m, MonadCatch m, MonadIO m) => H.ExecConfig -> m Integer
+getDesiredPoolNumberValue execConfig = do
+  govStateString <- H.execCli' execConfig
+    [ "conway", "query", "gov-state"
+    , "--volatile-tip"
+    ]
+
+  govStateJSON <- H.nothingFail (Aeson.decode (pack govStateString) :: Maybe Aeson.Value)
+  let mTargetPoolNum :: Maybe Integer
+      mTargetPoolNum = govStateJSON
+                             ^? AL.key "currentPParams"
+                              . AL.key "stakePoolTargetNum"
+                              . AL._Integer
+  evalMaybe mTargetPoolNum

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
@@ -43,7 +43,6 @@ import qualified Testnet.Process.Cli.Keys as P
 import           Testnet.Process.Cli.Transaction (retrieveTransactionId, signTx, submitTx)
 import qualified Testnet.Process.Run as H
 import qualified Testnet.Property.Util as H
-import           Testnet.Runtime
 import           Testnet.Types (KeyPair (..),
                    PaymentKeyInfo (paymentKeyInfoAddr, paymentKeyInfoPair), PoolNode (..),
                    SomeKeyPair (SomeKeyPair), StakingKey, TestnetRuntime (..), nodeSocketPath)
@@ -82,7 +81,7 @@ hprop_check_predefined_abstain_drep = H.integrationWorkspace "test-activity" $ \
         , cardanoNumDReps = 3
         }
 
-  testnetRuntime@TestnetRuntime
+  TestnetRuntime
     { testnetMagic
     , poolNodes
     , wallets=wallet0:wallet1:wallet2:_
@@ -96,8 +95,6 @@ hprop_check_predefined_abstain_drep = H.integrationWorkspace "test-activity" $ \
   let socketPath = nodeSocketPath poolRuntime
 
   epochStateView <- getEpochStateView configurationFile socketPath
-
-  startLedgerNewEpochStateLogging testnetRuntime tempAbsPath'
 
   H.note_ $ "Sprocket: " <> show poolSprocket1
   H.note_ $ "Abs path: " <> tempAbsBasePath'

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
@@ -123,15 +123,16 @@ hprop_check_predefined_abstain_drep = H.integrationWorkspace "test-activity" $ \
 
 delegateToAlwaysAbstain
   :: (HasCallStack, MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m)
-  => H.ExecConfig
-  -> EpochStateView
-  -> NodeConfigFile 'In
-  -> File Socket 'InOut
-  -> ShelleyBasedEra ConwayEra
-  -> FilePath
-  -> String
-  -> PaymentKeyInfo
-  -> KeyPair StakingKey
+  => H.ExecConfig -- ^ Specifies the CLI execution configuration.
+  -> EpochStateView -- ^ Current epoch state view for transaction building. It can be obtained
+                    -- using the 'getEpochStateView' function.
+  -> NodeConfigFile 'In -- ^ Path to the node configuration file as returned by 'cardanoTestnetDefault'.
+  -> File Socket 'InOut -- ^ Path to the cardano-node unix socket file.
+  -> ShelleyBasedEra ConwayEra -- ^ The Shelley-based era (e.g., 'ConwayEra') in which the transaction will be constructed.
+  -> FilePath -- ^ Base directory path where generated files will be stored.
+  -> String -- ^ Name for the subfolder that will be created under 'work' folder.
+  -> PaymentKeyInfo -- ^ Wallet that will pay for the transaction.
+  -> KeyPair StakingKey -- ^ Staking key pair used for delegation.
   -> m ()
 delegateToAlwaysAbstain execConfig epochStateView configurationFile socketPath sbe work prefix
                         payingWallet skeyPair@(KeyPair vKeyFile _sKeyFile) = do
@@ -168,19 +169,21 @@ delegateToAlwaysAbstain execConfig epochStateView configurationFile socketPath s
 
 desiredPoolNumberProposalTest
   :: (HasCallStack, MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m, Foldable t)
-  => H.ExecConfig
-  -> EpochStateView
-  -> NodeConfigFile 'In
-  -> File Socket 'InOut
-  -> ConwayEraOnwards ConwayEra
-  -> FilePath
-  -> FilePath
-  -> PaymentKeyInfo
-  -> Maybe (String, Word32)
-  -> t (Int, String)
-  -> Integer
-  -> Integer
-  -> Integer
+  => H.ExecConfig -- ^ Specifies the CLI execution configuration.
+  -> EpochStateView -- ^ Current epoch state view for transaction building. It can be obtained
+  -> NodeConfigFile 'In -- ^ Path to the node configuration file as returned by 'cardanoTestnetDefault'.
+  -> File Socket 'InOut -- ^ Path to the cardano-node unix socket file.
+  -> ConwayEraOnwards ConwayEra -- ^ The ConwaysEraOnwards witness for the Conway era
+  -> FilePath -- ^ Base directory path where generated files will be stored.
+  -> String -- ^ Name for the subfolder that will be created under 'work' folder.
+  -> PaymentKeyInfo -- ^ Wallet that will pay for the transaction.
+  -> Maybe (String, Word32) -- ^ The transaction identifier and index of the previous passed
+                            -- governance action if any.
+  -> t (Int, String) -- ^ Model of votes to issue as a list of pairs of amount of each vote
+                     -- together with the vote (i.e: "yes", "no", "abstain")
+  -> Integer -- ^ What to change the @desiredPoolNumber@ to
+  -> Integer -- ^ What the expected result is of the change
+  -> Integer -- ^ How many epochs to wait before checking the result
   -> m (String, Word32)
 desiredPoolNumberProposalTest execConfig epochStateView configurationFile socketPath ceo work prefix
                               wallet previousProposalInfo votes change expected epochsToWait = do
@@ -211,16 +214,18 @@ desiredPoolNumberProposalTest execConfig epochStateView configurationFile socket
 
 makeDesiredPoolNumberChangeProposal
   :: (HasCallStack, H.MonadAssertion m, MonadTest m, MonadCatch m, MonadIO m)
-  => H.ExecConfig
-  -> EpochStateView
-  -> NodeConfigFile 'In
-  -> SocketPath
-  -> ConwayEraOnwards ConwayEra
-  -> FilePath
-  -> String
-  -> Maybe (String, Word32)
-  -> Word32
-  -> PaymentKeyInfo
+  => H.ExecConfig -- ^ Specifies the CLI execution configuration.
+  -> EpochStateView -- ^ Current epoch state view for transaction building. It can be obtained
+  -> NodeConfigFile 'In -- ^ Absolute path to the "configuration.yaml" file for the testnet
+                        -- as returned by the 'cardanoTestnetDefault' function.
+  -> SocketPath -- ^ Path to the cardano-node unix socket file.
+  -> ConwayEraOnwards ConwayEra -- ^ The conway era onwards witness for the era in which the transaction will be constructed.
+  -> FilePath -- ^ Base directory path where generated files will be stored.
+  -> String -- ^ Name for the subfolder that will be created under 'work' folder.
+  -> Maybe (String, Word32) -- ^ The transaction identifier and index of the previous passed
+                            -- governance action if any.
+  -> Word32 -- ^ What to change the @desiredPoolNumber@ to
+  -> PaymentKeyInfo -- ^ Wallet that will pay for the transaction.
   -> m (String, Word32)
 makeDesiredPoolNumberChangeProposal execConfig epochStateView configurationFile socketPath
                                     ceo work prefix prevGovActionInfo desiredPoolNumber wallet = do

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
@@ -50,6 +50,8 @@ import           Testnet.Types (KeyPair (..),
 import           Hedgehog
 import qualified Hedgehog.Extras as H
 import Testnet.Components.TestWatchdog (runWithDefaultWatchdog_)
+import Testnet.Components.Configuration (anyEraToString)
+import Data.Data (Typeable)
 
 -- | This test creates a default testnet with three DReps delegated to by three
 -- separate stake holders (one per DRep). We then do a proposal for an arbitrary
@@ -130,13 +132,13 @@ hprop_check_predefined_abstain_drep = H.integrationWorkspace "test-activity" $ \
                                        wallet0 Nothing [(1, "yes")] newNumberOfDesiredPools2 0 (Just newNumberOfDesiredPools2) 10
 
 delegateToAlwaysAbstain
-  :: (HasCallStack, MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m)
+  :: (HasCallStack, MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m, Typeable era)
   => H.ExecConfig -- ^ Specifies the CLI execution configuration.
   -> EpochStateView -- ^ Current epoch state view for transaction building. It can be obtained
                     -- using the 'getEpochStateView' function.
   -> NodeConfigFile 'In -- ^ Path to the node configuration file as returned by 'cardanoTestnetDefault'.
   -> File Socket 'InOut -- ^ Path to the cardano-node unix socket file.
-  -> ShelleyBasedEra ConwayEra -- ^ The Shelley-based era (e.g., 'ConwayEra') in which the transaction will be constructed.
+  -> ShelleyBasedEra era -- ^ The Shelley-based era (e.g., 'ConwayEra') in which the transaction will be constructed.
   -> FilePath -- ^ Base directory path where generated files will be stored.
   -> String -- ^ Name for the subfolder that will be created under 'work' folder.
   -> PaymentKeyInfo -- ^ Wallet that will pay for the transaction.
@@ -153,7 +155,7 @@ delegateToAlwaysAbstain execConfig epochStateView configurationFile socketPath s
   -- Create vote delegation certificate
   let voteDelegationCertificatePath = baseDir </> "delegation-certificate.delegcert"
   void $ H.execCli' execConfig
-    [ "conway", "stake-address", "vote-delegation-certificate"
+    [ anyEraToString cEra, "stake-address", "vote-delegation-certificate"
     , "--always-abstain"
     , "--stake-verification-key-file", unFile vKeyFile
     , "--out-file", voteDelegationCertificatePath

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
@@ -120,9 +120,9 @@ hprop_check_predefined_abstain_drep = H.integrationWorkspace "test-activity" $ \
                                        wallet0 Nothing [(1, "yes")] newNumberOfDesiredPools 3 (Just initialDesiredNumberOfPools) 10
 
   -- Take the last two stake delegators and delegate them to "Abstain".
-  delegateToAlwaysAbstain execConfig epochStateView configurationFile socketPath sbe gov "delegateToAbstain1"
+  delegateToAlwaysAbstain execConfig epochStateView sbe gov "delegateToAbstain1"
                           wallet1 (defaultDelegatorStakeKeyPair 2)
-  delegateToAlwaysAbstain execConfig epochStateView configurationFile socketPath sbe gov "delegateToAbstain2"
+  delegateToAlwaysAbstain execConfig epochStateView sbe gov "delegateToAbstain2"
                           wallet2 (defaultDelegatorStakeKeyPair 3)
 
   -- Do some other proposal and vote yes with first DRep only
@@ -136,15 +136,13 @@ delegateToAlwaysAbstain
   => H.ExecConfig -- ^ Specifies the CLI execution configuration.
   -> EpochStateView -- ^ Current epoch state view for transaction building. It can be obtained
                     -- using the 'getEpochStateView' function.
-  -> NodeConfigFile 'In -- ^ Path to the node configuration file as returned by 'cardanoTestnetDefault'.
-  -> File Socket 'InOut -- ^ Path to the cardano-node unix socket file.
   -> ShelleyBasedEra era -- ^ The Shelley-based era (e.g., 'ConwayEra') in which the transaction will be constructed.
   -> FilePath -- ^ Base directory path where generated files will be stored.
   -> String -- ^ Name for the subfolder that will be created under 'work' folder.
   -> PaymentKeyInfo -- ^ Wallet that will pay for the transaction.
   -> KeyPair StakingKey -- ^ Staking key pair used for delegation.
   -> m ()
-delegateToAlwaysAbstain execConfig epochStateView configurationFile socketPath sbe work prefix
+delegateToAlwaysAbstain execConfig epochStateView sbe work prefix
                         payingWallet skeyPair@(KeyPair vKeyFile _sKeyFile) = do
 
   let era = toCardanoEra sbe
@@ -174,8 +172,7 @@ delegateToAlwaysAbstain execConfig epochStateView configurationFile socketPath s
   submitTx execConfig cEra repRegSignedRegTx1
 
   -- Wait two epochs
-  (EpochNo epochAfterProp) <- getCurrentEpochNo epochStateView
-  void $ waitUntilEpoch configurationFile socketPath (EpochNo (epochAfterProp + 2))
+  void $ waitForEpochs epochStateView (EpochInterval 2)
 
 desiredPoolNumberProposalTest
   :: (HasCallStack, MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m, Foldable t)

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
@@ -50,6 +50,7 @@ import           Testnet.Types (KeyPair (..),
 
 import           Hedgehog
 import qualified Hedgehog.Extras as H
+import Testnet.Components.TestWatchdog (runWithDefaultWatchdog_)
 
 -- | This test creates a default testnet with three DReps and one stake holder delegated to each.
 -- We then do a proposal for an arbitrary parameter change (in this case to the
@@ -63,7 +64,7 @@ import qualified Hedgehog.Extras as H
 -- Execute me with:
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/Predefined Abstain DRep/"'@
 hprop_check_predefined_abstain_drep :: Property
-hprop_check_predefined_abstain_drep = H.integrationWorkspace "test-activity" $ \tempAbsBasePath' -> do
+hprop_check_predefined_abstain_drep = H.integrationWorkspace "test-activity" $ \tempAbsBasePath' -> runWithDefaultWatchdog_ $ do
   -- Start a local test net
   conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
@@ -25,7 +25,7 @@ import           Data.ByteString.Lazy.Char8 (pack)
 import           Data.String (fromString)
 import qualified Data.Text as Text
 import           Data.Word (Word32)
-import           GHC.Stack (callStack)
+import           GHC.Stack (HasCallStack, callStack)
 import           Lens.Micro ((^?))
 import           System.FilePath ((</>))
 
@@ -51,7 +51,7 @@ import qualified Hedgehog.Extras as H
 -- @desiredNumberOfPools@ parameter) to check that it fails, when the first DRep votes "yes" and the
 -- last two vote "no". Later we chack that if we change the stake holders under the DReps that vote
 -- "no" to delegate to the automate "always abstain" DRep, the same kind of proposal passes.
--- 
+--
 -- This test is meant to ensure that delegating to "always abstain" has the desired effect of
 -- counting as abstaining for the stake delegated.
 --
@@ -122,7 +122,7 @@ hprop_check_predefined_abstain_drep = H.integrationWorkspace "test-activity" $ \
                                        wallet0 Nothing [(1, "yes")] newNumberOfDesiredPools2 newNumberOfDesiredPools2 2
 
 delegateToAlwaysAbstain
-  :: (MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m)
+  :: (HasCallStack, MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m)
   => H.ExecConfig
   -> EpochStateView
   -> NodeConfigFile 'In
@@ -167,7 +167,7 @@ delegateToAlwaysAbstain execConfig epochStateView configurationFile socketPath s
   void $ waitUntilEpoch configurationFile socketPath (EpochNo (epochAfterProp + 2))
 
 desiredPoolNumberProposalTest
-  :: (MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m, Foldable t)
+  :: (HasCallStack, MonadTest m, MonadIO m, H.MonadAssertion m, MonadCatch m, Foldable t)
   => H.ExecConfig
   -> EpochStateView
   -> NodeConfigFile 'In
@@ -210,7 +210,7 @@ desiredPoolNumberProposalTest execConfig epochStateView configurationFile socket
   return thisProposal
 
 makeDesiredPoolNumberChangeProposal
-  :: (H.MonadAssertion m, MonadTest m, MonadCatch m, MonadIO m)
+  :: (HasCallStack, H.MonadAssertion m, MonadTest m, MonadCatch m, MonadIO m)
   => H.ExecConfig
   -> EpochStateView
   -> NodeConfigFile 'In

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
@@ -80,7 +80,7 @@ hprop_check_predefined_abstain_drep = H.integrationWorkspace "test-activity" $ \
       era = toCardanoEra sbe
       cEra = AnyCardanoEra era
       fastTestnetOptions = cardanoDefaultTestnetOptions
-        { cardanoEpochLength = 100
+        { cardanoEpochLength = 200
         , cardanoNodeEra = cEra
         , cardanoNumDReps = 3
         }

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitution.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitution.hs
@@ -34,6 +34,7 @@ import           Testnet.Components.Configuration
 import           Testnet.Components.Query
 import           Testnet.Components.TestWatchdog
 import           Testnet.Defaults
+import           Testnet.EpochStateProcessing (waitForGovActionVotes)
 import           Testnet.Process.Cli.DRep
 import           Testnet.Process.Cli.Keys
 import           Testnet.Process.Cli.Transaction
@@ -182,7 +183,7 @@ hprop_ledger_events_propose_new_constitution = integrationWorkspace "propose-new
 
   submitTx execConfig cEra voteTxFp
 
-  _ <- waitForEpochs epochStateView (EpochInterval 1)
+  waitForGovActionVotes epochStateView ceo (EpochInterval 1)
 
   -- Count votes before checking for ratification. It may happen that the proposal gets removed after
   -- ratification because of a long waiting time, so we won't be able to access votes.

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitution.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitution.hs
@@ -70,7 +70,7 @@ hprop_ledger_events_propose_new_constitution = integrationWorkspace "propose-new
       era = toCardanoEra sbe
       cEra = AnyCardanoEra era
       fastTestnetOptions = cardanoDefaultTestnetOptions
-        { cardanoEpochLength = 100
+        { cardanoEpochLength = 200
         , cardanoNodeEra = cEra
         , cardanoNumDReps = numVotes
         }

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryWithdrawal.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryWithdrawal.hs
@@ -63,7 +63,7 @@ hprop_ledger_events_treasury_withdrawal = integrationRetryWorkspace 1  "treasury
       cEra = AnyCardanoEra era
 
       fastTestnetOptions = cardanoDefaultTestnetOptions
-        { cardanoEpochLength = 100
+        { cardanoEpochLength = 200
         , cardanoNodeEra = cEra
         , cardanoActiveSlotsCoeff = 0.3
         }

--- a/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
+++ b/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
@@ -17,6 +17,7 @@ import qualified Cardano.Testnet.Test.Gov.CommitteeAddNew as Gov
 import qualified Cardano.Testnet.Test.Gov.DRepDeposit as Gov
 import qualified Cardano.Testnet.Test.Gov.DRepRetirement as Gov
 import qualified Cardano.Testnet.Test.Gov.NoConfidence as Gov
+import qualified Cardano.Testnet.Test.Gov.PredefinedAbstainDRep as Gov
 import qualified Cardano.Testnet.Test.Gov.ProposeNewConstitution as Gov
 import qualified Cardano.Testnet.Test.Gov.ProposeNewConstitutionSPO as Gov
 import qualified Cardano.Testnet.Test.Gov.TreasuryGrowth as Gov
@@ -50,8 +51,8 @@ tests = do
             -- TODO: Replace foldBlocks with checkLedgerStateCondition
             , T.testGroup "Governance"
                 [ ignoreOnMacAndWindows "Committee Add New" Gov.hprop_constitutional_committee_add_new
-                -- FIXME: This test is broken - drepActivity is not updated within the expeted period
-                -- , ignoreOnWindows "DRep Activity" Gov.hprop_check_drep_activity
+                , ignoreOnWindows "Predefined Abstain DRep" Gov.hprop_check_predefined_abstain_drep
+                , ignoreOnWindows "DRep Activity" Gov.hprop_check_drep_activity
                 , ignoreOnMacAndWindows "Committee Motion Of No Confidence"  Gov.hprop_gov_no_confidence
                 , ignoreOnWindows "DRep Deposits" Gov.hprop_ledger_events_drep_deposits
                   -- FIXME Those tests are flaky

--- a/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
+++ b/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
@@ -14,11 +14,9 @@ import qualified Cardano.Testnet.Test.Cli.Query
 import qualified Cardano.Testnet.Test.Cli.QuerySlotNumber
 import qualified Cardano.Testnet.Test.FoldEpochState
 import qualified Cardano.Testnet.Test.Gov.CommitteeAddNew as Gov
-import qualified Cardano.Testnet.Test.Gov.DRepActivity as Gov
 import qualified Cardano.Testnet.Test.Gov.DRepDeposit as Gov
 import qualified Cardano.Testnet.Test.Gov.DRepRetirement as Gov
 import qualified Cardano.Testnet.Test.Gov.NoConfidence as Gov
-import qualified Cardano.Testnet.Test.Gov.PredefinedAbstainDRep as Gov
 import qualified Cardano.Testnet.Test.Gov.ProposeNewConstitution as Gov
 import qualified Cardano.Testnet.Test.Gov.ProposeNewConstitutionSPO as Gov
 import qualified Cardano.Testnet.Test.Gov.TreasuryGrowth as Gov
@@ -52,8 +50,9 @@ tests = do
             -- TODO: Replace foldBlocks with checkLedgerStateCondition
             , T.testGroup "Governance"
                 [ ignoreOnMacAndWindows "Committee Add New" Gov.hprop_constitutional_committee_add_new
-                , ignoreOnWindows "Predefined Abstain DRep" Gov.hprop_check_predefined_abstain_drep
-                , ignoreOnWindows "DRep Activity" Gov.hprop_check_drep_activity
+                -- TODO: Disabled because proposals for parameter changes are not working
+                -- , ignoreOnWindows "DRep Activity" Gov.hprop_check_drep_activity
+                -- , ignoreOnWindows "Predefined Abstain DRep" Gov.hprop_check_predefined_abstain_drep
                 , ignoreOnMacAndWindows "Committee Motion Of No Confidence"  Gov.hprop_gov_no_confidence
                 , ignoreOnWindows "DRep Deposits" Gov.hprop_ledger_events_drep_deposits
                   -- FIXME Those tests are flaky

--- a/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
+++ b/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
@@ -14,6 +14,7 @@ import qualified Cardano.Testnet.Test.Cli.Query
 import qualified Cardano.Testnet.Test.Cli.QuerySlotNumber
 import qualified Cardano.Testnet.Test.FoldEpochState
 import qualified Cardano.Testnet.Test.Gov.CommitteeAddNew as Gov
+import qualified Cardano.Testnet.Test.Gov.DRepActivity as Gov
 import qualified Cardano.Testnet.Test.Gov.DRepDeposit as Gov
 import qualified Cardano.Testnet.Test.Gov.DRepRetirement as Gov
 import qualified Cardano.Testnet.Test.Gov.NoConfidence as Gov


### PR DESCRIPTION
# Description

This PR aims to address this issue: https://github.com/IntersectMBO/cardano-node/issues/5600
With that aim, it adds two scenarios for automated DReps. This PR contains the first scenario:

## Scenario 1

- Create default testnet with 3 DReps and 3 stake holders delegated, one to each DRep.
- Do some proposal and vote `yes` with the first DRep only.
- **Check** that proposal does **NOT** pass.
- Take the last two stake delegators and delegate them to "Abstain".
- Do some other proposal and vote `yes` with first DRep only.
- **Check** the new proposal passes now.


# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff
