### PR TITLE
consensus/ledger/network: bump version for 8.12.1 release

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2024-06-13T08:49:27Z
-  , cardano-haskell-packages 2024-06-20T14:49:55Z
+  , cardano-haskell-packages 2024-06-27T00:19:07Z
 
 packages:
   cardano-node

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-node
-version:                8.12.0
+version:                8.12.1
 synopsis:               The cardano full node
 description:            The cardano full node.
 category:               Cardano,

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1718896150,
-        "narHash": "sha256-tLldSak3ilawlFiAENbuTos0W+oZQGVc1sbkUfv1hko=",
+        "lastModified": 1719449018,
+        "narHash": "sha256-SHrUrjiohM2RMe0DctdO3vDDA40tI8NVTKmwc3egaeY=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "81a484da765cc302d10956134f455f9493c80d14",
+        "rev": "6b048d1ad84220d47f870635e84df63590f5efa3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
* restores inbound metrics
* introduces conway reference scripts per byte at mempool
* changes algorithm of reference scripts per byte

# Description

Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
