### PR TITLE
Address issues with flakiness of DRep Activity test

### DIFF
--- a/cardano-testnet/src/Testnet/EpochStateProcessing.hs
+++ b/cardano-testnet/src/Testnet/EpochStateProcessing.hs
@@ -79,33 +79,30 @@ maybeExtractGovernanceActionIndex txid (AnyNewEpochState sbe newEpochState) =
     compareWithTxId _ x _ _ = x
 
 -- | Watch the epoch state view until the guard function returns 'Just' or the timeout epoch is reached.
--- Wait for at least @minWait@ epochs and at most @maxWait@ epochs.
+-- Wait for at most @maxWait@ epochs.
 -- The function will return the result of the guard function if it is met, otherwise it will return @Nothing@.
 watchEpochStateView
   :: forall m a. (HasCallStack, MonadIO m, MonadTest m, MonadAssertion m)
   => EpochStateView -- ^ The info to access the epoch state
   -> (AnyNewEpochState -> m (Maybe a)) -- ^ The guard function (@Just@ if the condition is met, @Nothing@ otherwise)
-  -> EpochInterval -- ^ The minimum number of epochs to wait
   -> EpochInterval -- ^ The maximum number of epochs to wait
   -> m (Maybe a)
-watchEpochStateView epochStateView f (EpochInterval minWait) (EpochInterval maxWait) = withFrozenCallStack $ do
+watchEpochStateView epochStateView f (EpochInterval maxWait) = withFrozenCallStack $ do
   AnyNewEpochState _ newEpochState <- getEpochState epochStateView
   let (EpochNo currentEpoch) = L.nesEL newEpochState
-  go (EpochNo $ currentEpoch + fromIntegral minWait) (EpochNo $ currentEpoch + fromIntegral maxWait)
+  go (EpochNo $ currentEpoch + fromIntegral maxWait)
     where
