### PR TITLE
Test SPOs cannot vote protocol parameter change proposals

### DIFF
--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -193,6 +193,7 @@ test-suite cardano-testnet-test
                         Cardano.Testnet.Test.Gov.DRepRetirement
                         Cardano.Testnet.Test.Gov.InfoAction
                         Cardano.Testnet.Test.Gov.NoConfidence
+                        Cardano.Testnet.Test.Gov.PParamChangeFailsSPO
                         Cardano.Testnet.Test.Gov.ProposeNewConstitution
                         Cardano.Testnet.Test.Gov.ProposeNewConstitutionSPO
                         Cardano.Testnet.Test.Gov.TreasuryGrowth

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepActivity.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepActivity.hs
@@ -3,12 +3,9 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Cardano.Testnet.Test.Gov.DRepActivity
   ( hprop_check_drep_activity
-  , makeActivityChangeProposal
-  , voteChangeProposal
   ) where
 
 import           Cardano.Api as Api
@@ -26,8 +23,6 @@ import           Control.Monad
 import           Control.Monad.Catch (MonadCatch)
 import           Data.Data (Typeable)
 import qualified Data.Map as Map
-import           Data.String
-import qualified Data.Text as Text
 import           Data.Word (Word32)
 import           GHC.Stack (HasCallStack, withFrozenCallStack)
 import           System.FilePath ((</>))
@@ -35,9 +30,8 @@ import           System.FilePath ((</>))
 import           Testnet.Components.Query
 import           Testnet.Defaults (defaultDRepKeyPair, defaultDelegatorStakeKeyPair)
 import           Testnet.Process.Cli.DRep
-import           Testnet.Process.Cli.Keys
 import           Testnet.Process.Cli.Transaction
-import           Testnet.Process.Run (execCli', mkExecConfig)
+import           Testnet.Process.Run (mkExecConfig)
 import           Testnet.Property.Util (integrationWorkspace)
 import           Testnet.Types
 
@@ -209,89 +203,6 @@ activityChangeProposalTest execConfig epochStateView ceo work prefix
       (nesEpochStateL . epochStateGovStateL . curPParamsGovStateL . ppDRepActivityL)
 
   pure thisProposal
-
--- | Create a proposal to change the DRep activity interval.
--- Return the transaction id and the index of the governance action.
-makeActivityChangeProposal
-  :: (HasCallStack, H.MonadAssertion m, MonadTest m, MonadCatch m, MonadIO m, Typeable era)
-  => H.ExecConfig -- ^ Specifies the CLI execution configuration.
-  -> EpochStateView -- ^ Current epoch state view for transaction building. It can be obtained
-                    -- using the 'getEpochStateView' function.
-  -> ConwayEraOnwards era -- ^ The 'ConwayEraOnwards' witness for current era.
-  -> FilePath -- ^ Base directory path where generated files will be stored.
-  -> String -- ^ Name for the subfolder that will be created under 'work' folder.
-  -> Maybe (String, Word32) -- ^ The transaction id and the index of the previosu governance action if any.
-  -> EpochInterval -- ^ The target DRep activity interval to be set by the proposal.
-  -> PaymentKeyInfo -- ^ Wallet that will pay for the transaction.
-  -> EpochInterval -- ^ Number of epochs to wait for the proposal to be registered by the chain.
-  -> m (String, Word32) -- ^ The transaction id and the index of the governance action.
-makeActivityChangeProposal execConfig epochStateView ceo work prefix
-                           prevGovActionInfo drepActivity wallet timeout = do
-
-  let sbe = conwayEraOnwardsToShelleyBasedEra ceo
-      era = toCardanoEra sbe
-      cEra = AnyCardanoEra era
-
-  baseDir <- H.createDirectoryIfMissing $ work </> prefix
-
-  let stakeVkeyFp = baseDir </> "stake.vkey"
-      stakeSKeyFp = baseDir </> "stake.skey"
-
-  cliStakeAddressKeyGen
-    $ KeyPair { verificationKey = File stakeVkeyFp
-              , signingKey = File stakeSKeyFp
-              }
-
-  proposalAnchorFile <- H.note $ baseDir </> "sample-proposal-anchor"
-  H.writeFile proposalAnchorFile "dummy anchor data"
-
-  proposalAnchorDataHash <- execCli' execConfig
-    [ "conway", "governance"
-    , "hash", "anchor-data", "--file-text", proposalAnchorFile
-    ]
-
-  minDRepDeposit <- getMinDRepDeposit epochStateView ceo
-
-  proposalFile <- H.note $ baseDir </> "sample-proposal-anchor"
-
-  void $ execCli' execConfig $
-    [ "conway", "governance", "action", "create-protocol-parameters-update"
-    , "--testnet"
-    , "--governance-action-deposit", show @Integer minDRepDeposit
-    , "--deposit-return-stake-verification-key-file", stakeVkeyFp
-    ] ++ concatMap (\(prevGovernanceActionTxId, prevGovernanceActionIndex) ->
-                      [ "--prev-governance-action-tx-id", prevGovernanceActionTxId
-                      , "--prev-governance-action-index", show prevGovernanceActionIndex
-                      ]) prevGovActionInfo ++
-    [ "--drep-activity", show (unEpochInterval drepActivity)
-    , "--anchor-url", "https://tinyurl.com/3wrwb2as"
-    , "--anchor-data-hash", proposalAnchorDataHash
-    , "--out-file", proposalFile
-    ]
-
-  proposalBody <- H.note $ baseDir </> "tx.body"
-  txIn <- findLargestUtxoForPaymentKey epochStateView sbe wallet
-
-  void $ execCli' execConfig
-    [ "conway", "transaction", "build"
-    , "--change-address", Text.unpack $ paymentKeyInfoAddr wallet
-    , "--tx-in", Text.unpack $ renderTxIn txIn
-    , "--proposal-file", proposalFile
-    , "--out-file", proposalBody
-    ]
-
-  signedProposalTx <- signTx execConfig cEra baseDir "signed-proposal"
-                             (File proposalBody) [SomeKeyPair $ paymentKeyInfoPair wallet]
-
-  submitTx execConfig cEra signedProposalTx
-
-  governanceActionTxId <- retrieveTransactionId execConfig signedProposalTx
-
-  governanceActionIndex <-
-    H.nothingFailM $ watchEpochStateUpdate epochStateView timeout $ \(anyNewEpochState, _, _) ->
-      return $ maybeExtractGovernanceActionIndex (fromString governanceActionTxId) anyNewEpochState
-
-  return (governanceActionTxId, governanceActionIndex)
 
 -- | Cast votes for a governance action.
 voteChangeProposal

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepActivity.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepActivity.hs
@@ -7,6 +7,8 @@
 
 module Cardano.Testnet.Test.Gov.DRepActivity
   ( hprop_check_drep_activity
+  , makeActivityChangeProposal
+  , voteChangeProposal
   ) where
 
 import           Cardano.Api as Api

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PParamChangeFailsSPO.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PParamChangeFailsSPO.hs
@@ -90,7 +90,7 @@ hprop_check_pparam_fails_spo = integrationWorkspace "test-pparam-spo" $ \tempAbs
     makeActivityChangeProposal execConfig epochStateView ceo baseDir "proposal"
                                Nothing (EpochInterval 3) wallet0 (EpochInterval 2)
 
-  failToVoteChangeProposalWithSPOs ceo execConfig epochStateView sbe baseDir "vote"
+  failToVoteChangeProposalWithSPOs ceo execConfig epochStateView baseDir "vote"
                                    governanceActionTxId governanceActionIndex propVotes wallet1
 
 -- | Cast votes for a governance action with SPO keys.
@@ -101,7 +101,6 @@ failToVoteChangeProposalWithSPOs
   -> H.ExecConfig -- ^ Specifies the CLI execution configuration.v
   -> EpochStateView -- ^ Current epoch state view for transaction building. It can be obtained
                     -- using the 'getEpochStateView' function.
-  -> ShelleyBasedEra era -- ^ The 'ShelleyBasedEra' witness for current era.
   -> FilePath -- ^ Base directory path where generated files will be stored.
   -> String -- ^ Name for the subfolder that will be created under 'work' folder.
   -> String -- ^ The transaction id of the governance action to vote.
@@ -111,11 +110,12 @@ failToVoteChangeProposalWithSPOs
                      -- (i.e: "yes", "no", "abstain").
   -> PaymentKeyInfo -- ^ Wallet that will pay for the transaction.
   -> m ()
-failToVoteChangeProposalWithSPOs ceo execConfig epochStateView sbe work prefix
+failToVoteChangeProposalWithSPOs ceo execConfig epochStateView work prefix
                                  governanceActionTxId governanceActionIndex votes wallet = withFrozenCallStack $ do
   baseDir <- H.createDirectoryIfMissing $ work </> prefix
 
-  let era = toCardanoEra sbe
+  let sbe = conwayEraOnwardsToShelleyBasedEra ceo
+      era = toCardanoEra sbe
       cEra = AnyCardanoEra era
 
   voteFiles <- SPO.generateVoteFiles ceo execConfig baseDir "vote-files"

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PParamChangeFailsSPO.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PParamChangeFailsSPO.hs
@@ -12,7 +12,6 @@ import           Cardano.Api as Api
 import           Cardano.Api.Ledger (EpochInterval (EpochInterval))
 
 import           Cardano.Testnet
-import           Cardano.Testnet.Test.Gov.DRepActivity (makeActivityChangeProposal)
 
 import           Prelude
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PParamChangeFailsSPO.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PParamChangeFailsSPO.hs
@@ -1,0 +1,132 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Testnet.Test.Gov.PParamChangeFailsSPO
+  ( hprop_check_pparam_fails_spo
+  ) where
+
+import           Cardano.Api as Api
+import           Cardano.Api.Ledger (EpochInterval (EpochInterval))
+
+import           Cardano.Testnet
+import           Cardano.Testnet.Test.Gov.DRepActivity (makeActivityChangeProposal)
+
+import           Prelude
+
+import           Control.Monad.Catch (MonadCatch)
+import           Data.Typeable (Typeable)
+import           Data.Word (Word32)
+import           System.FilePath ((</>))
+
+import           Testnet.Components.Query
+import           Testnet.Defaults (defaultSpoColdKeyPair, defaultSpoKeys)
+import           Testnet.Process.Cli.DRep
+import qualified Testnet.Process.Cli.SPO as SPO
+import           Testnet.Process.Cli.Transaction (failToSubmitTx, signTx)
+import           Testnet.Process.Run (mkExecConfig)
+import           Testnet.Property.Util (integrationWorkspace)
+import           Testnet.Types
+
+import           Hedgehog (Property, annotateShow)
+import qualified Hedgehog.Extras as H
+import           Hedgehog.Internal.Property (MonadTest)
+import           Hedgehog.Internal.Source (HasCallStack, withFrozenCallStack)
+
+-- | Test that SPOs cannot vote on a Protocol Parameter change
+-- | Execute me with:
+-- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/PParam change fails for SPO/"'@
+hprop_check_pparam_fails_spo :: Property
+hprop_check_pparam_fails_spo = integrationWorkspace "test-pparam-spo" $ \tempAbsBasePath' ->
+                                 H.runWithDefaultWatchdog_ $ do
+  -- Start a local test net
+  conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
+  let tempAbsPath' = unTmpAbsPath tempAbsPath
+      tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
+
+  work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
+
+  -- Create default testnet
+  let ceo = ConwayEraOnwardsConway
+      sbe = conwayEraOnwardsToShelleyBasedEra ceo
+      era = toCardanoEra sbe
+      cEra = AnyCardanoEra era
+      fastTestnetOptions = cardanoDefaultTestnetOptions
+        { cardanoEpochLength = 200
+        , cardanoNodeEra = cEra
+        }
+
+  TestnetRuntime
+    { testnetMagic
+    , poolNodes
+    , wallets=wallet0:wallet1:_wallet2:_
+    , configurationFile
+    }
+    <- cardanoTestnetDefault fastTestnetOptions conf
+
+  PoolNode{poolRuntime} <- H.headM poolNodes
+  poolSprocket1 <- H.noteShow $ nodeSprocket poolRuntime
+  execConfig <- mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
+  let socketPath = nodeSocketPath poolRuntime
+
+  epochStateView <- getEpochStateView configurationFile socketPath
+
+  H.note_ $ "Sprocket: " <> show poolSprocket1
+  H.note_ $ "Abs path: " <> tempAbsBasePath'
+  H.note_ $ "Socketpath: " <> unFile socketPath
+  H.note_ $ "Foldblocks config file: " <> unFile configurationFile
+
+  gov <- H.createDirectoryIfMissing $ work </> "governance"
+
+  baseDir <- H.createDirectoryIfMissing $ gov </> "output"
+
+
+  let propVotes :: [(String, Int)]
+      propVotes = zip (concatMap (uncurry replicate) [(1, "yes")]) [1..]
+  annotateShow propVotes
+
+  (governanceActionTxId, governanceActionIndex) <-
+    makeActivityChangeProposal execConfig epochStateView ceo baseDir "proposal"
+                               Nothing (EpochInterval 3) wallet0 (EpochInterval 2)
+
+  failToVoteChangeProposalWithSPOs ceo execConfig epochStateView sbe baseDir "vote"
+                                   governanceActionTxId governanceActionIndex propVotes wallet1
+
+-- | Cast votes for a governance action with SPO keys.
+failToVoteChangeProposalWithSPOs
+  :: (HasCallStack, MonadTest m, MonadIO m, MonadCatch m, H.MonadAssertion m, Typeable era)
+  => ConwayEraOnwards era -- ^ The conway era onwards witness for the era in which the
+                          -- transaction will be constructed.
+  -> H.ExecConfig -- ^ Specifies the CLI execution configuration.v
+  -> EpochStateView -- ^ Current epoch state view for transaction building. It can be obtained
+                    -- using the 'getEpochStateView' function.
+  -> ShelleyBasedEra era -- ^ The 'ShelleyBasedEra' witness for current era.
+  -> FilePath -- ^ Base directory path where generated files will be stored.
+  -> String -- ^ Name for the subfolder that will be created under 'work' folder.
+  -> String -- ^ The transaction id of the governance action to vote.
+  -> Word32 -- ^ The index of the governance action to vote.
+  -> [([Char], Int)] -- ^ Votes to be casted for the proposal. Each tuple contains the index
+                     -- of the default SPO that will make the vote and the type of the vote
+                     -- (i.e: "yes", "no", "abstain").
+  -> PaymentKeyInfo -- ^ Wallet that will pay for the transaction.
+  -> m ()
+failToVoteChangeProposalWithSPOs ceo execConfig epochStateView sbe work prefix
+                                 governanceActionTxId governanceActionIndex votes wallet = withFrozenCallStack $ do
+  baseDir <- H.createDirectoryIfMissing $ work </> prefix
+
+  let era = toCardanoEra sbe
+      cEra = AnyCardanoEra era
+
+  voteFiles <- SPO.generateVoteFiles ceo execConfig baseDir "vote-files"
+                                     governanceActionTxId governanceActionIndex
+                                     [(defaultSpoKeys idx, vote) | (vote, idx) <- votes]
+
+  voteTxBodyFp <- createVotingTxBody execConfig epochStateView sbe baseDir "vote-tx-body"
+                                     voteFiles wallet
+
+  let signingKeys = SomeKeyPair (paymentKeyInfoPair wallet):(SomeKeyPair . defaultSpoColdKeyPair . snd <$> votes)
+  voteTxFp <- signTx execConfig cEra baseDir "signed-vote-tx" voteTxBodyFp signingKeys
+
+  failToSubmitTx execConfig cEra voteTxFp "DisallowedVoters"

--- a/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
+++ b/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
@@ -17,6 +17,7 @@ import qualified Cardano.Testnet.Test.Gov.CommitteeAddNew as Gov
 import qualified Cardano.Testnet.Test.Gov.DRepDeposit as Gov
 import qualified Cardano.Testnet.Test.Gov.DRepRetirement as Gov
 import qualified Cardano.Testnet.Test.Gov.NoConfidence as Gov
+import qualified Cardano.Testnet.Test.Gov.PParamChangeFailsSPO as Gov
 import qualified Cardano.Testnet.Test.Gov.ProposeNewConstitution as Gov
 import qualified Cardano.Testnet.Test.Gov.ProposeNewConstitutionSPO as Gov
 import qualified Cardano.Testnet.Test.Gov.TreasuryGrowth as Gov
@@ -59,6 +60,7 @@ tests = do
                 , ignoreOnMacAndWindows "Propose And Ratify New Constitution" Gov.hprop_ledger_events_propose_new_constitution
                 , ignoreOnWindows "Propose New Constitution SPO" Gov.hprop_ledger_events_propose_new_constitution_spo
                 , ignoreOnWindows "Treasury Withdrawal" Gov.hprop_ledger_events_treasury_withdrawal
+                , ignoreOnWindows "PParam change fails for SPO" Gov.hprop_check_pparam_fails_spo
                 -- FIXME Those tests are flaky
                 -- , ignoreOnWindows "InfoAction" LedgerEvents.hprop_ledger_events_info_action
                 ]


### PR DESCRIPTION
# Description

This PR creates a test that ensures SPOs cannot vote proposals that change protocol parameters. In particular, it tests this by trying to change the DRep activity expiration time and then checking the voting transaction cannot be submitted.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff
