### PR TITLE
Refactor `ProposeNewConstitutionSPO` test to reuse code

### DIFF
--- a/cardano-testnet/src/Testnet/Components/DReps.hs
+++ b/cardano-testnet/src/Testnet/Components/DReps.hs
@@ -243,7 +243,7 @@ submitTx execConfig cEra signedTx =
 -- If the submission succeeds unexpectedly, it raises a failure message that is
 -- meant to be caught by @Hedgehog@.
 failToSubmitTx
-  :: (MonadTest m, MonadCatch m, MonadIO m)
+  :: (MonadTest m, MonadCatch m, MonadIO m, HasCallStack)
   => H.ExecConfig -- ^ Specifies the CLI execution configuration.
   -> AnyCardanoEra -- ^ Specifies the current Cardano era.
   -> File SignedTx In -- ^ Signed transaction to be submitted, obtained using 'signTx'.

--- a/cardano-testnet/src/Testnet/Components/DReps.hs
+++ b/cardano-testnet/src/Testnet/Components/DReps.hs
@@ -168,7 +168,11 @@ generateVoteFiles execConfig work prefix governanceActionTxId governanceActionIn
       ]
     return path
 
--- | Composes a voting transaction body (without signing) using @cardano-cli@.
+-- | Composes a voting transaction body file using @cardano-cli@.
+-- For the transaction to be valid it needs witnesses corresponding
+-- to the spent UTxOs and votes issued (typically these witnesses are
+-- cryptographic signatures). This function does not sign the transaction,
+-- that can be done with 'signTx'.
 --
 -- Returns the generated @File TxBody In@ file path to the transaction body.
 createVotingTxBody

--- a/cardano-testnet/src/Testnet/Components/DReps.hs
+++ b/cardano-testnet/src/Testnet/Components/DReps.hs
@@ -168,8 +168,7 @@ generateVoteFiles execConfig work prefix governanceActionTxId governanceActionIn
       ]
     return path
 
--- | Composes a decentralized representative (DRep) voting transaction body
--- (without signing) using @cardano-cli@.
+-- | Composes a voting transaction body (without signing) using @cardano-cli@.
 --
 -- Returns the generated @File TxBody In@ file path to the transaction body.
 createVotingTxBody
@@ -186,7 +185,7 @@ createVotingTxBody
                     -- as returned by 'cardanoTestnetDefault'.
   -> m (File TxBody In)
 createVotingTxBody execConfig epochStateView sbe work prefix votes wallet = do
-  let dRepVotingTxBody = File (work </> prefix <> ".txbody")
+  let votingTxBody = File (work </> prefix <> ".txbody")
   walletLargestUTXO <- findLargestUtxoForPaymentKey epochStateView sbe wallet
   void $ H.execCli' execConfig $
     [ "conway", "transaction", "build"
@@ -194,9 +193,9 @@ createVotingTxBody execConfig epochStateView sbe work prefix votes wallet = do
     , "--tx-in", Text.unpack $ renderTxIn walletLargestUTXO
     ] ++ (concat [["--vote-file", voteFile] | File voteFile <- votes]) ++
     [ "--witness-override", show @Int (length votes)
-    , "--out-file", unFile dRepVotingTxBody
+    , "--out-file", unFile votingTxBody
     ]
-  return dRepVotingTxBody
+  return votingTxBody
 
 -- Transaction signing
 

