### PR TITLE
Count votes in Propose Constitution test before ratification

### DIFF
--- a/cardano-node-chairman/test/Spec/Chairman/Cardano.hs
+++ b/cardano-node-chairman/test/Spec/Chairman/Cardano.hs
@@ -6,7 +6,7 @@ module Spec.Chairman.Cardano where
 
 import qualified Cardano.Testnet as H
 
-import qualified Testnet.Property.Utils as H
+import qualified Testnet.Property.Util as H
 
 import qualified Hedgehog as H
 

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
@@ -422,7 +422,7 @@ instance ( LogFormatting (Header blk)
       "Added request to queue to reprocess blocks postponed by LoE."
   forHuman ChainDB.PoppedReprocessLoEBlocksFromQueue =
       "Poppped request from queue to reprocess blocks postponed by LoE."
-  forHuman (ChainDB.ChainSelectionLoEDebug {}) =
+  forHuman ChainDB.ChainSelectionLoEDebug {} =
       "ChainDB LoE debug event"
   forMachine dtal (ChainDB.IgnoreBlockOlderThanK pt) =
       mconcat [ "kind" .= String "IgnoreBlockOlderThanK"

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -90,24 +90,24 @@ library
   hs-source-dirs:       src
   exposed-modules:      Cardano.Testnet
                         Parsers.Run
-                        Testnet.Start.Byron
-                        Testnet.Start.Types
                         Testnet.Components.Configuration
-                        Testnet.Components.DReps
-                        Testnet.Components.SPO
+                        Testnet.Components.DRep
                         Testnet.Components.Query
+                        Testnet.Components.SPO
                         Testnet.Components.TestWatchdog
                         Testnet.Defaults
-                        Testnet.Filepath
                         Testnet.EpochStateProcessing
-                        Testnet.Property.Assert
-                        Testnet.Property.Run
-                        Testnet.Property.Utils
+                        Testnet.Filepath
+                        Testnet.Ping
                         Testnet.Process.Cli
                         Testnet.Process.Run
+                        Testnet.Property.Assert
+                        Testnet.Property.Run
+                        Testnet.Property.Util
                         Testnet.Runtime
+                        Testnet.Start.Byron
+                        Testnet.Start.Types
                         Testnet.SubmitApi
-                        Testnet.Ping
 
   other-modules:        Parsers.Cardano
                         Parsers.Help
@@ -182,19 +182,19 @@ test-suite cardano-testnet-test
                         Cardano.Testnet.Test.Cli.Conway.Plutus
                         Cardano.Testnet.Test.Cli.Conway.StakeSnapshot
                         Cardano.Testnet.Test.Cli.KesPeriodInfo
-                        Cardano.Testnet.Test.Cli.Queries
+                        Cardano.Testnet.Test.Cli.Query
                         Cardano.Testnet.Test.Cli.QuerySlotNumber
                         Cardano.Testnet.Test.FoldBlocks
                         Cardano.Testnet.Test.Misc
 
-                        Cardano.Testnet.Test.Gov.DRepDeposits
+                        Cardano.Testnet.Test.Gov.DRepActivity
+                        Cardano.Testnet.Test.Gov.DRepDeposit
                         Cardano.Testnet.Test.Gov.DRepRetirement
                         Cardano.Testnet.Test.Gov.InfoAction
                         Cardano.Testnet.Test.Gov.ProposeNewConstitution
                         Cardano.Testnet.Test.Gov.ProposeNewConstitutionSPO
-                        Cardano.Testnet.Test.Gov.TreasuryWithdrawal
-                        Cardano.Testnet.Test.Gov.DRepActivity
                         Cardano.Testnet.Test.Gov.TreasuryGrowth
+                        Cardano.Testnet.Test.Gov.TreasuryWithdrawal
                         Cardano.Testnet.Test.SanityCheck
 
                         Cardano.Testnet.Test.Node.Shutdown

--- a/cardano-testnet/src/Cardano/Testnet.hs
+++ b/cardano-testnet/src/Cardano/Testnet.hs
@@ -47,7 +47,7 @@ import           Testnet.Components.Query
 import           Testnet.EpochStateProcessing
 import           Testnet.Filepath
 import           Testnet.Process.Run (procChairman)
-import           Testnet.Property.Utils
+import           Testnet.Property.Util
 import           Testnet.Runtime
 import           Testnet.Start.Cardano
 import           Testnet.Start.Types

--- a/cardano-testnet/src/Parsers/Cardano.hs
+++ b/cardano-testnet/src/Parsers/Cardano.hs
@@ -13,7 +13,7 @@ import           Options.Applicative
 import qualified Options.Applicative as OA
 
 import           Testnet.Process.Cli
-import           Testnet.Property.Utils
+import           Testnet.Property.Util
 import           Testnet.Runtime (readNodeLoggingFormat)
 import           Testnet.Start.Cardano
 import           Testnet.Start.Types

--- a/cardano-testnet/src/Testnet/Components/Configuration.hs
+++ b/cardano-testnet/src/Testnet/Components/Configuration.hs
@@ -49,7 +49,7 @@ import           System.FilePath.Posix (takeDirectory, (</>))
 import           Testnet.Defaults
 import           Testnet.Filepath
 import           Testnet.Process.Run (execCli_)
-import           Testnet.Property.Utils
+import           Testnet.Property.Util
 import           Testnet.Start.Types (CardanoTestnetOptions (..), anyEraToString, eraToString)
 
 import           Hedgehog

--- a/cardano-testnet/src/Testnet/Components/DRep.hs
+++ b/cardano-testnet/src/Testnet/Components/DRep.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Testnet.Components.DReps
+module Testnet.Components.DRep
   ( VoteFile
   , generateDRepKeyPair
   , generateRegistrationCertificate

--- a/cardano-testnet/src/Testnet/Components/Query.hs
+++ b/cardano-testnet/src/Testnet/Components/Query.hs
@@ -53,7 +53,7 @@ import           GHC.Stack
 import           Lens.Micro (to, (^.))
 
 import           Testnet.Property.Assert
-import           Testnet.Property.Utils (runInBackground)
+import           Testnet.Property.Util (runInBackground)
 import           Testnet.Runtime
 
 import qualified Hedgehog as H
@@ -63,7 +63,9 @@ import           Hedgehog.Internal.Property (MonadTest)
 
 -- | Block and wait for the desired epoch.
 waitUntilEpoch
-  :: (MonadIO m, MonadTest m, HasCallStack)
+  :: HasCallStack
+  => MonadIO m
+  => MonadTest m
   => NodeConfigFile In
   -> SocketPath
   -> EpochNo -- ^ Desired epoch
@@ -85,7 +87,8 @@ waitUntilEpoch nodeConfigFile socketPath desiredEpoch = withFrozenCallStack $ do
 
 -- | Wait for the number of epochs
 waitForEpochs
-  :: MonadTest m
+  :: HasCallStack
+  => MonadTest m
   => MonadAssertion m
   => MonadIO m
   => EpochStateView

--- a/cardano-testnet/src/Testnet/Components/SPO.hs
+++ b/cardano-testnet/src/Testnet/Components/SPO.hs
@@ -39,12 +39,12 @@ import qualified GHC.Stack as GHC
 import           Lens.Micro
 import           System.FilePath.Posix ((</>))
 
-import           Testnet.Components.DReps (VoteFile)
+import           Testnet.Components.DRep (VoteFile)
 import           Testnet.Filepath
 import           Testnet.Process.Cli hiding (File, unFile)
 import qualified Testnet.Process.Run as H
 import           Testnet.Process.Run (execCli, execCli', execCli_)
-import           Testnet.Property.Utils
+import           Testnet.Property.Util
 import           Testnet.Runtime (PoolNodeKeys (poolNodeKeysColdVkey))
 import           Testnet.Start.Types
 

--- a/cardano-testnet/src/Testnet/Property/Run.hs
+++ b/cardano-testnet/src/Testnet/Property/Run.hs
@@ -23,7 +23,7 @@ import qualified System.Exit as IO
 import qualified System.Info as SYS
 import qualified System.IO as IO
 
-import qualified Testnet.Property.Utils as H
+import qualified Testnet.Property.Util as H
 import           Testnet.Start.Types
 
 import           Hedgehog (Property)

--- a/cardano-testnet/src/Testnet/Property/Util.hs
+++ b/cardano-testnet/src/Testnet/Property/Util.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Testnet.Property.Utils
+module Testnet.Property.Util
   ( integration
   , integrationRetryWorkspace
   , integrationWorkspace

--- a/cardano-testnet/src/Testnet/Runtime.hs
+++ b/cardano-testnet/src/Testnet/Runtime.hs
@@ -70,7 +70,7 @@ import qualified System.Process as IO
 import           Testnet.Filepath
 import qualified Testnet.Ping as Ping
 import           Testnet.Process.Run
-import           Testnet.Property.Utils (runInBackground)
+import           Testnet.Property.Util (runInBackground)
 import           Testnet.Start.Types
 
 import           Hedgehog (MonadTest)

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/LeadershipSchedule.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/LeadershipSchedule.hs
@@ -42,7 +42,7 @@ import           Testnet.Process.Cli
 import qualified Testnet.Process.Run as H
 import           Testnet.Process.Run
 import           Testnet.Property.Assert
-import qualified Testnet.Property.Utils as H
+import qualified Testnet.Property.Util as H
 import           Testnet.Runtime
 
 import           Hedgehog (Property, (===))

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/StakeSnapshot.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/StakeSnapshot.hs
@@ -24,7 +24,7 @@ import qualified System.Info as SYS
 import           Testnet.Components.TestWatchdog
 import           Testnet.Process.Cli (execCliStdoutToJson)
 import qualified Testnet.Process.Run as H
-import qualified Testnet.Property.Utils as H
+import qualified Testnet.Property.Util as H
 import           Testnet.Runtime
 
 import           Hedgehog (Property, (===))

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/Transaction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/Transaction.hs
@@ -32,7 +32,7 @@ import           Testnet.Components.SPO
 import           Testnet.Components.TestWatchdog
 import qualified Testnet.Process.Run as H
 import           Testnet.Process.Run
-import qualified Testnet.Property.Utils as H
+import qualified Testnet.Property.Util as H
 import           Testnet.Runtime
 
 import           Hedgehog (Property)

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/Plutus.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/Plutus.hs
@@ -33,7 +33,7 @@ import           Testnet.Components.TestWatchdog
 import           Testnet.Defaults
 import qualified Testnet.Process.Run as H
 import           Testnet.Process.Run
-import qualified Testnet.Property.Utils as H
+import qualified Testnet.Property.Util as H
 import           Testnet.Runtime
 
 import           Hedgehog (Property)

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/StakeSnapshot.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/StakeSnapshot.hs
@@ -21,7 +21,7 @@ import qualified System.Info as SYS
 import           Testnet.Components.TestWatchdog
 import           Testnet.Process.Cli (execCliStdoutToJson)
 import qualified Testnet.Process.Run as H
-import qualified Testnet.Property.Utils as H
+import qualified Testnet.Property.Util as H
 import           Testnet.Runtime
 
 import           Hedgehog (Property, (===))

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/KesPeriodInfo.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/KesPeriodInfo.hs
@@ -36,7 +36,7 @@ import           Testnet.Components.TestWatchdog
 import           Testnet.Process.Cli
 import qualified Testnet.Process.Run as H
 import           Testnet.Process.Run
-import qualified Testnet.Property.Utils as H
+import qualified Testnet.Property.Util as H
 import           Testnet.Runtime
 
 import           Hedgehog (Property)

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Query.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Query.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Cardano.Testnet.Test.Cli.Queries
+module Cardano.Testnet.Test.Cli.Query
   ( hprop_cli_queries
   ) where
 
@@ -30,7 +30,7 @@ import           Testnet.Components.Query
 import           Testnet.Components.TestWatchdog
 import qualified Testnet.Process.Cli as H
 import qualified Testnet.Process.Run as H
-import qualified Testnet.Property.Utils as H
+import qualified Testnet.Property.Util as H
 import           Testnet.Runtime
 
 import           Hedgehog

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/QuerySlotNumber.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/QuerySlotNumber.hs
@@ -27,7 +27,7 @@ import qualified System.Info as SYS
 import           Testnet.Components.TestWatchdog
 import qualified Testnet.Process.Run as H
 import           Testnet.Process.Run
-import qualified Testnet.Property.Utils as H
+import qualified Testnet.Property.Util as H
 import           Testnet.Runtime
 
 import           Hedgehog (Property)

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/FoldBlocks.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/FoldBlocks.hs
@@ -22,7 +22,7 @@ import qualified System.Directory as IO
 import           System.FilePath ((</>))
 
 import           Testnet.Components.TestWatchdog
-import qualified Testnet.Property.Utils as H
+import qualified Testnet.Property.Util as H
 import           Testnet.Runtime
 
 import qualified Hedgehog as H

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepActivity.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepActivity.hs
@@ -32,7 +32,7 @@ import           GHC.Stack (HasCallStack, callStack)
 import           Lens.Micro ((^.))
 import           System.FilePath ((</>))
 
-import           Testnet.Components.DReps (createVotingTxBody, delegateToDRep, generateVoteFiles,
+import           Testnet.Components.DRep (createVotingTxBody, delegateToDRep, generateVoteFiles,
                    getLastPParamUpdateActionId, registerDRep, retrieveTransactionId, signTx,
                    submitTx)
 import           Testnet.Components.Query (EpochStateView, checkDRepState,
@@ -42,7 +42,7 @@ import           Testnet.Components.TestWatchdog
 import           Testnet.Defaults
 import qualified Testnet.Process.Cli as P
 import qualified Testnet.Process.Run as H
-import qualified Testnet.Property.Utils as H
+import qualified Testnet.Property.Util as H
 import           Testnet.Runtime
 
 import           Hedgehog

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepDeposit.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepDeposit.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE NamedFieldPuns #-}
 
-module Cardano.Testnet.Test.Gov.DRepDeposits
+module Cardano.Testnet.Test.Gov.DRepDeposit
   ( hprop_ledger_events_drep_deposits
   ) where
 
@@ -19,12 +19,12 @@ import           Control.Monad (void)
 import qualified Data.Map as Map
 import           System.FilePath ((</>))
 
-import           Testnet.Components.DReps (createCertificatePublicationTxBody, failToSubmitTx,
+import           Testnet.Components.DRep (createCertificatePublicationTxBody, failToSubmitTx,
                    generateDRepKeyPair, generateRegistrationCertificate, registerDRep, signTx)
 import           Testnet.Components.Query (checkDRepState, getEpochStateView, getMinDRepDeposit)
 import           Testnet.Components.TestWatchdog (runWithDefaultWatchdog_)
 import qualified Testnet.Process.Run as H
-import qualified Testnet.Property.Utils as H
+import qualified Testnet.Property.Util as H
 import           Testnet.Runtime (PaymentKeyInfo (paymentKeyInfoPair), PoolNode (poolRuntime),
                    TestnetRuntime (TestnetRuntime, configurationFile, poolNodes, testnetMagic, wallets))
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepRetirement.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepRetirement.hs
@@ -24,7 +24,7 @@ import           Testnet.Components.TestWatchdog
 import           Testnet.Defaults
 import qualified Testnet.Process.Cli as P
 import qualified Testnet.Process.Run as H
-import qualified Testnet.Property.Utils as H
+import qualified Testnet.Property.Util as H
 import           Testnet.Runtime
 
 import           Hedgehog

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/InfoAction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/InfoAction.hs
@@ -36,7 +36,7 @@ import           Testnet.Components.TestWatchdog
 import           Testnet.Defaults
 import qualified Testnet.Process.Cli as P
 import qualified Testnet.Process.Run as H
-import qualified Testnet.Property.Utils as H
+import qualified Testnet.Property.Util as H
 import           Testnet.Runtime
 
 import           Hedgehog

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitutionSPO.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitutionSPO.hs
@@ -26,15 +26,15 @@ import           GHC.Stack (HasCallStack)
 import           Lens.Micro
 import           System.FilePath ((</>))
 
-import           Testnet.Components.DReps (createVotingTxBody, failToSubmitTx,
-                   retrieveTransactionId, signTx, submitTx)
+import           Testnet.Components.DRep (createVotingTxBody, failToSubmitTx, retrieveTransactionId,
+                   signTx, submitTx)
 import           Testnet.Components.Query
 import           Testnet.Components.SPO (generateVoteFiles)
 import           Testnet.Components.TestWatchdog
 import           Testnet.Defaults (defaultSPOColdKeyPair, defaultSPOKeys)
 import qualified Testnet.Process.Cli as P
 import qualified Testnet.Process.Run as H
-import qualified Testnet.Property.Utils as H
+import qualified Testnet.Property.Util as H
 import           Testnet.Runtime
 
 import           Hedgehog

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryGrowth.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryGrowth.hs
@@ -22,7 +22,7 @@ import qualified System.Directory as IO
 import           System.FilePath ((</>))
 
 import           Testnet.Components.TestWatchdog
-import qualified Testnet.Property.Utils as H
+import qualified Testnet.Property.Util as H
 import           Testnet.Runtime
 
 import qualified Hedgehog as H

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryWithdrawal.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryWithdrawal.hs
@@ -41,7 +41,7 @@ import           Testnet.Components.TestWatchdog
 import           Testnet.Defaults
 import qualified Testnet.Process.Cli as P
 import qualified Testnet.Process.Run as H
-import qualified Testnet.Property.Utils as H
+import qualified Testnet.Property.Util as H
 import           Testnet.Runtime
 import           Testnet.Start.Types (eraToString)
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Node/Shutdown.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Node/Shutdown.hs
@@ -37,8 +37,8 @@ import           System.Process (interruptProcessGroupOf)
 import           Testnet.Components.TestWatchdog
 import           Testnet.Defaults
 import           Testnet.Process.Run
-import qualified Testnet.Property.Utils as H
-import           Testnet.Property.Utils
+import qualified Testnet.Property.Util as H
+import           Testnet.Property.Util
 import           Testnet.Runtime
 import           Testnet.Start.Byron
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SanityCheck.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SanityCheck.hs
@@ -21,7 +21,7 @@ import           GHC.Stack
 import           System.FilePath ((</>))
 
 import           Testnet.Components.TestWatchdog
-import qualified Testnet.Property.Utils as H
+import qualified Testnet.Property.Util as H
 import           Testnet.Runtime
 
 import           Hedgehog

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SubmitApi/Babbage/Transaction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SubmitApi/Babbage/Transaction.hs
@@ -39,7 +39,7 @@ import           Testnet.Components.SPO
 import           Testnet.Components.TestWatchdog
 import qualified Testnet.Process.Run as H
 import           Testnet.Process.Run
-import qualified Testnet.Property.Utils as H
+import qualified Testnet.Property.Util as H
 import           Testnet.Runtime
 import           Testnet.SubmitApi
 

--- a/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
+++ b/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
@@ -10,15 +10,15 @@ import qualified Cardano.Testnet.Test.Cli.Babbage.StakeSnapshot
 import qualified Cardano.Testnet.Test.Cli.Babbage.Transaction
 import qualified Cardano.Testnet.Test.Cli.Conway.Plutus
 import qualified Cardano.Testnet.Test.Cli.KesPeriodInfo
-import qualified Cardano.Testnet.Test.Cli.Queries
+import qualified Cardano.Testnet.Test.Cli.Query
 import qualified Cardano.Testnet.Test.Cli.QuerySlotNumber
 import qualified Cardano.Testnet.Test.FoldBlocks
-import qualified Cardano.Testnet.Test.Gov.DRepDeposits
-import qualified Cardano.Testnet.Test.Gov.DRepRetirement as DRepRetirement
-import qualified Cardano.Testnet.Test.Gov.ProposeNewConstitution
-import qualified Cardano.Testnet.Test.Gov.ProposeNewConstitutionSPO as LedgerEvents
-import qualified Cardano.Testnet.Test.Gov.TreasuryGrowth as LedgerEvents
-import qualified Cardano.Testnet.Test.Gov.TreasuryWithdrawal as LedgerEvents
+import qualified Cardano.Testnet.Test.Gov.DRepDeposit as Gov
+import qualified Cardano.Testnet.Test.Gov.DRepRetirement as Gov
+import qualified Cardano.Testnet.Test.Gov.ProposeNewConstitution as Gov
+import qualified Cardano.Testnet.Test.Gov.ProposeNewConstitutionSPO as Gov
+import qualified Cardano.Testnet.Test.Gov.TreasuryGrowth as Gov
+import qualified Cardano.Testnet.Test.Gov.TreasuryWithdrawal as Gov
 import qualified Cardano.Testnet.Test.Node.Shutdown
 import qualified Cardano.Testnet.Test.SanityCheck as LedgerEvents
 import qualified Cardano.Testnet.Test.SubmitApi.Babbage.Transaction
@@ -44,18 +44,19 @@ tests = do
     [ T.testGroup "Spec"
         [ T.testGroup "Ledger Events"
             [ H.ignoreOnWindows "Sanity Check" LedgerEvents.hprop_ledger_events_sanity_check
-            , H.ignoreOnWindows "Treasury Growth" LedgerEvents.prop_check_if_treasury_is_growing
+            , H.ignoreOnWindows "Treasury Growth" Gov.prop_check_if_treasury_is_growing
             -- TODO: Replace foldBlocks with checkLedgerStateCondition
             , T.testGroup "Governance"
-                [ H.ignoreOnMacAndWindows "ProposeAndRatifyNewConstitution" Cardano.Testnet.Test.Gov.ProposeNewConstitution.hprop_ledger_events_propose_new_constitution
+                [
                -- TODO: "DRep Activity" is too flaky at the moment. Disabling until we can fix it.
                -- , H.ignoreOnWindows "DRep Activity" Cardano.Testnet.Test.LedgerEvents.Gov.DRepActivity.hprop_check_drep_activity
-                , H.ignoreOnWindows "DRep Deposits" Cardano.Testnet.Test.Gov.DRepDeposits.hprop_ledger_events_drep_deposits
+                  H.ignoreOnWindows "DRep Deposits" Gov.hprop_ledger_events_drep_deposits
                   -- FIXME Those tests are flaky
                   -- , H.ignoreOnWindows "InfoAction" LedgerEvents.hprop_ledger_events_info_action
-                , H.ignoreOnWindows "ProposeNewConstitutionSPO" LedgerEvents.hprop_ledger_events_propose_new_constitution_spo
-                , H.ignoreOnWindows "TreasuryWithdrawal" LedgerEvents.hprop_ledger_events_treasury_withdrawal
-                , H.ignoreOnWindows "DRepRetirement" DRepRetirement.hprop_drep_retirement
+                , H.ignoreOnWindows "DRep Retirement" Gov.hprop_drep_retirement
+                , H.ignoreOnMacAndWindows "Propose And Ratify New Constitution" Gov.hprop_ledger_events_propose_new_constitution
+                , H.ignoreOnWindows "Propose New Constitution SPO" Gov.hprop_ledger_events_propose_new_constitution_spo
+                , H.ignoreOnWindows "Treasury Withdrawal" Gov.hprop_ledger_events_treasury_withdrawal
                 ]
             , T.testGroup "Plutus"
                 [ H.ignoreOnWindows "PlutusV3" Cardano.Testnet.Test.Cli.Conway.Plutus.hprop_plutus_v3]
@@ -64,7 +65,7 @@ tests = do
           [ H.ignoreOnWindows "Shutdown" Cardano.Testnet.Test.Node.Shutdown.hprop_shutdown
           -- ShutdownOnSigint fails on Mac with
           -- "Log file: /private/tmp/tmp.JqcjW7sLKS/kes-period-info-2-test-30c2d0d8eb042a37/logs/test-spo.stdout.log had no logs indicating the relevant node has minted blocks."
-          , H.ignoreOnMacAndWindows "ShutdownOnSigint" Cardano.Testnet.Test.Node.Shutdown.hprop_shutdownOnSigint
+          , H.ignoreOnMacAndWindows "Shutdown On Sigint" Cardano.Testnet.Test.Node.Shutdown.hprop_shutdownOnSigint
           -- ShutdownOnSlotSynced FAILS Still. The node times out and it seems the "shutdown-on-slot-synced" flag does nothing
           -- , H.ignoreOnWindows "ShutdownOnSlotSynced" Cardano.Testnet.Test.Node.Shutdown.hprop_shutdownOnSlotSynced
           , T.testGroup "Babbage"
@@ -81,7 +82,7 @@ tests = do
           , H.ignoreOnWindows "kes-period-info" Cardano.Testnet.Test.Cli.KesPeriodInfo.hprop_kes_period_info
           , H.ignoreOnWindows "query-slot-number" Cardano.Testnet.Test.Cli.QuerySlotNumber.hprop_querySlotNumber
           , H.ignoreOnWindows "foldBlocks receives ledger state" Cardano.Testnet.Test.FoldBlocks.prop_foldBlocks
-          , H.ignoreOnWindows "CliQueries" Cardano.Testnet.Test.Cli.Queries.hprop_cli_queries
+          , H.ignoreOnWindows "CliQueries" Cardano.Testnet.Test.Cli.Query.hprop_cli_queries
           ]
         ]
     , T.testGroup "SubmitApi"


### PR DESCRIPTION
# Description
This PR consists of two commits:
* `Count votes in Propose Constitution test before ratification`
  This fixes failure of votes counting when testing for constitution ratification: https://github.com/IntersectMBO/cardano-node/actions/runs/8977554294/job/24656515973#step:13:959
* `Refactor: use singular nouns for module names` 
  Renames modules to use singular nouns

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
