### PR TITLE
Update cardano-node after addition of the new BulkSync implementation

### DIFF
--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -141,7 +141,7 @@ library
                       , ouroboros-network-framework
                       , ouroboros-network-protocols
                       , plutus-ledger-api
-                      , plutus-tx
+                      , plutus-tx ^>= 1.30
                       , random
                       , serialise
                       , streaming

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2024-06-23T23:01:13Z
-  , cardano-haskell-packages 2024-07-03T01:26:49Z
+  , cardano-haskell-packages 2024-09-01T03:50:08Z
 
 packages:
   cardano-node

--- a/cabal.project
+++ b/cabal.project
@@ -69,9 +69,8 @@ allow-newer: katip:Win32
 source-repository-package
   type: git
   location: https://github.com/IntersectMBO/ouroboros-network
-  -- back-port of BulkSync for genesis to ouroboros-network-0.16.1.1
-  tag: fcb842fcd6f32b43a7cdf18a4301c1659a8bb879
-  --sha256: kjwUrduwwxC+5QRQNJa4stEBzz7kqDJyyHOgGMfDw7s=
+  tag: 5c304e5adbd27907c675bd60a2282264a65f117c
+  --sha256: Jn3Qqlsirlyu23bsFN2SO054LIe2rcsHUW1tN8Pm1Ks=
   subdir:
     ouroboros-network
     ouroboros-network-api
@@ -81,8 +80,8 @@ source-repository-package
   type: git
   location: https://github.com/IntersectMBO/ouroboros-consensus
   -- back-port of BulkSync for genesis to ouroboros-consensus-0.20.0.0
-  tag: 10ab97605c3b0e3205eb119a8b5b971123483415
-  --sha256: hdMbzbPpWzPDAlR4lWAzdPt99BHD8vzdVXo/SnHz4BM=
+  tag: 0874ad4a61854f50bf9303d9f662ae6b129fac6d
+  --sha256: iw9IWAnUz4SX6OIBfe4HsRukZr8adyLbCS36CJo+8OE=
   subdir:
     ouroboros-consensus
     ouroboros-consensus-cardano

--- a/cabal.project
+++ b/cabal.project
@@ -65,3 +65,28 @@ allow-newer: katip:Win32
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
+
+source-repository-package
+  type: git
+  location: https://github.com/IntersectMBO/ouroboros-network
+  -- back-port of BulkSync for genesis to ouroboros-network-0.16.1.1
+  tag: fcb842fcd6f32b43a7cdf18a4301c1659a8bb879
+  --sha256: kjwUrduwwxC+5QRQNJa4stEBzz7kqDJyyHOgGMfDw7s=
+  subdir:
+    ouroboros-network
+    ouroboros-network-api
+    ouroboros-network-protocols
+
+source-repository-package
+  type: git
+  location: https://github.com/IntersectMBO/ouroboros-consensus
+  -- back-port of BulkSync for genesis to ouroboros-consensus-0.20.0.0
+  tag: 10ab97605c3b0e3205eb119a8b5b971123483415
+  --sha256: hdMbzbPpWzPDAlR4lWAzdPt99BHD8vzdVXo/SnHz4BM=
+  subdir:
+    ouroboros-consensus
+    ouroboros-consensus-cardano
+    ouroboros-consensus-diffusion
+    ouroboros-consensus-protocol
+    sop-extras
+    strict-sop-core

--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -9,6 +9,8 @@
   - `--mempool-capacity-override` and `--no-mempool-capacity-override` can be set in the configuration file via the key `MempoolCapacityBytesOverride`.
   - `--snapshot-interval` can be set in the configuration file via the key `SnapshotInterval`.
   - `--num-of-disk-snapshots` can be set in the configuration file via the key `NumOfDiskSnapshots`.
+- Update tracing with Genesis messages
+- Update configuration with Genesis parameters
 
 ## 8.2.1 -- August 2023
 

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -157,7 +157,7 @@ library
                       , cardano-ledger-byron
                       , cardano-ledger-conway
                       , cardano-ledger-core
-                      , cardano-ledger-shelley
+                      , cardano-ledger-shelley >= 1.12.3.0
                       , cardano-prelude
                       , cardano-protocol-tpraos >= 1.0.2
                       , cardano-slotting >= 0.2
@@ -175,10 +175,10 @@ library
                       , generic-data
                       , hostname
                       , io-classes >= 1.4
-                      , iohk-monitoring
+                      , iohk-monitoring ^>= 0.1
                       , iproute
                       , lobemo-backend-aggregation
-                      , lobemo-backend-ekg
+                      , lobemo-backend-ekg ^>= 0.1
                       , lobemo-backend-monitoring
                       , lobemo-backend-trace-forwarder
                       , mtl

--- a/cardano-node/src/Cardano/Node/Configuration/POM.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/POM.hs
@@ -34,6 +34,8 @@ import           Cardano.Tracing.OrphanInstances.Network ()
 import           Ouroboros.Consensus.Mempool (MempoolCapacityBytes (..),
                    MempoolCapacityBytesOverride (..))
 import qualified Ouroboros.Consensus.Node as Consensus (NetworkP2PMode (..))
+import           Ouroboros.Consensus.Node.Genesis (GenesisConfig,
+                   GenesisConfigFlags (..), defaultGenesisConfigFlags, mkGenesisConfig)
 import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy (NumOfDiskSnapshots (..),
                    SnapshotInterval (..))
 import           Ouroboros.Network.NodeToNode (AcceptedConnectionsLimit (..), DiffusionMode (..))
@@ -163,8 +165,8 @@ data NodeConfiguration
          -- Enable Peer Sharing
        , ncPeerSharing :: PeerSharing
 
-       -- Enable Genesis syncing protocol
-       , ncEnableGenesis :: Bool
+       -- Genesis syncing protocol configuration
+       , ncGenesisConfig :: GenesisConfig
        } deriving (Eq, Show)
 
 
@@ -230,7 +232,8 @@ data PartialNodeConfiguration
        , pncPeerSharing :: !(Last PeerSharing)
 
          -- Genesis syncing protocol
-       , pncEnableGenesis :: !(Last Bool)
+       , pncEnableGenesis      :: !(Last Bool)
+       , pncGenesisConfigFlags :: !(Last GenesisConfigFlags)
        } deriving (Eq, Generic, Show)
 
 instance AdjustFilePaths PartialNodeConfiguration where
@@ -329,7 +332,8 @@ instance FromJSON PartialNodeConfiguration where
 
       -- Genesis syncing protocol
       -- DISABLED BY DEFAULT
-      pncEnableGenesis <- Last <$> v .:? "EnableGenesis" .!= Just False
+      pncEnableGenesis      <- Last <$> v .:? "EnableGenesis" .!= Just False
+      pncGenesisConfigFlags <- Last <$> v .:? "LowLevelGenesisOptions"
 
       pure PartialNodeConfiguration {
              pncProtocolConfig
@@ -366,6 +370,7 @@ instance FromJSON PartialNodeConfiguration where
            , pncEnableP2P
            , pncPeerSharing
            , pncEnableGenesis
+           , pncGenesisConfigFlags
            }
     where
       parseMempoolCapacityBytesOverride v = parseNoOverride <|> parseOverride
@@ -543,6 +548,7 @@ defaultPartialNodeConfiguration =
     , pncEnableP2P                      = Last (Just EnabledP2PMode)
     , pncPeerSharing                    = Last (Just PeerSharingDisabled)
     , pncEnableGenesis                  = Last (Just False)
+    , pncGenesisConfigFlags             = Last (Just defaultGenesisConfigFlags)
     }
 
 lastOption :: Parser a -> Parser (Last a)
@@ -608,9 +614,15 @@ makeNodeConfiguration pnc = do
     lastToEither "Missing PeerSharing"
     $ pncPeerSharing pnc
 
