### PR TITLE
README: Fix dead link to docs.cardano.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Obtaining ``cardano-node``
 Building from source
 ====================
 
-Documentation for building the node can be found `here <https://docs.cardano.org/getting-started/installing-the-cardano-node>`_.
+Documentation for building the node can be found `here <https://developers.cardano.org/docs/get-started/installing-cardano-node>`_.
 
 Executables
 ===========


### PR DESCRIPTION
# Description

Remove a dead link to `docs.cardano.org` in the README.

# Context

Fixes https://github.com/IntersectMBO/cardano-node/issues/5837