### PR TITLE
cardano-testnet: test some queries with a golden file

### DIFF
--- a/cardano-testnet/test/cardano-testnet-test/files/golden/queries/drepStateOut.json
+++ b/cardano-testnet/test/cardano-testnet-test/files/golden/queries/drepStateOut.json
@@ -1,0 +1,35 @@
+[
+    [
+        {
+            "keyHash": "<redacted>"
+        },
+        {
+            "anchor": null,
+            "deposit": 1000000,
+            "expiry": 1002,
+            "stake": 300000000000
+        }
+    ],
+    [
+        {
+            "keyHash": "<redacted>"
+        },
+        {
+            "anchor": null,
+            "deposit": 1000000,
+            "expiry": 1002,
+            "stake": 300000000000
+        }
+    ],
+    [
+        {
+            "keyHash": "<redacted>"
+        },
+        {
+            "anchor": null,
+            "deposit": 1000000,
+            "expiry": 1002,
+            "stake": 300000000000
+        }
+    ]
+]

--- a/cardano-testnet/test/cardano-testnet-test/files/golden/queries/tipOut.json
+++ b/cardano-testnet/test/cardano-testnet-test/files/golden/queries/tipOut.json
@@ -1,0 +1,10 @@
+{
+    "block": "<redacted>",
+    "epoch": "<redacted>",
+    "era": "Conway",
+    "hash": "<redacted>",
+    "slot": "<redacted>",
+    "slotInEpoch": "<redacted>",
+    "slotsToEpochEnd": "<redacted>",
+    "syncProgress": "100.00"
+}


### PR DESCRIPTION
# Description

Use a golden file (albeit partly redacted to account for unstable content) to test the output `query drep-state` and `query tip`. This will allow to catch intended changes to JSON schemas defined in `cardano-cli`.

# Context

Side effect of https://github.com/IntersectMBO/cardano-cli/issues/606. This PR wil make it trivial to check that https://github.com/IntersectMBO/cardano-cli/issues/606 is done without breaking anything.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] CI passes. See note on CI.  The following CI checks are required:
- [X] Self-reviewed the diff