-  ncEnableGenesis <-
+  enableGenesis <-
     lastToEither "Missing EnableGenesis"
     $ pncEnableGenesis pnc
+
+  mGenesisConfigFlags <- if enableGenesis
+    then fmap Just <$>
+      lastToEither "Missing GenesisConfigFlags"
+      $ pncGenesisConfigFlags pnc
+    else pure Nothing
 
   -- TODO: This is not mandatory
   experimentalProtocols <-
@@ -659,7 +671,7 @@ makeNodeConfiguration pnc = do
                  EnabledP2PMode  -> SomeNetworkP2PMode Consensus.EnabledP2PMode
                  DisabledP2PMode -> SomeNetworkP2PMode Consensus.DisabledP2PMode
              , ncPeerSharing
-             , ncEnableGenesis
+             , ncGenesisConfig = mkGenesisConfig mGenesisConfigFlags
              }
 
 ncProtocol :: NodeConfiguration -> Protocol

--- a/cardano-node/src/Cardano/Node/Orphans.hs
+++ b/cardano-node/src/Cardano/Node/Orphans.hs
@@ -7,6 +7,7 @@ module Cardano.Node.Orphans () where
 
 import           Cardano.Api ()
 
+import           Ouroboros.Consensus.Node.Genesis (GenesisConfigFlags (..))
 import           Ouroboros.Network.NodeToNode (AcceptedConnectionsLimit (..))
 import           Ouroboros.Network.SizeInBytes (SizeInBytes (..))
 
@@ -38,3 +39,15 @@ instance FromJSON AcceptedConnectionsLimit where
       <$> v .: "hardLimit"
       <*> v .: "softLimit"
       <*> v .: "delay"
+
+instance FromJSON GenesisConfigFlags where
+  parseJSON = withObject "GenesisConfigFlags" $ \v ->
+    GenesisConfigFlags
+      <$> v .:? "EnableCSJ"       .!= True
+      <*> v .:? "EnableLoEAndGDD" .!= True
+      <*> v .:? "EnableLoP"       .!= True
+      <*> v .:? "BulkSyncGracePeriod"
+      <*> v .:? "BucketCapacity"
+      <*> v .:? "BucketRate"
+      <*> v .:? "CSJJumpSize"
+      <*> v .:? "GDDRateLimit"

--- a/cardano-node/src/Cardano/Node/Orphans.hs
+++ b/cardano-node/src/Cardano/Node/Orphans.hs
@@ -46,7 +46,7 @@ instance FromJSON GenesisConfigFlags where
       <$> v .:? "EnableCSJ"       .!= True
       <*> v .:? "EnableLoEAndGDD" .!= True
       <*> v .:? "EnableLoP"       .!= True
-      <*> v .:? "BulkSyncGracePeriod"
+      <*> v .:? "BlockFetchGracePeriod"
       <*> v .:? "BucketCapacity"
       <*> v .:? "BucketRate"
       <*> v .:? "CSJJumpSize"

--- a/cardano-node/src/Cardano/Node/Parsers.hs
+++ b/cardano-node/src/Cardano/Node/Parsers.hs
@@ -127,6 +127,7 @@ nodeRunParser = do
            , pncEnableP2P = mempty
            , pncPeerSharing = mempty
            , pncEnableGenesis = mempty
+           , pncGenesisConfigFlags = mempty
            }
 
 parseSocketPath :: Text -> Parser SocketPath

--- a/cardano-node/src/Cardano/Node/Parsers.hs
+++ b/cardano-node/src/Cardano/Node/Parsers.hs
@@ -126,6 +126,7 @@ nodeRunParser = do
            , pncTargetNumberOfActiveBigLedgerPeers = mempty
            , pncEnableP2P = mempty
            , pncPeerSharing = mempty
+           , pncEnableGenesis = mempty
            }
 
 parseSocketPath :: Text -> Parser SocketPath

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -480,9 +480,7 @@ handleSimpleNode blockType runP p2pMode tracers nc onKernel = do
               , rnEnableP2P      = p2pMode
               , rnPeerSharing    = ncPeerSharing nc
               , rnGetUseBootstrapPeers = readTVar useBootstrapVar
-              , rnGenesisConfig = if ncEnableGenesis nc
-                  then Genesis.enableGenesisConfigDefault
-                  else Genesis.disableGenesisConfig
+              , rnGenesisConfig = ncGenesisConfig nc
               }
 #ifdef UNIX
         -- initial `SIGHUP` handler, which only rereads the topology file but
@@ -565,9 +563,7 @@ handleSimpleNode blockType runP p2pMode tracers nc onKernel = do
                 , rnEnableP2P      = p2pMode
                 , rnPeerSharing    = ncPeerSharing nc
                 , rnGetUseBootstrapPeers = pure DontUseBootstrapPeers
-                , rnGenesisConfig = if ncEnableGenesis nc
-                    then Genesis.enableGenesisConfigDefault
-                    else Genesis.disableGenesisConfig
+                , rnGenesisConfig = ncGenesisConfig nc
                 }
 #ifdef UNIX
         -- initial `SIGHUP` handler; it only warns that neither updating of

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -513,7 +513,8 @@ handleSimpleNode blockType runP p2pMode tracers nc onKernel = do
                   rnNodeKernelHook nodeArgs registry nodeKernel
             }
             StdRunNodeArgs
