### PR TITLE
Deprecate `serialiseTxLedgerCddl`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -31,6 +31,20 @@ packages:
   trace-resources
   trace-forward
 
+source-repository-package
+  type: git
+  location: https://github.com/IntersectMBO/cardano-api.git
+  tag: 1244e702287daedbde0cffa320d1eb423493321e
+  subdir: cardano-api
+  --sha256: 1wjhyliq3qv83m956mvinshd8cbrkyjlcx97s34qxi9cilskn210
+
+source-repository-package
+  type: git
+  location: https://github.com/IntersectMBO/cardano-cli.git
+  tag: 0196f48ebc713072bfb6efb74ef204f638456d78
+  subdir: cardano-cli
+  --sha256: 08z15kab32pw9r7ry6z8lakk854dq2ym81cbw8pifibbfihzqd1i
+
 program-options
   ghc-options: -Werror
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/Transaction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/Transaction.hs
@@ -37,6 +37,7 @@ import           Hedgehog (Property)
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
+import Cardano.Api.HasTypeProxy (Proxy(..))
 
 hprop_transaction :: Property
 hprop_transaction = integrationRetryWorkspace 0 "babbage-transaction" $ \tempAbsBasePath' -> runWithDefaultWatchdog_ $ do
@@ -86,7 +87,8 @@ hprop_transaction = integrationRetryWorkspace 0 "babbage-transaction" $ \tempAbs
     , "--out-file", txbodyFp
     ]
   cddlUnwitnessedTx <- H.readJsonFileOk txbodyFp
-  apiTx <- H.evalEither $ deserialiseTxLedgerCddl sbe cddlUnwitnessedTx
+  apiTx <- H.evalEither $ deserialiseFromTextEnvelope (proxyToAsType Proxy :: AsType (Tx BabbageEra))
+                                                      cddlUnwitnessedTx
   let txFee = L.unCoin $ extractTxFee apiTx
 
   -- This is the current calculated fee.

--- a/cardano-testnet/test/cardano-testnet-test/files/golden/queries/protocolParametersFileOut.json
+++ b/cardano-testnet/test/cardano-testnet-test/files/golden/queries/protocolParametersFileOut.json
@@ -1,5 +1,7 @@
 {
     "collateralPercentage": 150,
+    "committeeMaxTermLength": 200,
+    "committeeMinSize": 0,
     "costModels": {
         "PlutusV1": [
             205665,
@@ -582,12 +584,26 @@
             1
         ]
     },
-    "decentralization": null,
+    "dRepActivity": 100,
+    "dRepDeposit": 1000000,
+    "dRepVotingThresholds": {
+        "committeeNoConfidence": 0,
+        "committeeNormal": 0.5,
+        "hardForkInitiation": 0.5,
+        "motionNoConfidence": 0,
+        "ppEconomicGroup": 0.5,
+        "ppGovGroup": 0.5,
+        "ppNetworkGroup": 0.5,
+        "ppTechnicalGroup": 0.5,
+        "treasuryWithdrawal": 0.5,
+        "updateToConstitution": 0
+    },
     "executionUnitPrices": {
         "priceMemory": 5.77e-2,
         "priceSteps": 7.21e-5
     },
-    "extraPraosEntropy": null,
+    "govActionDeposit": 1000000,
+    "govActionLifetime": 1,
     "maxBlockBodySize": 65536,
     "maxBlockExecutionUnits": {
         "memory": 62000000,
@@ -601,11 +617,18 @@
     },
     "maxTxSize": 16384,
     "maxValueSize": 5000,
+    "minFeeRefScriptCostPerByte": 0,
     "minPoolCost": 0,
-    "minUTxOValue": null,
     "monetaryExpansion": 0.1,
     "poolPledgeInfluence": 0,
     "poolRetireMaxEpoch": 18,
+    "poolVotingThresholds": {
+        "committeeNoConfidence": 0.5,
+        "committeeNormal": 0.5,
+        "hardForkInitiation": 0.5,
+        "motionNoConfidence": 0.5,
+        "ppSecurityGroup": 0.5
+    },
     "protocolVersion": {
         "major": 10,
         "minor": 0

--- a/cardano-testnet/test/cardano-testnet-test/files/golden/queries/protocolParametersOut.txt
+++ b/cardano-testnet/test/cardano-testnet-test/files/golden/queries/protocolParametersOut.txt
@@ -1,5 +1,7 @@
 {
     "collateralPercentage": 150,
+    "committeeMaxTermLength": 200,
+    "committeeMinSize": 0,
     "costModels": {
         "PlutusV1": [
             205665,
@@ -582,12 +584,26 @@
             1
         ]
     },
-    "decentralization": null,
+    "dRepActivity": 100,
+    "dRepDeposit": 1000000,
+    "dRepVotingThresholds": {
+        "committeeNoConfidence": 0,
+        "committeeNormal": 0.5,
+        "hardForkInitiation": 0.5,
+        "motionNoConfidence": 0,
+        "ppEconomicGroup": 0.5,
+        "ppGovGroup": 0.5,
+        "ppNetworkGroup": 0.5,
+        "ppTechnicalGroup": 0.5,
+        "treasuryWithdrawal": 0.5,
+        "updateToConstitution": 0
+    },
     "executionUnitPrices": {
         "priceMemory": 5.77e-2,
         "priceSteps": 7.21e-5
     },
-    "extraPraosEntropy": null,
+    "govActionDeposit": 1000000,
+    "govActionLifetime": 1,
     "maxBlockBodySize": 65536,
     "maxBlockExecutionUnits": {
         "memory": 62000000,
@@ -601,11 +617,18 @@
     },
     "maxTxSize": 16384,
     "maxValueSize": 5000,
+    "minFeeRefScriptCostPerByte": 0,
     "minPoolCost": 0,
-    "minUTxOValue": null,
     "monetaryExpansion": 0.1,
     "poolPledgeInfluence": 0,
     "poolRetireMaxEpoch": 18,
+    "poolVotingThresholds": {
+        "committeeNoConfidence": 0.5,
+        "committeeNormal": 0.5,
+        "hardForkInitiation": 0.5,
+        "motionNoConfidence": 0.5,
+        "ppSecurityGroup": 0.5
+    },
     "protocolVersion": {
         "major": 10,
         "minor": 0


### PR DESCRIPTION
# Description

This PR fixes compilation issues and updates tests as a consequence of the deprecation of `serialiseTxLedgerCddl` in `cardano-api`. It serves as a test previous to merging [this PR](https://github.com/IntersectMBO/cardano-api/pull/534).

# Context

## `cardano-api`

- Main PR: https://github.com/IntersectMBO/cardano-api/pull/534
- Branch: [cardano-api/deprecate-serialiseTxLedgerCddl](https://github.com/IntersectMBO/cardano-api/tree/deprecate-serialiseTxLedgerCddl)
- Backported branch: [cardano-api/deprecate-serialiseTxLedgerCddl-testing](https://github.com/IntersectMBO/cardano-api/tree/deprecate-serialiseTxLedgerCddl-testing)

## `cardano-cli`

- PR: https://github.com/IntersectMBO/cardano-cli/pull/772
- In the end, done in PR: https://github.com/IntersectMBO/cardano-cli/pull/786
- Branch: [cardano-cli/deprecate-serialiseTxLedgerCddl-testing](https://github.com/IntersectMBO/cardano-cli/tree/deprecate-serialiseTxLedgerCddl-testing)

## `cardano-node`

- PR: https://github.com/IntersectMBO/cardano-node/pull/5867
- In the end, done in PR: https://github.com/IntersectMBO/cardano-node/pull/5879
- Branch: [cardano-node/deprecate-serialiseTxLedgerCddl-testing](https://github.com/IntersectMBO/cardano-node/tree/deprecate-serialiseTxLedgerCddl-testing)

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff
