### PR TITLE
Make it build with ghc-9.10

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -38,7 +38,7 @@ jobs:
         # If you edit these versions, make sure the version in the lonely macos-latest job below is updated accordingly
         # TODO add 9.8 again to the versions list when GHC-9.8 gets released with stm > 2.5.2,
         # see https://github.com/haskell/stm/issues/76
-        ghc: ["9.6"]
+        ghc: ["9.6", "9.10"]
         cabal: ["3.12"]
         sys:
           - { os: windows-latest, shell: 'C:/msys64/usr/bin/bash.exe -e {0}' }
@@ -49,7 +49,7 @@ jobs:
           - cabal: "3.12"
             ghc: "9.6"
             sys:
-              os: macos-latest
+              os: macos-13
               shell: bash
     defaults:
       run:

--- a/bench/locli/locli.cabal
+++ b/bench/locli/locli.cabal
@@ -114,7 +114,6 @@ library
                       , filepath
                       , fingertree
                       , hashable
-                      , ghc
                       , gnuplot
                       , iohk-monitoring
                       , optparse-applicative-fork

--- a/bench/locli/src/Data/DataDomain.hs
+++ b/bench/locli/src/Data/DataDomain.hs
@@ -10,7 +10,6 @@ where
 import Cardano.Prelude
 
 import Witherable qualified as Wither
-import Data.List.NonEmpty qualified as NE
 
 import Cardano.Util
 import Data.CDF
@@ -61,7 +60,7 @@ traverseDataDomain' ::
 traverseDataDomain' f xs =
   DataDomain
   <$> (Interval <$> f (xs <&> low . ddRaw) <*> f (xs <&> high . ddRaw))
-  <*> (let lohis = NE.unzip $ (fmap (low &&& high) . ddFiltered) `Wither.mapMaybe` xs
+  <*> (let lohis = neUnzip $ (fmap (low &&& high) . ddFiltered) `Wither.mapMaybe` xs
        in Just <$> (Interval <$> f (fst lohis) <*> f (snd lohis)))
   <*> f (xs <&> ddRawCount)
   <*> f (xs <&> ddFilteredCount)
@@ -97,3 +96,12 @@ intersectDataDomains xs =
   , ddRawCount      =   I $ sum $ xs <&> unI . ddRawCount
   , ddFilteredCount =   I $ sum $ xs <&> unI . ddFilteredCount
   }
+
+-- In base@4.20 the Data.List.NonEmpty.unzip is deprecated and suggests that
+-- Data.Function.unzip should be used instead,but base versions earlier than
+-- 4.20 do not have that.
+-- Neatest solution is to cargo cult it here and switch to Data.Function.unzip
+-- later.
+neUnzip :: Functor f => f (a,b) -> (f a, f b)
+neUnzip xs = (fst <$> xs, snd <$> xs)
+

--- a/bench/tx-generator/src/Cardano/TxGenerator/PureExample.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/PureExample.hs
@@ -21,7 +21,7 @@ import           Control.Monad (foldM)
 import           Control.Monad.Trans.State.Strict
 import           Data.Aeson (eitherDecodeFileStrict')
 import           Data.Either (fromRight)
-import           Data.List (foldl')
+import           Data.List as List (foldl')
 import           Data.String (fromString)
 import           System.Exit (die)
 
@@ -121,7 +121,7 @@ generateTx TxEnvironment{..}
       return $ Right funds
 
     addNewOutputFunds :: [Fund] -> Generator ()
-    addNewOutputFunds = put . foldl' insertFund emptyFundQueue
+    addNewOutputFunds = put . List.foldl' insertFund emptyFundQueue
 
     computeOutputValues :: [L.Coin] -> [L.Coin]
     computeOutputValues = inputsToOutputsWithFee fee numOfOutputs
@@ -147,7 +147,7 @@ generateTxPure ::
 generateTxPure TxEnvironment{..} inQueue
   = do
       (tx, txId) <- generator inputs outputs
-      let outQueue = foldl' insertFund emptyFundQueue (toFunds txId)
+      let outQueue = List.foldl' insertFund emptyFundQueue (toFunds txId)
       pure (tx, outQueue)
   where
     inputs = toList inQueue

--- a/cabal.project
+++ b/cabal.project
@@ -13,8 +13,8 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state:
-  , hackage.haskell.org 2024-08-15T08:53:32Z
-  , cardano-haskell-packages 2024-08-15T10:40:33Z
+  , hackage.haskell.org 2024-08-20T21:35:22Z
+  , cardano-haskell-packages 2024-08-18T22:35:14Z
 
 packages:
   cardano-node
@@ -58,10 +58,16 @@ package plutus-scripts-bench
   haddock-options: "--optghc=-fplugin-opt PlutusTx.Plugin:defer-errors"
 
 constraints:
-  wai-extra < 3.1.15,
+  , wai-extra < 3.1.15
 
 allow-newer:
-    katip:Win32
+  , katip:Win32
+
+  -- https://github.com/L0neGamer/ekg-json/pull/21
+  -- https://github.com/L0neGamer/ekg/issues/94
+  , ekg:base
+  , ekg:filepath
+  , ekg-json:base
 
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
@@ -71,10 +71,10 @@ import           Ouroboros.Network.TxSubmission.Outbound
 import           Control.Monad.Class.MonadTime.SI (Time (..))
 import           Data.Aeson (ToJSON, Value (Number, String), toJSON, (.=))
 import qualified Data.Aeson as Aeson
-import           Data.Foldable (Foldable (..))
 import           Data.Int (Int64)
 import           Data.IntPSQ (IntPSQ)
 import qualified Data.IntPSQ as Pq
+import qualified Data.List as List
 import qualified Data.Text as Text
 import           Data.Time (DiffTime, NominalDiffTime)
 import           Data.Word (Word32, Word64)
@@ -648,7 +648,7 @@ instance (LogFormatting peer, Show peer) =>
   forMachine _ xs       = mconcat
     [ "kind"  .= String "PeersFetch"
     , "peers" .= toJSON
-      (foldl' (\acc x -> forMachine DDetailed x : acc) [] xs) ]
+      (List.foldl' (\acc x -> forMachine DDetailed x : acc) [] xs) ]
 
   asMetrics peers = [IntM "BlockFetch.ConnectedPeers" (fromIntegral (length peers))]
 

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1723719216,
-        "narHash": "sha256-0RCMUZu1YthjOJUT6JHCfwxLZVobhTzx17nK7U745/I=",
+        "lastModified": 1724197463,
+        "narHash": "sha256-/ZHOKRX84tXckstr6rTYyjytF2yfrIpvGujRLyjZfUE=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "e4cfce4c4612111b0b51567cb4445a7740303f0e",
+        "rev": "610a202920ffe1d371035d35053152e9a0c77fce",
         "type": "github"
       },
       "original": {
@@ -544,11 +544,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1723681836,
-        "narHash": "sha256-xM2vL6GdCRnBvxUbQrDjTfCbFKrtX+b/Uy0Eg3Z+XHg=",
+        "lastModified": 1724200761,
+        "narHash": "sha256-IDenOlZc5aph7Jz6xNQXGNnnx896hUYrsRU8mbE4bVw=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "227179361e9c1b2738aebab640fdf91e8846590b",
+        "rev": "11b43aaf3ff8018897f1b84a3fb60cce9ae7056d",
         "type": "github"
       },
       "original": {

--- a/trace-dispatcher/src/Cardano/Logging/ConfigurationParser.hs
+++ b/trace-dispatcher/src/Cardano/Logging/ConfigurationParser.hs
@@ -18,7 +18,7 @@ import           Control.Exception (throwIO)
 import qualified Data.Aeson as AE
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as BS
-import           Data.List (foldl')
+import           Data.List as List (foldl')
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (catMaybes, listToMaybe)
 import           Data.Text (Text, intercalate, split)
@@ -122,7 +122,7 @@ parseRepresentation bs = transform (decodeEither' bs)
     transform (Right rl) = Right $ transform' emptyTraceConfig rl
     transform' :: TraceConfig -> ConfigRepresentation -> TraceConfig
     transform' TraceConfig {tcOptions=to'} cr =
-      let to''  = foldl' (\ tci (nsp, opts') ->
+      let to''  = List.foldl' (\ tci (nsp, opts') ->
                               let ns' = split (=='.') nsp
                                   ns'' = if ns' == [""] then [] else ns'
                                   ns''' = case ns'' of
@@ -164,7 +164,7 @@ configToRepresentation traceConfig =
     toOptionRepresentation :: Map.Map [Text] [ConfigOption]
                               ->  Map.Map Text ConfigOptionRep
     toOptionRepresentation internalOptMap =
-      foldl' conversion Map.empty (Map.toList internalOptMap)
+      List.foldl' conversion Map.empty (Map.toList internalOptMap)
 
     conversion :: Map.Map Text ConfigOptionRep
                 -> ([Text],[ConfigOption])

--- a/trace-dispatcher/src/Cardano/Logging/Consistency.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Consistency.hs
@@ -7,7 +7,7 @@ module Cardano.Logging.Consistency (
 import           Cardano.Logging.ConfigurationParser
 import           Cardano.Logging.Types
 
-import           Data.Foldable (foldl')
+import           Data.Foldable as Foldable (foldl')
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (mapMaybe)
 import qualified Data.Text as T
@@ -69,7 +69,7 @@ checkNamespace nsLookup ns = go nsLookup ns
 --   Warns as well if namespaces in all namespaces are ending in the
 --   middle of another namespace.
 asNSLookup :: [[T.Text]] -> (NSLookup, NSWarnings)
-asNSLookup = foldl' (fillLookup []) (NSLookup Map.empty, [])
+asNSLookup = Foldable.foldl' (fillLookup []) (NSLookup Map.empty, [])
   where
     fillLookup :: [T.Text] -> (NSLookup, NSWarnings) -> [T.Text] -> (NSLookup, NSWarnings)
     fillLookup _nsFull (NSLookup nsl, nsw)  [] = (NSLookup nsl, nsw)


### PR DESCRIPTION
# Description

Make it build with ghc-9.10. Contains quite few `allow-newer` stanzas which should be removed before this is ready for review.


# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff
