### PR TITLE
Add stylish-haskell to dev-shell and update versions

### DIFF
--- a/.github/workflows/check-hlint.yml
+++ b/.github/workflows/check-hlint.yml
@@ -23,7 +23,7 @@ jobs:
     - name: 'Set up HLint'
       uses: rwe/actions-hlint-setup@v1
       with:
-        version: 3.3
+        version: 3.5
 
     - name: 'Run HLint'
       uses: rwe/actions-hlint-run@v2

--- a/.github/workflows/stylish-haskell.yml
+++ b/.github/workflows/stylish-haskell.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
 
     env:
-      STYLISH_HASKELL_VERSION: "0.14.6.0"
+      STYLISH_HASKELL_VERSION: "0.14.4.0"
 
       STYLISH_HASKELL_PATHS: >
         cardano-git-rev

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -50,6 +50,7 @@ let
           cabal
           actionlint
           shellcheck
+          stylish-haskell
         ];
 
         withHoogle = true;


### PR DESCRIPTION
# Description

This PR adds `stylish-haskell` to the development shell and updated the CI checked versions to match those of the shell for `stylish-haskell` and `hlint`.

Motivation: Since the code checked against both tools by the CI, it only makes sense to have the right versions in the shell so that developers can format the files they commit conveniently and pass the CI more easily.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff
