### PR TITLE
Make Plutus spending script less flaky

### DIFF
--- a/cardano-testnet/src/Testnet/Types.hs
+++ b/cardano-testnet/src/Testnet/Types.hs
@@ -105,6 +105,14 @@ data TestnetRuntime = TestnetRuntime
 poolSprockets :: TestnetRuntime -> [Sprocket]
 poolSprockets = fmap (nodeSprocket . poolRuntime) . poolNodes
 
+data PoolNode = PoolNode
+  { poolRuntime :: NodeRuntime
+  , poolKeys :: PoolNodeKeys
+  }
+
+poolNodeStdout :: PoolNode -> FilePath
+poolNodeStdout = nodeStdout . poolRuntime
+
 data NodeRuntime = NodeRuntime
   { nodeName :: !String
   , nodeIpv4 :: !Text
@@ -118,14 +126,6 @@ data NodeRuntime = NodeRuntime
 
 nodeSocketPath :: NodeRuntime -> SocketPath
 nodeSocketPath = File . H.sprocketSystemName . nodeSprocket
-
-data PoolNode = PoolNode
-  { poolRuntime :: NodeRuntime
-  , poolKeys :: PoolNodeKeys
-  }
-
-poolNodeStdout :: PoolNode -> FilePath
-poolNodeStdout = nodeStdout . poolRuntime
 
 data ColdPoolKey
 data StakingKey


### PR DESCRIPTION
# Description

Plutus test in cardano-testnet seems to be flaky. Sample failure: https://github.com/IntersectMBO/cardano-node/actions/runs/9029521481/job/24812005694

This PR updates the test case to use `EpochStateView` instad of CLI commands.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