-              { srnBfcMaxConcurrencyDeadline    = unMaxConcurrencyDeadline <$> ncMaxConcurrencyDeadline nc
+              { srnBfcMaxConcurrencyBulkSync    = unMaxConcurrencyBulkSync <$> ncMaxConcurrencyBulkSync nc
+              , srnBfcMaxConcurrencyDeadline    = unMaxConcurrencyDeadline <$> ncMaxConcurrencyDeadline nc
               , srnChainDbValidateOverride      = ncValidateDB nc
               , srnDiskPolicyArgs               = diskPolicyArgs
               , srnDatabasePath                 = dbPath
@@ -586,7 +587,8 @@ handleSimpleNode blockType runP p2pMode tracers nc onKernel = do
                   rnNodeKernelHook nodeArgs registry nodeKernel
             }
             StdRunNodeArgs
-              { srnBfcMaxConcurrencyDeadline   = unMaxConcurrencyDeadline <$> ncMaxConcurrencyDeadline nc
+              { srnBfcMaxConcurrencyBulkSync   = unMaxConcurrencyBulkSync <$> ncMaxConcurrencyBulkSync nc
+              , srnBfcMaxConcurrencyDeadline   = unMaxConcurrencyDeadline <$> ncMaxConcurrencyDeadline nc
               , srnChainDbValidateOverride     = ncValidateDB nc
               , srnDiskPolicyArgs              = diskPolicyArgs
               , srnDatabasePath                = dbPath

--- a/cardano-node/src/Cardano/Node/Tracing/Consistency.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Consistency.hs
@@ -38,6 +38,7 @@ import           Ouroboros.Consensus.BlockchainTime.WallClock.Types (RelativeTim
 import           Ouroboros.Consensus.BlockchainTime.WallClock.Util (TraceBlockchainTimeEvent (..))
 import           Ouroboros.Consensus.Cardano.Block
 import           Ouroboros.Consensus.Ledger.Query (Query)
+import           Ouroboros.Consensus.Genesis.Governor (TraceGDDEvent)
 import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr, GenTxId)
 import           Ouroboros.Consensus.Mempool (TraceEventMempool (..))
 import           Ouroboros.Consensus.MiniProtocol.BlockFetch.Server
@@ -46,11 +47,13 @@ import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client (TraceChainSy
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Server (TraceChainSyncServerEvent)
 import           Ouroboros.Consensus.MiniProtocol.LocalTxSubmission.Server
                    (TraceLocalTxSubmissionServerEvent (..))
+import           Ouroboros.Consensus.Node.GSM (TraceGsmEvent)
 import qualified Ouroboros.Consensus.Protocol.Ledger.HotKey as HotKey
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
+import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client.Jumping as CSJumping
 import           Ouroboros.Network.Block (Point (..), SlotNo, Tip)
 import qualified Ouroboros.Network.BlockFetch.ClientState as BlockFetch
-import           Ouroboros.Network.BlockFetch.Decision
+import           Ouroboros.Network.BlockFetch.Decision.Trace as BlockFetch
 import           Ouroboros.Network.ConnectionHandler (ConnectionHandlerTrace (..))
 import           Ouroboros.Network.ConnectionId (ConnectionId)
 import           Ouroboros.Network.ConnectionManager.Types (ConnectionManagerTrace (..))
@@ -151,9 +154,7 @@ getAllNamespaces =
         chainSyncServerBlockNS = map (nsGetTuple . nsReplacePrefix ["ChainSync", "ServerBlock"])
                         (allNamespaces :: [Namespace (TraceChainSyncServerEvent blk)])
         blockFetchDecisionNS = map (nsGetTuple . nsReplacePrefix ["BlockFetch", "Decision"])
-                        (allNamespaces :: [Namespace [BlockFetch.TraceLabelPeer
-                                                      remotePeer
-                                                      (FetchDecision [Point (Header blk)])]])
+                        (allNamespaces :: [Namespace (TraceDecisionEvent remotePeer (Header blk))])
         blockFetchClientNS = map (nsGetTuple . nsReplacePrefix ["BlockFetch", "Client"])
                         (allNamespaces :: [Namespace (BlockFetch.TraceLabelPeer
                                                       remotePeer
@@ -184,6 +185,15 @@ getAllNamespaces =
 
         blockchainTimeNS = map (nsGetTuple . nsReplacePrefix  ["BlockchainTime"])
                         (allNamespaces :: [Namespace (TraceBlockchainTimeEvent RelativeTime)])
+
+        gsmEventNS = map (nsGetTuple . nsReplacePrefix  ["GsmEvent"])
+                         (allNamespaces :: [Namespace (TraceGsmEvent selection)])
+
+        csjEventNS = map nsGetTuple
+                         (allNamespaces :: [Namespace (CSJumping.TraceEvent peer)])
+
+        gddEventNS = map nsGetTuple
+                         (allNamespaces :: [Namespace (TraceGDDEvent peer blk)])
 
 -- Node to client
         keepAliveClientNS = map (nsGetTuple . nsReplacePrefix ["Net"])
@@ -390,6 +400,9 @@ getAllNamespaces =
             <> mempoolNS
             <> forgeNS
             <> blockchainTimeNS
+            <> gsmEventNS
+            <> csjEventNS
+            <> gddEventNS
 -- NodeToClient
             <> keepAliveClientNS
             <> chainSyncNS

--- a/cardano-node/src/Cardano/Node/Tracing/Documentation.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Documentation.hs
@@ -59,7 +59,7 @@ import qualified Ouroboros.Consensus.Protocol.Ledger.HotKey as HotKey
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import           Ouroboros.Network.Block (Point (..), Serialised, SlotNo, Tip)
 import qualified Ouroboros.Network.BlockFetch.ClientState as BlockFetch
-import           Ouroboros.Network.BlockFetch.Decision
+import qualified Ouroboros.Network.BlockFetch.Decision.Trace as BlockFetch
 import           Ouroboros.Network.ConnectionHandler (ConnectionHandlerTrace (..))
 import           Ouroboros.Network.ConnectionId (ConnectionId)
 import           Ouroboros.Network.ConnectionManager.Types (ConnectionManagerTrace (..))
@@ -278,9 +278,7 @@ docTracersFirstPhase condConfigFileName = do
                 ["BlockFetch", "Decision"]
     configureTracers configReflection trConfig [blockFetchDecisionTr]
     blockFetchDecisionTrDoc <- documentTracer (blockFetchDecisionTr ::
-       Trace IO [BlockFetch.TraceLabelPeer
-                                      remotePeer
-                                      (FetchDecision [Point (Header blk)])])
+       Trace IO (BlockFetch.TraceDecisionEvent remotePeer (Header blk)))
 
     blockFetchClientTr  <- mkCardanoTracer
                 trBase trForward mbTrEKG

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
@@ -34,7 +34,6 @@ import           Cardano.Node.Tracing.Tracers.KESInfo
 import           Cardano.Node.Tracing.Tracers.NodeToClient ()
 import           Cardano.Node.Tracing.Tracers.NodeToNode ()
 import           Cardano.Node.Tracing.Tracers.NodeVersion (getNodeVersion)
-
 import           Cardano.Node.Tracing.Tracers.NonP2P ()
 import           Cardano.Node.Tracing.Tracers.P2P ()
 import           Cardano.Node.Tracing.Tracers.Peer ()
@@ -324,6 +323,11 @@ mkConsensusTracers configReflection trBase trForward mbTrEKG _trDataPoint trConf
                 ["Consensus", "GSM"]
     configureTracers configReflection trConfig [consensusGsmTr]
 
+    !consensusGddTr <- mkCardanoTracer
+                trBase trForward mbTrEKG
+                ["Consensus", "GDD"]
+    configureTracers configReflection trConfig [consensusGddTr]
+
     !consensusCsjTr <- mkCardanoTracer
                 trBase trForward mbTrEKG
                 ["Consensus", "CSJ"]
@@ -366,7 +370,7 @@ mkConsensusTracers configReflection trBase trForward mbTrEKG _trDataPoint trConf
           traceWith consensusStartupErrorTr . ConsensusStartupException
       , Consensus.gsmTracer = Tracer $
           traceWith consensusGsmTr
-      , Consensus.gddTracer = Tracer $ \_ -> pure () -- TODO
+      , Consensus.gddTracer = Tracer $ traceWith consensusGddTr
       , Consensus.csjTracer = Tracer $ traceWith consensusCsjTr
       }
 

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
@@ -317,12 +317,17 @@ mkConsensusTracers configReflection trBase trForward mbTrEKG _trDataPoint trConf
     !consensusStartupErrorTr <- mkCardanoTracer
                 trBase trForward mbTrEKG
                 ["Consensus", "Startup"]
+    configureTracers configReflection trConfig [consensusStartupErrorTr]
 
     !consensusGsmTr <- mkCardanoTracer
                 trBase trForward mbTrEKG
                 ["Consensus", "GSM"]
+    configureTracers configReflection trConfig [consensusGsmTr]
 
-    configureTracers configReflection trConfig [consensusStartupErrorTr]
+    !consensusCsjTr <- mkCardanoTracer
+                trBase trForward mbTrEKG
+                ["Consensus", "CSJ"]
+    configureTracers configReflection trConfig [consensusCsjTr]
 
     pure $ Consensus.Tracers
       { Consensus.chainSyncClientTracer = Tracer $
@@ -361,6 +366,8 @@ mkConsensusTracers configReflection trBase trForward mbTrEKG _trDataPoint trConf
           traceWith consensusStartupErrorTr . ConsensusStartupException
       , Consensus.gsmTracer = Tracer $
           traceWith consensusGsmTr
+      , Consensus.gddTracer = Tracer $ \_ -> pure () -- TODO
+      , Consensus.csjTracer = Tracer $ traceWith consensusCsjTr
       }
 
 mkNodeToClientTracers :: forall blk.

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
@@ -90,6 +90,7 @@ instance (  LogFormatting (Header blk)
   forHuman (ChainDB.TraceLedgerReplayEvent v)      = forHumanOrMachine v
   forHuman (ChainDB.TraceImmutableDBEvent v)       = forHumanOrMachine v
   forHuman (ChainDB.TraceVolatileDBEvent v)        = forHumanOrMachine v
+  forHuman (ChainDB.TraceChainSelStarvationEvent v)= forHumanOrMachine v
 
   forMachine details (ChainDB.TraceAddBlockEvent v) =
     forMachine details v
@@ -113,6 +114,8 @@ instance (  LogFormatting (Header blk)
     forMachine details v
   forMachine details (ChainDB.TraceVolatileDBEvent v) =
     forMachine details v
+  forMachine details (ChainDB.TraceChainSelStarvationEvent v) =
+    forMachine details v
 
   asMetrics (ChainDB.TraceAddBlockEvent v)          = asMetrics v
   asMetrics (ChainDB.TraceFollowerEvent v)          = asMetrics v
@@ -125,6 +128,7 @@ instance (  LogFormatting (Header blk)
   asMetrics (ChainDB.TraceLedgerReplayEvent v)      = asMetrics v
   asMetrics (ChainDB.TraceImmutableDBEvent v)       = asMetrics v
   asMetrics (ChainDB.TraceVolatileDBEvent v)        = asMetrics v
+  asMetrics (ChainDB.TraceChainSelStarvationEvent v)     = asMetrics v
 
 
 instance MetaTrace  (ChainDB.TraceEvent blk) where
@@ -150,6 +154,8 @@ instance MetaTrace  (ChainDB.TraceEvent blk) where
     nsPrependInner "ImmDbEvent" (namespaceFor ev)
   namespaceFor (ChainDB.TraceVolatileDBEvent ev) =
      nsPrependInner "VolatileDbEvent" (namespaceFor ev)
+  namespaceFor (ChainDB.TraceChainSelStarvationEvent ev) =
+    nsPrependInner "ChainSelStarvationEvent" (namespaceFor ev)
 
   severityFor (Namespace out ("AddBlockEvent" : tl)) (Just (ChainDB.TraceAddBlockEvent ev')) =
     severityFor (Namespace out tl) (Just ev')
@@ -195,6 +201,10 @@ instance MetaTrace  (ChainDB.TraceEvent blk) where
     severityFor (Namespace out tl) (Just ev')
   severityFor (Namespace out ("VolatileDbEvent" : tl)) Nothing =
     severityFor (Namespace out tl :: Namespace (VolDB.TraceEvent blk)) Nothing
+  severityFor (Namespace out ("ChainSelStarvationEvent" : tl)) (Just (ChainDB.TraceChainSelStarvationEvent ev')) =
+    severityFor (Namespace out tl) (Just ev')
+  severityFor (Namespace out ("ChainSelStarvationEvent" : tl)) Nothing =
+    severityFor (Namespace out tl :: Namespace (ChainDB.TraceChainSelStarvationEvent blk)) Nothing
   severityFor _ns _ = Nothing
 
   privacyFor (Namespace out ("AddBlockEvent" : tl)) (Just (ChainDB.TraceAddBlockEvent ev')) =
@@ -287,6 +297,10 @@ instance MetaTrace  (ChainDB.TraceEvent blk) where
     detailsFor (Namespace out tl) (Just ev')
   detailsFor (Namespace out ("VolatileDbEvent" : tl)) Nothing =
     detailsFor (Namespace out tl :: (Namespace (VolDB.TraceEvent blk))) Nothing
+  detailsFor (Namespace out ("ChainSelStarvationEvent" : tl)) (Just (ChainDB.TraceChainSelStarvationEvent ev')) =
+    detailsFor (Namespace out tl) (Just ev')
+  detailsFor (Namespace out ("ChainSelStarvationEvent" : tl)) Nothing =
+    detailsFor (Namespace out tl :: (Namespace (ChainDB.TraceChainSelStarvationEvent blk))) Nothing
   detailsFor _ _ = Nothing
 
   metricsDocFor (Namespace out ("AddBlockEvent" : tl)) =
@@ -311,6 +325,8 @@ instance MetaTrace  (ChainDB.TraceEvent blk) where
     metricsDocFor (Namespace out tl :: Namespace (ImmDB.TraceEvent blk))
   metricsDocFor (Namespace out ("VolatileDbEvent" : tl)) =
     metricsDocFor (Namespace out tl :: Namespace (VolDB.TraceEvent blk))
+  metricsDocFor (Namespace out ("ChainSelStarvationEvent" : tl)) =
+    metricsDocFor (Namespace out tl :: Namespace (ChainDB.TraceChainSelStarvationEvent blk))
   metricsDocFor _ = []
 
   documentFor (Namespace out ("AddBlockEvent" : tl)) =
@@ -335,6 +351,8 @@ instance MetaTrace  (ChainDB.TraceEvent blk) where
     documentFor (Namespace out tl :: Namespace (ImmDB.TraceEvent blk))
   documentFor (Namespace out ("VolatileDbEvent" : tl)) =
     documentFor (Namespace out tl :: Namespace (VolDB.TraceEvent blk))
+  documentFor (Namespace out ("ChainSelStarvationEvent" : tl)) =
+    documentFor (Namespace out tl :: Namespace (ChainDB.TraceChainSelStarvationEvent blk))
   documentFor _ = Nothing
 
   allNamespaces =
@@ -360,7 +378,8 @@ instance MetaTrace  (ChainDB.TraceEvent blk) where
                   (allNamespaces :: [Namespace (ImmDB.TraceEvent blk)])
           ++ map  (nsPrependInner "VolatileDbEvent")
                   (allNamespaces :: [Namespace (VolDB.TraceEvent blk)])
-
+          ++ map  (nsPrependInner "ChainSelStarvationEvent")
+                  (allNamespaces :: [Namespace (ChainDB.TraceChainSelStarvationEvent blk)])
 
 --------------------------------------------------------------------------------
 -- AddBlockEvent
@@ -1169,6 +1188,47 @@ instance MetaTrace (ChainDB.TraceValidationEvent blk) where
       , Namespace [] ["CandidateContainsFutureBlocksExceedingClockSkew"]
       , Namespace [] ["InvalidBlock"]
       , Namespace [] ["UpdateLedgerDb"]
+      ]
+
+--------------------------------------------------------------------------------
+-- TraceChainSelStarvationEvent
+--------------------------------------------------------------------------------
+
+instance ConvertRawHash blk
+          => LogFormatting (ChainDB.TraceChainSelStarvationEvent blk) where
+  forHuman (ChainDB.ChainSelStarvationStarted time) =
+      "Chain selection starvation started at " <> showT time
+  forHuman (ChainDB.ChainSelStarvationEnded time pt) =
+      "Chain selection starvation ended at " <> showT time <>
+      " because of " <> renderRealPointAsPhrase pt
+
+  forMachine _dtal (ChainDB.ChainSelStarvationStarted time) =
+    mconcat [ "kind" .= String "ChainSelStarvationStarted"
+            , "time" .= String (showT time) ]
+  forMachine dtal (ChainDB.ChainSelStarvationEnded time pt) =
+    mconcat [ "kind" .= String "ChainSelStarvationEnded"
+             , "time" .= String (showT time)
+             , "point" .= forMachine dtal pt ]
+
+instance MetaTrace (ChainDB.TraceChainSelStarvationEvent blk) where
+    namespaceFor ChainDB.ChainSelStarvationStarted {} =
+      Namespace [] ["ChainSelStarvationStarted"]
+    namespaceFor ChainDB.ChainSelStarvationEnded {} =
+      Namespace [] ["ChainSelStarvationEnded"]
+
+    severityFor (Namespace _ ["ChainSelStarvationStarted"]) _ = Just Debug
+    severityFor (Namespace _ ["ChainSelStarvationEnded"]) _ = Just Debug
+    severityFor _ _ = Nothing
+
+    documentFor (Namespace _ ["ChainSelStarvationStarted"]) = Just
+      "Chain selection starvation started."
+    documentFor (Namespace _ ["ChainSelStarvationEnded"]) = Just
+      "Chain selection starvation ended."
+    documentFor _ = Nothing
+
+    allNamespaces =
+      [ Namespace [] ["ChainSelStarvationStarted"]
+      , Namespace [] ["ChainSelStarvationEnded"]
       ]
 
 --------------------------------------------------------------------------------

--- a/cardano-node/src/Cardano/Tracing/Config.hs
+++ b/cardano-node/src/Cardano/Tracing/Config.hs
@@ -26,6 +26,7 @@ module Cardano.Tracing.Config
   , TraceBlockFetchServer
   , TraceChainDB
   , TraceChainSyncClient
+  , TraceChainSyncJumping
   , TraceChainSyncBlockServer
   , TraceChainSyncHeaderServer
   , TraceChainSyncProtocol
@@ -122,6 +123,7 @@ instance Semigroup PartialTraceOptions where
 
 type TraceAcceptPolicy = ("TraceAcceptPolicy" :: Symbol)
 type TraceBlockchainTime = ("TraceBlockchainTime" :: Symbol)
+type TraceChainSyncJumping = ("TraceChainSyncJumping" :: Symbol)
 type TraceBlockFetchClient = ("TraceBlockFetchClient" :: Symbol)
 type TraceBlockFetchDecisions = ("TraceBlockFetchDecisions" :: Symbol)
 type TraceBlockFetchProtocol = ("TraceBlockFetchProtocol" :: Symbol)
@@ -143,6 +145,8 @@ type TraceDnsSubscription = ("TraceDnsSubscription" :: Symbol)
 type TraceErrorPolicy = ("TraceErrorPolicy" :: Symbol)
 type TraceForge = ("TraceForge" :: Symbol)
 type TraceForgeStateInfo = ("TraceForgeStateInfo" :: Symbol)
+type TraceGdd = ("TraceGdd" :: Symbol)
+type TraceGsm = ("TraceGsm" :: Symbol)
 type TraceHandshake = ("TraceHandshake" :: Symbol)
 type TraceIpSubscription = ("TraceIpSubscription" :: Symbol)
 type TraceKeepAliveClient = ("TraceKeepAliveClient" :: Symbol)
@@ -173,7 +177,6 @@ type TraceTxInbound = ("TraceTxInbound" :: Symbol)
 type TraceTxOutbound = ("TraceTxOutbound" :: Symbol)
 type TraceTxSubmissionProtocol = ("TraceTxSubmissionProtocol" :: Symbol)
 type TraceTxSubmission2Protocol = ("TraceTxSubmission2Protocol" :: Symbol)
-type TraceGsm = ("TraceGsm" :: Symbol)
 
 newtype OnOff (name :: Symbol) = OnOff { isOn :: Bool } deriving (Eq, Show)
 
@@ -196,6 +199,7 @@ data TraceSelection
   , traceBlockFetchProtocolSerialised :: OnOff TraceBlockFetchProtocolSerialised
   , traceBlockFetchServer :: OnOff TraceBlockFetchServer
   , traceBlockchainTime :: OnOff TraceBlockchainTime
+  , traceChainSyncJumping :: OnOff TraceChainSyncJumping
   , traceChainDB :: OnOff TraceChainDB
   , traceChainSyncBlockServer :: OnOff TraceChainSyncBlockServer
   , traceChainSyncClient :: OnOff TraceChainSyncClient
@@ -212,6 +216,8 @@ data TraceSelection
   , traceErrorPolicy :: OnOff TraceErrorPolicy
   , traceForge :: OnOff TraceForge
   , traceForgeStateInfo :: OnOff TraceForgeStateInfo
+  , traceGdd :: OnOff TraceGdd
+  , traceGsm :: OnOff TraceGsm
   , traceHandshake :: OnOff TraceHandshake
   , traceInboundGovernor :: OnOff TraceInboundGovernor
   , traceInboundGovernorCounters :: OnOff TraceInboundGovernorCounters
@@ -242,7 +248,6 @@ data TraceSelection
   , traceTxOutbound :: OnOff TraceTxOutbound
   , traceTxSubmissionProtocol :: OnOff TraceTxSubmissionProtocol
   , traceTxSubmission2Protocol :: OnOff TraceTxSubmission2Protocol
-  , traceGsm :: OnOff TraceGsm
   } deriving (Eq, Show)
 
 
@@ -254,6 +259,7 @@ data PartialTraceSelection
       -- Per-trace toggles, alpha-sorted.
       , pTraceAcceptPolicy :: Last (OnOff TraceAcceptPolicy)
       , pTraceBlockchainTime :: Last (OnOff TraceBlockchainTime)
+      , pTraceChainSyncJumping :: Last (OnOff TraceChainSyncJumping)
       , pTraceBlockFetchClient :: Last (OnOff TraceBlockFetchClient)
       , pTraceBlockFetchDecisions :: Last (OnOff TraceBlockFetchDecisions)
       , pTraceBlockFetchProtocol :: Last (OnOff TraceBlockFetchProtocol)
@@ -275,6 +281,8 @@ data PartialTraceSelection
       , pTraceErrorPolicy :: Last (OnOff TraceErrorPolicy)
       , pTraceForge :: Last (OnOff TraceForge)
       , pTraceForgeStateInfo :: Last (OnOff TraceForgeStateInfo)
+      , pTraceGdd :: Last (OnOff TraceGdd)
+      , pTraceGsm :: Last (OnOff TraceGsm)
       , pTraceHandshake :: Last (OnOff TraceHandshake)
       , pTraceInboundGovernor :: Last (OnOff TraceInboundGovernor)
       , pTraceInboundGovernorCounters :: Last (OnOff TraceInboundGovernorCounters)
@@ -305,7 +313,6 @@ data PartialTraceSelection
       , pTraceTxOutbound :: Last (OnOff TraceTxOutbound)
       , pTraceTxSubmissionProtocol :: Last (OnOff TraceTxSubmissionProtocol)
       , pTraceTxSubmission2Protocol :: Last (OnOff TraceTxSubmission2Protocol)
-      , pTraceGsm :: Last (OnOff TraceGsm)
       } deriving (Eq, Generic, Show)
 
 
@@ -318,6 +325,7 @@ instance FromJSON PartialTraceSelection where
       <$> Last <$> v .:? "TracingVerbosity"
       <*> parseTracer (Proxy @TraceAcceptPolicy) v
       <*> parseTracer (Proxy @TraceBlockchainTime) v
+      <*> parseTracer (Proxy @TraceChainSyncJumping) v
       <*> parseTracer (Proxy @TraceBlockFetchClient) v
       <*> parseTracer (Proxy @TraceBlockFetchDecisions) v
       <*> parseTracer (Proxy @TraceBlockFetchProtocol) v
@@ -339,6 +347,8 @@ instance FromJSON PartialTraceSelection where
       <*> parseTracer (Proxy @TraceErrorPolicy) v
       <*> parseTracer (Proxy @TraceForge) v
       <*> parseTracer (Proxy @TraceForgeStateInfo) v
+      <*> parseTracer (Proxy @TraceGdd) v
+      <*> parseTracer (Proxy @TraceGsm) v
       <*> parseTracer (Proxy @TraceHandshake) v
       <*> parseTracer (Proxy @TraceInboundGovernor) v
       <*> parseTracer (Proxy @TraceInboundGovernorCounters) v
@@ -369,7 +379,6 @@ instance FromJSON PartialTraceSelection where
       <*> parseTracer (Proxy @TraceTxOutbound) v
       <*> parseTracer (Proxy @TraceTxSubmissionProtocol) v
       <*> parseTracer (Proxy @TraceTxSubmission2Protocol) v
-      <*> parseTracer (Proxy @TraceGsm) v
 
 
 defaultPartialTraceConfiguration :: PartialTraceSelection
@@ -379,6 +388,7 @@ defaultPartialTraceConfiguration =
     -- Per-trace toggles, alpha-sorted.
     , pTraceAcceptPolicy = pure $ OnOff False
     , pTraceBlockchainTime = pure $ OnOff False
+    , pTraceChainSyncJumping = pure $ OnOff False
     , pTraceBlockFetchClient = pure $ OnOff False
     , pTraceBlockFetchDecisions = pure $ OnOff True
     , pTraceBlockFetchProtocol = pure $ OnOff False
@@ -400,6 +410,8 @@ defaultPartialTraceConfiguration =
     , pTraceErrorPolicy = pure $ OnOff True
     , pTraceForge = pure $ OnOff True
     , pTraceForgeStateInfo = pure $ OnOff True
+    , pTraceGdd = pure $ OnOff True
+    , pTraceGsm = pure $ OnOff True
     , pTraceHandshake = pure $ OnOff False
     , pTraceInboundGovernor = pure $ OnOff True
     , pTraceInboundGovernorCounters = pure $ OnOff True
@@ -430,7 +442,6 @@ defaultPartialTraceConfiguration =
     , pTraceTxOutbound = pure $ OnOff False
     , pTraceTxSubmissionProtocol = pure $ OnOff False
     , pTraceTxSubmission2Protocol = pure $ OnOff False
-    , pTraceGsm = pure $ OnOff True
     }
 
 
@@ -442,6 +453,7 @@ partialTraceSelectionToEither (Last (Just (PartialTraceDispatcher pTraceSelectio
    traceVerbosity <- first Text.pack $ lastToEither "Default value not specified for TracingVerbosity" pTraceVerbosity
    traceAcceptPolicy <- proxyLastToEither (Proxy @TraceAcceptPolicy) pTraceAcceptPolicy
    traceBlockchainTime <- proxyLastToEither (Proxy @TraceBlockchainTime) pTraceBlockchainTime
+   traceChainSyncJumping <- proxyLastToEither (Proxy @TraceChainSyncJumping) pTraceChainSyncJumping
    traceBlockFetchClient <- proxyLastToEither (Proxy @TraceBlockFetchClient) pTraceBlockFetchClient
    traceBlockFetchDecisions <- proxyLastToEither (Proxy @TraceBlockFetchDecisions) pTraceBlockFetchDecisions
    traceBlockFetchProtocol <- proxyLastToEither (Proxy @TraceBlockFetchProtocol) pTraceBlockFetchProtocol
@@ -463,6 +475,8 @@ partialTraceSelectionToEither (Last (Just (PartialTraceDispatcher pTraceSelectio
    traceErrorPolicy <- proxyLastToEither (Proxy @TraceErrorPolicy) pTraceErrorPolicy
    traceForge <- proxyLastToEither (Proxy @TraceForge) pTraceForge
    traceForgeStateInfo <- proxyLastToEither (Proxy @TraceForgeStateInfo) pTraceForgeStateInfo
+   traceGdd <- proxyLastToEither (Proxy @TraceGdd) pTraceGdd
+   traceGsm <- proxyLastToEither (Proxy @TraceGsm) pTraceGsm
    traceHandshake <- proxyLastToEither (Proxy @TraceHandshake) pTraceHandshake
    traceInboundGovernor <- proxyLastToEither (Proxy @TraceInboundGovernor) pTraceInboundGovernor
    traceInboundGovernorCounters <- proxyLastToEither (Proxy @TraceInboundGovernorCounters) pTraceInboundGovernorCounters
@@ -493,7 +507,6 @@ partialTraceSelectionToEither (Last (Just (PartialTraceDispatcher pTraceSelectio
    traceTxOutbound <- proxyLastToEither (Proxy @TraceTxOutbound) pTraceTxOutbound
    traceTxSubmissionProtocol <- proxyLastToEither (Proxy @TraceTxSubmissionProtocol) pTraceTxSubmissionProtocol
    traceTxSubmission2Protocol <- proxyLastToEither (Proxy @TraceTxSubmission2Protocol) pTraceTxSubmission2Protocol
-   traceGsm <- proxyLastToEither (Proxy @TraceGsm) pTraceGsm
    Right $ TraceDispatcher $ TraceSelection
              { traceVerbosity = traceVerbosity
              , traceAcceptPolicy = traceAcceptPolicy
@@ -503,6 +516,7 @@ partialTraceSelectionToEither (Last (Just (PartialTraceDispatcher pTraceSelectio
              , traceBlockFetchProtocolSerialised = traceBlockFetchProtocolSerialised
              , traceBlockFetchServer = traceBlockFetchServer
              , traceBlockchainTime = traceBlockchainTime
+             , traceChainSyncJumping = traceChainSyncJumping
              , traceChainDB = traceChainDB
              , traceChainSyncBlockServer = traceChainSyncBlockServer
              , traceChainSyncClient = traceChainSyncClient
@@ -519,6 +533,8 @@ partialTraceSelectionToEither (Last (Just (PartialTraceDispatcher pTraceSelectio
              , traceErrorPolicy = traceErrorPolicy
              , traceForge = traceForge
              , traceForgeStateInfo = traceForgeStateInfo
+             , traceGdd = traceGdd
+             , traceGsm = traceGsm
              , traceHandshake = traceHandshake
              , traceInboundGovernor = traceInboundGovernor
              , traceInboundGovernorCounters = traceInboundGovernorCounters
@@ -549,7 +565,6 @@ partialTraceSelectionToEither (Last (Just (PartialTraceDispatcher pTraceSelectio
              , traceTxOutbound = traceTxOutbound
              , traceTxSubmissionProtocol = traceTxSubmissionProtocol
              , traceTxSubmission2Protocol = traceTxSubmission2Protocol
-             , traceGsm = traceGsm
              }
 
 partialTraceSelectionToEither (Last (Just (PartialTracingOnLegacy pTraceSelection))) = do
@@ -558,6 +573,7 @@ partialTraceSelectionToEither (Last (Just (PartialTracingOnLegacy pTraceSelectio
   traceVerbosity <- first Text.pack $ lastToEither "Default value not specified for TracingVerbosity" pTraceVerbosity
   traceAcceptPolicy <- proxyLastToEither (Proxy @TraceAcceptPolicy) pTraceAcceptPolicy
   traceBlockchainTime <- proxyLastToEither (Proxy @TraceBlockchainTime) pTraceBlockchainTime
+  traceChainSyncJumping <- proxyLastToEither (Proxy @TraceChainSyncJumping) pTraceChainSyncJumping
   traceBlockFetchClient <- proxyLastToEither (Proxy @TraceBlockFetchClient) pTraceBlockFetchClient
   traceBlockFetchDecisions <- proxyLastToEither (Proxy @TraceBlockFetchDecisions) pTraceBlockFetchDecisions
   traceBlockFetchProtocol <- proxyLastToEither (Proxy @TraceBlockFetchProtocol) pTraceBlockFetchProtocol
@@ -579,6 +595,8 @@ partialTraceSelectionToEither (Last (Just (PartialTracingOnLegacy pTraceSelectio
   traceErrorPolicy <- proxyLastToEither (Proxy @TraceErrorPolicy) pTraceErrorPolicy
   traceForge <- proxyLastToEither (Proxy @TraceForge) pTraceForge
   traceForgeStateInfo <- proxyLastToEither (Proxy @TraceForgeStateInfo) pTraceForgeStateInfo
+  traceGdd <- proxyLastToEither (Proxy @TraceGdd) pTraceGdd
+  traceGsm <- proxyLastToEither (Proxy @TraceGsm) pTraceGsm
   traceHandshake <- proxyLastToEither (Proxy @TraceHandshake) pTraceHandshake
   traceInboundGovernor <- proxyLastToEither (Proxy @TraceInboundGovernor) pTraceInboundGovernor
   traceIpSubscription <- proxyLastToEither (Proxy @TraceIpSubscription) pTraceIpSubscription
@@ -609,7 +627,6 @@ partialTraceSelectionToEither (Last (Just (PartialTracingOnLegacy pTraceSelectio
   traceTxOutbound <- proxyLastToEither (Proxy @TraceTxOutbound) pTraceTxOutbound
   traceTxSubmissionProtocol <- proxyLastToEither (Proxy @TraceTxSubmissionProtocol) pTraceTxSubmissionProtocol
   traceTxSubmission2Protocol <- proxyLastToEither (Proxy @TraceTxSubmission2Protocol) pTraceTxSubmission2Protocol
-  traceGsm <- proxyLastToEither (Proxy @TraceGsm) pTraceGsm
   Right $ TracingOnLegacy $ TraceSelection
             { traceVerbosity = traceVerbosity
             , traceAcceptPolicy = traceAcceptPolicy
@@ -619,6 +636,7 @@ partialTraceSelectionToEither (Last (Just (PartialTracingOnLegacy pTraceSelectio
             , traceBlockFetchProtocolSerialised = traceBlockFetchProtocolSerialised
             , traceBlockFetchServer = traceBlockFetchServer
             , traceBlockchainTime = traceBlockchainTime
+            , traceChainSyncJumping = traceChainSyncJumping
             , traceChainDB = traceChainDB
             , traceChainSyncBlockServer = traceChainSyncBlockServer
             , traceChainSyncClient = traceChainSyncClient
@@ -635,6 +653,8 @@ partialTraceSelectionToEither (Last (Just (PartialTracingOnLegacy pTraceSelectio
             , traceErrorPolicy = traceErrorPolicy
             , traceForge = traceForge
             , traceForgeStateInfo = traceForgeStateInfo
+            , traceGdd = traceGdd
+            , traceGsm = traceGsm
             , traceHandshake = traceHandshake
             , traceInboundGovernor = traceInboundGovernor
             , traceInboundGovernorCounters = traceInboundGovernorCounters
@@ -665,7 +685,6 @@ partialTraceSelectionToEither (Last (Just (PartialTracingOnLegacy pTraceSelectio
             , traceTxOutbound = traceTxOutbound
             , traceTxSubmissionProtocol = traceTxSubmissionProtocol
             , traceTxSubmission2Protocol = traceTxSubmission2Protocol
-            , traceGsm = traceGsm
             }
 
 proxyLastToEither :: KnownSymbol name => Proxy name -> Last (OnOff name) -> Either Text (OnOff name)

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -38,6 +38,7 @@ import           Ouroboros.Network.BlockFetch.ClientState (TraceFetchClientState
                    TraceLabelPeer (..))
 import qualified Ouroboros.Network.BlockFetch.ClientState as BlockFetch
 import           Ouroboros.Network.BlockFetch.Decision (FetchDecision, FetchDecline (..))
+import           Ouroboros.Network.BlockFetch.Decision.Trace (TraceDecisionEvent (..))
 import           Ouroboros.Network.ConnectionHandler (ConnectionHandlerTrace (..))
 import           Ouroboros.Network.ConnectionId (ConnectionId (..))
 import           Ouroboros.Network.ConnectionManager.Types (AbstractState (..),
@@ -2632,3 +2633,24 @@ instance FromJSON PeerTrustable where
 instance ToJSON PeerTrustable where
   toJSON IsTrustable = Bool True
   toJSON IsNotTrustable = Bool False
+
+
+instance HasPrivacyAnnotation (TraceDecisionEvent peer header) where
+instance HasSeverityAnnotation (TraceDecisionEvent peer header) where
+  getSeverityAnnotation _ = Debug
+instance ToObject peer
+      => Transformable Text IO (TraceDecisionEvent peer header) where
+  trTransformer = trStructuredText
+instance HasTextFormatter (TraceDecisionEvent peer header) where
+
+instance ToObject peer => ToObject (TraceDecisionEvent peer header) where
+  toObject verb (PeersFetch decisions) =
+    mconcat
+      [ "kind" .= String "PeersFetch"
+      , "decisions" .= toObject verb decisions
+      ]
+  toObject verb (PeerStarvedUs peer) =
+    mconcat
+      [ "kind" .= String "PeerStarvedUs"
+      , "peer" .= toObject verb peer
+      ]

--- a/cardano-node/src/Cardano/Tracing/Peer.hs
+++ b/cardano-node/src/Cardano/Tracing/Peer.hs
@@ -18,8 +18,8 @@ import           Cardano.Node.Orphans ()
 import           Cardano.Node.Queries
 import           Ouroboros.Consensus.Block (Header)
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client (ChainSyncClientHandle,
+                   ChainSyncClientHandleCollection(..),
                    csCandidate, viewChainSyncState)
-import           Ouroboros.Consensus.Util.NormalForm.StrictTVar (StrictTVar)
 import           Ouroboros.Consensus.Util.Orphans ()
 import qualified Ouroboros.Network.AnchoredFragment as Net
 import           Ouroboros.Network.Block (unSlotNo)
@@ -97,7 +97,7 @@ getCurrentPeers nkd = mapNodeKernelDataIO extractPeers nkd
   tuple3pop (a, b, _) = (a, b)
 
   getCandidates
-    :: StrictTVar IO (Map peer (ChainSyncClientHandle IO blk))
+    :: STM.STM IO (Map peer (ChainSyncClientHandle IO blk))
     -> STM.STM IO (Map peer (Net.AnchoredFragment (Header blk)))
   getCandidates handle = viewChainSyncState handle csCandidate
 
@@ -109,7 +109,7 @@ getCurrentPeers nkd = mapNodeKernelDataIO extractPeers nkd
                                        . Net.readFetchClientsStateVars
                                        . getFetchClientRegistry $ kernel
                                      )
-    candidates <- STM.atomically . getCandidates . getChainSyncHandles $ kernel
+    candidates <- STM.atomically . getCandidates . cschcMap . getChainSyncHandles $ kernel
 
     let peers = flip Map.mapMaybeWithKey candidates $ \cid af ->
                   maybe Nothing

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -87,11 +87,12 @@ import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import qualified Ouroboros.Consensus.Storage.LedgerDB as LedgerDB
 import           Ouroboros.Consensus.Util.Enclose
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block (BlockNo (..), ChainUpdate (..), HasHeader (..), Point,
+import           Ouroboros.Network.Block (BlockNo (..), ChainUpdate (..), HasHeader (..),
                    StandardHash, blockNo, pointSlot, unBlockNo)
 import           Ouroboros.Network.BlockFetch.ClientState (TraceFetchClientState (..),
                    TraceLabelPeer (..))
-import           Ouroboros.Network.BlockFetch.Decision (FetchDecision, FetchDecline (..))
+import           Ouroboros.Network.BlockFetch.Decision (FetchDecline (..))
+import           Ouroboros.Network.BlockFetch.Decision.Trace (TraceDecisionEvent (..))
 import           Ouroboros.Network.ConnectionId (ConnectionId)
 import           Ouroboros.Network.ConnectionManager.Types (ConnectionManagerCounters (..),
                    ConnectionManagerTrace (..))
@@ -294,18 +295,20 @@ instance ElidingTracer (WithSeverity (ChainDB.TraceEvent blk)) where
   reportelided t tr ev count = defaultelidedreporting  t tr ev count
 
 instance (StandardHash header, Eq peer) => ElidingTracer
-  (WithSeverity [TraceLabelPeer peer (FetchDecision [Point header])]) where
+  (WithSeverity (TraceDecisionEvent peer header)) where
   -- equivalent by type and severity
   isEquivalent (WithSeverity s1 _peers1)
                (WithSeverity s2 _peers2) = s1 == s2
   -- the types to be elided
-  doelide (WithSeverity _ peers) =
+  doelide (WithSeverity _ (PeersFetch peers)) =
     let checkDecision :: TraceLabelPeer peer (Either FetchDecline result) -> Bool
         checkDecision (TraceLabelPeer _peer (Left FetchDeclineChainNotPlausible)) = True
         checkDecision (TraceLabelPeer _peer (Left (FetchDeclineConcurrencyLimit _ _))) = True
         checkDecision (TraceLabelPeer _peer (Left (FetchDeclinePeerBusy _ _ _))) = True
         checkDecision _ = False
     in any checkDecision peers
+  doelide _ = False
+
   conteliding _tverb _tr _ (Nothing, _count) = return (Nothing, 0)
   conteliding tverb tr ev (_old, count) = do
       when (count > 0 && count `mod` 1000 == 0) $  -- report every 1000th message
@@ -509,6 +512,8 @@ mkTracers _ _ _ _ _ enableP2P =
       , Consensus.blockchainTimeTracer = nullTracer
       , Consensus.consensusErrorTracer = nullTracer
       , Consensus.gsmTracer = nullTracer
+      , Consensus.gddTracer = nullTracer
+      , Consensus.csjTracer = nullTracer
       }
     , nodeToClientTracers = NodeToClient.Tracers
       { NodeToClient.tChainSyncTracer = nullTracer
@@ -808,6 +813,8 @@ mkConsensusTracers mbEKGDirect trSel verb tr nodeKern fStats = do
     , Consensus.consensusErrorTracer =
         Tracer $ \err -> traceWith (toLogObject tr) (ConsensusStartupException err)
     , Consensus.gsmTracer = tracerOnOff (traceGsm trSel) verb "GSM" tr
+    , Consensus.csjTracer = tracerOnOff (traceChainSyncJumping trSel) verb "ChainSync Jumping" tr
+    , Consensus.gddTracer = tracerOnOff (traceGdd trSel) verb "GDD" tr
     }
  where
    mkForgeTracers :: IO ForgeTracers
@@ -1441,9 +1448,9 @@ teeTraceBlockFetchDecision
        , ToObject peer
        )
     => TracingVerbosity
-    -> MVar (Maybe (WithSeverity [TraceLabelPeer peer (FetchDecision [Point (Header blk)])]),Integer)
+    -> MVar (Maybe (WithSeverity (TraceDecisionEvent peer (Header blk))),Integer)
     -> Trace IO Text
-    -> Tracer IO (WithSeverity [TraceLabelPeer peer (FetchDecision [Point (Header blk)])])
+    -> Tracer IO (WithSeverity (TraceDecisionEvent peer (Header blk)))
 teeTraceBlockFetchDecision verb eliding tr =
   Tracer $ \ev -> do
     traceWith (teeTraceBlockFetchDecision' meTr) ev
@@ -1454,12 +1461,14 @@ teeTraceBlockFetchDecision verb eliding tr =
 
 teeTraceBlockFetchDecision'
     :: Trace IO Text
-    -> Tracer IO (WithSeverity [TraceLabelPeer peer (FetchDecision [Point (Header blk)])])
+    -> Tracer IO (WithSeverity (TraceDecisionEvent peer (Header blk)))
 teeTraceBlockFetchDecision' tr =
-    Tracer $ \(WithSeverity _ peers) -> do
-      meta <- mkLOMeta Info Confidential
-      let tr' = appendName "peers" tr
-      traceNamedObject tr' (meta, LogValue "connectedPeers" . PureI $ fromIntegral $ length peers)
+    Tracer $ \case
+      WithSeverity _ (PeersFetch peers) -> do
+        meta <- mkLOMeta Info Confidential
+        let tr' = appendName "peers" tr
+        traceNamedObject tr' (meta, LogValue "connectedPeers" . PureI $ fromIntegral $ length peers)
+      WithSeverity _ _ -> pure ()
 
 teeTraceBlockFetchDecisionElide
     :: ( Eq peer
@@ -1468,9 +1477,9 @@ teeTraceBlockFetchDecisionElide
        , ToObject peer
        )
     => TracingVerbosity
-    -> MVar (Maybe (WithSeverity [TraceLabelPeer peer (FetchDecision [Point (Header blk)])]),Integer)
+    -> MVar (Maybe (WithSeverity (TraceDecisionEvent peer (Header blk))),Integer)
     -> Trace IO Text
-    -> Tracer IO (WithSeverity [TraceLabelPeer peer (FetchDecision [Point (Header blk)])])
+    -> Tracer IO (WithSeverity (TraceDecisionEvent peer (Header blk)))
 teeTraceBlockFetchDecisionElide = elideToLogObject
 
 --------------------------------------------------------------------------------

--- a/cardano-testnet/CHANGELOG.md
+++ b/cardano-testnet/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Update `cardano-ping` dependency
 * Add `--num-dreps` parameter
+* Update tracing configuration for ChainSync jumping
 
 ## 8.7.0
 

--- a/cardano-testnet/src/Testnet/Defaults.hs
+++ b/cardano-testnet/src/Testnet/Defaults.hs
@@ -280,6 +280,7 @@ defaultYamlHardforkViaConfig era =
     , (proxyName (Proxy @TraceBlockFetchProtocolSerialised), Aeson.Bool False)
     , (proxyName (Proxy @TraceBlockFetchServer), Aeson.Bool False)
     , (proxyName (Proxy @TraceBlockchainTime), Aeson.Bool True)
+    , (proxyName (Proxy @TraceChainSyncJumping), Aeson.Bool False)
     , (proxyName (Proxy @TraceChainDB), Aeson.Bool True)
     , (proxyName (Proxy @TraceChainSyncClient), Aeson.Bool False)
     , (proxyName (Proxy @TraceChainSyncBlockServer), Aeson.Bool False)

--- a/configuration/cardano/mainnet-config.yaml
+++ b/configuration/cardano/mainnet-config.yaml
@@ -296,7 +296,7 @@ hasPrometheus:
 #   EnableCSJ:        True
 #   EnableLoEAndGDD:  True
 #   EnableLoP:        True
-#   BulkSyncGracePeriod: 10 # seconds
+#   BlockFetchGracePeriod: 10 # seconds
 #   BucketCapacity:  100000 # tokens
 #   BucketRate:         500 # tokens per second
 #   CSJJumpSize:       4320 # slots. This value is 2*k

--- a/configuration/cardano/mainnet-config.yaml
+++ b/configuration/cardano/mainnet-config.yaml
@@ -288,3 +288,16 @@ hasPrometheus:
 # Examples:
 #   MempoolCapacityBytesOverride: 1000000 (1MB)
 #   MempoolCapacityBytesOverride: NoOverride (default)
+
+# # Enable or disable the Genesis syncing algorithm
+# # All values are set to their default.
+# EnableGenesis: False
+# LowLevelGenesisOptions:
+#   EnableCSJ:        True
+#   EnableLoEAndGDD:  True
+#   EnableLoP:        True
+#   BulkSyncGracePeriod: 10 # seconds
+#   BucketCapacity:  100000 # tokens
+#   BucketRate:         500 # tokens per second
+#   CSJJumpSize:       4320 # slots. This value is 2*k
+#   GDDRateLimit:       1.0 # seconds

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1719971647,
-        "narHash": "sha256-Q/u1ZklzmymTSSY6/F48rGsWewVYf108torqR9+nFJU=",
+        "lastModified": 1725170790,
+        "narHash": "sha256-dByd5I847MxV5i9kps89yL1OAvi7iDyC95BU7EM2wtw=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "bfd6987c14410757c6cde47e6c45621e9664347f",
+        "rev": "3bed5fccc06ecc11d4a8427112f107876263e0f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This PR updates tracing and exposes the genesis configuration.

It requires https://github.com/IntersectMBO/ouroboros-consensus/pull/1179. `cabal.project` is made to point to a back-port of the BulkSync implementation on `ouroboros-network-0.16.1.1` and `ouroboros-consensus-0.20.0.0`.
