### PR TITLE
[cardano-testnet] Fix flaky test workspace cleanup and node port allocation

### DIFF
--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -73,8 +73,8 @@ library
                       , ouroboros-network-api
                       , prettyprinter
                       , process
-                      , random
                       , resourcet
+                      , retry
                       , safe-exceptions
                       , scientific
                       , si-timers
@@ -82,6 +82,7 @@ library
                       , tasty ^>= 1.5
                       , tasty-expected-failure
                       , tasty-hedgehog
+                      , temporary
                       , text
                       , time
                       , transformers

--- a/cardano-testnet/src/Cardano/Testnet.hs
+++ b/cardano-testnet/src/Cardano/Testnet.hs
@@ -6,7 +6,7 @@ module Cardano.Testnet (
   -- ** Start a testnet
   cardanoTestnet,
   cardanoTestnetDefault,
-  requestAvailablePortNumbers,
+  retryOnAddressInUseError,
 
   -- ** Testnet options
   CardanoTestnetOptions(..),

--- a/cardano-testnet/src/Testnet/Process/Run.hs
+++ b/cardano-testnet/src/Testnet/Process/Run.hs
@@ -144,9 +144,11 @@ procCli = GHC.withFrozenCallStack $ H.procFlex "cardano-cli" "CARDANO_CLI"
 -- | Create a 'CreateProcess' describing how to start the cardano-node process
 -- and an argument list.
 procNode
-  :: [String]
+  :: HasCallStack
+  => MonadIO m
+  => [String]
   -- ^ Arguments to the CLI command
-  -> ExceptT ExecutableError IO CreateProcess
+  -> ExceptT ExecutableError m CreateProcess
   -- ^ Captured stdout
 procNode = GHC.withFrozenCallStack $ procFlexNew "cardano-node" "CARDANO_NODE"
 
@@ -234,31 +236,32 @@ resourceAndIOExceptionHandlers = [ Handler $ pure . ProcessIOException
                                  , Handler $ pure . ResourceException
                                  ]
 
-
 procFlexNew
-  :: String
+  :: MonadIO m
+  => String
   -- ^ Cabal package name corresponding to the executable
   -> String
   -- ^ Environment variable pointing to the binary to run
   -> [String]
   -- ^ Arguments to the CLI command
-  -> ExceptT ExecutableError IO CreateProcess
+  -> ExceptT ExecutableError m CreateProcess
   -- ^ Captured stdout
 procFlexNew = procFlexNew' H.defaultExecConfig
 
 procFlexNew'
-  :: H.ExecConfig
+  :: MonadIO m
+  => H.ExecConfig
   -> String
   -- ^ Cabal package name corresponding to the executable
   -> String
   -- ^ Environment variable pointing to the binary to run
   -> [String]
   -- ^ Arguments to the CLI command
-  -> ExceptT ExecutableError IO CreateProcess
+  -> ExceptT ExecutableError m CreateProcess
   -- ^ Captured stdout
 procFlexNew' execConfig pkg binaryEnv arguments = GHC.withFrozenCallStack $ do
   bin <- binFlexNew pkg binaryEnv
-  return (IO.proc bin arguments)
+  pure (IO.proc bin arguments)
     { IO.env = getLast $ H.execConfigEnv execConfig
     , IO.cwd = getLast $ H.execConfigCwd execConfig
     -- this allows sending signals to the created processes, without killing the test-suite process
@@ -267,11 +270,12 @@ procFlexNew' execConfig pkg binaryEnv arguments = GHC.withFrozenCallStack $ do
 
 -- | Compute the path to the binary given a package name or an environment variable override.
 binFlexNew
-  :: String
+  :: MonadIO m
+  => String
   -- ^ Package name
   -> String
   -- ^ Environment variable pointing to the binary to run
-  -> ExceptT ExecutableError IO FilePath
+  -> ExceptT ExecutableError m FilePath
   -- ^ Path to executable
 binFlexNew pkg binaryEnv = do
   maybeEnvBin <- liftIO $ IO.lookupEnv binaryEnv
@@ -316,9 +320,10 @@ data ExecutableError
 -- to a haskell package.  It is assumed that the project has already been configured and the
 -- executable has been built.
 binDist
-  :: String
+  :: MonadIO m
+  => String
   -- ^ Package name
-  -> ExceptT ExecutableError IO FilePath
+  -> ExceptT ExecutableError m FilePath
   -- ^ Path to executable
 binDist pkg = do
   pJsonFp <- handleIOExceptT RetrievePlanJsonFailure planJsonFile

--- a/cardano-testnet/src/Testnet/Property/Util.hs
+++ b/cardano-testnet/src/Testnet/Property/Util.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -15,14 +16,23 @@ module Testnet.Property.Util
 
 import           Cardano.Api
 
+import           Control.Exception.Safe
+import           Control.Monad
+import           Control.Monad.Trans.Resource
+import qualified Control.Retry as R
 import qualified Data.Aeson as Aeson
 import           GHC.Stack
+import qualified System.Directory as IO
 import qualified System.Environment as IO
+import           System.FilePath ((</>))
 import           System.Info (os)
+import qualified System.IO as IO
+import qualified System.IO.Temp as IO
 import qualified System.IO.Unsafe as IO
 
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras as H
+import qualified Hedgehog.Extras.Stock.CallStack as H
 import           Hedgehog.Internal.Property (MonadTest)
 
 
@@ -43,16 +53,52 @@ integrationRetryWorkspace n workspaceName f = withFrozenCallStack $
   if disableRetries
     then
       integration $
-        H.runFinallies $ H.workspace (workspaceName <> "-no-retries") f
+        H.runFinallies $ workspace (workspaceName <> "-no-retries") f
     else
       integration $ H.retry n $ \i ->
-        H.runFinallies $ H.workspace (workspaceName <> "-" <> show i) f
+        H.runFinallies $ workspace (workspaceName <> "-" <> show i) f
+
+-- | Create a workspace directory which will exist for at least the duration of
+-- the supplied block.
+--
+-- The directory will have the supplied prefix but contain a generated random
+-- suffix to prevent interference between tests
+--
+-- The directory will be deleted if the block succeeds, but left behind if
+-- the block fails.
+-- TODO: this is a version which retries deleting of a workspace on exception - upstream to hedgehog-extras
+workspace
+  :: MonadTest m
+  => HasCallStack
+  => MonadResource m
+  => FilePath
+  -> (FilePath -> m ())
+  -> m ()
+workspace prefixPath f = withFrozenCallStack $ do
+  systemTemp <- H.evalIO IO.getCanonicalTemporaryDirectory
+  maybeKeepWorkspace <- H.evalIO $ IO.lookupEnv "KEEP_WORKSPACE"
+  ws <- H.evalIO $ IO.createTempDirectory systemTemp $ prefixPath <> "-test"
+  H.annotate $ "Workspace: " <> ws
+  H.evalIO $ IO.writeFile (ws </> "module") H.callerModuleName
+  f ws
+  when (os /= "mingw32" && maybeKeepWorkspace /= Just "1") $ do
+    -- try to delete the directory 5 times, 100ms apart
+    let retryPolicy = R.constantDelay 100_000 <> R.limitRetries 10
+        -- retry only on IOExceptions
+        ioExH _ = Handler $ \(_ :: IOException) -> pure True
+    -- For some reason, the temporary directory removal sometimes fails.
+    -- Lets wrap this in MonadResource try multiple times before we fail.
+    void
+      . register
+      . R.recovering retryPolicy [ioExH]
+      . const
+      $ IO.removePathForcibly ws
 
 -- | The 'FilePath' in '(FilePath -> H.Integration ())' is the work space directory.
 -- This is created (and returned) via 'H.workspace'.
 integrationWorkspace :: HasCallStack => FilePath -> (FilePath -> H.Integration ()) -> H.Property
 integrationWorkspace workspaceName f = withFrozenCallStack $
-  integration $ H.runFinallies $ H.workspace workspaceName f
+  integration $ H.runFinallies $ workspace workspaceName f
 
 isLinux :: Bool
 isLinux = os == "linux"

--- a/cardano-testnet/src/Testnet/Start/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Start/Cardano.hs
@@ -1,5 +1,8 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -17,7 +20,7 @@ module Testnet.Start.Cardano
   , cardanoTestnetDefault
   , getDefaultAlonzoGenesis
   , getDefaultShelleyGenesis
-  , requestAvailablePortNumbers
+  , retryOnAddressInUseError
   ) where
 
 
@@ -30,27 +33,24 @@ import           Cardano.Node.Configuration.Topology
 
 import           Prelude hiding (lines)
 
+import           Control.Concurrent (threadDelay)
 import           Control.Monad
 import           Data.Aeson
 import qualified Data.Aeson as Aeson
 import           Data.Bifunctor (first)
 import qualified Data.ByteString.Lazy as LBS
 import           Data.Either
-import           Data.IORef
 import qualified Data.List as L
 import           Data.Maybe
-import           Data.Text (Text)
 import qualified Data.Text as Text
-import           Data.Time (UTCTime)
+import           Data.Time (UTCTime, diffUTCTime)
+import           Data.Time.Clock (NominalDiffTime)
 import qualified Data.Time.Clock as DTC
 import           Data.Word (Word32)
-import           GHC.IO.Unsafe (unsafePerformIO)
 import           GHC.Stack
 import qualified GHC.Stack as GHC
-import           Network.Socket (PortNumber)
 import           System.FilePath ((</>))
 import qualified System.Info as OS
-import qualified System.Random.Stateful as R
 import           Text.Printf (printf)
 
 import           Testnet.Components.Configuration
@@ -66,6 +66,7 @@ import           Testnet.Types as TR hiding (shelleyGenesis)
 import           Hedgehog (MonadTest)
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras as H
+import qualified Hedgehog.Extras.Stock.IO.Network.Port as H
 import qualified Hedgehog.Extras.Stock.OS as OS
 
 -- | There are certain conditions that need to be met in order to run
@@ -122,41 +123,6 @@ getDefaultShelleyGenesis opts = do
   currentTime <- H.noteShowIO DTC.getCurrentTime
   startTime <- H.noteShow $ DTC.addUTCTime startTimeOffsetSeconds currentTime
   return (startTime, Defaults.defaultShelleyGenesis startTime opts)
-
--- | Hardcoded testnet IP address
-testnetIpv4Address :: Text
-testnetIpv4Address = "127.0.0.1"
-
--- | Starting port number, from which testnet nodes will get new ports.
-defaultTestnetNodeStartingPortNumber :: PortNumber
-defaultTestnetNodeStartingPortNumber = 20000
-
--- | Global counter used to track which testnet node's ports were already allocated
-availablePortNumber :: IORef PortNumber
-availablePortNumber = unsafePerformIO $ do
-  let startingPort = toInteger defaultTestnetNodeStartingPortNumber
-  -- add a random offset to the starting port number to avoid clashes when starting multiple testnets
-  randomPart <- R.uniformRM (1,9) R.globalStdGen
-  newIORef . fromInteger $ startingPort + randomPart * 1000
-{-# NOINLINE availablePortNumber #-}
-
--- | Request a list of unused port numbers for testnet nodes. This shifts 'availablePortNumber' by
--- 'maxPortsPerRequest' in order to make sure that each node gets an unique port.
-requestAvailablePortNumbers
-  :: HasCallStack
-  => MonadIO m
-  => MonadTest m
-  => Int -- ^ Number of ports to request
-  -> m [PortNumber]
-requestAvailablePortNumbers numberOfPorts
-  | numberOfPorts > fromIntegral maxPortsPerRequest = withFrozenCallStack $ do
-    H.note_ $ "Tried to allocate " <> show numberOfPorts <> " port numbers in one request. "
-      <> "It's allowed to allocate no more than " <> show maxPortsPerRequest <> " per request."
-    H.failure
-  | otherwise = liftIO $ atomicModifyIORef' availablePortNumber $ \n ->
-      (n + maxPortsPerRequest, [n..n + fromIntegral numberOfPorts - 1])
-    where
-      maxPortsPerRequest = 50
 
 -- | Setup a number of credentials and pools, like this:
 --
@@ -227,8 +193,6 @@ cardanoTestnet
       nPools = numPools testnetOptions
       nDReps = numDReps testnetOptions
       era = cardanoNodeEra testnetOptions
-
-  portNumbers <- requestAvailablePortNumbers numPoolNodes
 
    -- Sanity checks
   testnetMinimumConfigurationRequirements testnetOptions
@@ -340,12 +304,12 @@ cardanoTestnet
           }
         }
 
