### PR TITLE
Warn the protocol version is too low if we have `ExperimentalHardForksEnabled`

### DIFF
--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -9,6 +9,7 @@
   - `--mempool-capacity-override` and `--no-mempool-capacity-override` can be set in the configuration file via the key `MempoolCapacityBytesOverride`.
   - `--snapshot-interval` can be set in the configuration file via the key `SnapshotInterval`.
   - `--num-of-disk-snapshots` can be set in the configuration file via the key `NumOfDiskSnapshots`.
+- Add warning for when the protocol version is too low and we have set `ExperimentalHardForksEnabled`.
 
 ## 8.2.1 -- August 2023
 

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -177,6 +177,7 @@ library
                       , io-classes >= 1.4
                       , iohk-monitoring
                       , iproute
+                      , lens
                       , lobemo-backend-aggregation
                       , lobemo-backend-ekg
                       , lobemo-backend-monitoring


### PR DESCRIPTION
# Description

This PR makes `cardano-node` show a warning when the `ExperimentalHardForksEnabled` flag is set, and the specified version is less than the one specified for `Shelley` in its genesis file.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff
