### PR TITLE
Improve `NewEpochState` logging

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -31,8 +31,8 @@ packages:
   trace-resources
   trace-forward
 
-program-options
-  ghc-options: -Werror
+-- program-options
+--   ghc-options: -Werror
 
 test-show-details: direct
 

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -57,6 +57,7 @@ library
                       , containers
                       , contra-tracer
                       , data-default-class
+                      , Diff
                       , directory
                       , exceptions
                       , filepath

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -34,6 +34,7 @@ library
   build-depends:        aeson
                       , aeson-pretty
                       , ansi-terminal
+                      , async
                       , bytestring
                       , cardano-api ^>= 8.46
                       , cardano-cli ^>= 8.23

--- a/cardano-testnet/src/Testnet/Components/Query.hs
+++ b/cardano-testnet/src/Testnet/Components/Query.hs
@@ -248,13 +248,12 @@ getEpochStateView
   :: HasCallStack
   => MonadResource m
   => MonadTest m
-  => MonadCatch m
   => NodeConfigFile In -- ^ node Yaml configuration file path
   -> SocketPath -- ^ node socket path
   -> m EpochStateView
 getEpochStateView nodeConfigFile socketPath = withFrozenCallStack $ do
   epochStateView <- H.evalIO $ newIORef Nothing
-  runInBackground . runExceptT . foldEpochState nodeConfigFile socketPath QuickValidation (EpochNo maxBound) Nothing
+  runInBackground (return ()) . runExceptT . foldEpochState nodeConfigFile socketPath QuickValidation (EpochNo maxBound) Nothing
     $ \epochState slotNumber blockNumber -> do
         liftIO . writeIORef epochStateView $ Just (epochState, slotNumber, blockNumber)
         pure ConditionNotMet

--- a/cardano-testnet/src/Testnet/Property/Util.hs
+++ b/cardano-testnet/src/Testnet/Property/Util.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MonoLocalBinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -15,11 +16,13 @@ module Testnet.Property.Util
 
 import           Cardano.Api
 
-import           Control.Exception.Safe (MonadCatch)
+import           Control.Concurrent.Async
+import qualified Control.Exception as E
 import           Control.Monad
 import           Control.Monad.Trans.Resource
 import qualified Data.Aeson as Aeson
 import           GHC.Stack
+import           Network.Mux.Trace
 import qualified System.Environment as IO
 import           System.Info (os)
 import qualified System.IO.Unsafe as IO
@@ -60,18 +63,44 @@ integrationWorkspace workspaceName f = withFrozenCallStack $
 isLinux :: Bool
 isLinux = os == "linux"
 
-
 -- | Runs an action in background, and registers cleanup to `MonadResource m`
--- The argument forces IO monad to prevent leaking of `MonadResource` to the child thread
+-- Concurrency is tricky in the 'ResourceT' monad. See the "Concurrency" section of
+-- https://www.fpcomplete.com/blog/understanding-resourcet/.
 runInBackground :: MonadTest m
                 => MonadResource m
-                => MonadCatch m
-                => IO a
+                => IO ()
+                -> IO a
                 -> m ()
-runInBackground act = void . H.evalM $ allocate (H.async act) cleanUp
-  where
-    cleanUp :: H.Async a -> IO ()
-    cleanUp a = H.cancel a >> H.link a
+runInBackground runOnException act  =
+  void . H.evalIO
+       $ runResourceT
+       -- We don't 'wait' because this "background process" may not terminate.
+       -- If we 'wait' and it doesn't terminate, 'ResourceT' will not kill it
+       -- and the test will hang indefinitely.
+       -- Not waiting isn't a problem because this "background process"
+       -- is meant to run indefinitely and will be cleaned up by
+       -- 'ResourceT' when the test ends or fails.
+       -- We use 'asyncWithUnmask' because our logging thread is terminated via an exception.
+       -- In order to avoid competing for a file handle we must catch the exception which signals
+       -- the logging file is no longer being written to and we can now run the desired additional IO action we
+       -- want (runOnException). Attempting to share the 'FileHandle' and use concurrency primitives was not fruitful
+       -- and the section "Other ways to abuse ResourceT" in https://www.fpcomplete.com/blog/understanding-resourcet/
+       -- confirms this is problematic in 'ResourceT'.
+       $ resourceForkWith (\_ -> do r <- H.asyncWithUnmask (\restore -> restore act `E.onException` runOnException)
+                                    linkOnly ignoreException r
+                          ) $ return ()
+ where
+  ignoreException  :: E.SomeException -> Bool
+  ignoreException e =
+    case E.fromException e of
+     Just (MuxError errType _) ->
+       case errType of
+         MuxBearerClosed -> False
+         -- This is expected as the background thread is killed.
+         -- However we do want to be made aware about other
+         -- exceptions.
+         _ -> True
+     _ -> False
 
 decodeEraUTxO :: (IsShelleyBasedEra era, MonadTest m) => ShelleyBasedEra era -> Aeson.Value -> m (UTxO era)
 decodeEraUTxO _ = H.jsonErrorFail . Aeson.fromJSON

--- a/cardano-testnet/src/Testnet/Property/Util.hs
+++ b/cardano-testnet/src/Testnet/Property/Util.hs
@@ -71,7 +71,7 @@ runInBackground :: MonadTest m
 runInBackground act = void . H.evalM $ allocate (H.async act) cleanUp
   where
     cleanUp :: H.Async a -> IO ()
-    cleanUp a = H.cancel a >> void (H.link a)
+    cleanUp a = H.cancel a >> H.link a
 
 decodeEraUTxO :: (IsShelleyBasedEra era, MonadTest m) => ShelleyBasedEra era -> Aeson.Value -> m (UTxO era)
 decodeEraUTxO _ = H.jsonErrorFail . Aeson.fromJSON

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs
@@ -131,7 +131,7 @@ hprop_gov_no_confidence = integrationWorkspace "no-confidence" $ \tempAbsBasePat
 
   epochStateView <- getEpochStateView configurationFile (File socketPath)
 
-  H.nothingFailM $ watchEpochStateUpdate epochStateView (EpochInterval 3) $ \(anyNewEpochState, _, _) ->
+  H.nothingFailM $ watchEpochStateUpdate epochStateView (EpochInterval 3) $ \anyNewEpochState->
     pure $ committeeIsPresent True anyNewEpochState
 
   -- Step 2. Propose motion of no confidence. DRep and SPO voting thresholds must be met.
@@ -223,11 +223,11 @@ hprop_gov_no_confidence = integrationWorkspace "no-confidence" $ \tempAbsBasePat
 
   -- Step 4. We confirm the no confidence motion has been ratified by checking
   -- for an empty constitutional committee.
-  H.nothingFailM $ watchEpochStateView epochStateView (return . committeeIsPresent False) (EpochInterval 10)
+  H.nothingFailM $ watchEpochStateUpdate epochStateView (EpochInterval 10) (return . committeeIsPresent False)
 
 -- | Checks if the committee is empty or not.
