### PR TITLE
Updates to use latest ghc-9.6 & 9.8 point releases

### DIFF
--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -31,17 +31,17 @@ jobs:
 
     - name: Fetch nix cache and update cabal indices
       run: |
-        nix develop .\#project.x86_64-linux.projectVariants.ghc964.shell --command \
+        nix develop .\#project.x86_64-linux.projectVariants.ghc96.shell --command \
           cabal update
 
     - name: Build whole project
       run: |
-        nix develop .\#project.x86_64-linux.projectVariants.ghc964.shell --command \
+        nix develop .\#project.x86_64-linux.projectVariants.ghc96.shell --command \
           cabal build all
 
     - name: Build documentation
       run: |
-        nix develop .\#project.x86_64-linux.projectVariants.ghc964.shell --command \
+        nix develop .\#project.x86_64-linux.projectVariants.ghc96.shell --command \
           cabal haddock-project --local --output=./haddocks --internal --foreign-libraries
 
     - name: Compress haddocks

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         # If you edit these versions, make sure the version in the lonely macos-latest job below is updated accordingly
-        ghc: ["9.6.4", "9.8.1"]
+        ghc: ["9.6", "9.8"]
         cabal: ["3.10.2.1"]
         os: [windows-latest, ubuntu-latest]
         include:
@@ -34,7 +34,7 @@ jobs:
           # We want a single job, because macOS runners are scarce.
           - os: macos-latest
             cabal: "3.10.2.1"
-            ghc: "9.6.4"
+            ghc: "9.6"
 
     env:
       # Modify this value to "invalidate" the cabal cache.

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -22,7 +22,7 @@ let
       name = "cardano-node";
       compiler-nix-name = lib.mkDefault "ghc8107";
       # extra-compilers
-      flake.variants = lib.genAttrs ["ghc964"] (x: {compiler-nix-name = x;});
+      flake.variants = lib.genAttrs ["ghc96"] (x: {compiler-nix-name = x;});
       cabalProjectLocal = ''
         repository cardano-haskell-packages-local
           url: file:${CHaP}


### PR DESCRIPTION
# Description

    This isn't actively used in haskell.nix; however, it's common to
    exchange the roles of 8.10.7 and the 9.6 release in the list of flake
    variants there. In lieu of explicitly using 9.6.5, using nix' ghc96
    alias for the latest point release of 9.6 makes sense to avoid needing
    to churn the codebase at each such release. Similar applies to 9.8
    within haskell.yml. github-page.yml also needs updating to work with
    the changed variant name for building haddock documentation.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