-      go :: EpochNo -> EpochNo -> m (Maybe a)
-      go (EpochNo startEpoch) (EpochNo timeout) = do
+      go :: EpochNo -> m (Maybe a)
+      go (EpochNo timeout) = do
         epochState@(AnyNewEpochState _ newEpochState') <- getEpochState epochStateView
         let (EpochNo currentEpoch) = L.nesEL newEpochState'
-        if currentEpoch < startEpoch
-        then do H.threadDelay 100_000
-                go (EpochNo startEpoch) (EpochNo timeout)
-        else do condition <- f epochState
-                case condition of
-                  Just result -> pure (Just result)
-                  Nothing ->
-                    if currentEpoch > timeout
-                    then pure Nothing
-                    else do H.threadDelay 100_000
-                            go (EpochNo startEpoch) (EpochNo timeout)
+        condition <- f epochState
+        case condition of
+          Just result -> pure (Just result)
+          Nothing -> do
+            if currentEpoch > timeout
+              then pure Nothing
+              else do
+                H.threadDelay 100_000
+                go (EpochNo timeout)
 

--- a/cardano-testnet/src/Testnet/EpochStateProcessing.hs
+++ b/cardano-testnet/src/Testnet/EpochStateProcessing.hs
@@ -89,13 +89,13 @@ watchEpochStateView
   -> m (Maybe a)
 watchEpochStateView epochStateView f (EpochInterval maxWait) = withFrozenCallStack $ do
   AnyNewEpochState _ newEpochState <- getEpochState epochStateView
-  let (EpochNo currentEpoch) = L.nesEL newEpochState
+  let EpochNo currentEpoch = L.nesEL newEpochState
   go (EpochNo $ currentEpoch + fromIntegral maxWait)
     where
       go :: EpochNo -> m (Maybe a)
       go (EpochNo timeout) = do
         epochState@(AnyNewEpochState _ newEpochState') <- getEpochState epochStateView
-        let (EpochNo currentEpoch) = L.nesEL newEpochState'
+        let EpochNo currentEpoch = L.nesEL newEpochState'
         condition <- f epochState
         case condition of
           Just result -> pure (Just result)

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepActivity.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepActivity.hs
@@ -64,7 +64,7 @@ hprop_check_drep_activity = H.integrationWorkspace "test-activity" $ \tempAbsBas
       era = toCardanoEra sbe
       cEra = AnyCardanoEra era
       fastTestnetOptions = cardanoDefaultTestnetOptions
-        { cardanoEpochLength = 100
+        { cardanoEpochLength = 200
         , cardanoNodeEra = cEra
         , cardanoNumDReps = 1
         }
@@ -93,8 +93,8 @@ hprop_check_drep_activity = H.integrationWorkspace "test-activity" $ \tempAbsBas
 
   -- This proposal should pass
   let minEpochsToWaitIfChanging = 0 -- The change already provides a min bound
-      minEpochsToWaitIfNotChanging = 3 -- We cannot wait for change since there is no change (we wait a bit)
-      maxEpochsToWaitAfterProposal = 10 -- If it takes more than 10 epochs we give up in any case
+      minEpochsToWaitIfNotChanging = 2 -- We cannot wait for change since there is no change (we wait a bit)
+      maxEpochsToWaitAfterProposal = 2 -- If it takes more than 2 epochs we give up in any case
       firstTargetDRepActivity = 3
   void $ activityChangeProposalTest execConfig epochStateView configurationFile socketPath ceo gov
                                     "firstProposal" wallet0 [(1, "yes")] firstTargetDRepActivity

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepActivity.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepActivity.hs
@@ -190,9 +190,8 @@ activityChangeProposalTest execConfig epochStateView configurationFile socketPat
   H.note_ $ "Epoch after \"" <> prefix <> "\" prop: " <> show epochAfterProp
 
   void $ waitForEpochs epochStateView minWait
-  case mExpected of
-    Nothing -> return ()
-    Just expected -> H.nothingFailM $ watchEpochStateView epochStateView (isDRepActivityUpdated expected) maxWait
+  forM_ mExpected $ \expected ->
+    H.nothingFailM $ watchEpochStateView epochStateView (isDRepActivityUpdated expected) maxWait
 
   return thisProposal
 

--- a/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
+++ b/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
@@ -14,6 +14,7 @@ import qualified Cardano.Testnet.Test.Cli.Query
 import qualified Cardano.Testnet.Test.Cli.QuerySlotNumber
 import qualified Cardano.Testnet.Test.FoldEpochState
 import qualified Cardano.Testnet.Test.Gov.CommitteeAddNew as Gov
+import qualified Cardano.Testnet.Test.Gov.DRepActivity as Gov
 import qualified Cardano.Testnet.Test.Gov.DRepDeposit as Gov
 import qualified Cardano.Testnet.Test.Gov.DRepRetirement as Gov
 import qualified Cardano.Testnet.Test.Gov.ProposeNewConstitution as Gov
@@ -49,8 +50,7 @@ tests = do
             -- TODO: Replace foldBlocks with checkLedgerStateCondition
             , T.testGroup "Governance"
                 [ H.ignoreOnMacAndWindows "Committee Add New" Gov.hprop_constitutional_committee_add_new
-               -- TODO: "DRep Activity" is too flaky at the moment. Disabling until we can fix it.
-               -- , H.ignoreOnWindows "DRep Activity" Cardano.Testnet.Test.LedgerEvents.Gov.DRepActivity.hprop_check_drep_activity
+                , H.ignoreOnWindows "DRep Activity" Gov.hprop_check_drep_activity
                 , H.ignoreOnWindows "DRep Deposits" Gov.hprop_ledger_events_drep_deposits
                   -- FIXME Those tests are flaky
                   -- , H.ignoreOnWindows "InfoAction" LedgerEvents.hprop_ledger_events_info_action


### PR DESCRIPTION
# Description

DRep Activity test was disabled because it was failing often. This PR aims to address this issues and reenable it.

It seems the flakiness was due to two things:
 - Using `foldEpochState` repeatedly, I am now polling with `getEpochState` instead.
 - Using only `100` slots per epoch, I am now using `200`.

I will remove the last two commits when it gets approved and before merging.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff
