### PR TITLE
Add more context to invalid snapshot events

### DIFF
--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
@@ -1494,7 +1494,13 @@ instance ( StandardHash blk
   forHuman (LedgerDB.DeletedSnapshot snap) =
       "Deleted old snapshot " <> showT snap
   forHuman (LedgerDB.InvalidSnapshot snap failure) =
-      "Invalid snapshot " <> showT snap <> showT failure
+      "Invalid snapshot " <> showT snap <> showT failure <> context
+    where
+      context = case failure of
+        LedgerDB.InitFailureRead{} ->
+             " This is most likely an expected change in the serialization format,"
+          <> " which currently requires a chain replay"
+        _ -> ""
 
   forMachine dtals (LedgerDB.TookSnapshot snap pt) =
     mconcat [ "kind" .= String "TookSnapshot"

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
@@ -587,7 +587,13 @@ instance ( ConvertRawHash blk
           <> "%"
       ChainDB.TraceSnapshotEvent ev -> case ev of
         LedgerDB.InvalidSnapshot snap failure ->
-          "Invalid snapshot " <> showT snap <> showT failure
+          "Invalid snapshot " <> showT snap <> showT failure <> context
+          where
+            context = case failure of
+              LedgerDB.InitFailureRead{} ->
+                   " This is most likely an expected change in the serialization format,"
+                <> " which currently requires a chain replay"
+              _ -> ""
         LedgerDB.TookSnapshot snap pt ->
           "Took ledger snapshot " <> showT snap <>
           " at " <> renderRealPointAsPhrase pt


### PR DESCRIPTION
# Description

This PR adds a bit of context for when deserializing the ledger snapshot fails. Almost aways (apart from bugs/file corruption), this is due to an expected change in the serialization format, which currently requires replaying from Genesis. In the future, the Ledger team might implement migration/upgrade logic for this case, see https://github.com/IntersectMBO/cardano-ledger/issues/3220.

See #5908 for a recent example for users being puzzled by this message.

I opted to only modify the "human" representation, but I don't have a strong opinion here.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