--- a/cardano-testnet/src/Testnet/Components/SPO.hs
+++ b/cardano-testnet/src/Testnet/Components/SPO.hs
@@ -406,17 +406,16 @@ registerSingleSpo identifier tap@(TmpAbsolutePath tempAbsPath') nodeConfigFile s
               currentRegistedPoolsJson
   return (poolId, poolColdSkeyFp, poolColdVkeyFp, vrfSkeyFp, vrfVkeyFp)
 
--- | Generates Stake Pool Operator (SPO) voting files (without signing)
--- using @cardano-cli@.
---
+-- | Generates Stake Pool Operator (SPO) voting files, using @cardano-cli@.
 --
 -- Returns a list of generated @File VoteFile In@ representing the paths to
 -- the generated voting files.
 generateVoteFiles :: (MonadTest m, MonadIO m, MonadCatch m)
-  => ConwayEraOnwards era -- ^ The conway era onwards witness for the era in which the transaction will be constructed.
+  => ConwayEraOnwards era -- ^ The conway era onwards witness for the era in which the
+                          -- transaction will be constructed.
   -> H.ExecConfig -- ^ Specifies the CLI execution configuration.
   -> FilePath -- ^ Base directory path where the voting files and directories will be
-              -- stored
+              -- stored.
   -> String -- ^ Name for the subfolder that will be created under 'work' to store
             -- the output voting files.
   -> String -- ^ Transaction ID string of the governance action.

--- a/cardano-testnet/src/Testnet/Components/SPO.hs
+++ b/cardano-testnet/src/Testnet/Components/SPO.hs
@@ -14,6 +14,7 @@ module Testnet.Components.SPO
   , createStakeKeyDeregistrationCertificate
   , decodeEraUTxO
   , registerSingleSpo
+  , generateVoteFiles
   ) where
 
 import qualified Cardano.Api.Ledger as L
@@ -32,21 +33,24 @@ import qualified Data.Map.Strict as Map
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import qualified Data.Text as Text
+import           Data.Word (Word32)
 import           GHC.Stack (HasCallStack)
 import qualified GHC.Stack as GHC
 import           Lens.Micro
 import           System.FilePath.Posix ((</>))
 
+import           Testnet.Components.DReps (VoteFile)
 import           Testnet.Filepath
