### PR TITLE
cardano-tracer: Define `systemd` flag for cabal, enabled by default. 

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -51,7 +51,7 @@ package snap-server
   flags: +openssl
 
 package bitvec
-   flags: -simd
+  flags: -simd
 
 -- required for haddocks to build successfully
 package plutus-scripts-bench

--- a/cardano-tracer/CHANGELOG.md
+++ b/cardano-tracer/CHANGELOG.md
@@ -1,7 +1,9 @@
 # ChangeLog
 
-## 0.2.4 (July 12, 2024)
+## 0.2.4 (August 13, 2024)
 
+* `systemd` is enabled by default. To disable it use the cabal
+  flag: `-f -systemd`.
 * Put RTView behind a feature flag that is disabled by default. To enable RTView,
   use the cabal flag `-f +rtview`. No change to the service configuration.
 * EKG monitoring moved from `threepenny-gui` to direct HTML rendering.

--- a/cardano-tracer/README.md
+++ b/cardano-tracer/README.md
@@ -1,5 +1,9 @@
 # Cardano Tracer
 
+> Attention: systemd is enabled by default on Linux. It can be
+> disabled manually with a cabal flag: `-f -systemd` when building on
+> systems without it.
+
 `cardano-tracer` is a service for logging and monitoring over Cardano nodes. After it is connected to the node, it periodically asks the node for different information, receives it, and handles it.
 
 For more details please [read the documentation](https://github.com/intersectmbo/cardano-node/blob/master/cardano-tracer/docs/cardano-tracer.md).

--- a/cardano-tracer/cardano-tracer.cabal
+++ b/cardano-tracer/cardano-tracer.cabal
@@ -17,9 +17,14 @@ extra-doc-files:        README.md
                         CHANGELOG.md
 
 flag rtview
-  Description: Enable RTView. False by default. Enable with `-f +rtview`.
-  Default: False
-  Manual:  True
+  description:          Enable RTView. False by default. Enable with `-f +rtview`.
+  default:              False
+  manual:               True
+
+flag systemd
+  description:          Enable systemd support.
+  default:              True
+  manual:               True
 
 common project-config
   default-language:     Haskell2010
@@ -34,6 +39,9 @@ common project-config
                       , ScopedTypeVariables
                       , StandaloneKindSignatures
                       , TypeApplications
+
+  if flag(systemd) && os(linux)
+    cpp-options:        -DSYSTEMD
 
   if flag(rtview)
     CPP-Options:        -DRTVIEW=1
@@ -185,7 +193,7 @@ library
                       , unordered-containers
                       , yaml
 
-  if os(linux)
+  if flag(systemd) && os(linux)
     build-depends:      libsystemd-journal >= 1.4.4
 
   if os(windows)
@@ -246,6 +254,7 @@ library demo-forwarder-lib
                       , vector
                       , vector-algorithms
                       , QuickCheck
+
 
 executable demo-forwarder
   import:               project-config

--- a/cardano-tracer/docs/cardano-tracer.md
+++ b/cardano-tracer/docs/cardano-tracer.md
@@ -32,6 +32,10 @@ You can think of Cardano node as a **producer** of logging/monitoring informatio
 
 There are 3 kinds of such an information:
 
+> Attention: systemd is enabled by default on Linux. It can be
+> disabled manually with a cabal flag: `-f -systemd` when building on
+> systems without it.
+
 1. Trace object, which contains different logging data. `cardano-tracer` constantly asks for new trace objects each `N` seconds, receives them and stores them in the log files and/or in Linux `systemd`'s journal.
 2. EKG metric, which contains some system metric. Please [read EKG documentation](https://hackage.haskell.org/package/ekg-core) for more info. `cardano-tracer` constantly asks for new EKG metrics each `N` seconds, receives them and displays them using monitoring tools.
 3. Data points, which contains arbitrary information about the node. Please note that `cardano-tracer` asks for new data points only by _explicit_ request when it needs it, there is no constant asking.

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/Logs/Journal.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/Logs/Journal.hs
@@ -1,10 +1,5 @@
 {-# LANGUAGE CPP #-}
-
-#if defined(linux_HOST_OS)
-#define LINUX
-#endif
-
-#ifdef LINUX
+#ifdef SYSTEMD
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 #endif
@@ -13,13 +8,13 @@ module Cardano.Tracer.Handlers.Logs.Journal
   ( writeTraceObjectsToJournal
   ) where
 
-#ifdef LINUX
+#ifdef SYSTEMD
 import qualified Cardano.Logging as L
 #endif
 import           Cardano.Logging (TraceObject (..))
 import           Cardano.Tracer.Types (NodeName)
 
-#ifdef LINUX
+#ifdef SYSTEMD
 import           Data.Char (isDigit)
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Text as T
@@ -66,7 +61,7 @@ writeTraceObjectsToJournal nodeName = mapM_ (sendJournalFields . mkJournalFields
   mkPriority L.Alert     = Alert
   mkPriority L.Emergency = Emergency
 #else
--- It works on Linux only.
+-- It works only on Linux distributions with systemd support.
 writeTraceObjectsToJournal :: NodeName -> [TraceObject] -> IO ()
-writeTraceObjectsToJournal _ _ = return ()
+writeTraceObjectsToJournal _ _ = pure ()
 #endif

--- a/cardano-tracer/test/Cardano/Tracer/Test/Acceptor.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/Acceptor.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 


### PR DESCRIPTION
# Description

* [issue *#5021*](https://github.com/IntersectMBO/cardano-node/issues/5021): *cardano-tracer* `systemd` dependency

The `systemd` is now behind a feature flag, enabled by default on Linux.

```cabal
flag systemd
  description: Enable systemd support.
  default:     True
  manual:      True
```

For Linux systems that do not support `systemd`, disable by configuring cabal with `-f -systemd`.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