-committeeIsPresent :: Bool -> AnyNewEpochState -> Maybe ()
-committeeIsPresent committeeExists (AnyNewEpochState sbe newEpochState) =
+committeeIsPresent :: Bool -> (AnyNewEpochState, SlotNo, BlockNo) -> Maybe ()
+committeeIsPresent committeeExists (AnyNewEpochState sbe newEpochState, _, _) =
   caseShelleyToBabbageOrConwayEraOnwards
     (const $ error "Constitutional committee does not exist pre-Conway era")
     (const $ let mCommittee = newEpochState

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs
@@ -223,9 +223,7 @@ hprop_gov_no_confidence = integrationWorkspace "no-confidence" $ \tempAbsBasePat
 
   -- Step 4. We confirm the no confidence motion has been ratified by checking
   -- for an empty constitutional committee.
-
-  H.nothingFailM $ watchEpochStateUpdate epochStateView (EpochInterval 10) $ \(anyNewEpochState, _, _) ->
-    pure $ committeeIsPresent False anyNewEpochState
+  H.nothingFailM $ watchEpochStateView epochStateView (return . committeeIsPresent False) (EpochInterval 10)
 
 -- | Checks if the committee is empty or not.
 committeeIsPresent :: Bool -> AnyNewEpochState -> Maybe ()


### PR DESCRIPTION
# Description

Improvements
1. The log output of `startLedgerNewEpochStateLogging` is now pretty JSON
2. Output the diff of each transition of `NewEpochState` (i.e per block or at the turn of the epoch) to <tmp workspace directory>/logs/ledger-new-epoch-state-diffs.log

Prior output format of generated logs (calling `show` after each block application/epoch transition):
```
#### BLOCK ####
NewEpochState {nesEL = EpochNo 0, nesBprev = BlocksMade (fromList []), nesBcur = BlocksMade (fromList [(KeyHash "af20b2f144dc28a3bd62a300fa285666e3d3dc211ba483a2e4944846",1)]), nesEs = EpochState {esAccountState = AccountState {asTreasury = Coin 0, asReserves = Coin 191999999999}, esLState = LedgerState {lsUTxOState = UTxOState {utxosUtxo = UTxO (fromList [(TxIn (TxId {unTxId = SafeHash "2a9bb38ea6d56726250b03ab8dabfdce9dc9fb0021472e93cc51f6497775fbb2"}) (TxIx 0),(Addr Testnet (KeyHashObj (KeyHash "a17ad57373ec284b7ef329b744affdacf26dac6f6797ef0a715fe53d")) (StakeRefBase (KeyHashObj (KeyHash "0a19ee2042807a1b6925c170e545de22e0dc1b5f3e4dff4d70f70ca6"))),MaryValue (Coin 300000000000) (MultiAsset (fromList [])),NoDatum,SNothing)),(TxIn (TxId {unTxId = SafeHash "49e5059fc654f4640243b2c6ede2f2537009281722ba7a53816787ac2c0f3070"}) (TxIx 0),(AddrBootstrap (BootstrapAddress (Address {addrRoot = 06f9f79cccef8ecbf9e680d3302f4d6916dbdb0bb094ff58cc7155ab, addrAttributes = Attributes { data_ = AddrAttributes {aaVKDerivationPath = Nothing, aaNetworkMagic = NetworkTestnet 42} }, addrType = ATVerKey})),MaryValue (Coin 2666666667) (MultiAsset (fromList [])),NoDatum,SNothing)),(TxIn (TxId {unTxId = SafeHash "4ed4fd57533f3ba7316d47c013c19b21126940c20aa360ba09c7c4dead4852bc"}) (TxIx 0),(Addr Testnet (KeyHashObj (KeyHash "674a339680452ac1e2a8260c872b12ff98a5cdc19d4fca8f606bfa31")) StakeRefNull,MaryValue (Coin 300000000000) (MultiAsset (fromList [])),NoDatum,SNothing)),(TxIn (TxId {unTxId = SafeHash "59a53a350e4b6e28ba38f920bcc3a9104fee48ecda7a4efad9765af078d32b5c"}) (TxIx 0),(Addr Testnet (KeyHashObj (KeyHash "05c601a3a326f7499d3c63d59613b1f04097c4fb1b5c9798ea3922bc")) (StakeRefBase (KeyHashObj (KeyHash "411dbefbd05427f8f6b4cd4e53205dc0d19df3080874fff3b9e3e3d9"))),MaryValue (Coin 300000000000) (MultiAsset (fromList [])),NoDatum,SNothing)),(TxIn (TxId {unTxId = SafeHash "5f1f67f02daf2ce83dfc94a1e6c6b2f29ed41751887772ee5f922258926f62a3"}) (TxIx 0),(AddrBootstrap (BootstrapAddress (Address {addrRoot = a7011aecc6f237f2200606114ed891f3f07482ec1e58aba2d5300a89, addrAttributes = Attributes { data_ = AddrAttributes {aaVKDerivationPath = Nothing, aaNetworkMagic = NetworkTestnet 42} }, addrType = ATVerKey})),MaryValue (Coin 2666666667) (MultiAsset (fromList [])),NoDatum,SNothing)),(TxIn (TxId {unTxId = SafeHash "6d77de0e223335be259cb9764dcb279259249a562ed309a254f963b336158d0d"}) (TxIx 0),(AddrBootstrap 

#### BLOCK ####
NewEpochState {nesEL = EpochNo 1, nesBprev = BlocksMade (fromList []), nesBcur = BlocksMade (fromList [(KeyHash "af20b2f144dc28a3bd62a300fa285666e3d3dc211ba483a2e4944846",2)]), nesEs = EpochState {esAccountState = AccountState {asTreasury = Coin 0, asReserves = Coin 191999999999}, esLState = LedgerState {lsUTxOState = UTxOState {utxosUtxo = UTxO (fromList [(TxIn (TxId {unTxId = SafeHash "2a9bb38ea6d56726250b03ab8dabfdce9dc9fb0021472e93cc51f6497775fbb2"}) (TxIx 0),(Addr Testnet (KeyHashObj (KeyHash "a17ad57373ec284b7ef329b744affdacf26dac6f6797ef0a715fe53d")) (StakeRefBase (KeyHashObj (KeyHash "0a19ee2042807a1b6925c170e545de22e0dc1b5f3e4dff4d70f70ca6"))),MaryValue (Coin 300000000000) (MultiAsset (fromList [])),NoDatum,SNothing)),(TxIn (TxId {unTxId = SafeHash "49e5059fc654f4640243b2c6ede2f2537009281722ba7a53816787ac2c0f3070"}) (TxIx 0),(AddrBootstrap (BootstrapAddress (Address {addrRoot = 06f9f79cccef8ecbf9e680d3302f4d6916dbdb0bb094ff58cc7155ab, addrAttributes = Attributes { data_ = AddrAttributes {aaVKDerivationPath = Nothing, aaNetworkMagic = NetworkTestnet 42} }, addrType = ATVerKey})),MaryValue (Coin 2666666667) (MultiAsset (fromList [])),NoDatum,SNothing)),(TxIn (TxId {unTxId = SafeHash "4ed4fd57533f3ba7316d47c013c19b21126940c20aa360ba09c7c4dead4852bc"}) (TxIx 0),(Addr Testnet (KeyHashObj (KeyHash "674a339680452ac1e2a8260c872b12ff98a5cdc19d4fca8f606bfa31")) StakeRefNull,MaryValue (Coin 300000000000) (MultiAsset (fromList [])),NoDatum,SNothing)),(TxIn (TxId {unTxId = SafeHash "59a53a350e4b6e28ba38f920bcc3a9104fee48ecda7a4efad9765af078d32b5c"}) (TxIx 0),(Addr Testnet (KeyHashObj (KeyHash "05c601a3a326f7499d3c63d59613b1f04097c4fb1b5c9798ea3922bc")) (StakeRefBase (KeyHashObj (KeyHash "411dbefbd05427f8f6b4cd4e53205dc0d19df3080874fff3b9e3e3d9"))),MaryValue (Coin 300000000000) (MultiAsset (fromList [])),NoDatum,SNothing)),(TxIn (TxId {unTxId = SafeHash "5f1f67f02daf2ce83dfc94a1e6c6b2f29ed41751887772ee5f922258926f62a3"}) (TxIx 0),(AddrBootstrap (BootstrapAddress (Address {addrRoot = a7011aecc6f237f2200606114ed891f3f07482ec1e58aba2d5300a89, addrAttributes = Attributes { data_ = AddrAttributes {aaVKDerivationPath = Nothing, aaNetworkMagic = NetworkTestnet 42} }, addrType = ATVerKey})),MaryValue (Coin 2666666667) (MultiAsset (fromList [])),NoDatum,SNothing)),(TxIn (TxId {unTxId = SafeHash "6d77de0e223335be259cb9764dcb279259249a562ed309a254f963b336158d0d"}) (TxIx 0),(AddrBootstrap 
```
Pretty JSON output improvement:
```
#### BLOCK ####
{
    "currentEpoch": 0,
    "currentEpochBlocks": {
        "814e499df8e9ff7732c07c342ce0f0ecc1b939d36515177035232588": 1
    },
    "currentEpochState": {
        "esAccountState": {
            "reserves": 191999999999,
            "treasury": 0
        },
        "esLState": {
            "delegationState": {
                "dstate": {
                    "fGenDelegs": [],
                    "genDelegs": {
                        "07a6850426b4c50b03658f91e271d159c7d093b59e3faf68aad92f63": {
                            "delegate": "c45e6e2952d6bd58767b66b134e18ca4bdd46a85b400e75bb84b70ef",
                            "vrf": "0bd71f801f2fe70513488248bab5fbba0aa479e964b29458ea296927de012c18"
                        },
                        ....

#### BLOCK ####
{
    "currentEpoch": 0,
    "currentEpochBlocks": {
        "814e499df8e9ff7732c07c342ce0f0ecc1b939d36515177035232588": 2
    },
    "currentEpochState": {
        "esAccountState": {
            "reserves": 191999999999,
            "treasury": 0
        },
        "esLState": {
            "delegationState": {
                "dstate": {
                    "fGenDelegs": [],
                    "genDelegs": {
                        "07a6850426b4c50b03658f91e271d159c7d093b59e3faf68aad92f63": {
                            "delegate": "c45e6e2952d6bd58767b66b134e18ca4bdd46a85b400e75bb84b70ef",
                            "vrf": "0bd71f801f2fe70513488248bab5fbba0aa479e964b29458ea296927de012c18"
                        },
                        ....
```
New epoch state diff output:
```
Epoch state transition: 4
6c6
<         "e42f09a8c25b867068c106567fedec0da386f4b661ccc6dd56db99d9": 3
---
>         "e42f09a8c25b867068c106567fedec0da386f4b661ccc6dd56db99d9": 4

Epoch state transition: 5
3c3
<     "currentEpoch": 0,
---
>     "currentEpoch": 1,
5,6c5
<         "814e499df8e9ff7732c07c342ce0f0ecc1b939d36515177035232588": 1,
<         "e42f09a8c25b867068c106567fedec0da386f4b661ccc6dd56db99d9": 4
---
>         "814e499df8e9ff7732c07c342ce0f0ecc1b939d36515177035232588": 1
121c120
<                 "deposited": 1000000,
---
>                 "deposited": 4000000,
780c779,780
<                         "tag": "NoPParamsUpdate"
---
>                         "contents": null,
>                         "tag": "PotentialPParamsUpdate"
783c783,820
<                         "enactedGovActions": [],
---
>                         "enactedGovActions": [
>                             {
>                                 "actionId": {
>                                     "govActionIx": 0,
>                                     "txId": "6047fc73079a2efab718be3a39705ad17e26b8b06bc22678248688bff9cd7ae3"
>                                 },
........
```
# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