-import           Testnet.Process.Cli
+import           Testnet.Process.Cli hiding (File, unFile)
+import qualified Testnet.Process.Run as H
 import           Testnet.Process.Run (execCli, execCli', execCli_)
 import           Testnet.Property.Utils
+import           Testnet.Runtime (PoolNodeKeys (poolNodeKeysColdVkey))
 import           Testnet.Start.Types
 
 import           Hedgehog
 import           Hedgehog.Extras (ExecConfig)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import qualified Hedgehog.Extras as H
 
 checkStakePoolRegistered
   :: (MonadTest m, MonadCatch m, MonadIO m, HasCallStack)
@@ -401,3 +405,45 @@ registerSingleSpo identifier tap@(TmpAbsolutePath tempAbsPath') nodeConfigFile s
               poolColdVkeyFp
               currentRegistedPoolsJson
   return (poolId, poolColdSkeyFp, poolColdVkeyFp, vrfSkeyFp, vrfVkeyFp)
+
+
+-- | Generates Stake Pool Operator (SPO) voting files (without signing)
+-- using @cardano-cli@.
+--
+-- This function takes the following parameters:
+--
+-- * 'execConfig': Specifies the CLI execution configuration.
+-- * 'work': Base directory path where the voting files and directories will be
+--           stored.
+-- * 'prefix': Name for the subfolder that will be created under 'work' to store
+--             the output voting files.
+-- * 'governanceActionTxId': Transaction ID string of the governance action.
+-- * 'governanceActionIndex': Index of the governance action.
+-- * 'allVotes': List of tuples where each tuple contains a 'PoolNodeKeys'
+--               representing the SPO keys and a 'String' representing the
+--               vote type (i.e: "yes", "no", or "abstain").
+--
+-- Returns a list of generated @File VoteFile In@ representing the paths to
+-- the generated voting files.
+generateVoteFiles :: (MonadTest m, MonadIO m, MonadCatch m)
+  => H.ExecConfig
+  -> FilePath
+  -> String
+  -> String
+  -> Word32
+  -> [(PoolNodeKeys, [Char])]
+  -> m [File VoteFile In]
+generateVoteFiles execConfig work prefix governanceActionTxId governanceActionIndex allVotes = do
+  baseDir <- H.createDirectoryIfMissing $ work </> prefix
+  forM (zip [(1 :: Integer)..] allVotes) $ \(idx, (spoKeys, vote)) -> do
+    let path = File (baseDir </> "vote-" <> show idx)
+    void $ H.execCli' execConfig
+      [ "conway", "governance", "vote", "create"
+      , "--" ++ vote
+      , "--governance-action-tx-id", governanceActionTxId
+      , "--governance-action-index", show @Word32 governanceActionIndex
+      , "--cold-verification-key-file", poolNodeKeysColdVkey spoKeys
+      , "--out-file", unFile path
+      ]
+    return path
+

--- a/cardano-testnet/src/Testnet/Components/SPO.hs
+++ b/cardano-testnet/src/Testnet/Components/SPO.hs
@@ -409,30 +409,21 @@ registerSingleSpo identifier tap@(TmpAbsolutePath tempAbsPath') nodeConfigFile s
 -- | Generates Stake Pool Operator (SPO) voting files (without signing)
 -- using @cardano-cli@.
 --
--- This function takes the following parameters:
---
--- * 'ceo': The conway era onwards witness for the era in which the transaction will be constructed.
--- * 'execConfig': Specifies the CLI execution configuration.
--- * 'work': Base directory path where the voting files and directories will be
---           stored.
--- * 'prefix': Name for the subfolder that will be created under 'work' to store
---             the output voting files.
--- * 'governanceActionTxId': Transaction ID string of the governance action.
--- * 'governanceActionIndex': Index of the governance action.
--- * 'allVotes': List of tuples where each tuple contains a 'PoolNodeKeys'
---               representing the SPO keys and a 'String' representing the
---               vote type (i.e: "yes", "no", or "abstain").
 --
 -- Returns a list of generated @File VoteFile In@ representing the paths to
 -- the generated voting files.
 generateVoteFiles :: (MonadTest m, MonadIO m, MonadCatch m)
-  => ConwayEraOnwards era
-  -> H.ExecConfig
-  -> FilePath
-  -> String
-  -> String
-  -> Word32
-  -> [(PoolNodeKeys, [Char])]
+  => ConwayEraOnwards era -- ^ The conway era onwards witness for the era in which the transaction will be constructed.
+  -> H.ExecConfig -- ^ Specifies the CLI execution configuration.
+  -> FilePath -- ^ Base directory path where the voting files and directories will be
+              -- stored
+  -> String -- ^ Name for the subfolder that will be created under 'work' to store
+            -- the output voting files.
+  -> String -- ^ Transaction ID string of the governance action.
+  -> Word32 -- ^ Index of the governance action.
+  -> [(PoolNodeKeys, [Char])] -- ^ List of tuples where each tuple contains a 'PoolNodeKeys'
+                              -- representing the SPO keys and a 'String' representing the
+                              -- vote type (i.e: "yes", "no", or "abstain").
   -> m [File VoteFile In]
 generateVoteFiles ceo execConfig work prefix governanceActionTxId governanceActionIndex allVotes = do
   baseDir <- H.createDirectoryIfMissing $ work </> prefix

--- a/cardano-testnet/src/Testnet/Defaults.hs
+++ b/cardano-testnet/src/Testnet/Defaults.hs
@@ -18,13 +18,16 @@ module Testnet.Defaults
   , defaultDRepSkeyFp
   , defaultDRepKeyPair
   , defaultDelegatorStakeKeyPair
+  , defaultSPOKeys
+  , defaultSPOColdKeyPair
+  , defaultSPOColdVKeyFp
+  , defaultSPOColdSKeyFp
   , defaultShelleyGenesis
   , defaultGenesisFilepath
   , defaultYamlHardforkViaConfig
   , defaultMainnetTopology
   , plutusV3NonSpendingScript
   , plutusV3SpendingScript
-  , defaultSPOKeys
   ) where
 
 import           Cardano.Api (AnyCardanoEra (..), CardanoEra (..), pshow)
@@ -74,7 +77,7 @@ import           System.FilePath ((</>))
 
 import           Test.Cardano.Ledger.Core.Rational
 import           Testnet.Runtime (PaymentKeyPair (PaymentKeyPair), PoolNodeKeys (..),
-                   StakingKeyPair (StakingKeyPair))
+                   SPOColdKeyPair (..), StakingKeyPair (StakingKeyPair))
 import           Testnet.Start.Types
 
 {- HLINT ignore "Use underscore" -}
@@ -517,12 +520,24 @@ defaultDRepSkeyFp n = "drep-keys" </> ("drep" <> show n) </> "drep.skey"
 defaultDRepKeyPair :: Int -> PaymentKeyPair
 defaultDRepKeyPair n = PaymentKeyPair (defaultDRepVkeyFp n) (defaultDRepSkeyFp n)
 
+-- | The relative path to SPO cold verification key in directories created by cardano-testnet
+defaultSPOColdVKeyFp :: Int -> FilePath
+defaultSPOColdVKeyFp n = "pools-keys" </> "pool" <> show n </> "cold.vkey"
+
+-- | The relative path to SPO cold secret key in directories created by cardano-testnet
+defaultSPOColdSKeyFp :: Int -> FilePath
+defaultSPOColdSKeyFp n = "pools-keys" </> "pool" <> show n </> "cold.skey"
+
+-- | The relative path to SPO key cold key pair in directories created by cardano-testnet
+defaultSPOColdKeyPair :: Int -> SPOColdKeyPair
+defaultSPOColdKeyPair n = SPOColdKeyPair (defaultSPOColdVKeyFp n) (defaultSPOColdSKeyFp n)
+
 -- | The relative path to SPO key pairs in directories created by cardano-testnet
 defaultSPOKeys :: Int -> PoolNodeKeys
 defaultSPOKeys n =
   PoolNodeKeys
-    { poolNodeKeysColdVkey = "pools-keys" </> "pool" ++ show n </> "cold.vkey"
-    , poolNodeKeysColdSkey = "pools-keys" </> "pool" ++ show n </> "cold.skey"
+    { poolNodeKeysColdVkey = defaultSPOColdVKeyFp n
+    , poolNodeKeysColdSkey = defaultSPOColdSKeyFp n
     , poolNodeKeysVrfVkey = "pools-keys" </> "pool" ++ show n </> "vrf.vkey"
     , poolNodeKeysVrfSkey = "pools-keys" </> "pool" ++ show n </> "vrf.skey"
     , poolNodeKeysStakingVkey = "pools-keys" </> "pool" ++ show n </> "staking-reward.vkey"

--- a/cardano-testnet/src/Testnet/Defaults.hs
+++ b/cardano-testnet/src/Testnet/Defaults.hs
@@ -17,13 +17,14 @@ module Testnet.Defaults
   , defaultDRepVkeyFp
   , defaultDRepSkeyFp
   , defaultDRepKeyPair
+  , defaultDelegatorStakeKeyPair
   , defaultShelleyGenesis
   , defaultGenesisFilepath
   , defaultYamlHardforkViaConfig
   , defaultMainnetTopology
   , plutusV3NonSpendingScript
   , plutusV3SpendingScript
-  , defaultDelegatorStakeKeyPair
+  , defaultSPOKeys
   ) where
 
 import           Cardano.Api (AnyCardanoEra (..), CardanoEra (..), pshow)
@@ -72,7 +73,8 @@ import           Numeric.Natural
 import           System.FilePath ((</>))
 
 import           Test.Cardano.Ledger.Core.Rational
-import           Testnet.Runtime (PaymentKeyPair (PaymentKeyPair), StakingKeyPair (StakingKeyPair))
+import           Testnet.Runtime (PaymentKeyPair (PaymentKeyPair), PoolNodeKeys (..),
+                   StakingKeyPair (StakingKeyPair))
 import           Testnet.Start.Types
 
 {- HLINT ignore "Use underscore" -}
@@ -514,6 +516,18 @@ defaultDRepSkeyFp n = "drep-keys" </> ("drep" <> show n) </> "drep.skey"
 -- | The relative path to DRep key pairs in directories created by cardano-testnet
 defaultDRepKeyPair :: Int -> PaymentKeyPair
 defaultDRepKeyPair n = PaymentKeyPair (defaultDRepVkeyFp n) (defaultDRepSkeyFp n)
+
+-- | The relative path to SPO key pairs in directories created by cardano-testnet
+defaultSPOKeys :: Int -> PoolNodeKeys
+defaultSPOKeys n =
+  PoolNodeKeys
+    { poolNodeKeysColdVkey = "pools-keys" </> "pool" ++ show n </> "cold.vkey"
+    , poolNodeKeysColdSkey = "pools-keys" </> "pool" ++ show n </> "cold.skey"
+    , poolNodeKeysVrfVkey = "pools-keys" </> "pool" ++ show n </> "vrf.vkey"
+    , poolNodeKeysVrfSkey = "pools-keys" </> "pool" ++ show n </> "vrf.skey"
+    , poolNodeKeysStakingVkey = "pools-keys" </> "pool" ++ show n </> "staking-reward.vkey"
+    , poolNodeKeysStakingSkey = "pools-keys" </> "pool" ++ show n </> "staking-reward.skey"
+    }
 
 -- | The relative path to stake delegator stake keys in directories created by cardano-testnet
 defaultDelegatorStakeVkeyFp

--- a/cardano-testnet/src/Testnet/Runtime.hs
+++ b/cardano-testnet/src/Testnet/Runtime.hs
@@ -1,13 +1,13 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE InstanceSigs #-}
 
 module Testnet.Runtime
   ( LeadershipSlot(..)
@@ -20,6 +20,7 @@ module Testnet.Runtime
   , PoolNode(..)
   , PoolNodeKeys(..)
   , Delegator(..)
+  , SPOColdKeyPair(..)
   , KeyPair(..)
   , SomeKeyPair(..)
   , allNodes
@@ -113,6 +114,11 @@ data PoolNodeKeys = PoolNodeKeys
   , poolNodeKeysStakingSkey :: FilePath
   } deriving (Eq, Show)
 
+data SPOColdKeyPair = SPOColdKeyPair
+  { spoColdVKey :: FilePath
+  , spoColdSKey :: FilePath
+  } deriving (Eq, Show)
+
 data PaymentKeyPair = PaymentKeyPair
   { paymentVKey :: FilePath
   , paymentSKey :: FilePath
@@ -148,6 +154,10 @@ instance KeyPair PaymentKeyPair where
 instance KeyPair StakingKeyPair where
   secretKey :: StakingKeyPair -> FilePath
   secretKey = stakingSKey
+
+instance KeyPair SPOColdKeyPair where
+  secretKey :: SPOColdKeyPair -> FilePath
+  secretKey = spoColdSKey
 
 data SomeKeyPair = forall a . KeyPair a => SomeKeyPair a
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/DRepDeposits.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/DRepDeposits.hs
@@ -94,7 +94,7 @@ hprop_ledger_events_drep_deposits = H.integrationWorkspace "drep-deposits" $ \te
   drepSignedRegTx1 <- signTx execConfig cEra drepDir1 "signed-reg-tx"
                              drepRegTxBody1 [drepKeyPair1, paymentKeyInfoPair wallet0]
 
-  failToSubmitTx execConfig cEra drepSignedRegTx1
+  failToSubmitTx execConfig cEra drepSignedRegTx1 "ConwayDRepIncorrectDeposit"
 
   -- DRep 2 (enough deposit)
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/ProposeNewConstitutionSPO.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/ProposeNewConstitutionSPO.hs
@@ -22,15 +22,14 @@ import           Prelude
 
 import           Control.Monad.Trans.State.Strict (put)
 import           Data.Bifunctor (Bifunctor (..))
-import           Data.List (isInfixOf)
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as Text
 import           Data.Word
 import           GHC.Stack (HasCallStack)
 import           Lens.Micro
-import           System.Exit (ExitCode (ExitSuccess))
 import           System.FilePath ((</>))
 
+import           Testnet.Components.DReps (failToSubmitTx)
 import           Testnet.Components.Query
 import           Testnet.Components.TestWatchdog
 import qualified Testnet.Process.Cli as P
@@ -215,13 +214,7 @@ hprop_ledger_events_propose_new_constitution_spo = H.integrationWorkspace "propo
     ]
 
   -- Call should fail, because SPOs are unallowed to vote on the constitution
-  (exitCode, _, stderr) <- H.execCliAny execConfig
-    [ "conway", "transaction", "submit"
-    , "--tx-file", voteTxFp
-    ]
-
-  exitCode H./== ExitSuccess -- Dit it fail?
-  H.assert $ "DisallowedVoters" `isInfixOf` stderr -- Did it fail for the expected reason?
+  failToSubmitTx execConfig cEra (File voteTxFp) "DisallowedVoters"
 
 getConstitutionProposal
   :: (HasCallStack, MonadIO m, MonadTest m)


### PR DESCRIPTION
# Description

This PR simplifies the implementation of `ProposeNewConstitutionSPO` by using functions that were already created for other tests, and also improves some of those functions to have as much functionality as the original code, with a couple of minor exceptions.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff
