### PR TITLE
Add test for `query spo-stake-distribution`

### DIFF
--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -234,6 +234,7 @@ test-suite cardano-testnet-test
                       , hedgehog
                       , hedgehog-extras
                       , http-conduit
+                      , lens
                       , lens-aeson
                       , microlens
                       , mtl

--- a/cardano-testnet/src/Testnet/TestQueryCmds.hs
+++ b/cardano-testnet/src/Testnet/TestQueryCmds.hs
@@ -15,7 +15,7 @@ import           Testnet.TestEnumGenerator (genAllConstructorsList, genTestType)
 -- | A datatype with the same constructors as 'QueryCmds', but with a "Test" prefix and no arguments.
 -- The generated type is called 'TestQueryCmds'.
 $(genTestType ''QueryCmds)
--- | A list of all constructors of 'TestQueryCmds', which are nullary.
+
 -- | A list of all constructors of 'TestQueryCmds', which are nullary.
 -- The generated list is called 'allTestQueryCmdsConstructors'.
 $(genAllConstructorsList ''TestQueryCmds)

--- a/cardano-testnet/src/Testnet/TestQueryCmds.hs
+++ b/cardano-testnet/src/Testnet/TestQueryCmds.hs
@@ -15,7 +15,7 @@ import           Testnet.TestEnumGenerator (genAllConstructorsList, genTestType)
 -- | A datatype with the same constructors as 'QueryCmds', but with a "Test" prefix and no arguments.
 -- The generated type is called 'TestQueryCmds'.
 $(genTestType ''QueryCmds)
-
+-- | A list of all constructors of 'TestQueryCmds', which are nullary.
 -- | A list of all constructors of 'TestQueryCmds', which are nullary.
 -- The generated list is called 'allTestQueryCmdsConstructors'.
 $(genAllConstructorsList ''TestQueryCmds)

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Query.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Query.hs
@@ -61,7 +61,7 @@ import           Testnet.Components.Query (watchEpochStateUpdate, checkDRepsNumb
                    watchEpochStateUpdate )
 import           Testnet.Components.Configuration (eraToString)
 import qualified Testnet.Defaults as Defaults
-import Testnet.Process.Cli.Transaction (signTx, submitTx, retrieveTransactionId, TxOutAddress(ReferenceScriptAddress),
+import           Testnet.Process.Cli.Transaction (signTx, submitTx, retrieveTransactionId, TxOutAddress(ReferenceScriptAddress),
                    TxOutAddress(ReferenceScriptAddress), signTx, submitTx, retrieveTransactionId, retrieveTransactionId,
                    signTx, submitTx, mkSimpleSpendOutputsOnlyTx, mkSpendOutputsOnlyTx, retrieveTransactionId, signTx, submitTx )
 import           Testnet.Process.Run (execCli', execCliStdoutToJson, mkExecConfig)

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Query.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Query.hs
@@ -286,11 +286,11 @@ hprop_cli_queries = integrationWorkspace "cli-queries" $ \tempAbsBasePath' -> H.
       do
         -- Set up files and vars
         refScriptSizeWork <- H.createDirectoryIfMissing $ work </> "ref-script-size-test"
-        alwaysSucceedsSpendingPlutusPath <- File <$> liftIO (makeAbsolute "test/cardano-testnet-test/files/plutus/v3/always-succeeds.plutus")
+        plutusV3Script <- File <$> liftIO (makeAbsolute "test/cardano-testnet-test/files/plutus/v3/always-succeeds.plutus")
         let transferAmount = Coin 10_000_000
         -- Submit a transaction to publish the reference script
         txBody <- mkSpendOutputsOnlyTx execConfig epochStateView sbe refScriptSizeWork "tx-body" wallet1
-                    [(ReferenceScriptAddress alwaysSucceedsSpendingPlutusPath, transferAmount)]
+                    [(ReferenceScriptAddress plutusV3Script, transferAmount)]
         signedTx <- signTx execConfig cEra refScriptSizeWork "signed-tx" txBody [SomeKeyPair $ paymentKeyInfoPair wallet1]
         submitTx execConfig cEra signedTx
         -- Wait until transaction is on chain and obtain transaction identifier

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Query.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Query.hs
@@ -24,11 +24,11 @@ import           Cardano.CLI.Types.Key (VerificationKeyOrFile (VerificationKeyFi
 import           Cardano.CLI.Types.Output (QueryTipLocalStateOutput)
 import           Cardano.Crypto.Hash (hashToStringAsHex)
 import qualified Cardano.Ledger.BaseTypes as L
-import           Cardano.Ledger.Shelley.LedgerState (nesEpochStateL, esLStateL, lsUTxOStateL, utxosUtxoL, esLStateL,
-                                                     lsUTxOStateL, nesEpochStateL, utxosUtxoL)
-import qualified Cardano.Ledger.UTxO as L
 import           Cardano.Ledger.Core (valueTxOutL)
+import           Cardano.Ledger.Shelley.LedgerState (esLStateL, lsUTxOStateL, nesEpochStateL,
+                   utxosUtxoL)
 import qualified Cardano.Ledger.TxIn as L
+import qualified Cardano.Ledger.UTxO as L
 import           Cardano.Testnet
 
 import           Prelude
@@ -38,9 +38,9 @@ import           Control.Monad (forM_)
 import           Control.Monad.Catch (MonadCatch)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Encode.Pretty as Aeson
-import qualified Data.Aeson.Lens as Aeson
 import qualified Data.Aeson.Key as Aeson
 import qualified Data.Aeson.KeyMap as Aeson
+import qualified Data.Aeson.Lens as Aeson
 import           Data.Bifunctor (bimap)
 import qualified Data.ByteString.Lazy as LBS
 import           Data.Data (type (:~:) (Refl))
@@ -58,14 +58,13 @@ import           Lens.Micro ((^.))
 import           System.Directory (makeAbsolute)
 import           System.FilePath ((</>))
 
-import           Testnet.Components.Query (watchEpochStateUpdate, checkDRepsNumber, getEpochStateView, EpochStateView,
-                   checkDRepsNumber, getEpochStateView, watchEpochStateUpdate, checkDRepsNumber, getEpochStateView,
-                   watchEpochStateUpdate )
 import           Testnet.Components.Configuration (eraToString)
+import           Testnet.Components.Query (EpochStateView, checkDRepsNumber, getEpochStateView,
+                   watchEpochStateUpdate)
 import qualified Testnet.Defaults as Defaults
-import           Testnet.Process.Cli.Transaction (signTx, submitTx, retrieveTransactionId, TxOutAddress(ReferenceScriptAddress),
-                   TxOutAddress(ReferenceScriptAddress), signTx, submitTx, retrieveTransactionId, retrieveTransactionId,
-                   signTx, submitTx, mkSimpleSpendOutputsOnlyTx, mkSpendOutputsOnlyTx, retrieveTransactionId, signTx, submitTx )
+import           Testnet.Process.Cli.Transaction (TxOutAddress (ReferenceScriptAddress),
+                   mkSimpleSpendOutputsOnlyTx, mkSpendOutputsOnlyTx, retrieveTransactionId, signTx,
+                   submitTx)
 import           Testnet.Process.Run (execCli', execCliStdoutToJson, mkExecConfig)
 import           Testnet.Property.Assert (assertErasEqual)
 import           Testnet.Property.Util (integrationWorkspace)

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Query.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Query.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE NumericUnderscores #-}
 
 module Cardano.Testnet.Test.Cli.Query
   ( hprop_cli_queries
@@ -59,7 +60,7 @@ import           System.FilePath ((</>))
 import           Testnet.Components.Query (EpochStateView, checkDRepsNumber, getEpochStateView,
                    watchEpochStateUpdate)
 import qualified Testnet.Defaults as Defaults
-import           Testnet.Process.Cli.Transaction (TxOutAddress (ReferenceScriptAddress),
+import           Testnet.Process.Cli.Transaction (TxOutAddress (ReferenceScriptAddress), buildTransferTx, signTx, submitTx, retrieveTransactionId)
                    mkSimpleSpendOutputsOnlyTx, mkSpendOutputsOnlyTx, retrieveTransactionId, signTx,
                    submitTx)
 import           Testnet.Process.Run (execCli', execCliStdoutToJson, mkExecConfig)

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Query.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Query.hs
@@ -9,8 +9,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
 
-
-
 module Cardano.Testnet.Test.Cli.Query
   ( hprop_cli_queries
   ) where
@@ -23,15 +21,14 @@ import           Cardano.Api.Shelley (StakeCredential (StakeCredentialByKey), St
 
 import           Cardano.CLI.Types.Key (VerificationKeyOrFile (VerificationKeyFilePath),
                    readVerificationKeyOrFile)
-
 import           Cardano.CLI.Types.Output (QueryTipLocalStateOutput)
 import           Cardano.Crypto.Hash (hashToStringAsHex)
 import qualified Cardano.Ledger.BaseTypes as L
-import           Cardano.Ledger.Core (valueTxOutL)
-import           Cardano.Ledger.Shelley.LedgerState (esLStateL, lsUTxOStateL, nesEpochStateL,
-                   utxosUtxoL)
-import qualified Cardano.Ledger.TxIn as L
+import           Cardano.Ledger.Shelley.LedgerState (nesEpochStateL, esLStateL, lsUTxOStateL, utxosUtxoL, esLStateL,
+                                                     lsUTxOStateL, nesEpochStateL, utxosUtxoL)
 import qualified Cardano.Ledger.UTxO as L
+import           Cardano.Ledger.Core (valueTxOutL)
+import qualified Cardano.Ledger.TxIn as L
 import           Cardano.Testnet
 
 import           Prelude
@@ -44,9 +41,9 @@ import qualified Data.Aeson.Key as Aeson
 import qualified Data.Aeson.KeyMap as Aeson
 import           Data.Bifunctor (bimap)
 import qualified Data.ByteString.Lazy as LBS
-import           Data.Data ( type (:~:)(Refl) )
+import           Data.Data (type (:~:) (Refl))
 import qualified Data.Map as Map
-import           Data.String (IsString(fromString))
+import           Data.String (IsString (fromString))
 import           Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
@@ -59,15 +56,16 @@ import           Lens.Micro ((^.))
 import           System.Directory (makeAbsolute)
 import           System.FilePath ((</>))
 
+import           Testnet.Components.Query (watchEpochStateUpdate, checkDRepsNumber, getEpochStateView, EpochStateView,
+                   checkDRepsNumber, getEpochStateView, watchEpochStateUpdate, checkDRepsNumber, getEpochStateView,
+                   watchEpochStateUpdate )
 import           Testnet.Components.Configuration (eraToString)
-import           Testnet.Components.Query (EpochStateView, checkDRepsNumber, getEpochStateView,
-                   watchEpochStateUpdate)
 import qualified Testnet.Defaults as Defaults
-import           Testnet.Property.Assert (assertErasEqual)
-import           Testnet.Process.Cli.Transaction (TxOutAddress (ReferenceScriptAddress), signTx, submitTx, retrieveTransactionId,
-                   mkSimpleSpendOutputsOnlyTx, mkSpendOutputsOnlyTx, retrieveTransactionId, signTx,
-                   submitTx)
+import Testnet.Process.Cli.Transaction (signTx, submitTx, retrieveTransactionId, TxOutAddress(ReferenceScriptAddress),
+                   TxOutAddress(ReferenceScriptAddress), signTx, submitTx, retrieveTransactionId, retrieveTransactionId,
+                   signTx, submitTx, mkSimpleSpendOutputsOnlyTx, mkSpendOutputsOnlyTx, retrieveTransactionId, signTx, submitTx )
 import           Testnet.Process.Run (execCli', execCliStdoutToJson, mkExecConfig)
+import           Testnet.Property.Assert (assertErasEqual)
 import           Testnet.Property.Util (integrationWorkspace)
 import           Testnet.TestQueryCmds (TestQueryCmds (..), forallQueryCommands)
 import           Testnet.Types


### PR DESCRIPTION
# Description

This PR adds a test for the new command `query spo-stake-distribution`.

Associated PRs:
- In `cardano-api`: https://github.com/IntersectMBO/cardano-api/pull/598
- In `cardano-cli`: https://github.com/IntersectMBO/cardano-cli/pull/854

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff
