### PR TITLE
cardano-testnet | remove --byron-era and add --conway-era in cardano-testnet CLI options

### DIFF
--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
@@ -1,12 +1,12 @@
 Usage: cardano-testnet (cardano | version | help)
 
 Usage: cardano-testnet cardano [--num-pool-nodes COUNT]
-  [ --byron-era
-  | --shelley-era
+  [ --shelley-era
   | --allegra-era
   | --mary-era
   | --alonzo-era
   | --babbage-era
+  | --conway-era
   ]
   [--epoch-length SLOTS]
   [--slot-length SECONDS]

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/cardano.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/cardano.cli
@@ -1,10 +1,10 @@
 Usage: cardano-testnet cardano [--num-pool-nodes COUNT]
-  [ --byron-era
-  | --shelley-era
+  [ --shelley-era
   | --allegra-era
   | --mary-era
   | --alonzo-era
   | --babbage-era
+  | --conway-era
   ]
   [--epoch-length SLOTS]
   [--slot-length SECONDS]
@@ -22,12 +22,12 @@ Available options:
   --num-pool-nodes COUNT   Number of pool nodes. Note this uses a default node
                            configuration for all nodes.
                            (default: [SpoTestnetNodeOptions Nothing [],SpoTestnetNodeOptions Nothing [],SpoTestnetNodeOptions Nothing []])
-  --byron-era              Specify the Byron era
   --shelley-era            Specify the Shelley era
   --allegra-era            Specify the Allegra era
   --mary-era               Specify the Mary era
   --alonzo-era             Specify the Alonzo era
   --babbage-era            Specify the Babbage era (default)
+  --conway-era             Specify the Conway era
   --epoch-length SLOTS     Epoch length, in number of slots (default: 500)
   --slot-length SECONDS    Slot length (default: 0.1)
   --testnet-magic INT      Specify a testnet magic id.


### PR DESCRIPTION
# Description

Removes `--byron-era` and adds `--conway-era` in `cardano-testnet` CLI options.

Fixes https://github.com/IntersectMBO/cardano-node/issues/5922

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
