### PR TITLE
cardano-testnet: Waiting for blocks using `EpochStateView`.

### DIFF
--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -77,7 +77,7 @@ library
                       , safe-exceptions
                       , scientific
                       , si-timers
-                      , stm
+                      , stm > 2.5.1
                       , tasty ^>= 1.5
                       , tasty-expected-failure
                       , tasty-hedgehog

--- a/cardano-testnet/src/Testnet/EpochStateProcessing.hs
+++ b/cardano-testnet/src/Testnet/EpochStateProcessing.hs
@@ -1,16 +1,14 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Testnet.EpochStateProcessing
   ( maybeExtractGovernanceActionIndex
   , findCondition
-  , watchEpochStateView
   ) where
 
 import           Cardano.Api
-import           Cardano.Api.Ledger (EpochInterval (..), GovActionId (..))
+import           Cardano.Api.Ledger (GovActionId (..))
 import qualified Cardano.Api.Ledger as L
 
 import qualified Cardano.Ledger.Conway.Governance as L
@@ -25,11 +23,7 @@ import           Data.Word (Word32)
 import           GHC.Stack
 import           Lens.Micro ((^.))
 
-import           Testnet.Components.Query (EpochStateView, getEpochState)
-
 import           Hedgehog
-import           Hedgehog.Extras (MonadAssertion)
-import qualified Hedgehog.Extras as H
 
 findCondition
   :: HasCallStack
@@ -77,32 +71,4 @@ maybeExtractGovernanceActionIndex txid (AnyNewEpochState sbe newEpochState) =
     compareWithTxId (TxId ti1) Nothing (GovActionId (L.TxId ti2) (L.GovActionIx gai)) _
       | ti1 == L.extractHash ti2 = Just gai
     compareWithTxId _ x _ _ = x
-
--- | Watch the epoch state view until the guard function returns 'Just' or the timeout epoch is reached.
--- Wait for at most @maxWait@ epochs.
--- The function will return the result of the guard function if it is met, otherwise it will return @Nothing@.
-watchEpochStateView
-  :: forall m a. (HasCallStack, MonadIO m, MonadTest m, MonadAssertion m)
-  => EpochStateView -- ^ The info to access the epoch state
-  -> (AnyNewEpochState -> m (Maybe a)) -- ^ The guard function (@Just@ if the condition is met, @Nothing@ otherwise)
-  -> EpochInterval -- ^ The maximum number of epochs to wait
-  -> m (Maybe a)
-watchEpochStateView epochStateView f (EpochInterval maxWait) = withFrozenCallStack $ do
-  AnyNewEpochState _ newEpochState <- getEpochState epochStateView
-  let EpochNo currentEpoch = L.nesEL newEpochState
-  go (EpochNo $ currentEpoch + fromIntegral maxWait)
-    where
-      go :: EpochNo -> m (Maybe a)
-      go (EpochNo timeout) = do
-        epochState@(AnyNewEpochState _ newEpochState') <- getEpochState epochStateView
-        let EpochNo currentEpoch = L.nesEL newEpochState'
-        condition <- f epochState
-        case condition of
-          Just result -> pure (Just result)
-          Nothing -> do
-            if currentEpoch > timeout
-              then pure Nothing
-              else do
-                H.threadDelay 100_000
-                go (EpochNo timeout)
 

--- a/cardano-testnet/src/Testnet/Types.hs
+++ b/cardano-testnet/src/Testnet/Types.hs
@@ -105,6 +105,14 @@ data TestnetRuntime = TestnetRuntime
 poolSprockets :: TestnetRuntime -> [Sprocket]
 poolSprockets = fmap (nodeSprocket . poolRuntime) . poolNodes
 
+data PoolNode = PoolNode
+  { poolRuntime :: NodeRuntime
+  , poolKeys :: PoolNodeKeys
+  }
+
+poolNodeStdout :: PoolNode -> FilePath
+poolNodeStdout = nodeStdout . poolRuntime
+
 data NodeRuntime = NodeRuntime
   { nodeName :: !String
   , nodeIpv4 :: !Text
@@ -118,14 +126,6 @@ data NodeRuntime = NodeRuntime
 
 nodeSocketPath :: NodeRuntime -> SocketPath
 nodeSocketPath = File . H.sprocketSystemName . nodeSprocket
-
-data PoolNode = PoolNode
-  { poolRuntime :: NodeRuntime
-  , poolKeys :: PoolNodeKeys
-  }
-
-poolNodeStdout :: PoolNode -> FilePath
-poolNodeStdout = nodeStdout . poolRuntime
 
 data ColdPoolKey
 data StakingKey

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/Plutus.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/Plutus.hs
@@ -11,7 +11,6 @@ module Cardano.Testnet.Test.Cli.Conway.Plutus
   ) where
 
 import           Cardano.Api
-import qualified Cardano.Api.Ledger as L
 
 import           Cardano.Testnet
 
@@ -142,7 +141,7 @@ hprop_plutus_v3 = integrationWorkspace "all-plutus-script-purposes" $ \tempAbsBa
     , "--tx-file", sendAdaToScriptAddressTx
     ]
 
-  _ <- waitForEpochs epochStateView (L.EpochInterval 1)
+  H.noteShowM_ $ waitForBlocks epochStateView 1
 
   -- 2. Successfully spend conway spending script
   txinCollateral <- findLargestUtxoForPaymentKey epochStateView sbe wallet1

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryWithdrawal.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryWithdrawal.hs
@@ -164,8 +164,8 @@ hprop_ledger_events_treasury_withdrawal = integrationRetryWorkspace 1  "treasury
   txbodyFp <- H.note $ work </> "tx.body"
   txbodySignedFp <- H.note $ work </> "tx.body.signed"
 
-  -- wait for an epoch before using wallet0 again
-  void $ waitForEpochs epochStateView (EpochInterval 1)
+  -- wait for one block before using wallet0 again
+  H.noteShowM_ $ waitForBlocks epochStateView 1
 
   txin3 <- findLargestUtxoForPaymentKey epochStateView sbe wallet0
 


### PR DESCRIPTION
# Description

This PR provides new functions allowing to extract slot number and block number from epoch state view, and additionally wait for epoch state view updates. This cuts down the test execution time a bit. Waiting for an epoch in a plutus test takes ~70s, where one block wait is around 20s.

This PR is stacked on top of https://github.com/IntersectMBO/cardano-node/pull/5835

`watchEpochStateUpdate` was inspired by @palas 's `watchEpochStateUpdate` function in #5830 , but it uses `TChan` for waiting for an update, instead of polling.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
