### PR TITLE
Simplify epoch state diff logging

### DIFF
--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -34,7 +34,6 @@ library
   build-depends:        aeson
                       , aeson-pretty
                       , ansi-terminal
-                      , async
                       , bytestring
                       , cardano-api ^>= 8.46
                       , cardano-cli ^>= 8.23

--- a/cardano-testnet/src/Testnet/Components/Query.hs
+++ b/cardano-testnet/src/Testnet/Components/Query.hs
@@ -248,12 +248,13 @@ getEpochStateView
   :: HasCallStack
   => MonadResource m
   => MonadTest m
+  => MonadCatch m
   => NodeConfigFile In -- ^ node Yaml configuration file path
   -> SocketPath -- ^ node socket path
   -> m EpochStateView
 getEpochStateView nodeConfigFile socketPath = withFrozenCallStack $ do
   epochStateView <- H.evalIO $ newIORef Nothing
-  runInBackground (return ()) . runExceptT . foldEpochState nodeConfigFile socketPath QuickValidation (EpochNo maxBound) Nothing
+  runInBackground . runExceptT . foldEpochState nodeConfigFile socketPath QuickValidation (EpochNo maxBound) Nothing
     $ \epochState slotNumber blockNumber -> do
         liftIO . writeIORef epochStateView $ Just (epochState, slotNumber, blockNumber)
         pure ConditionNotMet

--- a/cardano-testnet/src/Testnet/Property/Util.hs
+++ b/cardano-testnet/src/Testnet/Property/Util.hs
@@ -16,13 +16,11 @@ module Testnet.Property.Util
 
 import           Cardano.Api
 
-import           Control.Concurrent.Async
-import qualified Control.Exception as E
+import           Control.Exception.Safe (MonadCatch)
 import           Control.Monad
 import           Control.Monad.Trans.Resource
 import qualified Data.Aeson as Aeson
 import           GHC.Stack
-import           Network.Mux.Trace
 import qualified System.Environment as IO
 import           System.Info (os)
 import qualified System.IO.Unsafe as IO
@@ -64,43 +62,16 @@ isLinux :: Bool
 isLinux = os == "linux"
 
 -- | Runs an action in background, and registers cleanup to `MonadResource m`
--- Concurrency is tricky in the 'ResourceT' monad. See the "Concurrency" section of
--- https://www.fpcomplete.com/blog/understanding-resourcet/.
+-- The argument forces IO monad to prevent leaking of `MonadResource` to the child thread
 runInBackground :: MonadTest m
                 => MonadResource m
-                => IO ()
-                -> IO a
+                => MonadCatch m
+                => IO a
                 -> m ()
-runInBackground runOnException act  =
-  void . H.evalIO
-       $ runResourceT
-       -- We don't 'wait' because this "background process" may not terminate.
-       -- If we 'wait' and it doesn't terminate, 'ResourceT' will not kill it
-       -- and the test will hang indefinitely.
-       -- Not waiting isn't a problem because this "background process"
-       -- is meant to run indefinitely and will be cleaned up by
-       -- 'ResourceT' when the test ends or fails.
-       -- We use 'asyncWithUnmask' because our logging thread is terminated via an exception.
-       -- In order to avoid competing for a file handle we must catch the exception which signals
-       -- the logging file is no longer being written to and we can now run the desired additional IO action we
-       -- want (runOnException). Attempting to share the 'FileHandle' and use concurrency primitives was not fruitful
-       -- and the section "Other ways to abuse ResourceT" in https://www.fpcomplete.com/blog/understanding-resourcet/
-       -- confirms this is problematic in 'ResourceT'.
-       $ resourceForkWith (\_ -> do r <- H.asyncWithUnmask (\restore -> restore act `E.onException` runOnException)
-                                    linkOnly ignoreException r
-                          ) $ return ()
- where
-  ignoreException  :: E.SomeException -> Bool
-  ignoreException e =
-    case E.fromException e of
-     Just (MuxError errType _) ->
-       case errType of
-         MuxBearerClosed -> False
-         -- This is expected as the background thread is killed.
-         -- However we do want to be made aware about other
-         -- exceptions.
-         _ -> True
-     _ -> False
+runInBackground act = void . H.evalM $ allocate (H.async act) cleanUp
+  where
+    cleanUp :: H.Async a -> IO ()
+    cleanUp a = H.cancel a >> H.link a
 
 decodeEraUTxO :: (IsShelleyBasedEra era, MonadTest m) => ShelleyBasedEra era -> Aeson.Value -> m (UTxO era)
 decodeEraUTxO _ = H.jsonErrorFail . Aeson.fromJSON


### PR DESCRIPTION
# Description

Simplify epoch state diff logging. This is a follow-up from https://github.com/IntersectMBO/cardano-node/pull/5854. Now diffs are logged live.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
