### PR TITLE
release-upload: generate checksums of artifacts

### DIFF
--- a/.github/workflows/release-upload.yaml
+++ b/.github/workflows/release-upload.yaml
@@ -78,7 +78,7 @@ jobs:
               cp result/cardano-node-*-*.zip .
               ;;              
           esac
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ github.sha }}-${{ matrix.arch }}       
           path: cardano-node-*-*.*
@@ -89,15 +89,9 @@ jobs:
     name: "Upload Assets"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: ${{ github.sha }}-linux
-      - uses: actions/download-artifact@v3
-        with:
-          name: ${{ github.sha }}-macos
-      - uses: actions/download-artifact@v3
-        with:
-          name: ${{ github.sha }}-win64
+          merge-multiple: true
       - name: Release
         uses: input-output-hk/action-gh-release@v1
         with:

--- a/.github/workflows/release-upload.yaml
+++ b/.github/workflows/release-upload.yaml
@@ -92,6 +92,15 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           merge-multiple: true
+      - name: Checksums
+        run: |
+          # find returns something like this:
+          # "cardano-node-8.11.0-linux.tar.gz cardano-node-8.11.0-macos.tar.gz ..."
+          # We use the first member of this list to compute the prefix "cardano-node-8.11.0"
+          first_archive=$(find . -maxdepth 1 -name "cardano-node-*" -printf '%P\n' | head -n 1)
+          # Then we trim the architecture-specific suffix (last "-" and after)
+          sha256sums_filename=$(echo "${first_archive%-*}-sha256sums.txt")
+          sha256sum cardano-node-* >> "$sha256sums_filename"
       - name: Release
         uses: input-output-hk/action-gh-release@v1
         with:
@@ -100,3 +109,4 @@ jobs:
             cardano-node-*-win64.zip
             cardano-node-*-macos.tar.gz
             cardano-node-*-linux.tar.gz
+            cardano-node-*-sha256sums.txt


### PR DESCRIPTION
# Context

* This is the cardano-node version of https://github.com/IntersectMBO/cardano-cli/pull/762
* Was asked by a user: https://github.com/IntersectMBO/cardano-cli/issues/755#issuecomment-2107020047
* Anyway a good practice to make it possible for users to verify the integrity of their downloads and a number of deployments tools require assets to have attached checksums.
* The change of version of `{download,upload}-artifact` is motivated by the fact that `v3` will be shutdown at the end of the year: https://github.com/actions/upload-artifact#actionsupload-artifact

# How to trust this PR

* Look at the assets generated when producing a release with this PR: https://github.com/IntersectMBO/cardano-node/releases/tag/untagged-0ccd023f738aead32ba8
* Observe it contains the checksums: 

![image](https://github.com/IntersectMBO/cardano-node/assets/634720/f8b26c1f-3de3-45dd-8dcc-16327d7af0cb)

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff