### PR TITLE
cardano-testnet | Add `cardano-cli query treasury`  check in treasury growth test

### DIFF
--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryGrowth.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryGrowth.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Cardano.Testnet.Test.Gov.TreasuryGrowth where
 
@@ -21,7 +22,9 @@ import           Lens.Micro ((^.))
 import qualified System.Directory as IO
 import           System.FilePath ((</>))
 
+import           Testnet.Process.Run (execCli', mkExecConfig)
 import           Testnet.Property.Util (integrationRetryWorkspace)
+import           Testnet.Start.Types (eraToString)
 import           Testnet.Types
 
 import qualified Hedgehog as H
@@ -34,20 +37,24 @@ prop_check_if_treasury_is_growing :: H.Property
 prop_check_if_treasury_is_growing = integrationRetryWorkspace 0 "growing-treasury" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   -- Start testnet
   conf@Conf{tempAbsPath=TmpAbsolutePath tempAbsPath'} <- TN.mkConf tempAbsBasePath'
+  let tempBaseAbsPath = makeTmpBaseAbsPath $ tempAbsPath conf
 
-  let era = BabbageEra
+  let era = ConwayEra
       options = cardanoDefaultTestnetOptions
                   { cardanoEpochLength = 100
                   , cardanoNodeEra = AnyCardanoEra era -- TODO: We should only support the latest era and the upcoming era
                   , cardanoActiveSlotsCoeff = 0.3
                   }
 
-  runtime@TestnetRuntime{configurationFile} <- cardanoTestnetDefault options conf
+  TestnetRuntime{testnetMagic, configurationFile, poolNodes} <- cardanoTestnetDefault options conf
 
-  -- Get socketPath
-  socketPathAbs <- Api.File <$> do
-    socketPath' <- H.sprocketArgumentName <$> H.headM (poolSprockets runtime)
-    H.noteIO (IO.canonicalizePath $ tempAbsPath' </> socketPath')
+  (execConfig, socketPathAbs) <- do
+    PoolNode{poolRuntime} <- H.headM poolNodes
+    poolSprocket1 <- H.noteShow $ nodeSprocket poolRuntime
+    let socketPath' = H.sprocketArgumentName poolSprocket1
+    socketPathAbs <- Api.File <$> H.noteIO (IO.canonicalizePath $ tempAbsPath' </> socketPath')
+    execConfig <- mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
+    pure (execConfig, socketPathAbs)
 
   (_condition, treasuryValues) <- H.leftFailM . H.evalIO . runExceptT $
     Api.foldEpochState configurationFile socketPathAbs Api.QuickValidation (EpochNo 10) M.empty handler
@@ -64,6 +71,10 @@ prop_check_if_treasury_is_growing = integrationRetryWorkspace 0 "growing-treasur
      else do
        H.note_ "treasury is not growing"
        H.failure
+
+  -- check if treasury query is returning positive amount
+  treasury <- read @Integer <$> execCli' execConfig [ eraToString era, "query", "treasury" ]
+  H.assertWith treasury (> 0)
   where
     handler :: AnyNewEpochState -> SlotNo -> BlockNo -> StateT (Map EpochNo Integer) IO ConditionResult
     handler (AnyNewEpochState _ newEpochState) _slotNo _blockNo = do


### PR DESCRIPTION
# Description

Add `cardano-cli query treasury` check to treasury growth test.
Tests https://github.com/IntersectMBO/cardano-cli/pull/845

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
