### PR TITLE
node-8.12.2

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -64,3 +64,11 @@ allow-newer: katip:Win32
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
+
+source-repository-package
+  type: git
+  location: https://github.com/intersectmbo/ouroboros-network.git
+  tag: 7f41d8a9ddffee1b2e921fba52f6ed0f0f644f62
+  subdir:
+    ouroboros-network
+  --sha256: sha256-psXCB+Z81cBcJdPP1GmqqVuPUyxU0jBvQ9Lve405ku4=

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2024-06-13T08:49:27Z
-  , cardano-haskell-packages 2024-06-27T00:19:07Z
+  , cardano-haskell-packages 2024-06-28T18:16:58Z
 
 packages:
   cardano-node
@@ -64,11 +64,3 @@ allow-newer: katip:Win32
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
-
-source-repository-package
-  type: git
-  location: https://github.com/intersectmbo/ouroboros-network.git
-  tag: 7f41d8a9ddffee1b2e921fba52f6ed0f0f644f62
-  subdir:
-    ouroboros-network
-  --sha256: sha256-psXCB+Z81cBcJdPP1GmqqVuPUyxU0jBvQ9Lve405ku4=

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -874,7 +874,7 @@ mkP2PArguments NodeConfiguration {
       , P2P.daProtocolIdleTimeout   = ncProtocolIdleTimeout
       , P2P.daTimeWaitTimeout       = ncTimeWaitTimeout
       , P2P.daDeadlineChurnInterval = 3300
-      , P2P.daBulkChurnInterval     = 300
+      , P2P.daBulkChurnInterval     = 900
       , P2P.daOwnPeerSharing        = ncPeerSharing
       }
   where

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1719449018,
-        "narHash": "sha256-SHrUrjiohM2RMe0DctdO3vDDA40tI8NVTKmwc3egaeY=",
+        "lastModified": 1719609872,
+        "narHash": "sha256-a6M9mYbJh4ctk4aOpkyztmFOt0H72GK1Gg4BbV8atTU=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "6b048d1ad84220d47f870635e84df63590f5efa3",
+        "rev": "9ad99f2c3fb290ceab85c98b4761622cd9e2d97c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Description

* Include churn fix from ouroboros-network 0.16.1.1
* Increase bulk churn duration to 15 minutes.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