-
     -- Add Byron, Shelley and Alonzo genesis hashes to node configuration
     config <- createConfigJson (TmpAbsolutePath tmpAbsPath) era
 
     H.evalIO $ LBS.writeFile (unFile configurationFile) config
 
+    portNumbers <- replicateM numPoolNodes $ H.randomPort testnetDefaultIpv4Address
     -- Byron related
     forM_ (zip [1..] portNumbers) $ \(i, portNumber) -> do
       let iStr = printf "%03d" (i - 1)
@@ -357,7 +321,7 @@ cardanoTestnet
     forM_ (zip [1..] portNumbers) $ \(i, myPortNumber) -> do
       let producers = flip map (filter (/= myPortNumber) portNumbers) $ \otherProducerPort ->
             RemoteAddress
-              { raAddress = testnetIpv4Address
+              { raAddress = showIpv4Address testnetDefaultIpv4Address
               , raPort = otherProducerPort
               , raValency = 1
               }
@@ -370,8 +334,8 @@ cardanoTestnet
       let nodeName = mkNodeName i
           keyDir = tmpAbsPath </> poolKeyDir i
       H.note_ $ "Node name: " <> nodeName
-      eRuntime <- runExceptT $
-        startNode (TmpAbsolutePath tmpAbsPath) nodeName testnetIpv4Address port testnetMagic
+      eRuntime <- runExceptT . retryOnAddressInUseError $
+        startNode (TmpAbsolutePath tmpAbsPath) nodeName testnetDefaultIpv4Address port testnetMagic
           [ "run"
           , "--config", unFile configurationFile
           , "--topology", keyDir </> "topology.json"
@@ -440,3 +404,38 @@ cardanoTestnet
     writeGenesisSpecFile eraName toWrite = GHC.withFrozenCallStack $ do
       genesisJsonFile <- H.noteShow $ tmpAbsPath </> "genesis." <> eraName <> ".spec.json"
       H.evalIO $ LBS.writeFile genesisJsonFile $ Aeson.encode toWrite
+
+-- | Retry an action when `NodeAddressAlreadyInUseError` gets thrown from an action
+retryOnAddressInUseError
+  :: forall m a. HasCallStack
+  => MonadTest m
+  => MonadIO m
+  => ExceptT NodeStartFailure m a -- ^ action being retried
+  -> ExceptT NodeStartFailure m a
+retryOnAddressInUseError act = withFrozenCallStack $ go maximumTimeout retryTimeout
+  where
+    go :: HasCallStack => NominalDiffTime -> NominalDiffTime -> ExceptT NodeStartFailure m a
+    go timeout interval
+      | timeout <= 0 = withFrozenCallStack $ do
+        H.note_ "Exceeded timeout when retrying node start"
+        act
+      | otherwise = withFrozenCallStack $ do
+        !time <- liftIO DTC.getCurrentTime
+        catchError act $ \case
+          NodeAddressAlreadyInUseError _ -> do
+            liftIO $ threadDelay (round $ interval * 1_000_000)
+            !time' <- liftIO DTC.getCurrentTime
+            let elapsedTime = time' `diffUTCTime` time
+                newTimeout = timeout - elapsedTime
+            H.note_ $ "Retrying on 'address in use' error, timeout: " <> show newTimeout
+            go newTimeout interval
+          e -> throwError e
+
+    -- Retry timeout in seconds. This should be > 2 * net.inet.tcp.msl on darwin,
+    -- net.inet.tcp.msl in RFC 793 determines TIME_WAIT socket timeout.
+    -- Usually it's 30 or 60 seconds. We take two times that plus some extra time.
+    maximumTimeout = 150
+    -- Wait for that many seconds before retrying.
+    retryTimeout = 5
+
+

--- a/cardano-testnet/src/Testnet/Types.hs
+++ b/cardano-testnet/src/Testnet/Types.hs
@@ -38,6 +38,8 @@ module Testnet.Types
   , ShelleyGenesis(..)
   , shelleyGenesis
   , getStartTime
+  , testnetDefaultIpv4Address
+  , showIpv4Address
   ) where
 
 import           Cardano.Api
@@ -55,12 +57,14 @@ import           Prelude
 
 import           Control.Monad
 import qualified Data.Aeson as A
+import           Data.List (intercalate)
 import           Data.Text (Text)
 import           Data.Time.Clock (UTCTime)
+import           GHC.Exts (IsString (..))
 import           GHC.Generics (Generic)
 import qualified GHC.IO.Handle as IO
 import           GHC.Stack
-import           Network.Socket (PortNumber)
+import           Network.Socket (HostAddress, PortNumber, hostAddressToTuple, tupleToHostAddress)
 import           System.FilePath
 import qualified System.Process as IO
 
@@ -115,7 +119,7 @@ poolNodeStdout = nodeStdout . poolRuntime
 
 data NodeRuntime = NodeRuntime
   { nodeName :: !String
-  , nodeIpv4 :: !Text
+  , nodeIpv4 :: !HostAddress
   , nodePort :: !PortNumber
   , nodeSprocket :: !Sprocket
   , nodeStdinHandle :: !IO.Handle
@@ -191,3 +195,13 @@ readNodeLoggingFormat = \case
 
 allNodes :: TestnetRuntime -> [NodeRuntime]
 allNodes tr = fmap poolRuntime (poolNodes tr)
+
+-- | Hardcoded testnet IPv4 address pointing to the local host
+testnetDefaultIpv4Address :: HostAddress
+testnetDefaultIpv4Address = tupleToHostAddress (127, 0, 0, 1)
+
+-- | Format IPv4 address as a string-like e.g. @127.0.0.1@
+showIpv4Address :: IsString s => HostAddress -> s
+showIpv4Address address = fromString . intercalate "." $ show <$> [a,b,c,d]
+  where (a,b,c,d) = hostAddressToTuple address
+

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/LeadershipSchedule.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/LeadershipSchedule.hs
@@ -46,6 +46,7 @@ import           Testnet.Types
 
 import           Hedgehog (Property, (===))
 import qualified Hedgehog as H
+import qualified Hedgehog.Extras.Stock.IO.Network.Port as H
 import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
@@ -220,7 +221,7 @@ hprop_leadershipSchedule = integrationRetryWorkspace 2 "babbage-leadership-sched
   let valency = 1
       topology = RealNodeTopology $
         flip map poolNodes $ \PoolNode{poolRuntime=NodeRuntime{nodeIpv4,nodePort}} ->
-          RemoteAddress nodeIpv4 nodePort valency
+          RemoteAddress (showIpv4Address nodeIpv4) nodePort valency
   H.lbsWriteFile topologyFile $ Aeson.encode topology
   let testSpoKesVKey = work </> "kes.vkey"
       testSpoKesSKey = work </> "kes.skey"
@@ -248,8 +249,9 @@ hprop_leadershipSchedule = integrationRetryWorkspace 2 "babbage-leadership-sched
 
   jsonBS <- createConfigJson tempAbsPath (cardanoNodeEra cTestnetOptions)
   H.lbsWriteFile (unFile configurationFile) jsonBS
-  [newNodePort] <- requestAvailablePortNumbers 1
-  eRuntime <- runExceptT $ startNode (TmpAbsolutePath work) "test-spo" "127.0.0.1" newNodePort testnetMagic
+  newNodePort <- H.randomPort testnetDefaultIpv4Address
+  eRuntime <- runExceptT . retryOnAddressInUseError $
+    startNode (TmpAbsolutePath work) "test-spo" testnetDefaultIpv4Address newNodePort testnetMagic
         [ "run"
         , "--config", unFile configurationFile
         , "--topology", topologyFile

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/KesPeriodInfo.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/KesPeriodInfo.hs
@@ -42,6 +42,7 @@ import           Hedgehog (Property)
 import qualified Hedgehog as H
 import           Hedgehog.Extras (threadDelay)
 import           Hedgehog.Extras.Stock (sprocketSystemName)
+import qualified Hedgehog.Extras.Stock.IO.Network.Port as H
 import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
@@ -214,7 +215,7 @@ hprop_kes_period_info = integrationRetryWorkspace 2 "kes-period-info" $ \tempAbs
   let valency = 1
       topology = RealNodeTopology $
         flip map poolNodes $ \PoolNode{poolRuntime=NodeRuntime{nodeIpv4,nodePort}} ->
-            RemoteAddress nodeIpv4 nodePort valency
+            RemoteAddress (showIpv4Address nodeIpv4) nodePort valency
   H.lbsWriteFile topologyFile $ Aeson.encode topology
 
   let testSpoVrfVKey = work </> "vrf.vkey"
@@ -247,8 +248,9 @@ hprop_kes_period_info = integrationRetryWorkspace 2 "kes-period-info" $ \tempAbs
 
   jsonBS <- createConfigJson tempAbsPath (cardanoNodeEra cTestnetOptions)
   H.lbsWriteFile (unFile configurationFile) jsonBS
-  [newNodePortNumber] <- requestAvailablePortNumbers 1
-  eRuntime <- runExceptT $ startNode tempAbsPath "test-spo" "127.0.0.1" newNodePortNumber testnetMagic
+  newNodePortNumber <- H.randomPort testnetDefaultIpv4Address
+  eRuntime <- runExceptT . retryOnAddressInUseError $
+    startNode tempAbsPath "test-spo" testnetDefaultIpv4Address newNodePortNumber testnetMagic
         [ "run"
         , "--config", unFile configurationFile
         , "--topology", topologyFile


### PR DESCRIPTION
# Description

This PR fixes testnet startup nondeterministic issues:
1. workspace cleanup for successful tests: sometimes the directory could not get removed. Fixed by waiting and retrying.
1. on MacOS, when starting node with a random port number we were receiving "port in use" error, due to holding to the port by darwin kernel, resulting in port being stuck in `TIME_WAIT` state. Fixed by waiting and retrying.
1. stemming from nr 2: the operating system was also holding the lock to the `stderr` log file, resulting in node start retry failure. Fixed by additional manual closing of the file handle and using a different name of the log file.


# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
