### PR TITLE
Enable epoch state logging by default

### DIFF
--- a/cardano-testnet/src/Parsers/Cardano.hs
+++ b/cardano-testnet/src/Parsers/Cardano.hs
@@ -68,6 +68,11 @@ optsTestnet envCli = CardanoTestnetOptions
       <>  OA.showDefault
       <>  OA.value 3
       )
+  <*> OA.flag False True
+      (   OA.long "enable-new-epoch-state-logging"
+      <>  OA.help "Enable new epoch state logging to logs/ledger-epoch-state.log"
+      <>  OA.showDefault
+      )
 
 pNumSpoNodes :: Parser [TestnetNodeOptions]
 pNumSpoNodes =

--- a/cardano-testnet/src/Testnet/Start/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Start/Cardano.hs
@@ -418,6 +418,9 @@ cardanoTestnet
 
     H.assertExpectedSposInLedgerState stakePoolsFp testnetOptions execConfig
 
+    when (cardanoEnableNewEpochStateLogging testnetOptions) $
+      TR.startLedgerNewEpochStateLogging runtime tempBaseAbsPath
+
     pure runtime
   where
     writeGenesisSpecFile :: (MonadTest m, MonadIO m, HasCallStack) => ToJSON a => String -> a -> m ()

--- a/cardano-testnet/src/Testnet/Start/Types.hs
+++ b/cardano-testnet/src/Testnet/Start/Types.hs
@@ -47,6 +47,7 @@ data CardanoTestnetOptions = CardanoTestnetOptions
   , cardanoEnableP2P :: Bool
   , cardanoNodeLoggingFormat :: NodeLoggingFormat
   , cardanoNumDReps :: Int -- ^ The number of DReps to generate at creation
+  , cardanoEnableNewEpochStateLogging :: Bool -- ^ if epoch state logging is enabled
   } deriving (Eq, Show)
 
 cardanoDefaultTestnetOptions :: CardanoTestnetOptions
@@ -61,6 +62,7 @@ cardanoDefaultTestnetOptions = CardanoTestnetOptions
   , cardanoEnableP2P = False
   , cardanoNodeLoggingFormat = NodeLoggingFormatAsJson
   , cardanoNumDReps = 3
+  , cardanoEnableNewEpochStateLogging = True
   }
 
 -- | Specify a BFT node (Pre-Babbage era only) or an SPO (Shelley era onwards only)

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
@@ -16,6 +16,7 @@ Usage: cardano-testnet cardano [--num-pool-nodes COUNT]
   [--enable-p2p BOOL]
   [--nodeLoggingFormat LOGGING_FORMAT]
   [--num-dreps NUMBER]
+  [--enable-new-epoch-state-logging]
 
   Start a testnet in any era
 

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/cardano.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/cardano.cli
@@ -14,6 +14,7 @@ Usage: cardano-testnet cardano [--num-pool-nodes COUNT]
   [--enable-p2p BOOL]
   [--nodeLoggingFormat LOGGING_FORMAT]
   [--num-dreps NUMBER]
+  [--enable-new-epoch-state-logging]
 
   Start a testnet in any era
 
@@ -41,4 +42,7 @@ Available options:
                            (default: NodeLoggingFormatAsJson)
   --num-dreps NUMBER       Number of delegate representatives (DReps) to
                            generate (default: 3)
+  --enable-new-epoch-state-logging
+                           Enable new epoch state logging to
+                           logs/ledger-epoch-state.log
   -h,--help                Show this help text

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/DRepActivity.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/DRepActivity.hs
@@ -38,6 +38,7 @@ import           Testnet.Components.DReps (createVotingTxBody, delegateToDRep, g
 import           Testnet.Components.Query (EpochStateView, checkDRepState,
                    findLargestUtxoForPaymentKey, getCurrentEpochNo, getEpochStateView,
                    getMinDRepDeposit)
+import           Testnet.Components.TestWatchdog
 import           Testnet.Defaults
 import qualified Testnet.Process.Cli as P
 import qualified Testnet.Process.Run as H
@@ -51,7 +52,7 @@ import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
 -- | Execute me with:
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/DRep Activity/"'@
 hprop_check_drep_activity :: Property
-hprop_check_drep_activity = H.integrationWorkspace "test-activity" $ \tempAbsBasePath' -> do
+hprop_check_drep_activity = H.integrationWorkspace "test-activity" $ \tempAbsBasePath' -> runWithDefaultWatchdog_ $ do
   -- Start a local test net
   conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/InfoAction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/InfoAction.hs
@@ -62,7 +62,7 @@ hprop_ledger_events_info_action = H.integrationRetryWorkspace 0 "info-hash" $ \t
         , cardanoNodeEra = AnyCardanoEra era
         }
 
-  testnetRuntime@TestnetRuntime
+  TestnetRuntime
     { testnetMagic
     , poolNodes
     , wallets=wallet0:wallet1:_
@@ -79,8 +79,6 @@ hprop_ledger_events_info_action = H.integrationRetryWorkspace 0 "info-hash" $ \t
       socketPath = socketBase </> socketName'
 
   epochStateView <- getEpochStateView (File configurationFile) (File socketPath)
-
-  startLedgerNewEpochStateLogging testnetRuntime tempAbsPath'
 
   H.note_ $ "Sprocket: " <> show poolSprocket1
   H.note_ $ "Abs path: " <> tempAbsBasePath'

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/TreasuryWithdrawal.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/TreasuryWithdrawal.hs
@@ -69,7 +69,7 @@ hprop_ledger_events_treasury_withdrawal = H.integrationRetryWorkspace 1  "treasu
         , cardanoActiveSlotsCoeff = 0.3
         }
 
-  testnetRuntime@TestnetRuntime
+  TestnetRuntime
     { testnetMagic
     , poolNodes
     , wallets=wallet0:wallet1:_
@@ -91,8 +91,6 @@ hprop_ledger_events_treasury_withdrawal = H.integrationRetryWorkspace 1  "treasu
   H.note_ $ "Abs path: " <> tempAbsBasePath'
   H.note_ $ "Socketpath: " <> socketPath
   H.note_ $ "Foldblocks config file: " <> configurationFile
-
-  startLedgerNewEpochStateLogging testnetRuntime tempAbsPath'
 
   gov <- H.createDirectoryIfMissing $ work </> "governance"
   proposalAnchorFile <- H.note $ work </> gov </> "sample-proposal-anchor"

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/TreasuryGrowth.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/TreasuryGrowth.hs
@@ -45,12 +45,9 @@ prop_check_if_treasury_is_growing = H.integrationRetryWorkspace 0 "growing-treas
 
   runtime@TestnetRuntime{configurationFile} <- cardanoTestnetDefault options conf
 
-  -- uncomment for epoch state live access
-  -- startLedgerNewEpochStateLogging runtime tempAbsBasePath'
-
   -- Get socketPath
   socketPathAbs <- do
-    socketPath' <- H.noteShowM $ H.sprocketArgumentName <$> H.headM (poolSprockets runtime)
+    socketPath' <- H.sprocketArgumentName <$> H.headM (poolSprockets runtime)
     H.noteIO (IO.canonicalizePath $ tempAbsPath' </> socketPath')
 
   (_condition, treasuryValues) <- H.leftFailM . H.evalIO . runExceptT $


### PR DESCRIPTION
# Description

Enables epoch state logging by default for every test case. The default for `cardano-testnet` executable is `False`.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
