### PR TITLE
Nadia.chambers/txgen voting 001

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,10 @@ PROFILES_FORGE_STRESS_RTS := forge-stress-pre-rtsA4m forge-stress-pre-rtsA64m fo
 PROFILES_CHAINSYNC        := chainsync-early-byron  chainsync-early-byron-notracer  chainsync-early-byron-oldtracing
 PROFILES_CHAINSYNC        += chainsync-early-alonzo chainsync-early-alonzo-notracer chainsync-early-alonzo-oldtracing chainsync-early-alonzo-p2p
 PROFILES_VENDOR           := dish dish-plutus dish-10M dish-10M-plutus
+
+# These profiles are under active development and subject to change. Do not rely on their content in production.
+PROFILES_DEVELOPMENT      := development-voting # NOTE: Conway only - make development-voting ERA=coay
+
 # The dedicated P&T Nomad cluster on AWS
 # Cloud version of "default", "ci-test" and "ci-bench" plus value (52+explorer)
 # Not all local profiles are compatible or tested (yet) with a cloud runs
@@ -124,6 +128,7 @@ LOCAL_PROFILES += $(PROFILES_FORGE_STRESS_PRE)
 LOCAL_PROFILES += $(PROFILES_FORGE_STRESS_RTS)
 LOCAL_PROFILES += $(PROFILES_CHAINSYNC)
 LOCAL_PROFILES += $(PROFILES_VENDOR)
+LOCAL_PROFILES += $(PROFILES_DEVELOPMENT)
 CLOUD_PROFILES += $(PROFILES_NOMAD_PERF)
 CLOUD_PROFILES += $(PROFILES_NOMAD_PERF_DREP)
 CLOUD_PROFILES += $(PROFILES_NOMAD_PERF_NOP2P)

--- a/bench/tx-generator/src/Cardano/TxGenerator/GovExample.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/GovExample.hs
@@ -24,17 +24,7 @@
 {- HLINT ignore "Unused LANGUAGE pragma" -}
 {- HLINT ignore "Avoid lambda using `infix`" -}
 
-module  Cardano.TxGenerator.GovExample
-        -- (demo)
-        where
-{-
-
-import           Cardano.CLI.EraBased.Run.Query
-import           Cardano.CLI.Types.Errors.BootstrapWitnessError
-import           Cardano.CLI.Types.Errors.TxCmdError
-import           Cardano.CLI.Types.TxFeature
-
--}
+module  Cardano.TxGenerator.GovExample where
 
 import           Cardano.Api hiding (StakeAddress, StakeCredential)
 import qualified Cardano.Api as Api (NetworkId (..))
@@ -93,29 +83,8 @@ import           Cardano.CLI.EraBased.Commands.Governance.Actions (
                    , UpdateProtocolParametersPreConway (..)
                    , GovernanceActionHardforkInitCmdArgs (..)
                    , CostModelsFile (..))
-{- import           Cardano.CLI.EraBased.Commands.Governance.Actions (
-                     GovernanceActionCmds (..)
-                   , GovernanceActionUpdateCommitteeCmdArgs (..)
-                   , GovernanceActionCreateConstitutionCmdArgs (..)
-                   , GovernanceActionCreateNoConfidenceCmdArgs (..)
-                   , GovernanceActionInfoCmdArgs (..)
-                   , GovernanceActionViewCmdArgs (..)
-                   , GovernanceActionProtocolParametersUpdateCmdArgs (..)
-                   , GovernanceActionTreasuryWithdrawalCmdArgs (..)
-                   , UpdateProtocolParametersConwayOnwards (..)
-                   , UpdateProtocolParametersPreConway (..)
-                   , GovernanceActionHardforkInitCmdArgs (..)
-                   , CostModelsFile (..)) -}
 import qualified Cardano.CLI.EraBased.Commands.Governance.Actions as CLI (renderGovernanceActionCmds)
-{- import qualified Cardano.CLI.EraBased.Commands.Transaction as CLI (TransactionBuildRawCmdArgs (..)) -}
 import           Cardano.CLI.EraBased.Run.Governance.Actions (GovernanceActionsError (..))
-{- import qualified Cardano.CLI.EraBased.Run.Governance.Actions as CLI (
-                     runGovernanceActionCmds
-                   , addCostModelsToEraBasedProtocolParametersUpdate) -}
-{- import qualified Cardano.CLI.EraBased.Run.Governance.Vote as CLI (
-                     runGovernanceVoteCmds
-                     -- These two aren't exported, barring a customised cardano-cli lib:
-                     , runGovernanceVoteCreateCmd, runGovernanceVoteViewCmd) -}
 import           Cardano.CLI.Json.Friendly (FriendlyFormat (..)
                    , friendlyTx
                    , friendlyTxBody)
@@ -190,9 +159,6 @@ import           Cardano.Ledger.BaseTypes (Network (..), StrictMaybe (..), Url)
 import           Cardano.Ledger.Coin (Coin (..))
 import qualified Cardano.Ledger.Coin as Ledger ()
 import           Cardano.Ledger.Crypto -- exports only types and classes
-{- import           Cardano.Ledger.Conway.Governance (GovAction (..)
-                   , GovActionId (..)
-                   , ProposalProcedure (..)) -}
 import           Cardano.TxGenerator.FundQueue (Fund (..), FundInEra (..), FundQueue)
 import qualified Cardano.TxGenerator.FundQueue as FundQueue (emptyFundQueue, getFundCoin, getFundKey, getFundTxIn, getFundWitness, insertFund, toList)
 import           Cardano.TxGenerator.Setup.SigningKey
@@ -240,47 +206,7 @@ import           Paths_tx_generator
 import           System.Exit (die)
 import qualified System.IO as IO (print)
 
--- Not exported, hence cutting and pasting.
--- This might take a number of imports to be able to include:
-{-
-type ConwayEraOnwardsConstraints era =
-  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
-  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
-  , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
-  , Consensus.ShelleyBlock (ConsensusProtocol era) (ShelleyLedgerEra era) ~ ConsensusBlockForEra era
-  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
-  , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
-  , L.AlonzoEraTxOut (ShelleyLedgerEra era)
-  , L.BabbageEraTxBody (ShelleyLedgerEra era)
-  , L.ConwayEraGov (ShelleyLedgerEra era)
-  , L.ConwayEraPParams (ShelleyLedgerEra era)
-  , L.ConwayEraTxBody (ShelleyLedgerEra era)
-  , L.ConwayEraTxCert (ShelleyLedgerEra era)
-  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
-  , L.Era (ShelleyLedgerEra era)
-  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
-  , L.EraGov (ShelleyLedgerEra era)
-  , L.EraPParams (ShelleyLedgerEra era)
-  , L.EraTx (ShelleyLedgerEra era)
-  , L.EraTxBody (ShelleyLedgerEra era)
-  , L.EraTxOut (ShelleyLedgerEra era)
-  , L.EraUTxO (ShelleyLedgerEra era)
-  , L.GovState (ShelleyLedgerEra era) ~ L.ConwayGovState (ShelleyLedgerEra era)
-  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
-  , L.MaryEraTxBody (ShelleyLedgerEra era)
-  , L.Script (ShelleyLedgerEra era) ~ L.AlonzoScript (ShelleyLedgerEra era)
-  , L.ScriptsNeeded (ShelleyLedgerEra era) ~ L.AlonzoScriptsNeeded (ShelleyLedgerEra era)
-  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
-  , L.TxCert (ShelleyLedgerEra era) ~ L.ConwayTxCert (ShelleyLedgerEra era)
-  , L.Value (ShelleyLedgerEra era) ~ L.MaryValue L.StandardCrypto
-  , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
-  , FromCBOR (DebugLedgerState era)
-  , IsCardanoEra era
-  , IsShelleyBasedEra era
-  , ToJSON (DebugLedgerState era)
-  , Typeable era
-  )
--}
+-- It may be worth including ConwayEraOnwardsConstraints somehow.
 
 
 demo :: IO ()
@@ -322,20 +248,6 @@ signingKey = fromRight (error "signingKey: parseError") $ parseSigningKeyTE keyD
               , teDescription = fromString "Genesis Initial UTxO Signing Key"
               , teRawCBOR = "X \vl1~\182\201v(\152\250A\202\157h0\ETX\248h\153\171\SI/m\186\242D\228\NAK\182(&\162"}
 
-{-
-drepSigningKey' :: _ (SigningKey _) = fromJSON "{\
-    \\"type\": \"DRepSigningKey_ed25519\",\
-    \\"description\": \"Delegate Representative Signing Key\",\
-    \\"cborHex\": \"5820ac0757312cf883baa809d8cf6c3c48e86acc70db9c6eb5511666c8b128d9020a\"\
-    \}"
--}
-{-
-parseJSON = withObject "TextEnvelope" $ \v ->
-    TextEnvelope
-      <$> (v .: "type")
-      <*> (v .: "description")
-      <*> (parseJSONBase16 =<< v .: "cborHex")
--}
 drepSigningKey :: SigningKey PaymentKey
 drepSigningKey = fromRight (error "drepSigningKey: parseError") $ parseSigningKeyTE keyData
   where

--- a/bench/tx-generator/src/Cardano/TxGenerator/GovExample.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/GovExample.hs
@@ -65,26 +65,7 @@ import qualified Cardano.Chain.Common as Byron (AddrAttributes (..), NetworkMagi
 
 import qualified Cardano.CLI.EraBased.Commands.Transaction as Cmd
 -- Unqualified imports of types need to be re-qualified before a PR.
-import           Cardano.CLI.EraBased.Commands.Governance.Vote (
-                     GovernanceVoteCmds (..)
-                   , GovernanceVoteCreateCmdArgs (..)
-                   , GovernanceVoteViewCmdArgs (..))
 -- Adjust line break to stylish-haskell/fourmolu/etc.
-import           Cardano.CLI.EraBased.Commands.Governance.Actions (
-                     GovernanceActionCmds (..)
-                   , GovernanceActionUpdateCommitteeCmdArgs (..)
-                   , GovernanceActionCreateConstitutionCmdArgs (..)
-                   , GovernanceActionCreateNoConfidenceCmdArgs (..)
-                   , GovernanceActionInfoCmdArgs (..)
-                   , GovernanceActionViewCmdArgs (..)
-                   , GovernanceActionProtocolParametersUpdateCmdArgs (..)
-                   , GovernanceActionTreasuryWithdrawalCmdArgs (..)
-                   , UpdateProtocolParametersConwayOnwards (..)
-                   , UpdateProtocolParametersPreConway (..)
-                   , GovernanceActionHardforkInitCmdArgs (..)
-                   , CostModelsFile (..))
-import qualified Cardano.CLI.EraBased.Commands.Governance.Actions as CLI (renderGovernanceActionCmds)
-import           Cardano.CLI.EraBased.Run.Governance.Actions (GovernanceActionsError (..))
 import           Cardano.CLI.Json.Friendly (FriendlyFormat (..)
                    , friendlyTx
                    , friendlyTxBody)

--- a/bench/tx-generator/src/Cardano/TxGenerator/GovExample.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/GovExample.hs
@@ -1,20 +1,25 @@
-{-# LANGUAGE BlockArguments        #-}
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE EmptyCase             #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE GADTs                 #-}
-{-# LANGUAGE LambdaCase            #-}
-{-# LANGUAGE NamedFieldPuns        #-}
-{-# LANGUAGE PartialTypeSignatures #-}
-{-# LANGUAGE PatternSynonyms       #-}
-{-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE RecordWildCards       #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TupleSections         #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE BlockArguments             #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DuplicateRecordFields      #-}
+{-# LANGUAGE EmptyCase                  #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE PartialTypeSignatures      #-}
+{-# LANGUAGE PatternSynonyms            #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TupleSections              #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeOperators              #-}
 
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns  #-}
 {-# OPTIONS_GHC -Wno-error=partial-type-signatures #-}
@@ -75,24 +80,11 @@ import qualified Cardano.Chain.Common as Byron (AddrAttributes (..), NetworkMagi
 
 import qualified Cardano.CLI.EraBased.Commands.Transaction as Cmd
 -- Unqualified imports of types need to be re-qualified before a PR.
-import           Cardano.CLI.EraBased.Commands.Governance.Vote (
+{- import           Cardano.CLI.EraBased.Commands.Governance.Vote (
                      GovernanceVoteCmds (..)
                    , GovernanceVoteCreateCmdArgs (..)
-                   , GovernanceVoteViewCmdArgs (..))
+                   , GovernanceVoteViewCmdArgs (..)) -}
 -- Adjust line break to stylish-haskell/fourmolu/etc.
-import           Cardano.CLI.EraBased.Commands.Governance.Actions (
-                     GovernanceActionCmds (..)
-                   , GovernanceActionUpdateCommitteeCmdArgs (..)
-                   , GovernanceActionCreateConstitutionCmdArgs (..)
-                   , GovernanceActionCreateNoConfidenceCmdArgs (..)
-                   , GovernanceActionInfoCmdArgs (..)
-                   , GovernanceActionViewCmdArgs (..)
-                   , GovernanceActionProtocolParametersUpdateCmdArgs (..)
-                   , GovernanceActionTreasuryWithdrawalCmdArgs (..)
-                   , UpdateProtocolParametersConwayOnwards (..)
-                   , UpdateProtocolParametersPreConway (..)
-                   , GovernanceActionHardforkInitCmdArgs (..)
-                   , CostModelsFile (..))
 {- import           Cardano.CLI.EraBased.Commands.Governance.Actions (
                      GovernanceActionCmds (..)
                    , GovernanceActionUpdateCommitteeCmdArgs (..)
@@ -106,9 +98,22 @@ import           Cardano.CLI.EraBased.Commands.Governance.Actions (
                    , UpdateProtocolParametersPreConway (..)
                    , GovernanceActionHardforkInitCmdArgs (..)
                    , CostModelsFile (..)) -}
-import qualified Cardano.CLI.EraBased.Commands.Governance.Actions as CLI (renderGovernanceActionCmds)
+{- import           Cardano.CLI.EraBased.Commands.Governance.Actions (
+                     GovernanceActionCmds (..)
+                   , GovernanceActionUpdateCommitteeCmdArgs (..)
+                   , GovernanceActionCreateConstitutionCmdArgs (..)
+                   , GovernanceActionCreateNoConfidenceCmdArgs (..)
+                   , GovernanceActionInfoCmdArgs (..)
+                   , GovernanceActionViewCmdArgs (..)
+                   , GovernanceActionProtocolParametersUpdateCmdArgs (..)
+                   , GovernanceActionTreasuryWithdrawalCmdArgs (..)
+                   , UpdateProtocolParametersConwayOnwards (..)
+                   , UpdateProtocolParametersPreConway (..)
+                   , GovernanceActionHardforkInitCmdArgs (..)
+                   , CostModelsFile (..)) -}
+-- import qualified Cardano.CLI.EraBased.Commands.Governance.Actions as CLI (renderGovernanceActionCmds)
 {- import qualified Cardano.CLI.EraBased.Commands.Transaction as CLI (TransactionBuildRawCmdArgs (..)) -}
-import           Cardano.CLI.EraBased.Run.Governance.Actions (GovernanceActionsError (..))
+-- import           Cardano.CLI.EraBased.Run.Governance.Actions (GovernanceActionsError (..))
 {- import qualified Cardano.CLI.EraBased.Run.Governance.Actions as CLI (
                      runGovernanceActionCmds
                    , addCostModelsToEraBasedProtocolParametersUpdate) -}
@@ -184,6 +189,10 @@ import qualified Cardano.CLI.Types.Errors.TxValidationError as CLI (
 import           Cardano.CLI.Types.Governance (AnyVotingStakeVerificationKeyOrHashOrFile (..))
 import qualified Cardano.CLI.Types.Output as CLI (renderScriptCosts)
 import           Cardano.CLI.Types.TxFeature (TxFeature (..))
+-- import qualified Cardano.Crypto.PinnedSizedBytes as Crypto (PinnedSizedBytes)
+-- import qualified Cardano.Crypto.Libsodium.Constants as Crypto (CRYPTO_SIGN_ED25519_SECRETKEYBYTES)
+-- import qualified Cardano.Crypto.DSIGN.Class as Crypto (SignKeyDSIGN)
+-- import qualified Cardano.Crypto.DSIGN.Ed25519 as Crypto (Ed25519DSIGN)
 import qualified Cardano.Ledger.Api.PParams as Ledger (ppMinFeeAL)
 import qualified Cardano.Ledger.Api.Tx.Cert as Ledger (pattern RetirePoolTxCert)
 import           Cardano.Ledger.BaseTypes (Network (..), StrictMaybe (..), Url)
@@ -205,7 +214,7 @@ import qualified Control.Monad as Monad (foldM, forM)
 import           Control.Monad.Trans.State.Strict
 
 
-import           Data.Aeson ((.=))
+import           Data.Aeson ((.=) {-, fromJSON-})
 import qualified Data.Aeson as Aeson (eitherDecodeFileStrict', object)
 import qualified Data.Aeson.Encode.Pretty as Aeson (encodePretty)
 import           Data.Bifunctor (bimap, first)
@@ -220,11 +229,14 @@ import qualified Data.Map.Strict as Map (fromList, keysSet)
 import qualified Data.Maybe as Maybe (catMaybes, fromMaybe, mapMaybe)
 import           Data.Set (Set)
 import qualified Data.Set as Set ((\\), elems, fromList, toList)
-import           Data.String (fromString)
+import           Data.String (IsString (..), fromString)
 import           Data.Text (Text)
 import qualified Data.Text as Text (pack)
 import qualified Data.Text.IO as Text (putStrLn)
 import           Data.Type.Equality ((:~:)(..), TestEquality (..))
+
+
+-- import           GHC.Generics
 
 
 import           Lens.Micro ((^.))
@@ -323,12 +335,34 @@ signingKey = fromRight (error "signingKey: parseError") $ parseSigningKeyTE keyD
               , teRawCBOR = "X \vl1~\182\201v(\152\250A\202\157h0\ETX\248h\153\171\SI/m\186\242D\228\NAK\182(&\162"}
 
 {-
-drepSigningKey' :: _ (SigningKey _) = fromJSON "{\
+ - src/Cardano/TxGenerator/GovExample.hs:337:1: error:
+ -  • Can't make a derived instance of
+ -      ‘Generic
+ -         (Crypto.PinnedSizedBytes
+ -            Crypto.CRYPTO_SIGN_ED25519_SECRETKEYBYTES)’:
+ -      The data constructors of ‘Crypto.PinnedSizedBytes’ are not all in scope
+ -        so you cannot derive an instance for it
+ -  • In the stand-alone deriving instance for
+ -      ‘Generic (Crypto.PinnedSizedBytes Crypto.CRYPTO_SIGN_ED25519_SECRETKEYBYTES)’
+deriving instance Generic  (Crypto.PinnedSizedBytes
+                            Crypto.CRYPTO_SIGN_ED25519_SECRETKEYBYTES)
+deriving instance FromJSON (Crypto.PinnedSizedBytes
+                            Crypto.CRYPTO_SIGN_ED25519_SECRETKEYBYTES)
+deriving instance FromJSON (Crypto.SignKeyDSIGN Crypto.Ed25519DSIGN)
+deriving instance FromJSON PaymentKey
+deriving instance Generic  PaymentKey
+deriving instance Generic  (SigningKey PaymentKey)
+deriving instance FromJSON (SigningKey PaymentKey)
+
+drepSigningKey' :: _ (SigningKey PaymentKey) = drepSigningKeyString
+ -}
+
+drepSigningKeyString :: IsString s => s
+drepSigningKeyString = "{\
     \\"type\": \"DRepSigningKey_ed25519\",\
     \\"description\": \"Delegate Representative Signing Key\",\
     \\"cborHex\": \"5820ac0757312cf883baa809d8cf6c3c48e86acc70db9c6eb5511666c8b128d9020a\"\
     \}"
--}
 {-
 parseJSON = withObject "TextEnvelope" $ \v ->
     TextEnvelope

--- a/bench/tx-generator/src/Cardano/TxGenerator/GovExample.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/GovExample.hs
@@ -1,0 +1,252 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
+
+module  Cardano.TxGenerator.GovExample
+        -- (demo)
+        where
+
+import           Cardano.Api
+import           Cardano.Api.Shelley (LedgerProtocolParameters, Vote, convertToLedgerProtocolParameters, createVotingProcedure)
+
+import qualified Cardano.CLI.Types.Governance as CLI (AnyVotingStakeVerificationKeyOrHashOrFile (..))
+import qualified Cardano.Ledger.BaseTypes as Ledger (Url)
+import qualified Cardano.Ledger.Coin as Ledger
+import           Cardano.TxGenerator.FundQueue
+import           Cardano.TxGenerator.Setup.SigningKey
+import           Cardano.TxGenerator.Types (FundSource, FundToStoreList, TxEnvironment (..), TxGenError (..), TxGenerator)
+import           Cardano.TxGenerator.Utils (inputsToOutputsWithFee)
+import           Cardano.TxGenerator.UTxO (ToUTxOList, makeToUTxOList, mkUTxOVariant)
+
+import           Control.Monad (foldM)
+import           Control.Monad.Trans.State.Strict
+import           Data.Aeson (eitherDecodeFileStrict')
+import           Data.Bifunctor (bimap)
+import           Data.Either (fromRight)
+import           Data.Function ((&))
+import           Data.List (foldl')
+import           Data.Maybe (mapMaybe)
+import           Data.String (fromString)
+import           Data.Text (Text)
+import           System.Exit (die)
+
+import           Paths_tx_generator
+
+
+demo :: IO ()
+demo = getDataFileName "data/protocol-parameters.json" >>= demo'
+
+demo' :: FilePath -> IO ()
+demo' parametersFile = do
+  protocolParameters <- either die pure =<< eitherDecodeFileStrict' parametersFile
+  let
+      demoEnv :: TxEnvironment ConwayEra
+      demoEnv = TxEnvironment {
+          txEnvNetworkId = Mainnet
+        , txEnvProtocolParams = protocolParameters
+        , txEnvFee = TxFeeExplicit ShelleyBasedEraConway 100000
+        , txEnvMetadata = TxMetadataNone
+        }
+
+  run1 <- foldM (worker $ generateTx demoEnv) (emptyFundQueue `insertFund` genesisFund) [1..10]
+  run2 <- foldM (worker $ generateTxM demoEnv) (emptyFundQueue `insertFund` genesisFund) [1..10]
+  putStrLn $ "Are run results identical? " ++ show (toList run1 == toList run2)
+  where
+    worker ::
+         Generator (Either TxGenError (Tx ConwayEra))
+      -> FundQueue
+      -> Int
+      -> IO FundQueue
+    worker pureGenerator generatorState counter = do
+      putStrLn $ "running tx-generator. Iteration : " ++ show counter
+      let (res, newState) = runState pureGenerator generatorState
+      case res of
+        Right tx -> print tx
+        Left err -> print err
+      return newState
+
+signingKey :: SigningKey PaymentKey
+signingKey = fromRight (error "signingKey: parseError") $ parseSigningKeyTE keyData
+  where
+    keyData = TextEnvelope { teType = TextEnvelopeType "GenesisUTxOSigningKey_ed25519"
+              , teDescription = fromString "Genesis Initial UTxO Signing Key"
+              , teRawCBOR = "X \vl1~\182\201v(\152\250A\202\157h0\ETX\248h\153\171\SI/m\186\242D\228\NAK\182(&\162"}
+
+genesisTxIn :: TxIn
+genesisValue :: TxOutValue ConwayEra
+
+(genesisTxIn, genesisValue) =
+  ( TxIn "900fc5da77a0747da53f7675cbb7d149d46779346dea2f879ab811ccc72a2162" (TxIx 0)
+  , lovelaceToTxOutValue ShelleyBasedEraConway $ Ledger.Coin 90000000000000
+  )
+
+genesisFund :: Fund
+genesisFund
+  = Fund $ InAnyCardanoEra ConwayEra fundInEra
+  where
+    fundInEra :: FundInEra ConwayEra
+    fundInEra  = FundInEra {
+        _fundTxIn = genesisTxIn
+      , _fundVal = genesisValue
+      , _fundWitness = KeyWitness KeyWitnessForSpending
+      , _fundSigningKey = Just signingKey
+      }
+
+type Generator = State FundQueue
+
+-- Need to ask Carlos or Aniket what anchors are about.
+-- The particular issue is what could be substituted for the URL if it
+-- turns out fake ones like I used earlier error out.
+-- Cardano.Api.Governance.Actions.createAnchor
+--         :: Url -> ByteString -> Anchor StandardCrypto
+localGenVote :: ConwayEraOnwards era -> Vote -> IO ()
+localGenVote era vote = do
+  _procedure <- pure $ createVotingProcedure
+                             (era {- eon :: ConwayEraOnwards era {- the type signature chokes? -} -} )
+                             (vote {- votingChoice -} :: Vote)
+                             (Nothing :: Maybe (Ledger.Url, Text))
+  _ <- shelleyBasedEraConstraints localShelleyBasedEra do
+    _ <- pure (undefined :: CLI.AnyVotingStakeVerificationKeyOrHashOrFile)
+    pure undefined
+  pure ()
+  where
+    localShelleyBasedEra = conwayEraOnwardsToShelleyBasedEra era
+
+localGenTx :: forall era. ()
+  => IsShelleyBasedEra era
+  => ShelleyBasedEra era
+  -> LedgerProtocolParameters era
+  -> (TxInsCollateral era, [Fund])
+  -> TxFee era
+  -> TxMetadataInEra era
+  -> TxGenerator era
+localGenTx sbe ledgerParameters (collateral, collFunds) fee metadata inFunds outputs
+  = bimap
+      ApiError
+      (\b -> (signShelleyTransaction (shelleyBasedEra @era) b $ map WitnessPaymentKey allKeys, getTxId b))
+      (createAndValidateTransactionBody (shelleyBasedEra @era) txBodyContent)
+ where
+  allKeys = mapMaybe getFundKey $ inFunds ++ collFunds
+  txBodyContent = defaultTxBodyContent sbe
+    & setTxIns (map (\f -> (getFundTxIn f, BuildTxWith $ getFundWitness f)) inFunds)
+    & setTxInsCollateral collateral
+    & setTxOuts outputs
+    & setTxFee fee
+    & setTxValidityLowerBound TxValidityNoLowerBound
+    & setTxValidityUpperBound (defaultTxValidityUpperBound sbe)
+    & setTxMetadata metadata
+    & setTxProtocolParams (BuildTxWith (Just ledgerParameters))
+
+
+localSourceToStoreTransaction ::
+     Monad m
+  => TxGenerator era
+  -> FundSource m
+  -> ([Ledger.Coin] -> split)
+  -> ToUTxOList era split
+  -> FundToStoreList m                --inline to ToUTxOList
+  -> m (Either TxGenError (Tx era))
+localSourceToStoreTransaction txGenerator fundSource inToOut mkTxOut fundToStore =
+  fundSource >>= either (return . Left) go
+ where
+  go inputFunds = do
+    let
+      -- 'getFundCoin' unwraps the 'TxOutValue' in a fund field
+      -- so it's all just 'Lovelace' instead of a coproduct
+      -- maintaining distinctions.
+      outValues = inToOut $ map getFundCoin inputFunds
+      (outputs, toFunds) = mkTxOut outValues
+    case txGenerator inputFunds outputs of
+        Left err -> return $ Left err
+        Right (tx, txId) -> do
+          fundToStore $ toFunds txId
+          return $ Right tx
+
+generateTx ::
+     TxEnvironment ConwayEra
+  -> Generator (Either TxGenError (Tx ConwayEra))
+generateTx TxEnvironment{..}
+  = localSourceToStoreTransaction
+        generator
+        consumeInputFunds
+        computeOutputValues
+        (makeToUTxOList $ repeat computeUTxO)
+        addNewOutputFunds
+  where
+    TxFeeExplicit _ fee = txEnvFee
+
+    generator :: TxGenerator ConwayEra
+    generator =
+        case convertToLedgerProtocolParameters shelleyBasedEra txEnvProtocolParams of
+          Right ledgerParameters ->
+            localGenTx ShelleyBasedEraConway ledgerParameters collateralFunds txEnvFee txEnvMetadata
+          Left err -> \_ _ -> Left (ApiError err)
+      where
+        -- collateralFunds are needed for Plutus transactions
+        collateralFunds :: (TxInsCollateral ConwayEra, [Fund])
+        collateralFunds = (TxInsCollateralNone, [])
+
+-- Create a transaction that uses all the available funds.
+    consumeInputFunds :: Generator (Either TxGenError [Fund])
+    consumeInputFunds = do
+      funds <- toList <$> get
+      put emptyFundQueue
+      return $ Right funds
+
+    addNewOutputFunds :: [Fund] -> Generator ()
+    addNewOutputFunds = put . foldl' insertFund emptyFundQueue
+
+    computeOutputValues :: [Ledger.Coin] -> [Ledger.Coin]
+    computeOutputValues = inputsToOutputsWithFee fee numOfOutputs
+      where numOfOutputs = 2
+
+    computeUTxO = mkUTxOVariant txEnvNetworkId signingKey
+
+
+generateTxM ::
+      TxEnvironment ConwayEra
+  ->  Generator (Either TxGenError (Tx ConwayEra))
+generateTxM txEnv
+  = do
+      inFunds <- get
+      case generateTxPure txEnv inFunds of
+        Right (tx, outFunds)  -> put outFunds >> pure (Right tx)
+        Left err              -> pure (Left err)
+
+generateTxPure ::
+     TxEnvironment ConwayEra
+  -> FundQueue
+  -> Either TxGenError (Tx ConwayEra, FundQueue)
+generateTxPure TxEnvironment{..} inQueue
+  = do
+      (tx, txId) <- generator inputs outputs
+      let outQueue = foldl' insertFund emptyFundQueue (toFunds txId)
+      pure (tx, outQueue)
+  where
+    inputs = toList inQueue
+    TxFeeExplicit _ fee = txEnvFee
+
+    generator :: TxGenerator ConwayEra
+    generator =
+        case convertToLedgerProtocolParameters shelleyBasedEra txEnvProtocolParams of
+          Right ledgerParameters ->
+            localGenTx ShelleyBasedEraConway ledgerParameters collateralFunds txEnvFee txEnvMetadata
+          Left err -> \_ _ -> Left (ApiError err)
+      where
+        -- collateralFunds are needed for Plutus transactions
+        collateralFunds :: (TxInsCollateral ConwayEra, [Fund])
+        collateralFunds = (TxInsCollateralNone, [])
+
+    outValues = computeOutputValues $ map getFundCoin inputs
+    (outputs, toFunds) = makeToUTxOList (repeat computeUTxO) outValues
+
+    computeOutputValues :: [Ledger.Coin] -> [Ledger.Coin]
+    computeOutputValues = inputsToOutputsWithFee fee numOfOutputs
+      where numOfOutputs = 2
+
+    computeUTxO = mkUTxOVariant txEnvNetworkId signingKey

--- a/bench/tx-generator/src/Cardano/TxGenerator/GovExample.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/GovExample.hs
@@ -15,18 +15,28 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE TypeOperators         #-}
 
--- These are all pretty reasonable warning options.
--- Maybe all but unused-imports should be suppressed in the cabal
--- configuration higher up in the codebase?
-{-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns  #-}
-{-# OPTIONS_GHC -Wno-error=partial-type-signatures #-}
-{-# OPTIONS_GHC -Wno-error=unused-imports          #-}
-{-# OPTIONS_GHC -Wno-unrecognised-pragmas          #-}
+{- These are all pretty reasonable warning options.
+ - Maybe all but unused-imports should be suppressed in the cabal
+ - configuration higher up in the codebase?
+ - These disablings of warnings and makings of warnings not errors
+ - ("softenings") aren't needed anymore as the code now stands.
+ - It could still be useful to keep these ready to reactivate in
+ - the event of rapid code restructurings until it comes time to
+ - do the final cleanup of the commit sequence.
+ -* OPTIONS_GHC -fno-warn-incomplete-uni-patterns  *-
+ -* OPTIONS_GHC -Wno-error=partial-type-signatures *-
+ -* OPTIONS_GHC -Wno-error=unused-imports          *-
+ -* OPTIONS_GHC -Wno-unrecognised-pragmas          *-
+ -}
 
-{- There used to be:
- - HLINT ignore "Unused LANGUAGE pragma"
- - HLINT ignore "Avoid lambda using `infix`"
- - but the warnings got silenced. -}
+{- These also used to be needed to pass hlint checks, but the warnings
+ - have likewise since been silenced, so they're no longer needed to
+ - make progress in the interim. In like fashion, it may be useful to
+ - let these disabled pragmas linger until the point of final clean-up
+ - of the commit sequence for intensive restructurings.
+ -* HLINT ignore "Unused LANGUAGE pragma"          *-
+ -* HLINT ignore "Avoid lambda using `infix`"      *-
+ -}
 
 module  Cardano.TxGenerator.GovExample where
 

--- a/bench/tx-generator/src/Cardano/TxGenerator/GovExample.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/GovExample.hs
@@ -1,40 +1,79 @@
-{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE BlockArguments        #-}
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE EmptyCase             #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE NamedFieldPuns        #-}
 {-# LANGUAGE PartialTypeSignatures #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
+{-# LANGUAGE PatternSynonyms       #-}
+{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TupleSections         #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
+
+{-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns  #-}
 {-# OPTIONS_GHC -Wno-error=partial-type-signatures #-}
-{-# OPTIONS_GHC -Wno-error=unused-imports #-}
+{-# OPTIONS_GHC -Wno-error=unused-imports          #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas          #-}
+
+{- HLINT ignore "Unused LANGUAGE pragma" -}
+{- HLINT ignore "Avoid lambda using `infix`" -}
 
 module  Cardano.TxGenerator.GovExample
         -- (demo)
         where
+{-
 
-import           Cardano.Api hiding (ScriptHash, StakeAddress, StakeCredential)
-import qualified Cardano.Api as Api (NetworkId (..), ScriptHash, StakeAddress, StakeCredential)
+import           Cardano.CLI.EraBased.Run.Query
+import           Cardano.CLI.Types.Errors.BootstrapWitnessError
+import           Cardano.CLI.Types.Errors.TxCmdError
+import           Cardano.CLI.Types.TxFeature
+
+-}
+
+import           Cardano.Api hiding (StakeAddress, StakeCredential)
+import qualified Cardano.Api as Api (NetworkId (..))
+import qualified Cardano.Api.Byron as Byron (WitnessNetworkIdOrByronAddress (..))
+import qualified Cardano.Api.Ledger as Ledger (ConwayEraTxCert (..)
+                   , ConwayTxCert (..)
+                   , Credential (..)
+                   , EraCrypto
+                   , KeyRole (..)
+                   , PParams (..)
+                   , Prices (..)
+                   , ShelleyEraTxCert (..)
+                   , ShelleyTxCert (..)
+                   , TxCert
+                   , pattern UnRegDepositTxCert
+                   , pattern UnRegTxCert
+                   , ppPricesL)
 import           Cardano.Api.Shelley (GovernanceAction (..)
-                   , GovernanceActionId (..)
-                   , GovernancePoll (..)
-                   , GovernancePollAnswer (..)
-                   , GovernancePollError (..)
+                   , Hash (..)
+                   , PoolId
+                   , PlutusScriptOrReferenceInput (..)
                    , Proposal (..)
+                   , ReferenceScript (..)
+                   , ShelleyLedgerEra
+                   , SimpleScriptOrReferenceInput (..)
+                   , StakeAddress (..)
+                   , StakeCredential (..)
                    , Vote (..)
-                   , Voter (..)
-                   , VotingProcedure (..)
                    , VotingProcedures (..)
                    , LedgerProtocolParameters (..))
 import qualified Cardano.Api.Shelley as Api (
                      convertToLedgerProtocolParameters
-                   , createProposalProcedure
                    , createVotingProcedure
-                   , renderGovernancePollError
-                   , fromProposalProcedure
-                   , hashGovernancePoll
-                   , verifyPollAnswer)
+                   , fromShelleyStakeCredential
+                   , getTxBodyAndWitnesses)
+import qualified Cardano.Binary as CBOR (serialize')
+import qualified Cardano.Chain.Common as Byron (AddrAttributes (..), NetworkMagic (..), mkAttributes)
 
+import qualified Cardano.CLI.EraBased.Commands.Transaction as Cmd
 -- Unqualified imports of types need to be re-qualified before a PR.
 import           Cardano.CLI.EraBased.Commands.Governance.Vote (
                      GovernanceVoteCmds (..)
@@ -54,7 +93,7 @@ import           Cardano.CLI.EraBased.Commands.Governance.Actions (
                    , UpdateProtocolParametersPreConway (..)
                    , GovernanceActionHardforkInitCmdArgs (..)
                    , CostModelsFile (..))
-import           Cardano.CLI.EraBased.Commands.Governance.Actions (
+{- import           Cardano.CLI.EraBased.Commands.Governance.Actions (
                      GovernanceActionCmds (..)
                    , GovernanceActionUpdateCommitteeCmdArgs (..)
                    , GovernanceActionCreateConstitutionCmdArgs (..)
@@ -66,49 +105,140 @@ import           Cardano.CLI.EraBased.Commands.Governance.Actions (
                    , UpdateProtocolParametersConwayOnwards (..)
                    , UpdateProtocolParametersPreConway (..)
                    , GovernanceActionHardforkInitCmdArgs (..)
-                   , CostModelsFile (..))
+                   , CostModelsFile (..)) -}
 import qualified Cardano.CLI.EraBased.Commands.Governance.Actions as CLI (renderGovernanceActionCmds)
+{- import qualified Cardano.CLI.EraBased.Commands.Transaction as CLI (TransactionBuildRawCmdArgs (..)) -}
 import           Cardano.CLI.EraBased.Run.Governance.Actions (GovernanceActionsError (..))
-import qualified Cardano.CLI.EraBased.Run.Governance.Actions as CLI (
+{- import qualified Cardano.CLI.EraBased.Run.Governance.Actions as CLI (
                      runGovernanceActionCmds
-                   , addCostModelsToEraBasedProtocolParametersUpdate)
-import qualified Cardano.CLI.EraBased.Run.Governance.Vote as CLI (
-                     runGovernanceVoteCmds {-
+                   , addCostModelsToEraBasedProtocolParametersUpdate) -}
+{- import qualified Cardano.CLI.EraBased.Run.Governance.Vote as CLI (
+                     runGovernanceVoteCmds
                      -- These two aren't exported, barring a customised cardano-cli lib:
-                     , runGovernanceVoteCreateCmd, runGovernanceVoteViewCmd -})
-import           Cardano.CLI.Types.Governance (
-                     AnyVotingStakeVerificationKeyOrHashOrFile (..)
-                   , ConwayVote
-                   , VoteDelegationTarget (..)
-                   , VoteFile
-                   , VType (..))
+                     , runGovernanceVoteCreateCmd, runGovernanceVoteViewCmd) -}
+import           Cardano.CLI.Json.Friendly (FriendlyFormat (..)
+                   , friendlyTx
+                   , friendlyTxBody)
+import           Cardano.CLI.Read (ByronOrShelleyWitness (..)
+                   , IncompleteCddlTxBody (..)
+                   , ShelleyBootstrapWitnessSigningKeyData (..))
+import qualified Cardano.CLI.Read as CLI (categoriseSomeSigningWitness
+                   , fileOrPipe
+                   , readFileScriptInAnyLang
+                   , readFileTx
+                   , readFileTxBody
+                   , readFileTxKeyWitness
+                   , readScriptDataOrFile
+                   , readScriptWitness
+                   , readScriptWitnessFiles
+                   , readScriptWitnessFilesTuple
+                   , readRequiredSigner
+                   , readTxGovernanceActions
+                   , readTxMetadata
+                   , readTxUpdateProposal
+                   , readVotingProceduresFiles
+                   , readWitnessSigningData)
+import qualified Cardano.CLI.EraBased.Run.Genesis as CLI (readProtocolParameters)
+import           Cardano.CLI.Types.Common (CertificateFile (..)
+                   , InputTxBodyOrTxFile (..)
+                   {-
+                    - QueryOutputFormat is renamed in the latest
+                    - cardano-cli. For whatever reason, I'm unable to
+                    - successfully get a sufficiently recent cardano-cli
+                    - tag to actually get used, so in the meantime,
+                    - I'm using the elder name, QueryOutputFormat.
+                    - , OutputFormatJsonOrText (..)
+                    - 
+                    -}
+                   {- , QueryOutputFormat (..) -}
+                   , ReferenceScriptAnyEra (..)
+                   , ReferenceScriptSize (..)
+                   , ScriptWitnessFiles (..)
+                   , TxBuildOutputOptions (..)
+                   , TxByronWitnessCount (..)
+                   , TxOutAnyEra (..)
+                   , TxOutChangeAddress (..)
+                   , TxOutDatumAnyEra (..)
+                   , TxOutShelleyBasedEra (..)
+                   , TxShelleyWitnessCount (..)
+                   , TxTreasuryDonation (..)
+                   , ViewOutputFormat (..)
+                   , WitnessFile (..))
+import           Cardano.CLI.Types.Errors.BootstrapWitnessError (BootstrapWitnessError (..))
+import           Cardano.CLI.Types.Errors.NodeEraMismatchError (NodeEraMismatchError (..))
+import           Cardano.CLI.Types.Errors.TxCmdError (
+                     AnyTxCmdTxExecUnitsErr (..)
+                   , AnyTxBodyErrorAutoBalance (..)
+                   , TxCmdError (..))
+import qualified Cardano.CLI.Types.Errors.TxValidationError as CLI (
+                     convertToTxVotingProcedures
+                   , convToTxProposalProcedures
+                   , validateRequiredSigners
+                   , validateTxAuxScripts
+                   , validateTxCurrentTreasuryValue
+                   , validateTxReturnCollateral
+                   , validateTxScriptValidity
+                   , validateTxTotalCollateral
+                   , validateTxTreasuryDonation
+                   , validateTxValidityLowerBound)
+import           Cardano.CLI.Types.Governance (AnyVotingStakeVerificationKeyOrHashOrFile (..))
+import qualified Cardano.CLI.Types.Output as CLI (renderScriptCosts)
+import           Cardano.CLI.Types.TxFeature (TxFeature (..))
+import qualified Cardano.Ledger.Api.PParams as Ledger (ppMinFeeAL)
+import qualified Cardano.Ledger.Api.Tx.Cert as Ledger (pattern RetirePoolTxCert)
 import           Cardano.Ledger.BaseTypes (Network (..), StrictMaybe (..), Url)
 import           Cardano.Ledger.Coin (Coin (..))
-import qualified Cardano.Ledger.Coin as Ledger hiding (Coin)
+import qualified Cardano.Ledger.Coin as Ledger ()
 import           Cardano.Ledger.Crypto -- exports only types and classes
-import           Cardano.Ledger.Conway.Governance (GovAction (..)
+{- import           Cardano.Ledger.Conway.Governance (GovAction (..)
                    , GovActionId (..)
-                   , ProposalProcedure (..))
-import qualified Cardano.Ledger.Conway.Governance as Governance ()
-import           Cardano.TxGenerator.FundQueue
+                   , ProposalProcedure (..)) -}
+import           Cardano.TxGenerator.FundQueue (Fund (..), FundInEra (..), FundQueue)
+import qualified Cardano.TxGenerator.FundQueue as FundQueue (emptyFundQueue, getFundCoin, getFundKey, getFundTxIn, getFundWitness, insertFund, toList)
 import           Cardano.TxGenerator.Setup.SigningKey
 import           Cardano.TxGenerator.Types (FundSource, FundToStoreList, TxEnvironment (..), TxGenError (..), TxGenerator)
 import           Cardano.TxGenerator.Utils (inputsToOutputsWithFee)
 import           Cardano.TxGenerator.UTxO (ToUTxOList, makeToUTxOList, mkUTxOVariant)
 
-import           Control.Monad (foldM)
+
+import qualified Control.Monad as Monad (foldM, forM)
 import           Control.Monad.Trans.State.Strict
-import           Data.Aeson (eitherDecodeFileStrict')
-import           Data.Bifunctor (bimap)
+
+
+import           Data.Aeson ((.=))
+import qualified Data.Aeson as Aeson (eitherDecodeFileStrict', object)
+import qualified Data.Aeson.Encode.Pretty as Aeson (encodePretty)
+import           Data.Bifunctor (bimap, first)
+import qualified Data.ByteString.Char8 as BS8
+import qualified Data.ByteString.Lazy.Char8 as LBS8
+import qualified Data.ByteString as ByteString
 import           Data.Either (fromRight)
 import           Data.Function ((&))
-import           Data.List (foldl')
-import           Data.Maybe (mapMaybe)
+import qualified Data.List as List (foldl', null)
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map (fromList, keysSet)
+import qualified Data.Maybe as Maybe (catMaybes, fromMaybe, mapMaybe)
+import           Data.Set (Set)
+import qualified Data.Set as Set ((\\), elems, fromList, toList)
 import           Data.String (fromString)
 import           Data.Text (Text)
-import           System.Exit (die)
+import qualified Data.Text as Text (pack)
+import qualified Data.Text.IO as Text (putStrLn)
+import           Data.Type.Equality ((:~:)(..), TestEquality (..))
+
+
+import           Lens.Micro ((^.))
+
+
+import qualified Ouroboros.Network.Protocol.LocalStateQuery.Type as Consensus (Target (..))
+import qualified Ouroboros.Network.Protocol.LocalTxSubmission.Client as Net.Tx (SubmitResult (..))
+
 
 import           Paths_tx_generator
+
+
+import           System.Exit (die)
+import qualified System.IO as IO (print)
 
 -- Not exported, hence cutting and pasting.
 -- This might take a number of imports to be able to include:
@@ -158,7 +288,7 @@ demo = getDataFileName "data/protocol-parameters.json" >>= demo'
 
 demo' :: FilePath -> IO ()
 demo' parametersFile = do
-  protocolParameters <- either die pure =<< eitherDecodeFileStrict' parametersFile
+  protocolParameters <- either die pure =<< Aeson.eitherDecodeFileStrict' parametersFile
   let
       demoEnv :: TxEnvironment ConwayEra
       demoEnv = TxEnvironment {
@@ -168,9 +298,9 @@ demo' parametersFile = do
         , txEnvMetadata = TxMetadataNone
         }
 
-  run1 <- foldM (worker $ generateTx demoEnv) (emptyFundQueue `insertFund` genesisFund) [1..10]
-  run2 <- foldM (worker $ generateTxM demoEnv) (emptyFundQueue `insertFund` genesisFund) [1..10]
-  putStrLn $ "Are run results identical? " ++ show (toList run1 == toList run2)
+  run1 <- Monad.foldM (worker $ generateTx demoEnv) (FundQueue.emptyFundQueue `FundQueue.insertFund` genesisFund) [1..10]
+  run2 <- Monad.foldM (worker $ generateTxM demoEnv) (FundQueue.emptyFundQueue `FundQueue.insertFund` genesisFund) [1..10]
+  putStrLn $ "Are run results identical? " ++ show (FundQueue.toList run1 == FundQueue.toList run2)
   where
     worker ::
          Generator (Either TxGenError (Tx ConwayEra))
@@ -191,6 +321,29 @@ signingKey = fromRight (error "signingKey: parseError") $ parseSigningKeyTE keyD
     keyData = TextEnvelope { teType = TextEnvelopeType "GenesisUTxOSigningKey_ed25519"
               , teDescription = fromString "Genesis Initial UTxO Signing Key"
               , teRawCBOR = "X \vl1~\182\201v(\152\250A\202\157h0\ETX\248h\153\171\SI/m\186\242D\228\NAK\182(&\162"}
+
+{-
+drepSigningKey' :: _ (SigningKey _) = fromJSON "{\
+    \\"type\": \"DRepSigningKey_ed25519\",\
+    \\"description\": \"Delegate Representative Signing Key\",\
+    \\"cborHex\": \"5820ac0757312cf883baa809d8cf6c3c48e86acc70db9c6eb5511666c8b128d9020a\"\
+    \}"
+-}
+{-
+parseJSON = withObject "TextEnvelope" $ \v ->
+    TextEnvelope
+      <$> (v .: "type")
+      <*> (v .: "description")
+      <*> (parseJSONBase16 =<< v .: "cborHex")
+-}
+drepSigningKey :: SigningKey PaymentKey
+drepSigningKey = fromRight (error "drepSigningKey: parseError") $ parseSigningKeyTE keyData
+  where
+    keyData = TextEnvelope { teType = TextEnvelopeType "DRepSigningKey_ed25519"
+                           , teDescription = fromString "Delegate Representative Signing Key"
+                           -- This is actually the CBOR as it appeared
+                           -- in the JSON file and needs conversion to raw CBOR.
+                           , teRawCBOR = "5820ac0757312cf883baa809d8cf6c3c48e86acc70db9c6eb5511666c8b128d9020a" }
 
 genesisTxIn :: TxIn
 genesisValue :: TxOutValue ConwayEra
@@ -234,7 +387,7 @@ localGenVote era vote = do
 
 -- Call into the CLI.
 localCheats :: forall era . {- ConwayEraOnwardsConstraints era => -} [GovernanceAction (ConwayEraOnwards era)]
-localCheats = [TreasuryWithdrawal [(undefined :: Network, undefined :: Api.StakeCredential, undefined :: Coin)] SNothing]
+localCheats = [TreasuryWithdrawal [(undefined :: Network, undefined :: StakeCredential, undefined :: Coin)] SNothing]
 
 -- runTxBuildRaw from CLI
 localGenTx :: forall era. ()
@@ -251,9 +404,9 @@ localGenTx sbe ledgerParameters (collateral, collFunds) fee metadata inFunds out
       (\b -> (signShelleyTransaction (shelleyBasedEra @era) b $ map WitnessPaymentKey allKeys, getTxId b))
       (createAndValidateTransactionBody (shelleyBasedEra @era) txBodyContent)
  where
-  allKeys = mapMaybe getFundKey $ inFunds ++ collFunds
+  allKeys = Maybe.mapMaybe FundQueue.getFundKey $ inFunds ++ collFunds
   txBodyContent = defaultTxBodyContent sbe
-    & setTxIns (map (\f -> (getFundTxIn f, BuildTxWith $ getFundWitness f)) inFunds)
+    & setTxIns (map (\f -> (FundQueue.getFundTxIn f, BuildTxWith $ FundQueue.getFundWitness f)) inFunds)
     & setTxInsCollateral collateral
     & setTxOuts outputs
     & setTxFee fee
@@ -279,7 +432,7 @@ localSourceToStoreTransaction txGenerator fundSource inToOut mkTxOut fundToStore
       -- 'getFundCoin' unwraps the 'TxOutValue' in a fund field
       -- so it's all just 'Lovelace' instead of a coproduct
       -- maintaining distinctions.
-      outValues = inToOut $ map getFundCoin inputFunds
+      outValues = inToOut $ map FundQueue.getFundCoin inputFunds
       (outputs, toFunds) = mkTxOut outValues
     case txGenerator inputFunds outputs of
         Left err -> return $ Left err
@@ -314,12 +467,12 @@ generateTx TxEnvironment{..}
 -- Create a transaction that uses all the available funds.
     consumeInputFunds :: Generator (Either TxGenError [Fund])
     consumeInputFunds = do
-      funds <- toList <$> get
-      put emptyFundQueue
+      funds <- FundQueue.toList <$> get
+      put FundQueue.emptyFundQueue
       return $ Right funds
 
     addNewOutputFunds :: [Fund] -> Generator ()
-    addNewOutputFunds = put . foldl' insertFund emptyFundQueue
+    addNewOutputFunds = put . List.foldl' FundQueue.insertFund FundQueue.emptyFundQueue
 
     computeOutputValues :: [Coin] -> [Coin]
     computeOutputValues = inputsToOutputsWithFee fee numOfOutputs
@@ -345,10 +498,10 @@ generateTxPure ::
 generateTxPure TxEnvironment{..} inQueue
   = do
       (tx, txId) <- generator inputs outputs
-      let outQueue = foldl' insertFund emptyFundQueue (toFunds txId)
+      let outQueue = List.foldl' FundQueue.insertFund FundQueue.emptyFundQueue (toFunds txId)
       pure (tx, outQueue)
   where
-    inputs = toList inQueue
+    inputs = FundQueue.toList inQueue
     TxFeeExplicit _ fee = txEnvFee
 
     generator :: TxGenerator ConwayEra
@@ -362,7 +515,7 @@ generateTxPure TxEnvironment{..} inQueue
         collateralFunds :: (TxInsCollateral ConwayEra, [Fund])
         collateralFunds = (TxInsCollateralNone, [])
 
-    outValues = computeOutputValues $ map getFundCoin inputs
+    outValues = computeOutputValues $ map FundQueue.getFundCoin inputs
     (outputs, toFunds) = makeToUTxOList (repeat computeUTxO) outValues
 
     computeOutputValues :: [Coin] -> [Coin]
@@ -370,3 +523,1743 @@ generateTxPure TxEnvironment{..} inQueue
       where numOfOutputs = 2
 
     computeUTxO = mkUTxOVariant txEnvNetworkId signingKey
+
+
+runTransactionCmds :: Cmd.TransactionCmds era -> ExceptT TxCmdError IO ()
+runTransactionCmds = \case
+  Cmd.TransactionBuildCmd args -> runTransactionBuildCmd args
+  Cmd.TransactionBuildEstimateCmd args -> runTransactionBuildEstimateCmd args
+  Cmd.TransactionBuildRawCmd args -> runTransactionBuildRawCmd args
+  Cmd.TransactionSignCmd args -> runTransactionSignCmd args
+  Cmd.TransactionSubmitCmd args -> runTransactionSubmitCmd args
+  Cmd.TransactionCalculateMinFeeCmd args -> runTransactionCalculateMinFeeCmd args
+  Cmd.TransactionCalculateMinValueCmd args -> runTransactionCalculateMinValueCmd args
+  Cmd.TransactionHashScriptDataCmd args -> runTransactionHashScriptDataCmd args
+  Cmd.TransactionTxIdCmd args -> runTransactionTxIdCmd args
+  Cmd.TransactionViewCmd args -> runTransactionViewCmd args
+  Cmd.TransactionPolicyIdCmd args -> runTransactionPolicyIdCmd args
+  Cmd.TransactionWitnessCmd args -> runTransactionWitnessCmd args
+  Cmd.TransactionSignWitnessCmd args -> runTransactionSignWitnessCmd args
+
+-- ----------------------------------------------------------------------------
+-- Building transactions
+--
+
+runTransactionBuildCmd
+  :: ()
+  => Cmd.TransactionBuildCmdArgs era
+  -> ExceptT TxCmdError IO ()
+runTransactionBuildCmd
+  Cmd.TransactionBuildCmdArgs
+    { eon
+    , nodeSocketPath
+    , consensusModeParams
+    , networkId = networkId
+    , mScriptValidity = mScriptValidity
+    , mOverrideWitnesses = mOverrideWitnesses
+    , txins
+    , readOnlyReferenceInputs
+    , requiredSigners = reqSigners
+    , txinsc
+    , mReturnCollateral = mReturnColl
+    , mTotalCollateral
+    , txouts
+    , changeAddresses
+    , mValue
+    , mValidityLowerBound
+    , mValidityUpperBound
+    , certificates
+    , withdrawals
+    , metadataSchema
+    , scriptFiles
+    , metadataFiles
+    , mUpdateProposalFile
+    , voteFiles
+    , proposalFiles
+    , treasuryDonation -- Maybe TxTreasuryDonation
+    , buildOutputOptions
+    } = shelleyBasedEraConstraints eon $ do
+    let era = toCardanoEra eon
+
+    -- The user can specify an era prior to the era that the node is currently in.
+    -- We cannot use the user specified era to construct a query against a node because it may differ
+    -- from the node's era and this will result in the 'QueryEraMismatch' failure.
+
+    let localNodeConnInfo =
+          LocalNodeConnectInfo
+            { localConsensusModeParams = consensusModeParams
+            , localNodeNetworkId = networkId
+            , localNodeSocketPath = nodeSocketPath
+            }
+
+    inputsAndMaybeScriptWits <- firstExceptT TxCmdScriptWitnessError $ CLI.readScriptWitnessFiles eon txins
+    certFilesAndMaybeScriptWits <-
+      firstExceptT TxCmdScriptWitnessError $ CLI.readScriptWitnessFiles eon certificates
+
+    -- TODO: Conway Era - How can we make this more composable?
+    certsAndMaybeScriptWits <-
+      sequence
+        [ fmap
+            (,mSwit)
+            ( firstExceptT TxCmdReadTextViewFileError . newExceptT $
+                readFileTextEnvelope AsCertificate (File certFile)
+            )
+        | (CertificateFile certFile, mSwit) <- certFilesAndMaybeScriptWits
+        ]
+    withdrawalsAndMaybeScriptWits <-
+      firstExceptT TxCmdScriptWitnessError $
+        CLI.readScriptWitnessFilesTuple eon withdrawals
+    txMetadata <-
+      firstExceptT TxCmdMetadataError . newExceptT $
+        CLI.readTxMetadata eon metadataSchema metadataFiles
+    valuesWithScriptWits <- readValueScriptWitnesses eon $ Maybe.fromMaybe mempty mValue
+    scripts <-
+      firstExceptT TxCmdScriptFileError $
+        mapM (CLI.readFileScriptInAnyLang . unFile) scriptFiles
+    txAuxScripts <-
+      hoistEither $ first TxCmdAuxScriptsValidationError $ CLI.validateTxAuxScripts eon scripts
+
+    mProp <- case mUpdateProposalFile of
+      Just (Featured w (Just updateProposalFile)) ->
+        CLI.readTxUpdateProposal w updateProposalFile & firstExceptT TxCmdReadTextViewFileError
+      _ -> pure TxUpdateProposalNone
+
+    requiredSigners <-
+      mapM (firstExceptT TxCmdRequiredSignerError . newExceptT . CLI.readRequiredSigner) reqSigners
+    mReturnCollateral <- Monad.forM mReturnColl $ toTxOutInShelleyBasedEra eon
+
+    txOuts <- mapM (toTxOutInAnyEra eon) txouts
+
+    -- Conway related
+    votingProceduresAndMaybeScriptWits <-
+      inEonForEra
+        (pure mempty)
+        (\w -> firstExceptT TxCmdVoteError $ ExceptT (CLI.readVotingProceduresFiles w voteFiles))
+        era
+
+    proposals <-
+      newExceptT $
+        first TxCmdProposalError
+          <$> CLI.readTxGovernanceActions eon proposalFiles
+
+    -- the same collateral input can be used for several plutus scripts
+    let filteredTxinsc = Set.toList $ Set.fromList txinsc
+
+    let allReferenceInputs =
+          getAllReferenceInputs
+            inputsAndMaybeScriptWits
+            (snd valuesWithScriptWits)
+            certsAndMaybeScriptWits
+            withdrawalsAndMaybeScriptWits
+            votingProceduresAndMaybeScriptWits
+            proposals
+            readOnlyReferenceInputs
+
+    let inputsThatRequireWitnessing = [input | (input, _) <- inputsAndMaybeScriptWits]
+        allTxInputs = inputsThatRequireWitnessing ++ allReferenceInputs ++ filteredTxinsc
+
+    AnyCardanoEra nodeEra <-
+      lift (executeLocalStateQueryExpr localNodeConnInfo Consensus.VolatileTip queryCurrentEra)
+        & onLeft (left . TxCmdQueryConvenienceError . AcqFailure)
+        & onLeft (left . TxCmdQueryConvenienceError . QceUnsupportedNtcVersion)
+
+    (txEraUtxo, _, eraHistory, systemStart, _, _, _, featuredCurrentTreasuryValueM) <-
+      lift
+        ( executeLocalStateQueryExpr
+            localNodeConnInfo
+            Consensus.VolatileTip
+            (queryStateForBalancedTx nodeEra allTxInputs [])
+        )
+        & onLeft (left . TxCmdQueryConvenienceError . AcqFailure)
+        & onLeft (left . TxCmdQueryConvenienceError)
+
+    let currentTreasuryValueAndDonation =
+          case (treasuryDonation, unFeatured <$> featuredCurrentTreasuryValueM) of
+            (Nothing, _) -> Nothing -- We shouldn't specify the treasury value when no donation is being done
+            (Just _td, Nothing) -> Nothing -- TODO: Current treasury value couldn't be obtained but is required: we should fail suggesting that the node's version is too old
+            (Just td, Just ctv) -> Just (ctv, td)
+
+    -- We need to construct the txBodycontent outside of runTxBuild
+    BalancedTxBody txBodyContent balancedTxBody _ _ <-
+      runTxBuild
+        eon
+        nodeSocketPath
+        networkId
+        mScriptValidity
+        inputsAndMaybeScriptWits
+        readOnlyReferenceInputs
+        filteredTxinsc
+        mReturnCollateral
+        mTotalCollateral
+        txOuts
+        changeAddresses
+        valuesWithScriptWits
+        mValidityLowerBound
+        mValidityUpperBound
+        certsAndMaybeScriptWits
+        withdrawalsAndMaybeScriptWits
+        requiredSigners
+        txAuxScripts
+        txMetadata
+        mProp
+        mOverrideWitnesses
+        votingProceduresAndMaybeScriptWits
+        proposals
+        currentTreasuryValueAndDonation
+
+    -- TODO: Calculating the script cost should live as a different command.
+    -- Why? Because then we can simply read a txbody and figure out
+    -- the script cost vs having to build the tx body each time
+    case buildOutputOptions of
+      OutputScriptCostOnly fp -> do
+        let BuildTxWith mTxProtocolParams = txProtocolParams txBodyContent
+
+        pparams <- pure mTxProtocolParams & onNothing (left TxCmdProtocolParametersNotPresentInTxBody)
+        executionUnitPrices <-
+          pure (getExecutionUnitPrices era pparams) & onNothing (left TxCmdPParamExecutionUnitsNotAvailable)
+
+        Refl <-
+          testEquality era nodeEra
+            & hoistMaybe (TxCmdTxNodeEraMismatchError $ NodeEraMismatchError era nodeEra)
+
+        scriptExecUnitsMap <-
+          firstExceptT (TxCmdTxExecUnitsErr . AnyTxCmdTxExecUnitsErr) $
+            hoistEither $
+              evaluateTransactionExecutionUnits
+                era
+                systemStart
+                (toLedgerEpochInfo eraHistory)
+                pparams
+                txEraUtxo
+                balancedTxBody
+
+        let mScriptWits = forEraInEon era [] $ \sbe -> collectTxBodyScriptWitnesses sbe txBodyContent
+
+        scriptCostOutput <-
+          firstExceptT TxCmdPlutusScriptCostErr $
+            hoistEither $
+              CLI.renderScriptCosts
+                txEraUtxo
+                executionUnitPrices
+                mScriptWits
+                scriptExecUnitsMap
+        liftIO $ LBS8.writeFile (unFile fp) $ Aeson.encodePretty scriptCostOutput
+      OutputTxBodyOnly fpath ->
+        let noWitTx = makeSignedTransaction [] balancedTxBody
+         in lift (cardanoEraConstraints era $ writeTxFileTextEnvelopeCddl eon fpath noWitTx)
+              & onLeft (left . TxCmdWriteFileError)
+
+runTransactionBuildEstimateCmd
+  :: ()
+  => Cmd.TransactionBuildEstimateCmdArgs era
+  -> ExceptT TxCmdError IO ()
+runTransactionBuildEstimateCmd -- TODO change type
+  Cmd.TransactionBuildEstimateCmdArgs
+    { eon
+    , mScriptValidity
+    , shelleyWitnesses
+    , mByronWitnesses
+    , protocolParamsFile
+    , totalUTxOValue
+    , txins
+    , readOnlyReferenceInputs = readOnlyRefIns
+    , requiredSigners = reqSigners
+    , txinsc = txInsCollateral
+    , mReturnCollateral = mReturnColl
+    , txouts
+    , changeAddress = TxOutChangeAddress changeAddr
+    , mValue
+    , mValidityLowerBound
+    , mValidityUpperBound
+    , certificates
+    , withdrawals
+    , metadataSchema
+    , scriptFiles
+    , metadataFiles
+    , mUpdateProposalFile
+    , voteFiles
+    , proposalFiles
+    , plutusCollateral
+    , totalReferenceScriptSize
+    -- The new field name:
+    -- , currentTreasuryValueAndDonation
+    , currentTreasuryValue
+    , treasuryDonation
+    , txBodyOutFile
+    } = do
+    let sbe = maryEraOnwardsToShelleyBasedEra eon
+    ledgerPParams <-
+      firstExceptT TxCmdProtocolParamsError $ CLI.readProtocolParameters sbe protocolParamsFile
+    inputsAndMaybeScriptWits <-
+      firstExceptT TxCmdScriptWitnessError $
+        CLI.readScriptWitnessFiles sbe txins
+    certFilesAndMaybeScriptWits <-
+      firstExceptT TxCmdScriptWitnessError $
+        CLI.readScriptWitnessFiles sbe certificates
+
+    withdrawalsAndMaybeScriptWits <-
+      firstExceptT TxCmdScriptWitnessError $
+        CLI.readScriptWitnessFilesTuple sbe withdrawals
+    txMetadata <-
+      firstExceptT TxCmdMetadataError
+        . newExceptT
+        $ CLI.readTxMetadata sbe metadataSchema metadataFiles
+    valuesWithScriptWits <- readValueScriptWitnesses sbe $ Maybe.fromMaybe mempty mValue
+    scripts <-
+      firstExceptT TxCmdScriptFileError $
+        mapM (CLI.readFileScriptInAnyLang . unFile) scriptFiles
+    txAuxScripts <-
+      hoistEither $ first TxCmdAuxScriptsValidationError $ CLI.validateTxAuxScripts sbe scripts
+
+    txUpdateProposal <- case mUpdateProposalFile of
+      Just (Featured w (Just updateProposalFile)) ->
+        CLI.readTxUpdateProposal w updateProposalFile & firstExceptT TxCmdReadTextViewFileError
+      _ -> pure TxUpdateProposalNone
+
+    requiredSigners <-
+      mapM (firstExceptT TxCmdRequiredSignerError . newExceptT . CLI.readRequiredSigner) reqSigners
+
+    mReturnCollateral <- mapM (toTxOutInShelleyBasedEra sbe) mReturnColl
+
+    txOuts <- mapM (toTxOutInAnyEra sbe) txouts
+
+    -- the same collateral input can be used for several plutus scripts
+    let filteredTxinsc = Set.toList $ Set.fromList txInsCollateral
+
+    -- Conway related
+    votingProceduresAndMaybeScriptWits <-
+      inEonForShelleyBasedEra
+        (pure mempty)
+        ( \w ->
+            firstExceptT TxCmdVoteError . ExceptT $
+              conwayEraOnwardsConstraints w $
+                CLI.readVotingProceduresFiles w voteFiles
+        )
+        sbe
+
+    proposals <-
+      lift (CLI.readTxGovernanceActions sbe proposalFiles)
+        & onLeft (left . TxCmdProposalError)
+
+    certsAndMaybeScriptWits <-
+      shelleyBasedEraConstraints sbe $
+        sequence
+          [ fmap
+              (,mSwit)
+              ( firstExceptT TxCmdReadTextViewFileError . newExceptT $
+                  readFileTextEnvelope AsCertificate (File certFile)
+              )
+          | (CertificateFile certFile, mSwit) <- certFilesAndMaybeScriptWits
+          ]
+
+    let currentTreasuryValueAndDonation ::
+             Maybe (TxCurrentTreasuryValue, TxTreasuryDonation)
+        currentTreasuryValueAndDonation = do
+          value    <- currentTreasuryValue
+          donation <- treasuryDonation
+          pure (value, donation)
+    txBodyContent <-
+      hoistEither $
+        constructTxBodyContent
+          sbe
+          mScriptValidity
+          (Just ledgerPParams)
+          inputsAndMaybeScriptWits
+          readOnlyRefIns
+          filteredTxinsc
+          mReturnCollateral
+          Nothing -- TODO: Remove total collateral parameter from estimateBalancedTxBody
+          txOuts
+          mValidityLowerBound
+          mValidityUpperBound
+          valuesWithScriptWits
+          certsAndMaybeScriptWits
+          withdrawalsAndMaybeScriptWits
+          requiredSigners
+          0
+          txAuxScripts
+          txMetadata
+          txUpdateProposal
+          votingProceduresAndMaybeScriptWits
+          proposals
+          currentTreasuryValueAndDonation
+    let stakeCredentialsToDeregisterMap = Map.fromList $ Maybe.catMaybes [getStakeDeregistrationInfo cert | (cert, _) <- certsAndMaybeScriptWits]
+        drepsToDeregisterMap = Map.fromList $ Maybe.catMaybes [getDRepDeregistrationInfo cert | (cert, _) <- certsAndMaybeScriptWits]
+        poolsToDeregister = Set.fromList $ Maybe.catMaybes [getPoolDeregistrationInfo cert | (cert, _) <- certsAndMaybeScriptWits]
+        totCol = Maybe.fromMaybe 0 plutusCollateral
+        pScriptExecUnits =
+          Map.fromList
+            [ (sWitIndex, execUnits)
+            | (sWitIndex, AnyScriptWitness (PlutusScriptWitness _ _ _ _ _ execUnits)) <-
+                collectTxBodyScriptWitnesses sbe txBodyContent
+            ]
+
+    BalancedTxBody _ balancedTxBody _ _ <-
+      hoistEither $
+        first TxCmdFeeEstimationError $
+          estimateBalancedTxBody
+            eon
+            txBodyContent
+            ledgerPParams
+            poolsToDeregister
+            stakeCredentialsToDeregisterMap
+            drepsToDeregisterMap
+            pScriptExecUnits
+            totCol
+            shelleyWitnesses
+            (Maybe.fromMaybe 0 mByronWitnesses)
+            (maybe 0 unReferenceScriptSize totalReferenceScriptSize)
+            (anyAddressInShelleyBasedEra sbe changeAddr)
+            totalUTxOValue
+
+    let noWitTx = makeSignedTransaction [] balancedTxBody
+    lift (writeTxFileTextEnvelopeCddl sbe txBodyOutFile noWitTx)
+      & onLeft (left . TxCmdWriteFileError)
+
+getPoolDeregistrationInfo
+  :: Certificate era
+  -> Maybe PoolId
+getPoolDeregistrationInfo (ShelleyRelatedCertificate w cert) =
+  shelleyToBabbageEraConstraints w $ getShelleyDeregistrationPoolId cert
+getPoolDeregistrationInfo (ConwayCertificate w cert) =
+  conwayEraOnwardsConstraints w $ getConwayDeregistrationPoolId cert
+
+getShelleyDeregistrationPoolId
+  :: Ledger.EraCrypto (ShelleyLedgerEra era) ~ StandardCrypto
+  => Ledger.ShelleyEraTxCert (ShelleyLedgerEra era)
+  => Ledger.TxCert (ShelleyLedgerEra era) ~ Ledger.ShelleyTxCert (ShelleyLedgerEra era)
+  => Ledger.ShelleyTxCert (ShelleyLedgerEra era)
+  -> Maybe PoolId
+getShelleyDeregistrationPoolId cert = do
+  case cert of
+    Ledger.RetirePoolTxCert poolId _ -> Just (StakePoolKeyHash poolId)
+    _ -> Nothing
+
+getConwayDeregistrationPoolId
+  :: Ledger.EraCrypto (ShelleyLedgerEra era) ~ StandardCrypto
+  => Ledger.TxCert (ShelleyLedgerEra era) ~ Ledger.ConwayTxCert (ShelleyLedgerEra era)
+  => Ledger.ConwayEraTxCert (ShelleyLedgerEra era)
+  => Ledger.ConwayTxCert (ShelleyLedgerEra era)
+  -> Maybe PoolId
+getConwayDeregistrationPoolId cert = do
+  case cert of
+    Ledger.RetirePoolTxCert poolId _ -> Just (StakePoolKeyHash poolId)
+    _ -> Nothing
+
+getDRepDeregistrationInfo
+  :: Certificate era
+  -> Maybe (Ledger.Credential Ledger.DRepRole StandardCrypto, Coin)
+getDRepDeregistrationInfo ShelleyRelatedCertificate{} = Nothing
+getDRepDeregistrationInfo (ConwayCertificate w cert) =
+  conwayEraOnwardsConstraints w $ getConwayDRepDeregistrationInfo cert
+
+getConwayDRepDeregistrationInfo
+  :: Ledger.EraCrypto (ShelleyLedgerEra era) ~ StandardCrypto
+  => Ledger.TxCert (ShelleyLedgerEra era) ~ Ledger.ConwayTxCert (ShelleyLedgerEra era)
+  => Ledger.ConwayEraTxCert (ShelleyLedgerEra era)
+  => Ledger.ConwayTxCert (ShelleyLedgerEra era)
+  -> Maybe (Ledger.Credential Ledger.DRepRole StandardCrypto, Coin)
+getConwayDRepDeregistrationInfo = Ledger.getUnRegDRepTxCert
+
+getStakeDeregistrationInfo
+  :: Certificate era
+  -> Maybe (StakeCredential, Coin)
+getStakeDeregistrationInfo (ShelleyRelatedCertificate w cert) =
+  shelleyToBabbageEraConstraints w $ getShelleyDeregistrationInfo cert
+getStakeDeregistrationInfo (ConwayCertificate w cert) =
+  conwayEraOnwardsConstraints w $ getConwayDeregistrationInfo cert
+
+-- There for no deposits required pre-conway for registering stake
+-- credentials.
+getShelleyDeregistrationInfo
+  :: Ledger.EraCrypto (ShelleyLedgerEra era) ~ StandardCrypto
+  => Ledger.ShelleyEraTxCert (ShelleyLedgerEra era)
+  => Ledger.TxCert (ShelleyLedgerEra era) ~ Ledger.ShelleyTxCert (ShelleyLedgerEra era)
+  => Ledger.ShelleyTxCert (ShelleyLedgerEra era)
+  -> Maybe (StakeCredential, Coin)
+getShelleyDeregistrationInfo cert = do
+  case cert of
+    Ledger.UnRegTxCert stakeCred -> Just (Api.fromShelleyStakeCredential stakeCred, 0)
+    _ -> Nothing
+
+getConwayDeregistrationInfo
+  :: Ledger.EraCrypto (ShelleyLedgerEra era) ~ StandardCrypto
+  => Ledger.TxCert (ShelleyLedgerEra era) ~ Ledger.ConwayTxCert (ShelleyLedgerEra era)
+  => Ledger.ConwayEraTxCert (ShelleyLedgerEra era)
+  => Ledger.ConwayTxCert (ShelleyLedgerEra era)
+  -> Maybe (StakeCredential, Coin)
+getConwayDeregistrationInfo cert = do
+  case cert of
+    Ledger.UnRegDepositTxCert stakeCred depositRefund -> Just (Api.fromShelleyStakeCredential stakeCred, depositRefund)
+    _ -> Nothing
+
+getExecutionUnitPrices :: CardanoEra era -> LedgerProtocolParameters era -> Maybe Ledger.Prices
+getExecutionUnitPrices cEra (LedgerProtocolParameters pp) =
+  forEraInEonMaybe cEra $ \aeo ->
+    alonzoEraOnwardsConstraints aeo $
+      pp ^. Ledger.ppPricesL
+
+runTransactionBuildRawCmd
+  :: ()
+  => Cmd.TransactionBuildRawCmdArgs era
+  -> ExceptT TxCmdError IO ()
+runTransactionBuildRawCmd
+  Cmd.TransactionBuildRawCmdArgs
+    { eon
+    , mScriptValidity
+    , txIns
+    , readOnlyRefIns
+    , txInsCollateral
+    , mReturnCollateral = mReturnColl
+    , mTotalCollateral
+    , requiredSigners = reqSigners
+    , txouts
+    , mValue
+    , mValidityLowerBound
+    , mValidityUpperBound
+    , fee
+    , certificates
+    , withdrawals
+    , metadataSchema
+    , scriptFiles
+    , metadataFiles
+    , mProtocolParamsFile
+    , mUpdateProprosalFile
+    , voteFiles
+    , proposalFiles
+    -- , currentTreasuryValueAndDonation
+    , currentTreasuryValue
+    , treasuryDonation
+    , txBodyOutFile
+    } = do
+    inputsAndMaybeScriptWits <-
+      firstExceptT TxCmdScriptWitnessError $
+        CLI.readScriptWitnessFiles eon txIns
+    certFilesAndMaybeScriptWits <-
+      firstExceptT TxCmdScriptWitnessError $
+        CLI.readScriptWitnessFiles eon certificates
+
+    withdrawalsAndMaybeScriptWits <-
+      firstExceptT TxCmdScriptWitnessError $
+        CLI.readScriptWitnessFilesTuple eon withdrawals
+    txMetadata <-
+      firstExceptT TxCmdMetadataError
+        . newExceptT
+        $ CLI.readTxMetadata eon metadataSchema metadataFiles
+    valuesWithScriptWits <- readValueScriptWitnesses eon $ Maybe.fromMaybe mempty mValue
+    scripts <-
+      firstExceptT TxCmdScriptFileError $
+        mapM (CLI.readFileScriptInAnyLang . unFile) scriptFiles
+    txAuxScripts <-
+      hoistEither $ first TxCmdAuxScriptsValidationError $ CLI.validateTxAuxScripts eon scripts
+
+    pparams <- Monad.forM mProtocolParamsFile $ \ppf ->
+      firstExceptT TxCmdProtocolParamsError (CLI.readProtocolParameters eon ppf)
+
+    let mLedgerPParams = LedgerProtocolParameters <$> pparams
+
+    txUpdateProposal <- case mUpdateProprosalFile of
+      Just (Featured w (Just updateProposalFile)) ->
+        CLI.readTxUpdateProposal w updateProposalFile & firstExceptT TxCmdReadTextViewFileError
+      _ -> pure TxUpdateProposalNone
+
+    requiredSigners <-
+      mapM (firstExceptT TxCmdRequiredSignerError . newExceptT . CLI.readRequiredSigner) reqSigners
+
+    mReturnCollateral <- mapM (toTxOutInShelleyBasedEra eon) mReturnColl
+
+    txOuts <- mapM (toTxOutInAnyEra eon) txouts
+
+    -- the same collateral input can be used for several plutus scripts
+    let filteredTxinsc = Set.toList $ Set.fromList txInsCollateral
+
+    -- Conway related
+    votingProceduresAndMaybeScriptWits <-
+      inEonForShelleyBasedEra
+        (pure mempty)
+        ( \w ->
+            firstExceptT TxCmdVoteError . ExceptT $
+              conwayEraOnwardsConstraints w $
+                CLI.readVotingProceduresFiles w voteFiles
+        )
+        eon
+
+    proposals <-
+      lift (CLI.readTxGovernanceActions eon proposalFiles)
+        & onLeft (left . TxCmdProposalError)
+
+    certsAndMaybeScriptWits <-
+      shelleyBasedEraConstraints eon $
+        sequence
+          [ fmap
+              (,mSwit)
+              ( firstExceptT TxCmdReadTextViewFileError . newExceptT $
+                  readFileTextEnvelope AsCertificate (File certFile)
+              )
+          | (CertificateFile certFile, mSwit) <- certFilesAndMaybeScriptWits
+          ]
+    let currentTreasuryValueAndDonation ::
+             Maybe (TxCurrentTreasuryValue, TxTreasuryDonation)
+        currentTreasuryValueAndDonation = do
+          value    <- currentTreasuryValue
+          donation <- treasuryDonation
+          pure (value, donation)
+    txBody <-
+      hoistEither $
+        runTxBuildRaw
+          eon
+          mScriptValidity
+          inputsAndMaybeScriptWits
+          readOnlyRefIns
+          filteredTxinsc
+          mReturnCollateral
+          mTotalCollateral
+          txOuts
+          mValidityLowerBound
+          mValidityUpperBound
+          fee
+          valuesWithScriptWits
+          certsAndMaybeScriptWits
+          withdrawalsAndMaybeScriptWits
+          requiredSigners
+          txAuxScripts
+          txMetadata
+          mLedgerPParams
+          txUpdateProposal
+          votingProceduresAndMaybeScriptWits
+          proposals
+          currentTreasuryValueAndDonation
+
+    let noWitTx = makeSignedTransaction [] txBody
+    lift (writeTxFileTextEnvelopeCddl eon txBodyOutFile noWitTx)
+      & onLeft (left . TxCmdWriteFileError)
+
+runTxBuildRaw
+  :: ()
+  => ShelleyBasedEra era
+  -> Maybe ScriptValidity
+  -- ^ Mark script as expected to pass or fail validation
+  -> [(TxIn, Maybe (ScriptWitness WitCtxTxIn era))]
+  -- ^ TxIn with potential script witness
+  -> [TxIn]
+  -- ^ Read only reference inputs
+  -> [TxIn]
+  -- ^ TxIn for collateral
+  -> Maybe (TxOut CtxTx era)
+  -- ^ Return collateral
+  -> Maybe Coin
+  -- ^ Total collateral
+  -> [TxOut CtxTx era]
+  -> Maybe SlotNo
+  -- ^ Tx lower bound
+  -> TxValidityUpperBound era
+  -- ^ Tx upper bound
+  -> Coin
+  -- ^ Tx fee
+  -> (Value, [ScriptWitness WitCtxMint era])
+  -- ^ Multi-Asset value(s)
+  -> [(Certificate era, Maybe (ScriptWitness WitCtxStake era))]
+  -- ^ Certificate with potential script witness
+  -> [(StakeAddress, Coin, Maybe (ScriptWitness WitCtxStake era))]
+  -> [Hash PaymentKey]
+  -- ^ Required signers
+  -> TxAuxScripts era
+  -> TxMetadataInEra era
+  -> Maybe (LedgerProtocolParameters era)
+  -> TxUpdateProposal era
+  -> [(VotingProcedures era, Maybe (ScriptWitness WitCtxStake era))]
+  -> [(Proposal era, Maybe (ScriptWitness WitCtxStake era))]
+  -> Maybe (TxCurrentTreasuryValue, TxTreasuryDonation)
+  -> Either TxCmdError (TxBody era)
+runTxBuildRaw
+  sbe
+  mScriptValidity
+  inputsAndMaybeScriptWits
+  readOnlyRefIns
+  txinsc
+  mReturnCollateral
+  mTotCollateral
+  txouts
+  mLowerBound
+  mUpperBound
+  fee
+  valuesWithScriptWits
+  certsAndMaybeSriptWits
+  withdrawals
+  reqSigners
+  txAuxScripts
+  txMetadata
+  mpparams
+  txUpdateProposal
+  votingProcedures
+  proposals
+  mCurrentTreasuryValueAndDonation = do
+    txBodyContent <-
+      constructTxBodyContent
+        sbe
+        mScriptValidity
+        (unLedgerProtocolParameters <$> mpparams)
+        inputsAndMaybeScriptWits
+        readOnlyRefIns
+        txinsc
+        mReturnCollateral
+        mTotCollateral
+        txouts
+        mLowerBound
+        mUpperBound
+        valuesWithScriptWits
+        certsAndMaybeSriptWits
+        withdrawals
+        reqSigners
+        fee
+        txAuxScripts
+        txMetadata
+        txUpdateProposal
+        votingProcedures
+        proposals
+        mCurrentTreasuryValueAndDonation
+
+    first TxCmdTxBodyError $ createAndValidateTransactionBody sbe txBodyContent
+
+constructTxBodyContent
+  :: ShelleyBasedEra era
+  -> Maybe ScriptValidity
+  -> Maybe (Ledger.PParams (ShelleyLedgerEra era))
+  -> [(TxIn, Maybe (ScriptWitness WitCtxTxIn era))]
+  -- ^ TxIn with potential script witness
+  -> [TxIn]
+  -- ^ Read only reference inputs
+  -> [TxIn]
+  -- ^ TxIn for collateral
+  -> Maybe (TxOut CtxTx era)
+  -- ^ Return collateral
+  -> Maybe Coin
+  -- ^ Total collateral
+  -> [TxOut CtxTx era]
+  -- ^ Normal outputs
+  -> Maybe SlotNo
+  -- ^ Tx lower bound
+  -> TxValidityUpperBound era
+  -- ^ Tx upper bound
+  -> (Value, [ScriptWitness WitCtxMint era])
+  -- ^ Multi-Asset value(s)
+  -> [(Certificate era, Maybe (ScriptWitness WitCtxStake era))]
+  -- ^ Certificate with potential script witness
+  -> [(StakeAddress, Coin, Maybe (ScriptWitness WitCtxStake era))]
+  -- ^ Withdrawals
+  -> [Hash PaymentKey]
+  -- ^ Required signers
+  -> Coin
+  -- ^ Tx fee
+  -> TxAuxScripts era
+  -> TxMetadataInEra era
+  -> TxUpdateProposal era
+  -> [(VotingProcedures era, Maybe (ScriptWitness WitCtxStake era))]
+  -> [(Proposal era, Maybe (ScriptWitness WitCtxStake era))]
+  -> Maybe (TxCurrentTreasuryValue, TxTreasuryDonation)
+  -- ^ The current treasury value and the donation. This is a stop gap as the
+  -- semantics of the donation and treasury value depend on the script languages
+  -- being used.
+  -> Either TxCmdError (TxBodyContent BuildTx era)
+constructTxBodyContent
+  sbe
+  mScriptValidity
+  mPparams
+  inputsAndMaybeScriptWits
+  readOnlyRefIns
+  txinsc
+  mReturnCollateral
+  mTotCollateral
+  txouts
+  mLowerBound
+  mUpperBound
+  valuesWithScriptWits
+  certsAndMaybeScriptWits
+  withdrawals
+  reqSigners
+  fee
+  txAuxScripts
+  txMetadata
+  txUpdateProposal
+  votingProcedures
+  proposals
+  mCurrentTreasuryValueAndDonation =
+    do
+      let allReferenceInputs =
+            getAllReferenceInputs
+              inputsAndMaybeScriptWits
+              (snd valuesWithScriptWits)
+              certsAndMaybeScriptWits
+              withdrawals
+              votingProcedures
+              proposals
+              readOnlyRefIns
+
+      validatedCollateralTxIns <- validateTxInsCollateral sbe txinsc
+      validatedRefInputs <- validateTxInsReference sbe allReferenceInputs
+      validatedTotCollateral <-
+        first TxCmdNotSupportedInEraValidationError $ CLI.validateTxTotalCollateral sbe mTotCollateral
+      validatedRetCol <-
+        first TxCmdNotSupportedInEraValidationError $ CLI.validateTxReturnCollateral sbe mReturnCollateral
+      let txFee = TxFeeExplicit sbe fee
+      validatedLowerBound <-
+        first TxCmdNotSupportedInEraValidationError $ CLI.validateTxValidityLowerBound sbe mLowerBound
+      validatedReqSigners <-
+        first TxCmdNotSupportedInEraValidationError $ CLI.validateRequiredSigners sbe reqSigners
+      validatedMintValue <- createTxMintValue sbe valuesWithScriptWits
+      validatedTxScriptValidity <-
+        first TxCmdNotSupportedInEraValidationError $ CLI.validateTxScriptValidity sbe mScriptValidity
+      validatedVotingProcedures <-
+        first TxCmdTxGovDuplicateVotes $ CLI.convertToTxVotingProcedures votingProcedures
+      validatedCurrentTreasuryValue <-
+        first
+          TxCmdNotSupportedInEraValidationError
+          (CLI.validateTxCurrentTreasuryValue sbe (fst <$> mCurrentTreasuryValueAndDonation))
+      validatedTreasuryDonation <-
+        first
+          TxCmdNotSupportedInEraValidationError
+          (CLI.validateTxTreasuryDonation sbe (snd <$> mCurrentTreasuryValueAndDonation))
+      return $
+        shelleyBasedEraConstraints sbe $
+          ( defaultTxBodyContent sbe
+              & setTxIns (validateTxIns inputsAndMaybeScriptWits)
+              & setTxInsCollateral validatedCollateralTxIns
+              & setTxInsReference validatedRefInputs
+              & setTxOuts txouts
+              & setTxTotalCollateral validatedTotCollateral
+              & setTxReturnCollateral validatedRetCol
+              & setTxFee txFee
+              & setTxValidityLowerBound validatedLowerBound
+              & setTxValidityUpperBound mUpperBound
+              & setTxMetadata txMetadata
+              & setTxAuxScripts txAuxScripts
+              & setTxExtraKeyWits validatedReqSigners
+              & setTxProtocolParams (BuildTxWith $ LedgerProtocolParameters <$> mPparams)
+              & setTxWithdrawals (TxWithdrawals sbe $ map convertWithdrawals withdrawals)
+              & setTxCertificates (convertCertificates sbe certsAndMaybeScriptWits)
+              & setTxUpdateProposal txUpdateProposal
+              & setTxMintValue validatedMintValue
+              & setTxScriptValidity validatedTxScriptValidity
+          )
+            { -- TODO: Create set* function for proposal procedures and voting procedures
+              txProposalProcedures =
+                forShelleyBasedEraInEonMaybe sbe (`Featured` CLI.convToTxProposalProcedures proposals)
+            , txVotingProcedures = forShelleyBasedEraInEonMaybe sbe (`Featured` validatedVotingProcedures)
+            }
+            & setTxCurrentTreasuryValue validatedCurrentTreasuryValue
+            & setTxTreasuryDonation validatedTreasuryDonation
+   where
+    convertWithdrawals
+      :: (StakeAddress, Coin, Maybe (ScriptWitness WitCtxStake era))
+      -> (StakeAddress, Coin, BuildTxWith BuildTx (Witness WitCtxStake era))
+    convertWithdrawals (sAddr, ll, mScriptWitnessFiles) =
+      case mScriptWitnessFiles of
+        Just sWit -> (sAddr, ll, BuildTxWith $ ScriptWitness ScriptWitnessForStakeAddr sWit)
+        Nothing -> (sAddr, ll, BuildTxWith $ KeyWitness KeyWitnessForStakeAddr)
+
+runTxBuild
+  :: ()
+  => ShelleyBasedEra era
+  -> SocketPath
+  -> NetworkId
+  -> Maybe ScriptValidity
+  -- ^ Mark script as expected to pass or fail validation
+  -> [(TxIn, Maybe (ScriptWitness WitCtxTxIn era))]
+  -- ^ Read only reference inputs
+  -> [TxIn]
+  -- ^ TxIn with potential script witness
+  -> [TxIn]
+  -- ^ TxIn for collateral
+  -> Maybe (TxOut CtxTx era)
+  -- ^ Return collateral
+  -> Maybe Coin
+  -- ^ Total collateral
+  -> [TxOut CtxTx era]
+  -- ^ Normal outputs
+  -> TxOutChangeAddress
+  -- ^ A change output
+  -> (Value, [ScriptWitness WitCtxMint era])
+  -- ^ Multi-Asset value(s)
+  -> Maybe SlotNo
+  -- ^ Tx lower bound
+  -> TxValidityUpperBound era
+  -- ^ Tx upper bound
+  -> [(Certificate era, Maybe (ScriptWitness WitCtxStake era))]
+  -- ^ Certificate with potential script witness
+  -> [(StakeAddress, Coin, Maybe (ScriptWitness WitCtxStake era))]
+  -> [Hash PaymentKey]
+  -- ^ Required signers
+  -> TxAuxScripts era
+  -> TxMetadataInEra era
+  -> TxUpdateProposal era
+  -> Maybe Word
+  -> [(VotingProcedures era, Maybe (ScriptWitness WitCtxStake era))]
+  -> [(Proposal era, Maybe (ScriptWitness WitCtxStake era))]
+  -> Maybe (TxCurrentTreasuryValue, TxTreasuryDonation)
+  -- ^ The current treasury value and the donation.
+  -> ExceptT TxCmdError IO (BalancedTxBody era)
+runTxBuild
+  sbe
+  socketPath
+  networkId
+  mScriptValidity
+  inputsAndMaybeScriptWits
+  readOnlyRefIns
+  txinsc
+  mReturnCollateral
+  mTotCollateral
+  txouts
+  (TxOutChangeAddress changeAddr)
+  valuesWithScriptWits
+  mLowerBound
+  mUpperBound
+  certsAndMaybeScriptWits
+  withdrawals
+  reqSigners
+  txAuxScripts
+  txMetadata
+  txUpdateProposal
+  mOverrideWits
+  votingProcedures
+  proposals
+  mCurrentTreasuryValueAndDonation =
+    shelleyBasedEraConstraints sbe $ do
+      -- TODO: All functions should be parameterized by ShelleyBasedEra
+      -- as it's not possible to call this function with ByronEra
+      let era = toCardanoEra sbe
+          inputsThatRequireWitnessing = [input | (input, _) <- inputsAndMaybeScriptWits]
+
+      let allReferenceInputs =
+            getAllReferenceInputs
+              inputsAndMaybeScriptWits
+              (snd valuesWithScriptWits)
+              certsAndMaybeScriptWits
+              withdrawals
+              votingProcedures
+              proposals
+              readOnlyRefIns
+
+      let allTxInputs = inputsThatRequireWitnessing ++ allReferenceInputs ++ txinsc
+          localNodeConnInfo =
+            LocalNodeConnectInfo
+              { localConsensusModeParams = CardanoModeParams $ EpochSlots 21600
+              , localNodeNetworkId = networkId
+              , localNodeSocketPath = socketPath
+              }
+
+      AnyCardanoEra nodeEra <-
+        lift (executeLocalStateQueryExpr localNodeConnInfo Consensus.VolatileTip queryCurrentEra)
+          & onLeft (left . TxCmdQueryConvenienceError . AcqFailure)
+          & onLeft (left . TxCmdQueryConvenienceError . QceUnsupportedNtcVersion)
+
+      Refl <-
+        testEquality era nodeEra
+          & hoistMaybe (TxCmdTxNodeEraMismatchError $ NodeEraMismatchError era nodeEra)
+
+      let certs =
+            case convertCertificates sbe certsAndMaybeScriptWits of
+              TxCertificates _ cs _ -> cs
+              _ -> []
+
+      (txEraUtxo, pparams, eraHistory, systemStart, stakePools, stakeDelegDeposits, drepDelegDeposits, _) <-
+        lift
+          ( executeLocalStateQueryExpr localNodeConnInfo Consensus.VolatileTip $
+              queryStateForBalancedTx nodeEra allTxInputs certs
+          )
+          & onLeft (left . TxCmdQueryConvenienceError . AcqFailure)
+          & onLeft (left . TxCmdQueryConvenienceError)
+
+      txBodyContent <-
+        hoistEither $
+          constructTxBodyContent
+            sbe
+            mScriptValidity
+            (Just $ unLedgerProtocolParameters pparams)
+            inputsAndMaybeScriptWits
+            readOnlyRefIns
+            txinsc
+            mReturnCollateral
+            mTotCollateral
+            txouts
+            mLowerBound
+            mUpperBound
+            valuesWithScriptWits
+            certsAndMaybeScriptWits
+            withdrawals
+            reqSigners
+            0
+            txAuxScripts
+            txMetadata
+            txUpdateProposal
+            votingProcedures
+            proposals
+            mCurrentTreasuryValueAndDonation
+
+      firstExceptT TxCmdTxInsDoNotExist
+        . hoistEither
+        $ txInsExistInUTxO allTxInputs txEraUtxo
+      firstExceptT TxCmdQueryNotScriptLocked
+        . hoistEither
+        $ notScriptLockedTxIns txinsc txEraUtxo
+
+      cAddr <-
+        pure (anyAddressInEra era changeAddr)
+          & onLeft (error $ "runTxBuild: Byron address used: " <> show changeAddr) -- should this throw instead?
+      balancedTxBody@(BalancedTxBody _ _ _ fee) <-
+        firstExceptT (TxCmdBalanceTxBody . AnyTxBodyErrorAutoBalance)
+          . hoistEither
+          $ makeTransactionBodyAutoBalance
+            sbe
+            systemStart
+            (toLedgerEpochInfo eraHistory)
+            pparams
+            stakePools
+            stakeDelegDeposits
+            drepDelegDeposits
+            txEraUtxo
+            txBodyContent
+            cAddr
+            mOverrideWits
+
+      liftIO $ putStrLn $ "Estimated transaction fee: " <> (show fee :: String)
+
+      return balancedTxBody
+
+convertCertificates
+  :: ()
+  => ShelleyBasedEra era
+  -> [(Certificate era, Maybe (ScriptWitness WitCtxStake era))]
+  -> TxCertificates BuildTx era
+convertCertificates sbe certsAndScriptWitnesses =
+  TxCertificates sbe certs $ BuildTxWith reqWits
+ where
+  certs = map fst certsAndScriptWitnesses
+  reqWits = Map.fromList $ Maybe.mapMaybe convert certsAndScriptWitnesses
+  convert
+    :: (Certificate era, Maybe (ScriptWitness WitCtxStake era))
+    -> Maybe (StakeCredential, Witness WitCtxStake era)
+  convert (cert, mScriptWitnessFiles) = do
+    sCred <- selectStakeCredentialWitness cert
+    Just $ case mScriptWitnessFiles of
+      Just sWit -> (sCred, ScriptWitness ScriptWitnessForStakeAddr sWit)
+      Nothing -> (sCred, KeyWitness KeyWitnessForStakeAddr)
+
+-- ----------------------------------------------------------------------------
+-- Transaction body validation and conversion
+--
+
+txFeatureMismatch
+  :: ()
+  => Monad m
+  => CardanoEra era
+  -> TxFeature
+  -> ExceptT TxCmdError m a
+txFeatureMismatch era feature =
+  hoistEither . Left $ TxCmdTxFeatureMismatch (anyCardanoEra era) feature
+
+txFeatureMismatchPure
+  :: CardanoEra era
+  -> TxFeature
+  -> Either TxCmdError a
+txFeatureMismatchPure era feature =
+  Left (TxCmdTxFeatureMismatch (anyCardanoEra era) feature)
+
+validateTxIns
+  :: [(TxIn, Maybe (ScriptWitness WitCtxTxIn era))]
+  -> [(TxIn, BuildTxWith BuildTx (Witness WitCtxTxIn era))]
+validateTxIns = map convert
+ where
+  convert
+    :: (TxIn, Maybe (ScriptWitness WitCtxTxIn era))
+    -> (TxIn, BuildTxWith BuildTx (Witness WitCtxTxIn era))
+  convert (txin, mScriptWitness) =
+    case mScriptWitness of
+      Just sWit ->
+        (txin, BuildTxWith $ ScriptWitness ScriptWitnessForSpending sWit)
+      Nothing ->
+        (txin, BuildTxWith $ KeyWitness KeyWitnessForSpending)
+
+validateTxInsCollateral
+  :: ShelleyBasedEra era
+  -> [TxIn]
+  -> Either TxCmdError (TxInsCollateral era)
+validateTxInsCollateral _ [] = return TxInsCollateralNone
+validateTxInsCollateral era txins = do
+  forShelleyBasedEraInEonMaybe era (\supported -> TxInsCollateral supported txins)
+    & maybe (txFeatureMismatchPure (toCardanoEra era) TxFeatureCollateral) Right
+
+validateTxInsReference
+  :: ShelleyBasedEra era
+  -> [TxIn]
+  -> Either TxCmdError (TxInsReference BuildTx era)
+validateTxInsReference _ [] = return TxInsReferenceNone
+validateTxInsReference sbe allRefIns = do
+  forShelleyBasedEraInEonMaybe sbe (\supported -> TxInsReference supported allRefIns)
+    & maybe (txFeatureMismatchPure (toCardanoEra sbe) TxFeatureReferenceInputs) Right
+
+getAllReferenceInputs
+  :: [(TxIn, Maybe (ScriptWitness WitCtxTxIn era))]
+  -> [ScriptWitness WitCtxMint era]
+  -> [(Certificate era, Maybe (ScriptWitness WitCtxStake era))]
+  -> [(StakeAddress, Coin, Maybe (ScriptWitness WitCtxStake era))]
+  -> [(VotingProcedures era, Maybe (ScriptWitness WitCtxStake era))]
+  -> [(Proposal era, Maybe (ScriptWitness WitCtxStake era))]
+  -> [TxIn]
+  -- ^ Read only reference inputs
+  -> [TxIn]
+getAllReferenceInputs
+  txins
+  mintWitnesses
+  certFiles
+  withdrawals
+  votingProceduresAndMaybeScriptWits
+  propProceduresAnMaybeScriptWits
+  readOnlyRefIns = do
+    let txinsWitByRefInputs = [getReferenceInput sWit | (_, Just sWit) <- txins]
+        mintingRefInputs = map getReferenceInput mintWitnesses
+        certsWitByRefInputs = [getReferenceInput sWit | (_, Just sWit) <- certFiles]
+        withdrawalsWitByRefInputs = [getReferenceInput sWit | (_, _, Just sWit) <- withdrawals]
+        votesWitByRefInputs = [getReferenceInput sWit | (_, Just sWit) <- votingProceduresAndMaybeScriptWits]
+        propsWitByRefInputs = [getReferenceInput sWit | (_, Just sWit) <- propProceduresAnMaybeScriptWits]
+
+    Maybe.catMaybes $
+      concat
+        [ txinsWitByRefInputs
+        , mintingRefInputs
+        , certsWitByRefInputs
+        , withdrawalsWitByRefInputs
+        , votesWitByRefInputs
+        , propsWitByRefInputs
+        , map Just readOnlyRefIns
+        ]
+   where
+    getReferenceInput
+      :: ScriptWitness witctx era -> Maybe TxIn
+    getReferenceInput sWit =
+      case sWit of
+        PlutusScriptWitness _ _ (PReferenceScript refIn _) _ _ _ -> Just refIn
+        PlutusScriptWitness _ _ PScript{} _ _ _ -> Nothing
+        SimpleScriptWitness _ (SReferenceScript refIn _) -> Just refIn
+        SimpleScriptWitness _ SScript{} -> Nothing
+
+toAddressInAnyEra
+  :: CardanoEra era
+  -> AddressAny
+  -> Either TxCmdError (AddressInEra era)
+toAddressInAnyEra era addrAny = runExcept $ do
+  case addrAny of
+    AddressByron bAddr -> pure (AddressInEra ByronAddressInAnyEra bAddr)
+    AddressShelley sAddr -> do
+      sbe <-
+        requireShelleyBasedEra era
+          & onNothing (txFeatureMismatch era TxFeatureShelleyAddresses)
+
+      pure (AddressInEra (ShelleyAddressInEra sbe) sAddr)
+
+toAddressInShelleyBasedEra
+  :: ShelleyBasedEra era
+  -> Address ShelleyAddr
+  -> Either TxCmdError (AddressInEra era)
+toAddressInShelleyBasedEra sbe sAddr =
+  runExcept $
+    pure (AddressInEra (ShelleyAddressInEra sbe) sAddr)
+
+toTxOutValueInAnyEra
+  :: ShelleyBasedEra era
+  -> Value
+  -> Either TxCmdError (TxOutValue era)
+toTxOutValueInAnyEra era val =
+  caseShelleyToAllegraOrMaryEraOnwards
+    ( \_ -> case valueToLovelace val of
+        Just l -> return (TxOutValueShelleyBased era l)
+        Nothing -> txFeatureMismatchPure (toCardanoEra era) TxFeatureMultiAssetOutputs
+    )
+    (\w -> return (TxOutValueShelleyBased era (toLedgerValue w val)))
+    era
+
+toTxOutValueInShelleyBasedEra
+  :: ShelleyBasedEra era
+  -> Value
+  -> Either TxCmdError (TxOutValue era)
+toTxOutValueInShelleyBasedEra sbe val =
+  caseShelleyToAllegraOrMaryEraOnwards
+    ( \_ -> case valueToLovelace val of
+        Just l -> return (TxOutValueShelleyBased sbe l)
+        Nothing -> txFeatureMismatchPure (toCardanoEra sbe) TxFeatureMultiAssetOutputs
+    )
+    (\w -> return (TxOutValueShelleyBased sbe (toLedgerValue w val)))
+    sbe
+
+toTxOutInShelleyBasedEra
+  :: ShelleyBasedEra era
+  -> TxOutShelleyBasedEra
+  -> ExceptT TxCmdError IO (TxOut CtxTx era)
+toTxOutInShelleyBasedEra era (TxOutShelleyBasedEra addr' val' mDatumHash refScriptFp) = do
+  addr <- hoistEither $ toAddressInShelleyBasedEra era addr'
+  val <- hoistEither $ toTxOutValueInShelleyBasedEra era val'
+
+  datum <-
+    caseShelleyToMaryOrAlonzoEraOnwards
+      (const (pure TxOutDatumNone))
+      (\wa -> toTxAlonzoDatum wa mDatumHash)
+      era
+
+  refScript <-
+    inEonForEra
+      (pure ReferenceScriptNone)
+      (\wb -> getReferenceScript wb refScriptFp)
+      (toCardanoEra era)
+
+  pure $ TxOut addr val datum refScript
+
+toTxOutByronEra
+  :: TxOutAnyEra
+  -> ExceptT TxCmdError IO (TxOut CtxTx ByronEra)
+toTxOutByronEra (TxOutAnyEra addr' val' _ _) = do
+  addr <- hoistEither $ toAddressInAnyEra ByronEra addr'
+  let ada = TxOutValueByron $ selectLovelace val'
+  pure $ TxOut addr ada TxOutDatumNone ReferenceScriptNone
+
+-- TODO: toTxOutInAnyEra eventually will not be needed because
+-- byron related functionality will be treated
+-- separately
+toTxOutInAnyEra
+  :: ShelleyBasedEra era
+  -> TxOutAnyEra
+  -> ExceptT TxCmdError IO (TxOut CtxTx era)
+toTxOutInAnyEra era (TxOutAnyEra addr' val' mDatumHash refScriptFp) = do
+  let cEra = toCardanoEra era
+  addr <- hoistEither $ toAddressInAnyEra cEra addr'
+  val <- hoistEither $ toTxOutValueInAnyEra era val'
+
+  datum <-
+    caseShelleyToMaryOrAlonzoEraOnwards
+      (const (pure TxOutDatumNone))
+      (\wa -> toTxAlonzoDatum wa mDatumHash)
+      era
+
+  refScript <-
+    caseShelleyToAlonzoOrBabbageEraOnwards
+      (const (pure ReferenceScriptNone))
+      (\wb -> getReferenceScript wb refScriptFp)
+      era
+  pure $ TxOut addr val datum refScript
+
+getReferenceScript
+  :: ()
+  => BabbageEraOnwards era
+  -> ReferenceScriptAnyEra
+  -> ExceptT TxCmdError IO (ReferenceScript era)
+getReferenceScript w = \case
+  ReferenceScriptAnyEraNone -> return ReferenceScriptNone
+  ReferenceScriptAnyEra fp -> ReferenceScript w <$> firstExceptT TxCmdScriptFileError (CLI.readFileScriptInAnyLang fp)
+
+toTxAlonzoDatum
+  :: ()
+  => AlonzoEraOnwards era
+  -> TxOutDatumAnyEra
+  -> ExceptT TxCmdError IO (TxOutDatum CtxTx era)
+toTxAlonzoDatum supp cliDatum =
+  case cliDatum of
+    TxOutDatumByNone -> pure TxOutDatumNone
+    TxOutDatumByHashOnly h -> pure (TxOutDatumHash supp h)
+    TxOutDatumByHashOf sDataOrFile -> do
+      sData <- firstExceptT TxCmdScriptDataError $ CLI.readScriptDataOrFile sDataOrFile
+      pure (TxOutDatumHash supp $ hashScriptDataBytes sData)
+    TxOutDatumByValue sDataOrFile -> do
+      sData <- firstExceptT TxCmdScriptDataError $ CLI.readScriptDataOrFile sDataOrFile
+      pure (TxOutDatumInTx supp sData)
+    TxOutInlineDatumByValue sDataOrFile -> do
+      let cEra = toCardanoEra supp
+      forEraInEon cEra (txFeatureMismatch cEra TxFeatureInlineDatums) $ \babbageOnwards -> do
+        sData <- firstExceptT TxCmdScriptDataError $ CLI.readScriptDataOrFile sDataOrFile
+        pure $ TxOutDatumInline babbageOnwards sData
+
+-- TODO: Currently we specify the policyId with the '--mint' option on the cli
+-- and we added a separate '--policy-id' parser that parses the policy id for the
+-- given reference input (since we don't have the script in this case). To avoid asking
+-- for the policy id twice (in the build command) we can potentially query the UTxO and
+-- access the script (and therefore the policy id).
+createTxMintValue
+  :: forall era
+   . ShelleyBasedEra era
+  -> (Value, [ScriptWitness WitCtxMint era])
+  -> Either TxCmdError (TxMintValue BuildTx era)
+createTxMintValue era (val, scriptWitnesses) =
+  if List.null (valueToList val) && List.null scriptWitnesses
+    then return TxMintNone
+    else do
+      caseShelleyToAllegraOrMaryEraOnwards
+        (const (txFeatureMismatchPure (toCardanoEra era) TxFeatureMintValue))
+        ( \w -> do
+            -- The set of policy ids for which we need witnesses:
+            let witnessesNeededSet :: Set PolicyId
+                witnessesNeededSet =
+                  Set.fromList [pid | (AssetId pid _, _) <- valueToList val]
+
+            let witnessesProvidedMap :: Map PolicyId (ScriptWitness WitCtxMint era)
+                witnessesProvidedMap = Map.fromList $ gatherMintingWitnesses scriptWitnesses
+                witnessesProvidedSet = Map.keysSet witnessesProvidedMap
+
+            -- Check not too many, nor too few:
+            validateAllWitnessesProvided witnessesNeededSet witnessesProvidedSet
+            validateNoUnnecessaryWitnesses witnessesNeededSet witnessesProvidedSet
+            return (TxMintValue w val (BuildTxWith witnessesProvidedMap))
+        )
+        era
+ where
+  gatherMintingWitnesses
+    :: [ScriptWitness WitCtxMint era]
+    -> [(PolicyId, ScriptWitness WitCtxMint era)]
+  gatherMintingWitnesses [] = []
+  gatherMintingWitnesses (sWit : rest) =
+    case scriptWitnessPolicyId sWit of
+      Nothing -> gatherMintingWitnesses rest
+      Just pid -> (pid, sWit) : gatherMintingWitnesses rest
+
+  validateAllWitnessesProvided witnessesNeeded witnessesProvided
+    | null witnessesMissing = return ()
+    | otherwise = Left (TxCmdPolicyIdsMissing witnessesMissing (Set.toList witnessesProvided))
+   where
+    witnessesMissing = Set.elems (witnessesNeeded Set.\\ witnessesProvided)
+
+  validateNoUnnecessaryWitnesses witnessesNeeded witnessesProvided
+    | null witnessesExtra = return ()
+    | otherwise = Left (TxCmdPolicyIdsExcess witnessesExtra)
+   where
+    witnessesExtra = Set.elems (witnessesProvided Set.\\ witnessesNeeded)
+
+scriptWitnessPolicyId :: ScriptWitness witctx era -> Maybe PolicyId
+scriptWitnessPolicyId (SimpleScriptWitness _ (SScript script)) =
+  Just . scriptPolicyId $ SimpleScript script
+scriptWitnessPolicyId (SimpleScriptWitness _ (SReferenceScript _ mPid)) =
+  PolicyId <$> mPid
+scriptWitnessPolicyId (PlutusScriptWitness _ plutusVersion (PScript script) _ _ _) =
+  Just . scriptPolicyId $ PlutusScript plutusVersion script
+scriptWitnessPolicyId (PlutusScriptWitness _ _ (PReferenceScript _ mPid) _ _ _) =
+  PolicyId <$> mPid
+
+readValueScriptWitnesses
+  :: ShelleyBasedEra era
+  -> (Value, [ScriptWitnessFiles WitCtxMint])
+  -> ExceptT TxCmdError IO (Value, [ScriptWitness WitCtxMint era])
+readValueScriptWitnesses era (v, sWitFiles) = do
+  sWits <- mapM (firstExceptT TxCmdScriptWitnessError . CLI.readScriptWitness era) sWitFiles
+  return (v, sWits)
+
+-- ----------------------------------------------------------------------------
+-- Transaction signing
+--
+
+runTransactionSignCmd
+  :: ()
+  => Cmd.TransactionSignCmdArgs
+  -> ExceptT TxCmdError IO ()
+runTransactionSignCmd
+  Cmd.TransactionSignCmdArgs
+    { txOrTxBodyFile = txOrTxBody
+    , witnessSigningData = witnessSigningData
+    , mNetworkId = mNetworkId
+    , outTxFile = outTxFile
+    } = do
+    sks <- Monad.forM witnessSigningData $ \d ->
+      lift (CLI.readWitnessSigningData d)
+        & onLeft (left . TxCmdReadWitnessSigningDataError)
+
+    let (sksByron, sksShelley) = partitionSomeWitnesses $ map CLI.categoriseSomeSigningWitness sks
+
+    case txOrTxBody of
+      InputTxFile (File inputTxFilePath) -> do
+        inputTxFile <- liftIO $ CLI.fileOrPipe inputTxFilePath
+        anyTx <- lift (CLI.readFileTx inputTxFile) & onLeft (left . TxCmdTextEnvCddlError)
+
+        InAnyShelleyBasedEra sbe tx <- pure anyTx
+
+        let (txbody, existingTxKeyWits) = Api.getTxBodyAndWitnesses tx
+
+        byronWitnesses <-
+          pure (mkShelleyBootstrapWitnesses sbe mNetworkId txbody sksByron)
+            & onLeft (left . TxCmdBootstrapWitnessError)
+
+        let newShelleyKeyWits = map (makeShelleyKeyWitness sbe txbody) sksShelley
+            allKeyWits = existingTxKeyWits ++ newShelleyKeyWits ++ byronWitnesses
+            signedTx = makeSignedTransaction allKeyWits txbody
+
+        lift (writeTxFileTextEnvelopeCddl sbe outTxFile signedTx)
+          & onLeft (left . TxCmdWriteFileError)
+      InputTxBodyFile (File txbodyFilePath) -> do
+        txbodyFile <- liftIO $ CLI.fileOrPipe txbodyFilePath
+        IncompleteCddlTxBody { .. } <-
+          firstExceptT TxCmdTextEnvCddlError . newExceptT $
+            CLI.readFileTxBody txbodyFile
+
+        case unIncompleteCddlTxBody of
+          InAnyShelleyBasedEra sbe txbody -> do
+
+            -- Byron witnesses require the network ID. This can either be provided
+            -- directly or derived from a provided Byron address.
+            byronWitnesses <-
+              firstExceptT TxCmdBootstrapWitnessError
+                . hoistEither
+                $ mkShelleyBootstrapWitnesses sbe mNetworkId txbody sksByron
+
+            let shelleyKeyWitnesses = map (makeShelleyKeyWitness sbe txbody) sksShelley
+                tx = makeSignedTransaction (byronWitnesses ++ shelleyKeyWitnesses) txbody
+
+            lift (writeTxFileTextEnvelopeCddl sbe outTxFile tx)
+              & onLeft (left . TxCmdWriteFileError)
+
+-- ----------------------------------------------------------------------------
+-- Transaction submission
+--
+
+runTransactionSubmitCmd
+  :: ()
+  => Cmd.TransactionSubmitCmdArgs
+  -> ExceptT TxCmdError IO ()
+runTransactionSubmitCmd
+  Cmd.TransactionSubmitCmdArgs
+    { nodeSocketPath
+    , consensusModeParams
+    , networkId
+    , txFile
+    } = do
+    txFileOrPipe <- liftIO $ CLI.fileOrPipe txFile
+    InAnyShelleyBasedEra era tx <-
+      lift (CLI.readFileTx txFileOrPipe) & onLeft (left . TxCmdTextEnvCddlError)
+    let txInMode = TxInMode era tx
+        localNodeConnInfo =
+          LocalNodeConnectInfo
+            { localConsensusModeParams = consensusModeParams
+            , localNodeNetworkId = networkId
+            , localNodeSocketPath = nodeSocketPath
+            }
+
+    res <- liftIO $ submitTxToNodeLocal localNodeConnInfo txInMode
+    case res of
+      Net.Tx.SubmitSuccess -> liftIO $ Text.putStrLn "Transaction successfully submitted."
+      Net.Tx.SubmitFail reason ->
+        case reason of
+          TxValidationErrorInCardanoMode err -> left . TxCmdTxSubmitError . Text.pack $ show err
+          TxValidationEraMismatch mismatchErr -> left $ TxCmdTxSubmitErrorEraMismatch mismatchErr
+
+-- ----------------------------------------------------------------------------
+-- Transaction fee calculation
+--
+
+runTransactionCalculateMinFeeCmd
+  :: ()
+  => Cmd.TransactionCalculateMinFeeCmdArgs
+  -> ExceptT TxCmdError IO ()
+runTransactionCalculateMinFeeCmd
+  Cmd.TransactionCalculateMinFeeCmdArgs
+    { txBodyFile = File txbodyFilePath
+    , protocolParamsFile = protocolParamsFile
+    , txShelleyWitnessCount = TxShelleyWitnessCount nShelleyKeyWitnesses
+    , txByronWitnessCount = TxByronWitnessCount nByronKeyWitnesses
+    , referenceScriptSize = ReferenceScriptSize sReferenceScript
+    -- , outputFormat
+    -- , outFile
+    } = do
+    txbodyFile <- liftIO $ CLI.fileOrPipe txbodyFilePath
+    IncompleteCddlTxBody { .. } <-
+      firstExceptT TxCmdTextEnvCddlError . newExceptT $
+        CLI.readFileTxBody txbodyFile
+
+    let nShelleyKeyWitW32 = fromIntegral nShelleyKeyWitnesses
+
+    InAnyShelleyBasedEra sbe txbody <- pure unIncompleteCddlTxBody
+
+    lpparams <-
+      firstExceptT TxCmdProtocolParamsError $
+        CLI.readProtocolParameters sbe protocolParamsFile
+
+    let shelleyfee = evaluateTransactionFee sbe lpparams txbody nShelleyKeyWitW32 0 sReferenceScript
+
+    let byronfee =
+          shelleyBasedEraConstraints sbe $
+            calculateByronWitnessFees (lpparams ^. Ledger.ppMinFeeAL) nByronKeyWitnesses
+
+    let Coin fee = shelleyfee + byronfee
+        textToWrite = Text.pack ((show fee :: String) <> " Lovelace")
+        _jsonToWrite = Aeson.encodePretty $ Aeson.object ["fee" .= fee]
+
+    -- The Query prefix should go away whenever I can get to actually
+    -- link against the new cardano-cli.
+    -- This whole code block can't really be used until the update works.
+    -- What used to be there before the above was:
+    liftIO $ Text.putStrLn textToWrite
+    {-
+    case (newOutputFormat outputFormat outFile, outFile) of
+      (OutputFormatText, Nothing) ->
+        liftIO $ Text.putStrLn textToWrite
+      (OutputFormatText, Just file) ->
+        firstExceptT TxCmdWriteFileError . newExceptT $ writeTextFile file textToWrite
+      (OutputFormatJson, Nothing) ->
+        liftIO $ LBS8.putStrLn jsonToWrite
+      (OutputFormatJson, Just file) ->
+        firstExceptT TxCmdWriteFileError . newExceptT $ writeLazyByteStringFile file jsonToWrite
+    -}
+
+-- Extra logic to handle byron witnesses.
+-- TODO: move this to Cardano.API.Fee.evaluateTransactionFee.
+calculateByronWitnessFees
+  :: ()
+  => Coin
+  -- ^ The tx fee per byte (from protocol parameters)
+  -> Int
+  -- ^ The number of Byron key witnesses
+  -> Coin
+calculateByronWitnessFees txFeePerByte byronwitcount =
+  Coin $
+    toInteger txFeePerByte
+      * toInteger byronwitcount
+      * toInteger sizeByronKeyWitnesses
+ where
+  sizeByronKeyWitnesses = smallArray + keyObj + sigObj + ccodeObj + attrsObj
+
+  smallArray = 1
+
+  keyObj = 2 + keyLen
+  keyLen = 32
+
+  sigObj = 2 + sigLen
+  sigLen = 64
+
+  ccodeObj = 2 + ccodeLen
+  ccodeLen = 32
+
+  attrsObj = 2 + ByteString.length attributes
+
+  -- We assume testnet network magic here to avoid having
+  -- to thread the actual network ID into this function
+  -- merely to calculate the fees of byron witnesses more accurately.
+  -- This may slightly over-estimate min fees for byron witnesses
+  -- in mainnet transaction by one Word32 per witness.
+  attributes =
+    CBOR.serialize' $
+      Byron.mkAttributes
+        Byron.AddrAttributes
+          { Byron.aaVKDerivationPath = Nothing
+          , Byron.aaNetworkMagic = Byron.NetworkTestnet maxBound
+          }
+
+-- ----------------------------------------------------------------------------
+-- Transaction fee calculation
+--
+
+runTransactionCalculateMinValueCmd
+  :: ()
+  => Cmd.TransactionCalculateMinValueCmdArgs era
+  -> ExceptT TxCmdError IO ()
+runTransactionCalculateMinValueCmd
+  Cmd.TransactionCalculateMinValueCmdArgs
+    { eon
+    , protocolParamsFile
+    , txOut
+    } = do
+    pp <- firstExceptT TxCmdProtocolParamsError (CLI.readProtocolParameters eon protocolParamsFile)
+    out <- toTxOutInShelleyBasedEra eon txOut
+
+    let minValue = calculateMinimumUTxO eon out pp
+    liftIO . IO.print $ minValue
+
+runTransactionPolicyIdCmd
+  :: ()
+  => Cmd.TransactionPolicyIdCmdArgs
+  -> ExceptT TxCmdError IO ()
+runTransactionPolicyIdCmd
+  Cmd.TransactionPolicyIdCmdArgs
+    { scriptFile = File sFile
+    } = do
+    ScriptInAnyLang _ script <-
+      firstExceptT TxCmdScriptFileError $
+        CLI.readFileScriptInAnyLang sFile
+    liftIO . Text.putStrLn . serialiseToRawBytesHexText $ hashScript script
+
+partitionSomeWitnesses
+  :: [ByronOrShelleyWitness]
+  -> ( [ShelleyBootstrapWitnessSigningKeyData]
+     , [ShelleyWitnessSigningKey]
+     )
+partitionSomeWitnesses = reversePartitionedWits . List.foldl' go mempty
+ where
+  reversePartitionedWits (bw, skw) =
+    (reverse bw, reverse skw)
+
+  go (byronAcc, shelleyKeyAcc) byronOrShelleyWit =
+    case byronOrShelleyWit of
+      AByronWitness byronWit ->
+        (byronWit : byronAcc, shelleyKeyAcc)
+      AShelleyKeyWitness shelleyKeyWit ->
+        (byronAcc, shelleyKeyWit : shelleyKeyAcc)
+
+-- | Construct a Shelley bootstrap witness (i.e. a Byron key witness in the
+-- Shelley era).
+mkShelleyBootstrapWitness
+  :: ()
+  => ShelleyBasedEra era
+  -> Maybe NetworkId
+  -> TxBody era
+  -> ShelleyBootstrapWitnessSigningKeyData
+  -> Either BootstrapWitnessError (KeyWitness era)
+mkShelleyBootstrapWitness _ Nothing _ (ShelleyBootstrapWitnessSigningKeyData _ Nothing) =
+  Left MissingNetworkIdOrByronAddressError
+mkShelleyBootstrapWitness sbe (Just nw) txBody (ShelleyBootstrapWitnessSigningKeyData skey Nothing) =
+  Right $ makeShelleyBootstrapWitness sbe (Byron.WitnessNetworkId nw) txBody skey
+mkShelleyBootstrapWitness sbe _ txBody (ShelleyBootstrapWitnessSigningKeyData skey (Just addr)) =
+  Right $ makeShelleyBootstrapWitness sbe (Byron.WitnessByronAddress addr) txBody skey
+
+-- | Attempt to construct Shelley bootstrap witnesses until an error is
+-- encountered.
+mkShelleyBootstrapWitnesses
+  :: ()
+  => ShelleyBasedEra era
+  -> Maybe NetworkId
+  -> TxBody era
+  -> [ShelleyBootstrapWitnessSigningKeyData]
+  -> Either BootstrapWitnessError [KeyWitness era]
+mkShelleyBootstrapWitnesses sbe mnw txBody =
+  mapM (mkShelleyBootstrapWitness sbe mnw txBody)
+
+-- ----------------------------------------------------------------------------
+-- Other misc small commands
+--
+
+runTransactionHashScriptDataCmd
+  :: ()
+  => Cmd.TransactionHashScriptDataCmdArgs
+  -> ExceptT TxCmdError IO ()
+runTransactionHashScriptDataCmd
+  Cmd.TransactionHashScriptDataCmdArgs
+    { scriptDataOrFile
+    } = do
+    d <- firstExceptT TxCmdScriptDataError $ CLI.readScriptDataOrFile scriptDataOrFile
+    liftIO $ BS8.putStrLn $ serialiseToRawBytesHex (hashScriptDataBytes d)
+
+runTransactionTxIdCmd
+  :: ()
+  => Cmd.TransactionTxIdCmdArgs
+  -> ExceptT TxCmdError IO ()
+runTransactionTxIdCmd
+  Cmd.TransactionTxIdCmdArgs
+    { inputTxBodyOrTxFile
+    } = do
+    InAnyShelleyBasedEra _era txbody <-
+      case inputTxBodyOrTxFile of
+        InputTxBodyFile (File txbodyFilePath) -> do
+          txbodyFile <- liftIO $ CLI.fileOrPipe txbodyFilePath
+          IncompleteCddlTxBody { .. } <-
+            firstExceptT TxCmdTextEnvCddlError . newExceptT $
+              CLI.readFileTxBody txbodyFile
+          pure unIncompleteCddlTxBody
+        InputTxFile (File txFilePath) -> do
+          txFile <- liftIO $ CLI.fileOrPipe txFilePath
+          InAnyShelleyBasedEra era tx <- lift (CLI.readFileTx txFile) & onLeft (left . TxCmdTextEnvCddlError)
+          return . InAnyShelleyBasedEra era $ getTxBody tx
+
+    liftIO $ BS8.putStrLn $ serialiseToRawBytesHex (getTxId txbody)
+
+runTransactionViewCmd
+  :: ()
+  => Cmd.TransactionViewCmdArgs
+  -> ExceptT TxCmdError IO ()
+runTransactionViewCmd
+  Cmd.TransactionViewCmdArgs
+    { outputFormat
+    , mOutFile
+    , inputTxBodyOrTxFile
+    } =
+    case inputTxBodyOrTxFile of
+      InputTxBodyFile (File txbodyFilePath) -> do
+        txbodyFile <- liftIO $ CLI.fileOrPipe txbodyFilePath
+        IncompleteCddlTxBody { unIncompleteCddlTxBody = InAnyShelleyBasedEra era txbody } <-
+          firstExceptT TxCmdTextEnvCddlError . newExceptT $
+            CLI.readFileTxBody txbodyFile
+        -- Why are we differentiating between a transaction body and a transaction?
+        -- In the case of a transaction body, we /could/ simply call @makeSignedTransaction []@
+        -- to get a transaction which would allow us to reuse friendlyTxBS. However,
+        -- this would mean that we'd have an empty list of witnesses mentioned in the output, which
+        -- is arguably not part of the transaction body.
+        firstExceptT TxCmdWriteFileError . newExceptT $
+          case outputFormat of
+            ViewOutputFormatYaml -> friendlyTxBody FriendlyYaml mOutFile (toCardanoEra era) txbody
+            ViewOutputFormatJson -> friendlyTxBody FriendlyJson mOutFile (toCardanoEra era) txbody
+      InputTxFile (File txFilePath) -> do
+        txFile <- liftIO $ CLI.fileOrPipe txFilePath
+        InAnyShelleyBasedEra era tx <- lift (CLI.readFileTx txFile) & onLeft (left . TxCmdTextEnvCddlError)
+        firstExceptT TxCmdWriteFileError . newExceptT $
+          case outputFormat of
+            ViewOutputFormatYaml -> friendlyTx FriendlyYaml mOutFile (toCardanoEra era) tx
+            ViewOutputFormatJson -> friendlyTx FriendlyJson mOutFile (toCardanoEra era) tx
+
+-- ----------------------------------------------------------------------------
+-- Witness commands
+--
+
+runTransactionWitnessCmd
+  :: ()
+  => Cmd.TransactionWitnessCmdArgs
+  -> ExceptT TxCmdError IO ()
+runTransactionWitnessCmd
+  Cmd.TransactionWitnessCmdArgs
+    { txBodyFile = File txbodyFilePath
+    , witnessSigningData
+    , mNetworkId
+    , outFile
+    } = do
+    txbodyFile <- liftIO $ CLI.fileOrPipe txbodyFilePath
+    IncompleteCddlTxBody { unIncompleteCddlTxBody = InAnyShelleyBasedEra sbe txbody } <-
+      firstExceptT TxCmdTextEnvCddlError . newExceptT $
+        CLI.readFileTxBody txbodyFile
+    someWit <-
+      firstExceptT TxCmdReadWitnessSigningDataError
+        . newExceptT
+        $ CLI.readWitnessSigningData witnessSigningData
+    witness <-
+      case CLI.categoriseSomeSigningWitness someWit :: ByronOrShelleyWitness of
+        -- Byron witnesses require the network ID. This can either be provided
+        -- directly or derived from a provided Byron address.
+        AByronWitness bootstrapWitData ->
+          firstExceptT TxCmdBootstrapWitnessError
+            . hoistEither
+            $ mkShelleyBootstrapWitness sbe mNetworkId txbody bootstrapWitData
+        AShelleyKeyWitness skShelley ->
+          pure $ makeShelleyKeyWitness sbe txbody skShelley
+
+    firstExceptT TxCmdWriteFileError . newExceptT $
+      writeTxWitnessFileTextEnvelopeCddl sbe outFile witness
+
+runTransactionSignWitnessCmd
+  :: ()
+  => Cmd.TransactionSignWitnessCmdArgs
+  -> ExceptT TxCmdError IO ()
+runTransactionSignWitnessCmd
+  Cmd.TransactionSignWitnessCmdArgs
+    { txBodyFile = File txbodyFilePath
+    , witnessFiles = witnessFiles
+    , outFile = outFile
+    } = do
+    txbodyFile <- liftIO $ CLI.fileOrPipe txbodyFilePath
+    IncompleteCddlTxBody { unIncompleteCddlTxBody = InAnyShelleyBasedEra era txbody } <- lift (CLI.readFileTxBody txbodyFile) & onLeft (left . TxCmdTextEnvCddlError)
+    -- TODO: Left off here. Remember we were never reading byron key witnesses anyways!
+    witnesses <-
+      sequence
+        [ do
+            InAnyShelleyBasedEra era' witness <-
+              lift (CLI.readFileTxKeyWitness file) & onLeft (left . TxCmdCddlWitnessError)
+
+            case testEquality era era' of
+              Nothing ->
+                left $
+                  TxCmdWitnessEraMismatch
+                    (AnyCardanoEra $ toCardanoEra era)
+                    (AnyCardanoEra $ toCardanoEra era')
+                    witnessFile
+              Just Refl -> return witness
+        | witnessFile@(WitnessFile file) <- witnessFiles
+        ]
+
+    let tx = makeSignedTransaction witnesses txbody
+
+    lift (writeTxFileTextEnvelopeCddl era outFile tx) & onLeft (left . TxCmdWriteFileError)

--- a/bench/tx-generator/src/Cardano/TxGenerator/GovExample.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/GovExample.hs
@@ -1,25 +1,20 @@
-{-# LANGUAGE BlockArguments             #-}
-{-# LANGUAGE DataKinds                  #-}
-{-# LANGUAGE DeriveAnyClass             #-}
-{-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE DuplicateRecordFields      #-}
-{-# LANGUAGE EmptyCase                  #-}
-{-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE FlexibleInstances          #-}
-{-# LANGUAGE GADTs                      #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase                 #-}
-{-# LANGUAGE NamedFieldPuns             #-}
-{-# LANGUAGE PartialTypeSignatures      #-}
-{-# LANGUAGE PatternSynonyms            #-}
-{-# LANGUAGE RankNTypes                 #-}
-{-# LANGUAGE RecordWildCards            #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
-{-# LANGUAGE StandaloneDeriving         #-}
-{-# LANGUAGE TupleSections              #-}
-{-# LANGUAGE TypeApplications           #-}
-{-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE TypeOperators              #-}
+{-# LANGUAGE BlockArguments        #-}
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE EmptyCase             #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE NamedFieldPuns        #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE PatternSynonyms       #-}
+{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TupleSections         #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
 
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns  #-}
 {-# OPTIONS_GHC -Wno-error=partial-type-signatures #-}
@@ -80,11 +75,24 @@ import qualified Cardano.Chain.Common as Byron (AddrAttributes (..), NetworkMagi
 
 import qualified Cardano.CLI.EraBased.Commands.Transaction as Cmd
 -- Unqualified imports of types need to be re-qualified before a PR.
-{- import           Cardano.CLI.EraBased.Commands.Governance.Vote (
+import           Cardano.CLI.EraBased.Commands.Governance.Vote (
                      GovernanceVoteCmds (..)
                    , GovernanceVoteCreateCmdArgs (..)
-                   , GovernanceVoteViewCmdArgs (..)) -}
+                   , GovernanceVoteViewCmdArgs (..))
 -- Adjust line break to stylish-haskell/fourmolu/etc.
+import           Cardano.CLI.EraBased.Commands.Governance.Actions (
+                     GovernanceActionCmds (..)
+                   , GovernanceActionUpdateCommitteeCmdArgs (..)
+                   , GovernanceActionCreateConstitutionCmdArgs (..)
+                   , GovernanceActionCreateNoConfidenceCmdArgs (..)
+                   , GovernanceActionInfoCmdArgs (..)
+                   , GovernanceActionViewCmdArgs (..)
+                   , GovernanceActionProtocolParametersUpdateCmdArgs (..)
+                   , GovernanceActionTreasuryWithdrawalCmdArgs (..)
+                   , UpdateProtocolParametersConwayOnwards (..)
+                   , UpdateProtocolParametersPreConway (..)
+                   , GovernanceActionHardforkInitCmdArgs (..)
+                   , CostModelsFile (..))
 {- import           Cardano.CLI.EraBased.Commands.Governance.Actions (
                      GovernanceActionCmds (..)
                    , GovernanceActionUpdateCommitteeCmdArgs (..)
@@ -98,22 +106,9 @@ import qualified Cardano.CLI.EraBased.Commands.Transaction as Cmd
                    , UpdateProtocolParametersPreConway (..)
                    , GovernanceActionHardforkInitCmdArgs (..)
                    , CostModelsFile (..)) -}
-{- import           Cardano.CLI.EraBased.Commands.Governance.Actions (
-                     GovernanceActionCmds (..)
-                   , GovernanceActionUpdateCommitteeCmdArgs (..)
-                   , GovernanceActionCreateConstitutionCmdArgs (..)
-                   , GovernanceActionCreateNoConfidenceCmdArgs (..)
-                   , GovernanceActionInfoCmdArgs (..)
-                   , GovernanceActionViewCmdArgs (..)
-                   , GovernanceActionProtocolParametersUpdateCmdArgs (..)
-                   , GovernanceActionTreasuryWithdrawalCmdArgs (..)
-                   , UpdateProtocolParametersConwayOnwards (..)
-                   , UpdateProtocolParametersPreConway (..)
-                   , GovernanceActionHardforkInitCmdArgs (..)
-                   , CostModelsFile (..)) -}
--- import qualified Cardano.CLI.EraBased.Commands.Governance.Actions as CLI (renderGovernanceActionCmds)
+import qualified Cardano.CLI.EraBased.Commands.Governance.Actions as CLI (renderGovernanceActionCmds)
 {- import qualified Cardano.CLI.EraBased.Commands.Transaction as CLI (TransactionBuildRawCmdArgs (..)) -}
--- import           Cardano.CLI.EraBased.Run.Governance.Actions (GovernanceActionsError (..))
+import           Cardano.CLI.EraBased.Run.Governance.Actions (GovernanceActionsError (..))
 {- import qualified Cardano.CLI.EraBased.Run.Governance.Actions as CLI (
                      runGovernanceActionCmds
                    , addCostModelsToEraBasedProtocolParametersUpdate) -}
@@ -189,10 +184,6 @@ import qualified Cardano.CLI.Types.Errors.TxValidationError as CLI (
 import           Cardano.CLI.Types.Governance (AnyVotingStakeVerificationKeyOrHashOrFile (..))
 import qualified Cardano.CLI.Types.Output as CLI (renderScriptCosts)
 import           Cardano.CLI.Types.TxFeature (TxFeature (..))
--- import qualified Cardano.Crypto.PinnedSizedBytes as Crypto (PinnedSizedBytes)
--- import qualified Cardano.Crypto.Libsodium.Constants as Crypto (CRYPTO_SIGN_ED25519_SECRETKEYBYTES)
--- import qualified Cardano.Crypto.DSIGN.Class as Crypto (SignKeyDSIGN)
--- import qualified Cardano.Crypto.DSIGN.Ed25519 as Crypto (Ed25519DSIGN)
 import qualified Cardano.Ledger.Api.PParams as Ledger (ppMinFeeAL)
 import qualified Cardano.Ledger.Api.Tx.Cert as Ledger (pattern RetirePoolTxCert)
 import           Cardano.Ledger.BaseTypes (Network (..), StrictMaybe (..), Url)
@@ -214,7 +205,7 @@ import qualified Control.Monad as Monad (foldM, forM)
 import           Control.Monad.Trans.State.Strict
 
 
-import           Data.Aeson ((.=) {-, fromJSON-})
+import           Data.Aeson ((.=))
 import qualified Data.Aeson as Aeson (eitherDecodeFileStrict', object)
 import qualified Data.Aeson.Encode.Pretty as Aeson (encodePretty)
 import           Data.Bifunctor (bimap, first)
@@ -229,14 +220,11 @@ import qualified Data.Map.Strict as Map (fromList, keysSet)
 import qualified Data.Maybe as Maybe (catMaybes, fromMaybe, mapMaybe)
 import           Data.Set (Set)
 import qualified Data.Set as Set ((\\), elems, fromList, toList)
-import           Data.String (IsString (..), fromString)
+import           Data.String (fromString)
 import           Data.Text (Text)
 import qualified Data.Text as Text (pack)
 import qualified Data.Text.IO as Text (putStrLn)
 import           Data.Type.Equality ((:~:)(..), TestEquality (..))
-
-
--- import           GHC.Generics
 
 
 import           Lens.Micro ((^.))
@@ -335,34 +323,12 @@ signingKey = fromRight (error "signingKey: parseError") $ parseSigningKeyTE keyD
               , teRawCBOR = "X \vl1~\182\201v(\152\250A\202\157h0\ETX\248h\153\171\SI/m\186\242D\228\NAK\182(&\162"}
 
 {-
- - src/Cardano/TxGenerator/GovExample.hs:337:1: error:
- -  • Can't make a derived instance of
- -      ‘Generic
- -         (Crypto.PinnedSizedBytes
- -            Crypto.CRYPTO_SIGN_ED25519_SECRETKEYBYTES)’:
- -      The data constructors of ‘Crypto.PinnedSizedBytes’ are not all in scope
- -        so you cannot derive an instance for it
- -  • In the stand-alone deriving instance for
- -      ‘Generic (Crypto.PinnedSizedBytes Crypto.CRYPTO_SIGN_ED25519_SECRETKEYBYTES)’
-deriving instance Generic  (Crypto.PinnedSizedBytes
-                            Crypto.CRYPTO_SIGN_ED25519_SECRETKEYBYTES)
-deriving instance FromJSON (Crypto.PinnedSizedBytes
-                            Crypto.CRYPTO_SIGN_ED25519_SECRETKEYBYTES)
-deriving instance FromJSON (Crypto.SignKeyDSIGN Crypto.Ed25519DSIGN)
-deriving instance FromJSON PaymentKey
-deriving instance Generic  PaymentKey
-deriving instance Generic  (SigningKey PaymentKey)
-deriving instance FromJSON (SigningKey PaymentKey)
-
-drepSigningKey' :: _ (SigningKey PaymentKey) = drepSigningKeyString
- -}
-
-drepSigningKeyString :: IsString s => s
-drepSigningKeyString = "{\
+drepSigningKey' :: _ (SigningKey _) = fromJSON "{\
     \\"type\": \"DRepSigningKey_ed25519\",\
     \\"description\": \"Delegate Representative Signing Key\",\
     \\"cborHex\": \"5820ac0757312cf883baa809d8cf6c3c48e86acc70db9c6eb5511666c8b128d9020a\"\
     \}"
+-}
 {-
 parseJSON = withObject "TextEnvelope" $ \v ->
     TextEnvelope

--- a/bench/tx-generator/src/Cardano/TxGenerator/GovExample.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/GovExample.hs
@@ -103,7 +103,7 @@ import qualified Cardano.CLI.Read as CLI (categoriseSomeSigningWitness
                    , readTxUpdateProposal
                    , readVotingProceduresFiles
                    , readWitnessSigningData)
-import qualified Cardano.CLI.EraBased.Run.Genesis as CLI (
+import qualified Cardano.CLI.EraBased.Run.Genesis.Common as CLI (
                      readProtocolParameters)
 import           Cardano.CLI.Types.Common (CertificateFile (..)
                    , InputTxBodyOrTxFile (..)
@@ -696,9 +696,7 @@ runTransactionBuildEstimateCmd -- TODO change type
     , plutusCollateral
     , totalReferenceScriptSize
     -- The new field name:
-    -- , currentTreasuryValueAndDonation
-    , currentTreasuryValue
-    , treasuryDonation
+    , currentTreasuryValueAndDonation
     , txBodyOutFile
     } = do
     let sbe = maryEraOnwardsToShelleyBasedEra eon
@@ -766,12 +764,6 @@ runTransactionBuildEstimateCmd -- TODO change type
           | (CertificateFile certFile, mSwit) <- certFilesAndMaybeScriptWits
           ]
 
-    let currentTreasuryValueAndDonation ::
-             Maybe (TxCurrentTreasuryValue, TxTreasuryDonation)
-        currentTreasuryValueAndDonation = do
-          value    <- currentTreasuryValue
-          donation <- treasuryDonation
-          pure (value, donation)
     txBodyContent <-
       hoistEither $
         constructTxBodyContent
@@ -941,9 +933,7 @@ runTransactionBuildRawCmd
     , mUpdateProprosalFile
     , voteFiles
     , proposalFiles
-    -- , currentTreasuryValueAndDonation
-    , currentTreasuryValue
-    , treasuryDonation
+    , currentTreasuryValueAndDonation
     , txBodyOutFile
     } = do
     inputsAndMaybeScriptWits <-
@@ -1012,12 +1002,6 @@ runTransactionBuildRawCmd
               )
           | (CertificateFile certFile, mSwit) <- certFilesAndMaybeScriptWits
           ]
-    let currentTreasuryValueAndDonation ::
-             Maybe (TxCurrentTreasuryValue, TxTreasuryDonation)
-        currentTreasuryValueAndDonation = do
-          value    <- currentTreasuryValue
-          donation <- treasuryDonation
-          pure (value, donation)
     txBody <-
       hoistEither $
         runTxBuildRaw

--- a/bench/tx-generator/src/Cardano/TxGenerator/GovExample.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/GovExample.hs
@@ -40,8 +40,8 @@
 
 module  Cardano.TxGenerator.GovExample where
 
-import           Cardano.Api hiding (StakeAddress, StakeCredential)
-import qualified Cardano.Api as Api (NetworkId (..))
+-- import           Cardano.Api hiding (StakeAddress, StakeCredential)
+import qualified Cardano.Api as Api (NetworkId (..), TxMetadataInEra (..))
 import qualified Cardano.Api.Byron as Byron (WitnessNetworkIdOrByronAddress (..))
 import qualified Cardano.Api.Ledger as Ledger (ConwayEraTxCert (..)
                    , ConwayTxCert (..)
@@ -56,24 +56,185 @@ import qualified Cardano.Api.Ledger as Ledger (ConwayEraTxCert (..)
                    , pattern UnRegDepositTxCert
                    , pattern UnRegTxCert
                    , ppPricesL)
-import           Cardano.Api.Shelley (GovernanceAction (..)
+import           Cardano.Api.Shelley
+                   ( Address (..)
+                   , AddressAny (..)
+                   , AddressInEra (..)
+                   , AddressTypeInEra (..)
+                   , AlonzoEraOnwards (..)
+                   , AnyCardanoEra (..)
+                   , AnyScriptWitness (..)
+                   , AssetId (..)
+                   , AsType (..)
+                   , BabbageEraOnwards (..)
+                   , BalancedTxBody (..)
+                   , BuildTx
+                   , BuildTxWith (..)
+                   , ByronEra
+                   , CardanoEra (..)
+                   , Certificate (..)
+                   , ConsensusModeParams (..)
+                   , ConwayEra
+                   , ConwayEraOnwards (..)
+                   , CtxTx
+                   , GovernanceAction (..)
+                   , EpochSlots (..)
+                   , ExceptT (..)
+                   , Featured (..)
+                   , File (..)
                    , Hash (..)
-                   , PoolId
+                   , IsShelleyBasedEra (..)
+                   , InAnyCardanoEra (..)
+                   , InAnyShelleyBasedEra (..)
+                   , KeyWitness (..)
+                   , KeyWitnessInCtx (..)
+                   , LedgerProtocolParameters (..)
+                   , LocalNodeConnectInfo (..)
+                   , NetworkId (..)
+                   -- , type PlutusScript (..)
                    , PlutusScriptOrReferenceInput (..)
+                   , PolicyId (..)
+                   , PoolId
                    , Proposal (..)
+                   , QueryConvenienceError (..)
                    , ReferenceScript (..)
+                   , Script (..)
+                   , ScriptInAnyLang (..)
+                   , ScriptValidity (..)
+                   , ScriptWitness (..)
+                   , ScriptWitnessInCtx (..)
+                   , ShelleyAddr
+                   , ShelleyBasedEra (..)
                    , ShelleyLedgerEra
+                   , ShelleyWitnessSigningKey (..)
+                   -- , type SimpleScript (..)
                    , SimpleScriptOrReferenceInput (..)
+                   , SlotNo (..)
+                   , SocketPath
                    , StakeAddress (..)
                    , StakeCredential (..)
+                   , TextEnvelope (..)
+                   , TextEnvelopeType (..)
+                   , Tx (..)
+                   , TxAuxScripts (..)
+                   , TxBody (..)
+                   , TxBodyContent (..)
+                   , TxCertificates (..)
+                   , TxCurrentTreasuryValue (..)
+                   , TxFee (..)
+                   , TxIn (..)
+                   , TxInMode (..)
+                   , TxInsReference (..)
+                   , TxInsCollateral (..)
+                   , TxIx (..)
+                   , TxMintValue (..)
+                   , TxOut (..)
+                   , TxOutDatum (..)
+                   , TxOutValue (..)
+                   , TxUpdateProposal (..)
+                   , TxValidationErrorInCardanoMode (..)
+                   , TxValidityLowerBound (..)
+                   , TxValidityUpperBound (..)
+                   , TxWithdrawals (..)
+                   , Value
                    , Vote (..)
                    , VotingProcedures (..)
-                   , LedgerProtocolParameters (..))
-import qualified Cardano.Api.Shelley as Api (
-                     convertToLedgerProtocolParameters
+                   , Witness (..)
+                   , WitCtxMint
+                   , WitCtxStake
+                   , WitCtxTxIn)
+import qualified Cardano.Api.Shelley as Api
+                   ( alonzoEraOnwardsConstraints
+                   , anyAddressInEra
+                   , anyAddressInShelleyBasedEra
+                   , anyCardanoEra
+                   , calculateMinimumUTxO
+                   , cardanoEraConstraints
+                   , caseShelleyToAllegraOrMaryEraOnwards
+                   , caseShelleyToAlonzoOrBabbageEraOnwards
+                   , caseShelleyToMaryOrAlonzoEraOnwards
+                   , collectTxBodyScriptWitnesses
+                   , convertToLedgerProtocolParameters
+                   , conwayEraOnwardsConstraints
+                   , conwayEraOnwardsToShelleyBasedEra
+                   , createAndValidateTransactionBody
                    , createVotingProcedure
+                   , defaultTxBodyContent
+                   , defaultTxValidityUpperBound
+                   , estimateBalancedTxBody
+                   , evaluateTransactionExecutionUnits
+                   , evaluateTransactionFee
+                   , executeLocalStateQueryExpr
+                   , firstExceptT
+                   , forEraInEon
+                   , forEraInEonMaybe
+                   , forShelleyBasedEraInEonMaybe
                    , fromShelleyStakeCredential
-                   , getTxBodyAndWitnesses)
+                   , getTxBody
+                   , getTxBodyAndWitnesses
+                   , getTxId
+                   , hashScript
+                   , hashScriptDataBytes
+                   , hoistEither
+                   , hoistMaybe
+                   , inEonForEra
+                   , inEonForShelleyBasedEra
+                   , left
+                   , lift
+                   , liftIO
+                   , lovelaceToTxOutValue
+                   , makeShelleyBootstrapWitness
+                   , makeShelleyKeyWitness
+                   , makeSignedTransaction
+                   , makeTransactionBodyAutoBalance
+                   , maryEraOnwardsToShelleyBasedEra
+                   , newExceptT
+                   , notScriptLockedTxIns
+                   , onLeft
+                   , onNothing
+                   , queryCurrentEra
+                   , queryStateForBalancedTx
+                   , readFileTextEnvelope
+                   , requireShelleyBasedEra
+                   , runExcept
+                   , scriptPolicyId
+                   , selectLovelace
+                   , selectStakeCredentialWitness
+                   , serialiseToRawBytesHex
+                   , serialiseToRawBytesHexText
+                   , setTxAuxScripts
+                   , setTxCertificates
+                   , setTxCurrentTreasuryValue
+                   , setTxExtraKeyWits
+                   , setTxFee
+                   , setTxIns
+                   , setTxInsCollateral
+                   , setTxInsReference
+                   , setTxMetadata
+                   , setTxMintValue
+                   , setTxOuts
+                   , setTxProtocolParams
+                   , setTxScriptValidity
+                   , setTxReturnCollateral
+                   , setTxTotalCollateral
+                   , setTxTreasuryDonation
+                   , setTxUpdateProposal
+                   , setTxValidityLowerBound
+                   , setTxValidityUpperBound
+                   , setTxWithdrawals
+                   , shelleyBasedEraConstraints
+                   , shelleyToBabbageEraConstraints
+                   , signShelleyTransaction
+                   , submitTxToNodeLocal
+                   , toCardanoEra
+                   , toLedgerEpochInfo
+                   , toLedgerValue
+                   , txInsExistInUTxO
+                   , unFeatured
+                   , valueToList
+                   , valueToLovelace
+                   , writeTxFileTextEnvelopeCddl
+                   , writeTxWitnessFileTextEnvelopeCddl)
 
 import qualified Cardano.Binary as CBOR (serialize')
 import qualified Cardano.Chain.Common as Byron (AddrAttributes (..)
@@ -217,7 +378,7 @@ demo' parametersFile = do
           txEnvNetworkId = Api.Mainnet
         , txEnvProtocolParams = protocolParameters
         , txEnvFee = TxFeeExplicit ShelleyBasedEraConway 100000
-        , txEnvMetadata = TxMetadataNone
+        , txEnvMetadata = Api.TxMetadataNone
         }
 
   run1 <- Monad.foldM (worker $ generateTx demoEnv) (FundQueue.emptyFundQueue `FundQueue.insertFund` genesisFund) [1..10]
@@ -258,7 +419,7 @@ genesisValue :: TxOutValue ConwayEra
 
 (genesisTxIn, genesisValue) =
   ( TxIn "900fc5da77a0747da53f7675cbb7d149d46779346dea2f879ab811ccc72a2162" (TxIx 0)
-  , lovelaceToTxOutValue ShelleyBasedEraConway $ Coin 90000000000000
+  , Api.lovelaceToTxOutValue ShelleyBasedEraConway $ Coin 90000000000000
   )
 
 genesisFund :: Fund
@@ -286,12 +447,12 @@ localGenVote era vote = do
                              (era {- eon -} :: ConwayEraOnwards era)
                              (vote {- votingChoice -} :: Vote)
                              (Nothing :: Maybe (Url, Text))
-  _ <- shelleyBasedEraConstraints localShelleyBasedEra do
+  _ <- Api.shelleyBasedEraConstraints localShelleyBasedEra do
     _ <- pure (undefined :: AnyVotingStakeVerificationKeyOrHashOrFile)
     pure undefined
   pure ()
   where
-    localShelleyBasedEra = conwayEraOnwardsToShelleyBasedEra era
+    localShelleyBasedEra = Api.conwayEraOnwardsToShelleyBasedEra era
 
 -- Call into the CLI.
 localCheats :: forall era . {- ConwayEraOnwardsConstraints era => -} [GovernanceAction (ConwayEraOnwards era)]
@@ -304,24 +465,24 @@ localGenTx :: forall era. ()
   -> LedgerProtocolParameters era
   -> (TxInsCollateral era, [Fund])
   -> TxFee era
-  -> TxMetadataInEra era
+  -> Api.TxMetadataInEra era
   -> TxGenerator era
 localGenTx sbe ledgerParameters (collateral, collFunds) fee metadata inFunds outputs
   = bimap
       ApiError
-      (\b -> (signShelleyTransaction (shelleyBasedEra @era) b $ map WitnessPaymentKey allKeys, getTxId b))
-      (createAndValidateTransactionBody (shelleyBasedEra @era) txBodyContent)
+      (\b -> (Api.signShelleyTransaction (shelleyBasedEra @era) b $ map WitnessPaymentKey allKeys, Api.getTxId b))
+      (Api.createAndValidateTransactionBody (shelleyBasedEra @era) txBodyContent)
  where
   allKeys = Maybe.mapMaybe FundQueue.getFundKey $ inFunds ++ collFunds
-  txBodyContent = defaultTxBodyContent sbe
-    & setTxIns (map (\f -> (FundQueue.getFundTxIn f, BuildTxWith $ FundQueue.getFundWitness f)) inFunds)
-    & setTxInsCollateral collateral
-    & setTxOuts outputs
-    & setTxFee fee
-    & setTxValidityLowerBound TxValidityNoLowerBound
-    & setTxValidityUpperBound (defaultTxValidityUpperBound sbe)
-    & setTxMetadata metadata
-    & setTxProtocolParams (BuildTxWith (Just ledgerParameters))
+  txBodyContent = Api.defaultTxBodyContent sbe
+    & Api.setTxIns (map (\f -> (FundQueue.getFundTxIn f, BuildTxWith $ FundQueue.getFundWitness f)) inFunds)
+    & Api.setTxInsCollateral collateral
+    & Api.setTxOuts outputs
+    & Api.setTxFee fee
+    & Api.setTxValidityLowerBound TxValidityNoLowerBound
+    & Api.setTxValidityUpperBound (Api.defaultTxValidityUpperBound sbe)
+    & Api.setTxMetadata metadata
+    & Api.setTxProtocolParams (BuildTxWith (Just ledgerParameters))
 
 
 localSourceToStoreTransaction ::
@@ -486,8 +647,8 @@ runTransactionBuildCmd
     , proposalFiles
     , treasuryDonation -- Maybe TxTreasuryDonation
     , buildOutputOptions
-    } = shelleyBasedEraConstraints eon $ do
-    let era = toCardanoEra eon
+    } = Api.shelleyBasedEraConstraints eon $ do
+    let era = Api.toCardanoEra eon
 
     -- The user can specify an era prior to the era that the node is currently in.
     -- We cannot use the user specified era to construct a query against a node because it may differ
@@ -500,53 +661,53 @@ runTransactionBuildCmd
             , localNodeSocketPath = nodeSocketPath
             }
 
-    inputsAndMaybeScriptWits <- firstExceptT TxCmdScriptWitnessError $ CLI.readScriptWitnessFiles eon txins
+    inputsAndMaybeScriptWits <- Api.firstExceptT TxCmdScriptWitnessError $ CLI.readScriptWitnessFiles eon txins
     certFilesAndMaybeScriptWits <-
-      firstExceptT TxCmdScriptWitnessError $ CLI.readScriptWitnessFiles eon certificates
+      Api.firstExceptT TxCmdScriptWitnessError $ CLI.readScriptWitnessFiles eon certificates
 
     -- TODO: Conway Era - How can we make this more composable?
     certsAndMaybeScriptWits <-
       sequence
         [ fmap
             (,mSwit)
-            ( firstExceptT TxCmdReadTextViewFileError . newExceptT $
-                readFileTextEnvelope AsCertificate (File certFile)
+            ( Api.firstExceptT TxCmdReadTextViewFileError . Api.newExceptT $
+                Api.readFileTextEnvelope AsCertificate (File certFile)
             )
         | (CertificateFile certFile, mSwit) <- certFilesAndMaybeScriptWits
         ]
     withdrawalsAndMaybeScriptWits <-
-      firstExceptT TxCmdScriptWitnessError $
+      Api.firstExceptT TxCmdScriptWitnessError $
         CLI.readScriptWitnessFilesTuple eon withdrawals
     txMetadata <-
-      firstExceptT TxCmdMetadataError . newExceptT $
+      Api.firstExceptT TxCmdMetadataError . Api.newExceptT $
         CLI.readTxMetadata eon metadataSchema metadataFiles
     valuesWithScriptWits <- readValueScriptWitnesses eon $ Maybe.fromMaybe mempty mValue
     scripts <-
-      firstExceptT TxCmdScriptFileError $
+      Api.firstExceptT TxCmdScriptFileError $
         mapM (CLI.readFileScriptInAnyLang . unFile) scriptFiles
     txAuxScripts <-
-      hoistEither $ first TxCmdAuxScriptsValidationError $ CLI.validateTxAuxScripts eon scripts
+      Api.hoistEither $ first TxCmdAuxScriptsValidationError $ CLI.validateTxAuxScripts eon scripts
 
     mProp <- case mUpdateProposalFile of
       Just (Featured w (Just updateProposalFile)) ->
-        CLI.readTxUpdateProposal w updateProposalFile & firstExceptT TxCmdReadTextViewFileError
+        CLI.readTxUpdateProposal w updateProposalFile & Api.firstExceptT TxCmdReadTextViewFileError
       _ -> pure TxUpdateProposalNone
 
     requiredSigners <-
-      mapM (firstExceptT TxCmdRequiredSignerError . newExceptT . CLI.readRequiredSigner) reqSigners
+      mapM (Api.firstExceptT TxCmdRequiredSignerError . Api.newExceptT . CLI.readRequiredSigner) reqSigners
     mReturnCollateral <- Monad.forM mReturnColl $ toTxOutInShelleyBasedEra eon
 
     txOuts <- mapM (toTxOutInAnyEra eon) txouts
 
     -- Conway related
     votingProceduresAndMaybeScriptWits <-
-      inEonForEra
+      Api.inEonForEra
         (pure mempty)
-        (\w -> firstExceptT TxCmdVoteError $ ExceptT (CLI.readVotingProceduresFiles w voteFiles))
+        (\w -> Api.firstExceptT TxCmdVoteError $ ExceptT (CLI.readVotingProceduresFiles w voteFiles))
         era
 
     proposals <-
-      newExceptT $
+      Api.newExceptT $
         first TxCmdProposalError
           <$> CLI.readTxGovernanceActions eon proposalFiles
 
@@ -567,22 +728,22 @@ runTransactionBuildCmd
         allTxInputs = inputsThatRequireWitnessing ++ allReferenceInputs ++ filteredTxinsc
 
     AnyCardanoEra nodeEra <-
-      lift (executeLocalStateQueryExpr localNodeConnInfo Consensus.VolatileTip queryCurrentEra)
-        & onLeft (left . TxCmdQueryConvenienceError . AcqFailure)
-        & onLeft (left . TxCmdQueryConvenienceError . QceUnsupportedNtcVersion)
+      Api.lift (Api.executeLocalStateQueryExpr localNodeConnInfo Consensus.VolatileTip Api.queryCurrentEra)
+        & Api.onLeft (Api.left . TxCmdQueryConvenienceError . AcqFailure)
+        & Api.onLeft (Api.left . TxCmdQueryConvenienceError . QceUnsupportedNtcVersion)
 
     (txEraUtxo, _, eraHistory, systemStart, _, _, _, featuredCurrentTreasuryValueM) <-
-      lift
-        ( executeLocalStateQueryExpr
+      Api.lift
+        ( Api.executeLocalStateQueryExpr
             localNodeConnInfo
             Consensus.VolatileTip
-            (queryStateForBalancedTx nodeEra allTxInputs [])
+            (Api.queryStateForBalancedTx nodeEra allTxInputs [])
         )
-        & onLeft (left . TxCmdQueryConvenienceError . AcqFailure)
-        & onLeft (left . TxCmdQueryConvenienceError)
+        & Api.onLeft (Api.left . TxCmdQueryConvenienceError . AcqFailure)
+        & Api.onLeft (Api.left . TxCmdQueryConvenienceError)
 
     let currentTreasuryValueAndDonation =
-          case (treasuryDonation, unFeatured <$>
+          case (treasuryDonation, Api.unFeatured <$>
                    featuredCurrentTreasuryValueM) of
             -- We shouldn't specify the treasury value when no donation
             -- is being done
@@ -628,40 +789,40 @@ runTransactionBuildCmd
       OutputScriptCostOnly fp -> do
         let BuildTxWith mTxProtocolParams = txProtocolParams txBodyContent
 
-        pparams <- pure mTxProtocolParams & onNothing (left TxCmdProtocolParametersNotPresentInTxBody)
+        pparams <- pure mTxProtocolParams & Api.onNothing (Api.left TxCmdProtocolParametersNotPresentInTxBody)
         executionUnitPrices <-
-          pure (getExecutionUnitPrices era pparams) & onNothing (left TxCmdPParamExecutionUnitsNotAvailable)
+          pure (getExecutionUnitPrices era pparams) & Api.onNothing (Api.left TxCmdPParamExecutionUnitsNotAvailable)
 
         Refl <-
           testEquality era nodeEra
-            & hoistMaybe (TxCmdTxNodeEraMismatchError $ NodeEraMismatchError era nodeEra)
+            & Api.hoistMaybe (TxCmdTxNodeEraMismatchError $ NodeEraMismatchError era nodeEra)
 
         scriptExecUnitsMap <-
-          firstExceptT (TxCmdTxExecUnitsErr . AnyTxCmdTxExecUnitsErr) $
-            hoistEither $
-              evaluateTransactionExecutionUnits
+          Api.firstExceptT (TxCmdTxExecUnitsErr . AnyTxCmdTxExecUnitsErr) $
+            Api.hoistEither $
+              Api.evaluateTransactionExecutionUnits
                 era
                 systemStart
-                (toLedgerEpochInfo eraHistory)
+                (Api.toLedgerEpochInfo eraHistory)
                 pparams
                 txEraUtxo
                 balancedTxBody
 
-        let mScriptWits = forEraInEon era [] $ \sbe -> collectTxBodyScriptWitnesses sbe txBodyContent
+        let mScriptWits = Api.forEraInEon era [] $ \sbe -> Api.collectTxBodyScriptWitnesses sbe txBodyContent
 
         scriptCostOutput <-
-          firstExceptT TxCmdPlutusScriptCostErr $
-            hoistEither $
+          Api.firstExceptT TxCmdPlutusScriptCostErr $
+            Api.hoistEither $
               CLI.renderScriptCosts
                 txEraUtxo
                 executionUnitPrices
                 mScriptWits
                 scriptExecUnitsMap
-        liftIO $ LBS8.writeFile (unFile fp) $ Aeson.encodePretty scriptCostOutput
+        Api.liftIO $ LBS8.writeFile (unFile fp) $ Aeson.encodePretty scriptCostOutput
       OutputTxBodyOnly fpath ->
-        let noWitTx = makeSignedTransaction [] balancedTxBody
-         in lift (cardanoEraConstraints era $ writeTxFileTextEnvelopeCddl eon fpath noWitTx)
-              & onLeft (left . TxCmdWriteFileError)
+        let noWitTx = Api.makeSignedTransaction [] balancedTxBody
+         in Api.lift (Api.cardanoEraConstraints era $ Api.writeTxFileTextEnvelopeCddl eon fpath noWitTx)
+              & Api.onLeft (Api.left . TxCmdWriteFileError)
 
 runTransactionBuildEstimateCmd
   :: ()
@@ -699,37 +860,37 @@ runTransactionBuildEstimateCmd -- TODO change type
     , currentTreasuryValueAndDonation
     , txBodyOutFile
     } = do
-    let sbe = maryEraOnwardsToShelleyBasedEra eon
+    let sbe = Api.maryEraOnwardsToShelleyBasedEra eon
     ledgerPParams <-
-      firstExceptT TxCmdProtocolParamsError $ CLI.readProtocolParameters sbe protocolParamsFile
+      Api.firstExceptT TxCmdProtocolParamsError $ CLI.readProtocolParameters sbe protocolParamsFile
     inputsAndMaybeScriptWits <-
-      firstExceptT TxCmdScriptWitnessError $
+      Api.firstExceptT TxCmdScriptWitnessError $
         CLI.readScriptWitnessFiles sbe txins
     certFilesAndMaybeScriptWits <-
-      firstExceptT TxCmdScriptWitnessError $
+      Api.firstExceptT TxCmdScriptWitnessError $
         CLI.readScriptWitnessFiles sbe certificates
 
     withdrawalsAndMaybeScriptWits <-
-      firstExceptT TxCmdScriptWitnessError $
+      Api.firstExceptT TxCmdScriptWitnessError $
         CLI.readScriptWitnessFilesTuple sbe withdrawals
     txMetadata <-
-      firstExceptT TxCmdMetadataError
-        . newExceptT
+      Api.firstExceptT TxCmdMetadataError
+        . Api.newExceptT
         $ CLI.readTxMetadata sbe metadataSchema metadataFiles
     valuesWithScriptWits <- readValueScriptWitnesses sbe $ Maybe.fromMaybe mempty mValue
     scripts <-
-      firstExceptT TxCmdScriptFileError $
+      Api.firstExceptT TxCmdScriptFileError $
         mapM (CLI.readFileScriptInAnyLang . unFile) scriptFiles
     txAuxScripts <-
-      hoistEither $ first TxCmdAuxScriptsValidationError $ CLI.validateTxAuxScripts sbe scripts
+      Api.hoistEither $ first TxCmdAuxScriptsValidationError $ CLI.validateTxAuxScripts sbe scripts
 
     txUpdateProposal <- case mUpdateProposalFile of
       Just (Featured w (Just updateProposalFile)) ->
-        CLI.readTxUpdateProposal w updateProposalFile & firstExceptT TxCmdReadTextViewFileError
+        CLI.readTxUpdateProposal w updateProposalFile & Api.firstExceptT TxCmdReadTextViewFileError
       _ -> pure TxUpdateProposalNone
 
     requiredSigners <-
-      mapM (firstExceptT TxCmdRequiredSignerError . newExceptT . CLI.readRequiredSigner) reqSigners
+      mapM (Api.firstExceptT TxCmdRequiredSignerError . Api.newExceptT . CLI.readRequiredSigner) reqSigners
 
     mReturnCollateral <- mapM (toTxOutInShelleyBasedEra sbe) mReturnColl
 
@@ -740,32 +901,32 @@ runTransactionBuildEstimateCmd -- TODO change type
 
     -- Conway related
     votingProceduresAndMaybeScriptWits <-
-      inEonForShelleyBasedEra
+      Api.inEonForShelleyBasedEra
         (pure mempty)
         ( \w ->
-            firstExceptT TxCmdVoteError . ExceptT $
-              conwayEraOnwardsConstraints w $
+            Api.firstExceptT TxCmdVoteError . ExceptT $
+              Api.conwayEraOnwardsConstraints w $
                 CLI.readVotingProceduresFiles w voteFiles
         )
         sbe
 
     proposals <-
-      lift (CLI.readTxGovernanceActions sbe proposalFiles)
-        & onLeft (left . TxCmdProposalError)
+      Api.lift (CLI.readTxGovernanceActions sbe proposalFiles)
+        & Api.onLeft (Api.left . TxCmdProposalError)
 
     certsAndMaybeScriptWits <-
-      shelleyBasedEraConstraints sbe $
+      Api.shelleyBasedEraConstraints sbe $
         sequence
           [ fmap
               (,mSwit)
-              ( firstExceptT TxCmdReadTextViewFileError . newExceptT $
-                  readFileTextEnvelope AsCertificate (File certFile)
+              ( Api.firstExceptT TxCmdReadTextViewFileError . Api.newExceptT $
+                  Api.readFileTextEnvelope AsCertificate (File certFile)
               )
           | (CertificateFile certFile, mSwit) <- certFilesAndMaybeScriptWits
           ]
 
     txBodyContent <-
-      hoistEither $
+      Api.hoistEither $
         constructTxBodyContent
           sbe
           mScriptValidity
@@ -774,7 +935,7 @@ runTransactionBuildEstimateCmd -- TODO change type
           readOnlyRefIns
           filteredTxinsc
           mReturnCollateral
-          Nothing -- TODO: Remove total collateral parameter from estimateBalancedTxBody
+          Nothing -- TODO: Remove total collateral parameter from Api.estimateBalancedTxBody
           txOuts
           mValidityLowerBound
           mValidityUpperBound
@@ -797,13 +958,13 @@ runTransactionBuildEstimateCmd -- TODO change type
           Map.fromList
             [ (sWitIndex, execUnits)
             | (sWitIndex, AnyScriptWitness (PlutusScriptWitness _ _ _ _ _ execUnits)) <-
-                collectTxBodyScriptWitnesses sbe txBodyContent
+                Api.collectTxBodyScriptWitnesses sbe txBodyContent
             ]
 
     BalancedTxBody _ balancedTxBody _ _ <-
-      hoistEither $
+      Api.hoistEither $
         first TxCmdFeeEstimationError $
-          estimateBalancedTxBody
+          Api.estimateBalancedTxBody
             eon
             txBodyContent
             ledgerPParams
@@ -815,20 +976,20 @@ runTransactionBuildEstimateCmd -- TODO change type
             shelleyWitnesses
             (Maybe.fromMaybe 0 mByronWitnesses)
             (maybe 0 unReferenceScriptSize totalReferenceScriptSize)
-            (anyAddressInShelleyBasedEra sbe changeAddr)
+            (Api.anyAddressInShelleyBasedEra sbe changeAddr)
             totalUTxOValue
 
-    let noWitTx = makeSignedTransaction [] balancedTxBody
-    lift (writeTxFileTextEnvelopeCddl sbe txBodyOutFile noWitTx)
-      & onLeft (left . TxCmdWriteFileError)
+    let noWitTx = Api.makeSignedTransaction [] balancedTxBody
+    Api.lift (Api.writeTxFileTextEnvelopeCddl sbe txBodyOutFile noWitTx)
+      & Api.onLeft (Api.left . TxCmdWriteFileError)
 
 getPoolDeregistrationInfo
   :: Certificate era
   -> Maybe PoolId
 getPoolDeregistrationInfo (ShelleyRelatedCertificate w cert) =
-  shelleyToBabbageEraConstraints w $ getShelleyDeregistrationPoolId cert
+  Api.shelleyToBabbageEraConstraints w $ getShelleyDeregistrationPoolId cert
 getPoolDeregistrationInfo (ConwayCertificate w cert) =
-  conwayEraOnwardsConstraints w $ getConwayDeregistrationPoolId cert
+  Api.conwayEraOnwardsConstraints w $ getConwayDeregistrationPoolId cert
 
 getShelleyDeregistrationPoolId
   :: Ledger.EraCrypto (ShelleyLedgerEra era) ~ StandardCrypto
@@ -857,7 +1018,7 @@ getDRepDeregistrationInfo
   -> Maybe (Ledger.Credential Ledger.DRepRole StandardCrypto, Coin)
 getDRepDeregistrationInfo ShelleyRelatedCertificate{} = Nothing
 getDRepDeregistrationInfo (ConwayCertificate w cert) =
-  conwayEraOnwardsConstraints w $ getConwayDRepDeregistrationInfo cert
+  Api.conwayEraOnwardsConstraints w $ getConwayDRepDeregistrationInfo cert
 
 getConwayDRepDeregistrationInfo
   :: Ledger.EraCrypto (ShelleyLedgerEra era) ~ StandardCrypto
@@ -871,9 +1032,9 @@ getStakeDeregistrationInfo
   :: Certificate era
   -> Maybe (StakeCredential, Coin)
 getStakeDeregistrationInfo (ShelleyRelatedCertificate w cert) =
-  shelleyToBabbageEraConstraints w $ getShelleyDeregistrationInfo cert
+  Api.shelleyToBabbageEraConstraints w $ getShelleyDeregistrationInfo cert
 getStakeDeregistrationInfo (ConwayCertificate w cert) =
-  conwayEraOnwardsConstraints w $ getConwayDeregistrationInfo cert
+  Api.conwayEraOnwardsConstraints w $ getConwayDeregistrationInfo cert
 
 -- There for no deposits required pre-conway for registering stake
 -- credentials.
@@ -901,8 +1062,8 @@ getConwayDeregistrationInfo cert = do
 
 getExecutionUnitPrices :: CardanoEra era -> LedgerProtocolParameters era -> Maybe Ledger.Prices
 getExecutionUnitPrices cEra (LedgerProtocolParameters pp) =
-  forEraInEonMaybe cEra $ \aeo ->
-    alonzoEraOnwardsConstraints aeo $
+  Api.forEraInEonMaybe cEra $ \aeo ->
+    Api.alonzoEraOnwardsConstraints aeo $
       pp ^. Ledger.ppPricesL
 
 runTransactionBuildRawCmd
@@ -937,38 +1098,38 @@ runTransactionBuildRawCmd
     , txBodyOutFile
     } = do
     inputsAndMaybeScriptWits <-
-      firstExceptT TxCmdScriptWitnessError $
+      Api.firstExceptT TxCmdScriptWitnessError $
         CLI.readScriptWitnessFiles eon txIns
     certFilesAndMaybeScriptWits <-
-      firstExceptT TxCmdScriptWitnessError $
+      Api.firstExceptT TxCmdScriptWitnessError $
         CLI.readScriptWitnessFiles eon certificates
 
     withdrawalsAndMaybeScriptWits <-
-      firstExceptT TxCmdScriptWitnessError $
+      Api.firstExceptT TxCmdScriptWitnessError $
         CLI.readScriptWitnessFilesTuple eon withdrawals
     txMetadata <-
-      firstExceptT TxCmdMetadataError
-        . newExceptT
+      Api.firstExceptT TxCmdMetadataError
+        . Api.newExceptT
         $ CLI.readTxMetadata eon metadataSchema metadataFiles
     valuesWithScriptWits <- readValueScriptWitnesses eon $ Maybe.fromMaybe mempty mValue
     scripts <-
-      firstExceptT TxCmdScriptFileError $
+      Api.firstExceptT TxCmdScriptFileError $
         mapM (CLI.readFileScriptInAnyLang . unFile) scriptFiles
     txAuxScripts <-
-      hoistEither $ first TxCmdAuxScriptsValidationError $ CLI.validateTxAuxScripts eon scripts
+      Api.hoistEither $ first TxCmdAuxScriptsValidationError $ CLI.validateTxAuxScripts eon scripts
 
     pparams <- Monad.forM mProtocolParamsFile $ \ppf ->
-      firstExceptT TxCmdProtocolParamsError (CLI.readProtocolParameters eon ppf)
+      Api.firstExceptT TxCmdProtocolParamsError (CLI.readProtocolParameters eon ppf)
 
     let mLedgerPParams = LedgerProtocolParameters <$> pparams
 
     txUpdateProposal <- case mUpdateProprosalFile of
       Just (Featured w (Just updateProposalFile)) ->
-        CLI.readTxUpdateProposal w updateProposalFile & firstExceptT TxCmdReadTextViewFileError
+        CLI.readTxUpdateProposal w updateProposalFile & Api.firstExceptT TxCmdReadTextViewFileError
       _ -> pure TxUpdateProposalNone
 
     requiredSigners <-
-      mapM (firstExceptT TxCmdRequiredSignerError . newExceptT . CLI.readRequiredSigner) reqSigners
+      mapM (Api.firstExceptT TxCmdRequiredSignerError . Api.newExceptT . CLI.readRequiredSigner) reqSigners
 
     mReturnCollateral <- mapM (toTxOutInShelleyBasedEra eon) mReturnColl
 
@@ -979,31 +1140,31 @@ runTransactionBuildRawCmd
 
     -- Conway related
     votingProceduresAndMaybeScriptWits <-
-      inEonForShelleyBasedEra
+      Api.inEonForShelleyBasedEra
         (pure mempty)
         ( \w ->
-            firstExceptT TxCmdVoteError . ExceptT $
-              conwayEraOnwardsConstraints w $
+            Api.firstExceptT TxCmdVoteError . ExceptT $
+              Api.conwayEraOnwardsConstraints w $
                 CLI.readVotingProceduresFiles w voteFiles
         )
         eon
 
     proposals <-
-      lift (CLI.readTxGovernanceActions eon proposalFiles)
-        & onLeft (left . TxCmdProposalError)
+      Api.lift (CLI.readTxGovernanceActions eon proposalFiles)
+        & Api.onLeft (Api.left . TxCmdProposalError)
 
     certsAndMaybeScriptWits <-
-      shelleyBasedEraConstraints eon $
+      Api.shelleyBasedEraConstraints eon $
         sequence
           [ fmap
               (,mSwit)
-              ( firstExceptT TxCmdReadTextViewFileError . newExceptT $
-                  readFileTextEnvelope AsCertificate (File certFile)
+              ( Api.firstExceptT TxCmdReadTextViewFileError . Api.newExceptT $
+                  Api.readFileTextEnvelope AsCertificate (File certFile)
               )
           | (CertificateFile certFile, mSwit) <- certFilesAndMaybeScriptWits
           ]
     txBody <-
-      hoistEither $
+      Api.hoistEither $
         runTxBuildRaw
           eon
           mScriptValidity
@@ -1028,9 +1189,9 @@ runTransactionBuildRawCmd
           proposals
           currentTreasuryValueAndDonation
 
-    let noWitTx = makeSignedTransaction [] txBody
-    lift (writeTxFileTextEnvelopeCddl eon txBodyOutFile noWitTx)
-      & onLeft (left . TxCmdWriteFileError)
+    let noWitTx = Api.makeSignedTransaction [] txBody
+    Api.lift (Api.writeTxFileTextEnvelopeCddl eon txBodyOutFile noWitTx)
+      & Api.onLeft (Api.left . TxCmdWriteFileError)
 
 runTxBuildRaw
   :: ()
@@ -1062,7 +1223,7 @@ runTxBuildRaw
   -> [Hash PaymentKey]
   -- ^ Required signers
   -> TxAuxScripts era
-  -> TxMetadataInEra era
+  -> Api.TxMetadataInEra era
   -> Maybe (LedgerProtocolParameters era)
   -> TxUpdateProposal era
   -> [(VotingProcedures era, Maybe (ScriptWitness WitCtxStake era))]
@@ -1117,7 +1278,7 @@ runTxBuildRaw
         proposals
         mCurrentTreasuryValueAndDonation
 
-    first TxCmdTxBodyError $ createAndValidateTransactionBody sbe txBodyContent
+    first TxCmdTxBodyError $ Api.createAndValidateTransactionBody sbe txBodyContent
 
 constructTxBodyContent
   :: ShelleyBasedEra era
@@ -1150,7 +1311,7 @@ constructTxBodyContent
   -> Coin
   -- ^ Tx fee
   -> TxAuxScripts era
-  -> TxMetadataInEra era
+  -> Api.TxMetadataInEra era
   -> TxUpdateProposal era
   -> [(VotingProcedures era, Maybe (ScriptWitness WitCtxStake era))]
   -> [(Proposal era, Maybe (ScriptWitness WitCtxStake era))]
@@ -1218,34 +1379,34 @@ constructTxBodyContent
           TxCmdNotSupportedInEraValidationError
           (CLI.validateTxTreasuryDonation sbe (snd <$> mCurrentTreasuryValueAndDonation))
       return $
-        shelleyBasedEraConstraints sbe $
-          ( defaultTxBodyContent sbe
-              & setTxIns (validateTxIns inputsAndMaybeScriptWits)
-              & setTxInsCollateral validatedCollateralTxIns
-              & setTxInsReference validatedRefInputs
-              & setTxOuts txouts
-              & setTxTotalCollateral validatedTotCollateral
-              & setTxReturnCollateral validatedRetCol
-              & setTxFee txFee
-              & setTxValidityLowerBound validatedLowerBound
-              & setTxValidityUpperBound mUpperBound
-              & setTxMetadata txMetadata
-              & setTxAuxScripts txAuxScripts
-              & setTxExtraKeyWits validatedReqSigners
-              & setTxProtocolParams (BuildTxWith $ LedgerProtocolParameters <$> mPparams)
-              & setTxWithdrawals (TxWithdrawals sbe $ map convertWithdrawals withdrawals)
-              & setTxCertificates (convertCertificates sbe certsAndMaybeScriptWits)
-              & setTxUpdateProposal txUpdateProposal
-              & setTxMintValue validatedMintValue
-              & setTxScriptValidity validatedTxScriptValidity
+        Api.shelleyBasedEraConstraints sbe $
+          ( Api.defaultTxBodyContent sbe
+              & Api.setTxIns (validateTxIns inputsAndMaybeScriptWits)
+              & Api.setTxInsCollateral validatedCollateralTxIns
+              & Api.setTxInsReference validatedRefInputs
+              & Api.setTxOuts txouts
+              & Api.setTxTotalCollateral validatedTotCollateral
+              & Api.setTxReturnCollateral validatedRetCol
+              & Api.setTxFee txFee
+              & Api.setTxValidityLowerBound validatedLowerBound
+              & Api.setTxValidityUpperBound mUpperBound
+              & Api.setTxMetadata txMetadata
+              & Api.setTxAuxScripts txAuxScripts
+              & Api.setTxExtraKeyWits validatedReqSigners
+              & Api.setTxProtocolParams (BuildTxWith $ LedgerProtocolParameters <$> mPparams)
+              & Api.setTxWithdrawals (TxWithdrawals sbe $ map convertWithdrawals withdrawals)
+              & Api.setTxCertificates (convertCertificates sbe certsAndMaybeScriptWits)
+              & Api.setTxUpdateProposal txUpdateProposal
+              & Api.setTxMintValue validatedMintValue
+              & Api.setTxScriptValidity validatedTxScriptValidity
           )
             { -- TODO: Create set* function for proposal procedures and voting procedures
               txProposalProcedures =
-                forShelleyBasedEraInEonMaybe sbe (`Featured` CLI.convToTxProposalProcedures proposals)
-            , txVotingProcedures = forShelleyBasedEraInEonMaybe sbe (`Featured` validatedVotingProcedures)
+                Api.forShelleyBasedEraInEonMaybe sbe (`Featured` CLI.convToTxProposalProcedures proposals)
+            , txVotingProcedures = Api.forShelleyBasedEraInEonMaybe sbe (`Featured` validatedVotingProcedures)
             }
-            & setTxCurrentTreasuryValue validatedCurrentTreasuryValue
-            & setTxTreasuryDonation validatedTreasuryDonation
+            & Api.setTxCurrentTreasuryValue validatedCurrentTreasuryValue
+            & Api.setTxTreasuryDonation validatedTreasuryDonation
    where
     convertWithdrawals
       :: (StakeAddress, Coin, Maybe (ScriptWitness WitCtxStake era))
@@ -1288,7 +1449,7 @@ runTxBuild
   -> [Hash PaymentKey]
   -- ^ Required signers
   -> TxAuxScripts era
-  -> TxMetadataInEra era
+  -> Api.TxMetadataInEra era
   -> TxUpdateProposal era
   -> Maybe Word
   -> [(VotingProcedures era, Maybe (ScriptWitness WitCtxStake era))]
@@ -1321,10 +1482,10 @@ runTxBuild
   votingProcedures
   proposals
   mCurrentTreasuryValueAndDonation =
-    shelleyBasedEraConstraints sbe $ do
+    Api.shelleyBasedEraConstraints sbe $ do
       -- TODO: All functions should be parameterized by ShelleyBasedEra
       -- as it's not possible to call this function with ByronEra
-      let era = toCardanoEra sbe
+      let era = Api.toCardanoEra sbe
           inputsThatRequireWitnessing = [input | (input, _) <- inputsAndMaybeScriptWits]
 
       let allReferenceInputs =
@@ -1346,13 +1507,13 @@ runTxBuild
               }
 
       AnyCardanoEra nodeEra <-
-        lift (executeLocalStateQueryExpr localNodeConnInfo Consensus.VolatileTip queryCurrentEra)
-          & onLeft (left . TxCmdQueryConvenienceError . AcqFailure)
-          & onLeft (left . TxCmdQueryConvenienceError . QceUnsupportedNtcVersion)
+        Api.lift (Api.executeLocalStateQueryExpr localNodeConnInfo Consensus.VolatileTip Api.queryCurrentEra)
+          & Api.onLeft (Api.left . TxCmdQueryConvenienceError . AcqFailure)
+          & Api.onLeft (Api.left . TxCmdQueryConvenienceError . QceUnsupportedNtcVersion)
 
       Refl <-
         testEquality era nodeEra
-          & hoistMaybe (TxCmdTxNodeEraMismatchError $ NodeEraMismatchError era nodeEra)
+          & Api.hoistMaybe (TxCmdTxNodeEraMismatchError $ NodeEraMismatchError era nodeEra)
 
       let certs =
             case convertCertificates sbe certsAndMaybeScriptWits of
@@ -1362,15 +1523,15 @@ runTxBuild
 -- use readProtocolParametersOrDie from ApiTest.hs
 -- also protocolParamMaxBlockExUnits and protocolParamMaxTxExUnits
       (txEraUtxo, pparams, eraHistory, systemStart, stakePools, stakeDelegDeposits, drepDelegDeposits, _) <-
-        lift
-          ( executeLocalStateQueryExpr localNodeConnInfo Consensus.VolatileTip $
-              queryStateForBalancedTx nodeEra allTxInputs certs
+        Api.lift
+          ( Api.executeLocalStateQueryExpr localNodeConnInfo Consensus.VolatileTip $
+              Api.queryStateForBalancedTx nodeEra allTxInputs certs
           )
-          & onLeft (left . TxCmdQueryConvenienceError . AcqFailure)
-          & onLeft (left . TxCmdQueryConvenienceError)
+          & Api.onLeft (Api.left . TxCmdQueryConvenienceError . AcqFailure)
+          & Api.onLeft (Api.left . TxCmdQueryConvenienceError)
 
       txBodyContent <-
-        hoistEither $
+        Api.hoistEither $
           constructTxBodyContent
             sbe
             mScriptValidity
@@ -1395,23 +1556,23 @@ runTxBuild
             proposals
             mCurrentTreasuryValueAndDonation
 
-      firstExceptT TxCmdTxInsDoNotExist
-        . hoistEither
-        $ txInsExistInUTxO allTxInputs txEraUtxo
-      firstExceptT TxCmdQueryNotScriptLocked
-        . hoistEither
-        $ notScriptLockedTxIns txinsc txEraUtxo
+      Api.firstExceptT TxCmdTxInsDoNotExist
+        . Api.hoistEither
+        $ Api.txInsExistInUTxO allTxInputs txEraUtxo
+      Api.firstExceptT TxCmdQueryNotScriptLocked
+        . Api.hoistEither
+        $ Api.notScriptLockedTxIns txinsc txEraUtxo
 
       cAddr <-
-        pure (anyAddressInEra era changeAddr)
-          & onLeft (error $ "runTxBuild: Byron address used: " <> show changeAddr) -- should this throw instead?
+        pure (Api.anyAddressInEra era changeAddr)
+          & Api.onLeft (error $ "runTxBuild: Byron address used: " <> show changeAddr) -- should this throw instead?
       balancedTxBody@(BalancedTxBody _ _ _ fee) <-
-        firstExceptT (TxCmdBalanceTxBody . AnyTxBodyErrorAutoBalance)
-          . hoistEither
-          $ makeTransactionBodyAutoBalance
+        Api.firstExceptT (TxCmdBalanceTxBody . AnyTxBodyErrorAutoBalance)
+          . Api.hoistEither
+          $ Api.makeTransactionBodyAutoBalance
             sbe
             systemStart
-            (toLedgerEpochInfo eraHistory)
+            (Api.toLedgerEpochInfo eraHistory)
             pparams
             stakePools
             stakeDelegDeposits
@@ -1421,7 +1582,7 @@ runTxBuild
             cAddr
             mOverrideWits
 
-      liftIO $ putStrLn $ "Estimated transaction fee: " <> (show fee :: String)
+      Api.liftIO $ putStrLn $ "Estimated transaction fee: " <> (show fee :: String)
 
       return balancedTxBody
 
@@ -1439,7 +1600,7 @@ convertCertificates sbe certsAndScriptWitnesses =
     :: (Certificate era, Maybe (ScriptWitness WitCtxStake era))
     -> Maybe (StakeCredential, Witness WitCtxStake era)
   convert (cert, mScriptWitnessFiles) = do
-    sCred <- selectStakeCredentialWitness cert
+    sCred <- Api.selectStakeCredentialWitness cert
     Just $ case mScriptWitnessFiles of
       Just sWit -> (sCred, ScriptWitness ScriptWitnessForStakeAddr sWit)
       Nothing -> (sCred, KeyWitness KeyWitnessForStakeAddr)
@@ -1455,14 +1616,14 @@ txFeatureMismatch
   -> TxFeature
   -> ExceptT TxCmdError m a
 txFeatureMismatch era feature =
-  hoistEither . Left $ TxCmdTxFeatureMismatch (anyCardanoEra era) feature
+  Api.hoistEither . Left $ TxCmdTxFeatureMismatch (Api.anyCardanoEra era) feature
 
 txFeatureMismatchPure
   :: CardanoEra era
   -> TxFeature
   -> Either TxCmdError a
 txFeatureMismatchPure era feature =
-  Left (TxCmdTxFeatureMismatch (anyCardanoEra era) feature)
+  Left (TxCmdTxFeatureMismatch (Api.anyCardanoEra era) feature)
 
 validateTxIns
   :: [(TxIn, Maybe (ScriptWitness WitCtxTxIn era))]
@@ -1485,8 +1646,8 @@ validateTxInsCollateral
   -> Either TxCmdError (TxInsCollateral era)
 validateTxInsCollateral _ [] = return TxInsCollateralNone
 validateTxInsCollateral era txins = do
-  forShelleyBasedEraInEonMaybe era (`TxInsCollateral` txins)
-    & maybe (txFeatureMismatchPure (toCardanoEra era) TxFeatureCollateral) Right
+  Api.forShelleyBasedEraInEonMaybe era (`TxInsCollateral` txins)
+    & maybe (txFeatureMismatchPure (Api.toCardanoEra era) TxFeatureCollateral) Right
 
 validateTxInsReference
   :: ShelleyBasedEra era
@@ -1494,8 +1655,8 @@ validateTxInsReference
   -> Either TxCmdError (TxInsReference BuildTx era)
 validateTxInsReference _ [] = return TxInsReferenceNone
 validateTxInsReference sbe allRefIns = do
-  forShelleyBasedEraInEonMaybe sbe (`TxInsReference` allRefIns)
-    & maybe (txFeatureMismatchPure (toCardanoEra sbe) TxFeatureReferenceInputs) Right
+  Api.forShelleyBasedEraInEonMaybe sbe (`TxInsReference` allRefIns)
+    & maybe (txFeatureMismatchPure (Api.toCardanoEra sbe) TxFeatureReferenceInputs) Right
 
 getAllReferenceInputs
   :: [(TxIn, Maybe (ScriptWitness WitCtxTxIn era))]
@@ -1546,13 +1707,13 @@ toAddressInAnyEra
   :: CardanoEra era
   -> AddressAny
   -> Either TxCmdError (AddressInEra era)
-toAddressInAnyEra era addrAny = runExcept $ do
+toAddressInAnyEra era addrAny = Api.runExcept $ do
   case addrAny of
     AddressByron bAddr -> pure (AddressInEra ByronAddressInAnyEra bAddr)
     AddressShelley sAddr -> do
       sbe <-
-        requireShelleyBasedEra era
-          & onNothing (txFeatureMismatch era TxFeatureShelleyAddresses)
+        Api.requireShelleyBasedEra era
+          & Api.onNothing (txFeatureMismatch era TxFeatureShelleyAddresses)
 
       pure (AddressInEra (ShelleyAddressInEra sbe) sAddr)
 
@@ -1561,7 +1722,7 @@ toAddressInShelleyBasedEra
   -> Address ShelleyAddr
   -> Either TxCmdError (AddressInEra era)
 toAddressInShelleyBasedEra sbe sAddr =
-  runExcept $
+  Api.runExcept $
     pure (AddressInEra (ShelleyAddressInEra sbe) sAddr)
 
 toTxOutValueInAnyEra
@@ -1569,12 +1730,12 @@ toTxOutValueInAnyEra
   -> Value
   -> Either TxCmdError (TxOutValue era)
 toTxOutValueInAnyEra era val =
-  caseShelleyToAllegraOrMaryEraOnwards
-    ( \_ -> case valueToLovelace val of
+  Api.caseShelleyToAllegraOrMaryEraOnwards
+    ( \_ -> case Api.valueToLovelace val of
         Just l -> return (TxOutValueShelleyBased era l)
-        Nothing -> txFeatureMismatchPure (toCardanoEra era) TxFeatureMultiAssetOutputs
+        Nothing -> txFeatureMismatchPure (Api.toCardanoEra era) TxFeatureMultiAssetOutputs
     )
-    (\w -> return (TxOutValueShelleyBased era (toLedgerValue w val)))
+    (\w -> return (TxOutValueShelleyBased era (Api.toLedgerValue w val)))
     era
 
 toTxOutValueInShelleyBasedEra
@@ -1582,12 +1743,12 @@ toTxOutValueInShelleyBasedEra
   -> Value
   -> Either TxCmdError (TxOutValue era)
 toTxOutValueInShelleyBasedEra sbe val =
-  caseShelleyToAllegraOrMaryEraOnwards
-    ( \_ -> case valueToLovelace val of
+  Api.caseShelleyToAllegraOrMaryEraOnwards
+    ( \_ -> case Api.valueToLovelace val of
         Just l -> return (TxOutValueShelleyBased sbe l)
-        Nothing -> txFeatureMismatchPure (toCardanoEra sbe) TxFeatureMultiAssetOutputs
+        Nothing -> txFeatureMismatchPure (Api.toCardanoEra sbe) TxFeatureMultiAssetOutputs
     )
-    (\w -> return (TxOutValueShelleyBased sbe (toLedgerValue w val)))
+    (\w -> return (TxOutValueShelleyBased sbe (Api.toLedgerValue w val)))
     sbe
 
 toTxOutInShelleyBasedEra
@@ -1595,20 +1756,20 @@ toTxOutInShelleyBasedEra
   -> TxOutShelleyBasedEra
   -> ExceptT TxCmdError IO (TxOut CtxTx era)
 toTxOutInShelleyBasedEra era (TxOutShelleyBasedEra addr' val' mDatumHash refScriptFp) = do
-  addr <- hoistEither $ toAddressInShelleyBasedEra era addr'
-  val <- hoistEither $ toTxOutValueInShelleyBasedEra era val'
+  addr <- Api.hoistEither $ toAddressInShelleyBasedEra era addr'
+  val <- Api.hoistEither $ toTxOutValueInShelleyBasedEra era val'
 
   datum <-
-    caseShelleyToMaryOrAlonzoEraOnwards
+    Api.caseShelleyToMaryOrAlonzoEraOnwards
       (const (pure TxOutDatumNone))
       (`toTxAlonzoDatum` mDatumHash)
       era
 
   refScript <-
-    inEonForEra
+    Api.inEonForEra
       (pure ReferenceScriptNone)
       (`getReferenceScript` refScriptFp)
-      (toCardanoEra era)
+      (Api.toCardanoEra era)
 
   pure $ TxOut addr val datum refScript
 
@@ -1616,8 +1777,8 @@ toTxOutByronEra
   :: TxOutAnyEra
   -> ExceptT TxCmdError IO (TxOut CtxTx ByronEra)
 toTxOutByronEra (TxOutAnyEra addr' val' _ _) = do
-  addr <- hoistEither $ toAddressInAnyEra ByronEra addr'
-  let ada = TxOutValueByron $ selectLovelace val'
+  addr <- Api.hoistEither $ toAddressInAnyEra ByronEra addr'
+  let ada = TxOutValueByron $ Api.selectLovelace val'
   pure $ TxOut addr ada TxOutDatumNone ReferenceScriptNone
 
 -- TODO: toTxOutInAnyEra eventually will not be needed because
@@ -1628,18 +1789,18 @@ toTxOutInAnyEra
   -> TxOutAnyEra
   -> ExceptT TxCmdError IO (TxOut CtxTx era)
 toTxOutInAnyEra era (TxOutAnyEra addr' val' mDatumHash refScriptFp) = do
-  let cEra = toCardanoEra era
-  addr <- hoistEither $ toAddressInAnyEra cEra addr'
-  val <- hoistEither $ toTxOutValueInAnyEra era val'
+  let cEra = Api.toCardanoEra era
+  addr <- Api.hoistEither $ toAddressInAnyEra cEra addr'
+  val <- Api.hoistEither $ toTxOutValueInAnyEra era val'
 
   datum <-
-    caseShelleyToMaryOrAlonzoEraOnwards
+    Api.caseShelleyToMaryOrAlonzoEraOnwards
       (const (pure TxOutDatumNone))
       (`toTxAlonzoDatum` mDatumHash)
       era
 
   refScript <-
-    caseShelleyToAlonzoOrBabbageEraOnwards
+    Api.caseShelleyToAlonzoOrBabbageEraOnwards
       (const (pure ReferenceScriptNone))
       (`getReferenceScript` refScriptFp)
       era
@@ -1652,7 +1813,7 @@ getReferenceScript
   -> ExceptT TxCmdError IO (ReferenceScript era)
 getReferenceScript w = \case
   ReferenceScriptAnyEraNone -> return ReferenceScriptNone
-  ReferenceScriptAnyEra fp -> ReferenceScript w <$> firstExceptT TxCmdScriptFileError (CLI.readFileScriptInAnyLang fp)
+  ReferenceScriptAnyEra fp -> ReferenceScript w <$> Api.firstExceptT TxCmdScriptFileError (CLI.readFileScriptInAnyLang fp)
 
 toTxAlonzoDatum
   :: ()
@@ -1664,15 +1825,15 @@ toTxAlonzoDatum supp cliDatum =
     TxOutDatumByNone -> pure TxOutDatumNone
     TxOutDatumByHashOnly h -> pure (TxOutDatumHash supp h)
     TxOutDatumByHashOf sDataOrFile -> do
-      sData <- firstExceptT TxCmdScriptDataError $ CLI.readScriptDataOrFile sDataOrFile
-      pure (TxOutDatumHash supp $ hashScriptDataBytes sData)
+      sData <- Api.firstExceptT TxCmdScriptDataError $ CLI.readScriptDataOrFile sDataOrFile
+      pure (TxOutDatumHash supp $ Api.hashScriptDataBytes sData)
     TxOutDatumByValue sDataOrFile -> do
-      sData <- firstExceptT TxCmdScriptDataError $ CLI.readScriptDataOrFile sDataOrFile
+      sData <- Api.firstExceptT TxCmdScriptDataError $ CLI.readScriptDataOrFile sDataOrFile
       pure (TxOutDatumInTx supp sData)
     TxOutInlineDatumByValue sDataOrFile -> do
-      let cEra = toCardanoEra supp
-      forEraInEon cEra (txFeatureMismatch cEra TxFeatureInlineDatums) $ \babbageOnwards -> do
-        sData <- firstExceptT TxCmdScriptDataError $ CLI.readScriptDataOrFile sDataOrFile
+      let cEra = Api.toCardanoEra supp
+      Api.forEraInEon cEra (txFeatureMismatch cEra TxFeatureInlineDatums) $ \babbageOnwards -> do
+        sData <- Api.firstExceptT TxCmdScriptDataError $ CLI.readScriptDataOrFile sDataOrFile
         pure $ TxOutDatumInline babbageOnwards sData
 
 -- TODO: Currently we specify the policyId with the '--mint' option on the cli
@@ -1686,16 +1847,16 @@ createTxMintValue
   -> (Value, [ScriptWitness WitCtxMint era])
   -> Either TxCmdError (TxMintValue BuildTx era)
 createTxMintValue era (val, scriptWitnesses) =
-  if List.null (valueToList val) && List.null scriptWitnesses
+  if List.null (Api.valueToList val) && List.null scriptWitnesses
     then return TxMintNone
     else do
-      caseShelleyToAllegraOrMaryEraOnwards
-        (const (txFeatureMismatchPure (toCardanoEra era) TxFeatureMintValue))
+      Api.caseShelleyToAllegraOrMaryEraOnwards
+        (const (txFeatureMismatchPure (Api.toCardanoEra era) TxFeatureMintValue))
         ( \w -> do
             -- The set of policy ids for which we need witnesses:
             let witnessesNeededSet :: Set PolicyId
                 witnessesNeededSet =
-                  Set.fromList [pid | (AssetId pid _, _) <- valueToList val]
+                  Set.fromList [pid | (AssetId pid _, _) <- Api.valueToList val]
 
             let witnessesProvidedMap :: Map PolicyId (ScriptWitness WitCtxMint era)
                 witnessesProvidedMap = Map.fromList $ gatherMintingWitnesses scriptWitnesses
@@ -1731,11 +1892,11 @@ createTxMintValue era (val, scriptWitnesses) =
 
 scriptWitnessPolicyId :: ScriptWitness witctx era -> Maybe PolicyId
 scriptWitnessPolicyId (SimpleScriptWitness _ (SScript script)) =
-  Just . scriptPolicyId $ SimpleScript script
+  Just . Api.scriptPolicyId $ SimpleScript script
 scriptWitnessPolicyId (SimpleScriptWitness _ (SReferenceScript _ mPid)) =
   PolicyId <$> mPid
 scriptWitnessPolicyId (PlutusScriptWitness _ plutusVersion (PScript script) _ _ _) =
-  Just . scriptPolicyId $ PlutusScript plutusVersion script
+  Just . Api.scriptPolicyId $ PlutusScript plutusVersion script
 scriptWitnessPolicyId (PlutusScriptWitness _ _ (PReferenceScript _ mPid) _ _ _) =
   PolicyId <$> mPid
 
@@ -1744,7 +1905,7 @@ readValueScriptWitnesses
   -> (Value, [ScriptWitnessFiles WitCtxMint])
   -> ExceptT TxCmdError IO (Value, [ScriptWitness WitCtxMint era])
 readValueScriptWitnesses era (v, sWitFiles) = do
-  sWits <- mapM (firstExceptT TxCmdScriptWitnessError . CLI.readScriptWitness era) sWitFiles
+  sWits <- mapM (Api.firstExceptT TxCmdScriptWitnessError . CLI.readScriptWitness era) sWitFiles
   return (v, sWits)
 
 -- ----------------------------------------------------------------------------
@@ -1763,15 +1924,15 @@ runTransactionSignCmd
     , outTxFile = outTxFile
     } = do
     sks <- Monad.forM witnessSigningData $ \d ->
-      lift (CLI.readWitnessSigningData d)
-        & onLeft (left . TxCmdReadWitnessSigningDataError)
+      Api.lift (CLI.readWitnessSigningData d)
+        & Api.onLeft (Api.left . TxCmdReadWitnessSigningDataError)
 
     let (sksByron, sksShelley) = partitionSomeWitnesses $ map CLI.categoriseSomeSigningWitness sks
 
     case txOrTxBody of
       InputTxFile (File inputTxFilePath) -> do
-        inputTxFile <- liftIO $ CLI.fileOrPipe inputTxFilePath
-        anyTx <- lift (CLI.readFileTx inputTxFile) & onLeft (left . TxCmdTextEnvCddlError)
+        inputTxFile <- Api.liftIO $ CLI.fileOrPipe inputTxFilePath
+        anyTx <- Api.lift (CLI.readFileTx inputTxFile) & Api.onLeft (Api.left . TxCmdTextEnvCddlError)
 
         InAnyShelleyBasedEra sbe tx <- pure anyTx
 
@@ -1779,18 +1940,18 @@ runTransactionSignCmd
 
         byronWitnesses <-
           pure (mkShelleyBootstrapWitnesses sbe mNetworkId txbody sksByron)
-            & onLeft (left . TxCmdBootstrapWitnessError)
+            & Api.onLeft (Api.left . TxCmdBootstrapWitnessError)
 
-        let newShelleyKeyWits = map (makeShelleyKeyWitness sbe txbody) sksShelley
+        let newShelleyKeyWits = map (Api.makeShelleyKeyWitness sbe txbody) sksShelley
             allKeyWits = existingTxKeyWits ++ newShelleyKeyWits ++ byronWitnesses
-            signedTx = makeSignedTransaction allKeyWits txbody
+            signedTx = Api.makeSignedTransaction allKeyWits txbody
 
-        lift (writeTxFileTextEnvelopeCddl sbe outTxFile signedTx)
-          & onLeft (left . TxCmdWriteFileError)
+        Api.lift (Api.writeTxFileTextEnvelopeCddl sbe outTxFile signedTx)
+          & Api.onLeft (Api.left . TxCmdWriteFileError)
       InputTxBodyFile (File txbodyFilePath) -> do
-        txbodyFile <- liftIO $ CLI.fileOrPipe txbodyFilePath
+        txbodyFile <- Api.liftIO $ CLI.fileOrPipe txbodyFilePath
         IncompleteCddlTxBody { .. } <-
-          firstExceptT TxCmdTextEnvCddlError . newExceptT $
+          Api.firstExceptT TxCmdTextEnvCddlError . Api.newExceptT $
             CLI.readFileTxBody txbodyFile
 
         case unIncompleteCddlTxBody of
@@ -1799,15 +1960,15 @@ runTransactionSignCmd
             -- Byron witnesses require the network ID. This can either be provided
             -- directly or derived from a provided Byron address.
             byronWitnesses <-
-              firstExceptT TxCmdBootstrapWitnessError
-                . hoistEither
+              Api.firstExceptT TxCmdBootstrapWitnessError
+                . Api.hoistEither
                 $ mkShelleyBootstrapWitnesses sbe mNetworkId txbody sksByron
 
-            let shelleyKeyWitnesses = map (makeShelleyKeyWitness sbe txbody) sksShelley
-                tx = makeSignedTransaction (byronWitnesses ++ shelleyKeyWitnesses) txbody
+            let shelleyKeyWitnesses = map (Api.makeShelleyKeyWitness sbe txbody) sksShelley
+                tx = Api.makeSignedTransaction (byronWitnesses ++ shelleyKeyWitnesses) txbody
 
-            lift (writeTxFileTextEnvelopeCddl sbe outTxFile tx)
-              & onLeft (left . TxCmdWriteFileError)
+            Api.lift (Api.writeTxFileTextEnvelopeCddl sbe outTxFile tx)
+              & Api.onLeft (Api.left . TxCmdWriteFileError)
 
 -- ----------------------------------------------------------------------------
 -- Transaction submission
@@ -1824,9 +1985,9 @@ runTransactionSubmitCmd
     , networkId
     , txFile
     } = do
-    txFileOrPipe <- liftIO $ CLI.fileOrPipe txFile
+    txFileOrPipe <- Api.liftIO $ CLI.fileOrPipe txFile
     InAnyShelleyBasedEra era tx <-
-      lift (CLI.readFileTx txFileOrPipe) & onLeft (left . TxCmdTextEnvCddlError)
+      Api.lift (CLI.readFileTx txFileOrPipe) & Api.onLeft (Api.left . TxCmdTextEnvCddlError)
     let txInMode = TxInMode era tx
         localNodeConnInfo =
           LocalNodeConnectInfo
@@ -1835,13 +1996,13 @@ runTransactionSubmitCmd
             , localNodeSocketPath = nodeSocketPath
             }
 
-    res <- liftIO $ submitTxToNodeLocal localNodeConnInfo txInMode
+    res <- Api.liftIO $ Api.submitTxToNodeLocal localNodeConnInfo txInMode
     case res of
-      Net.Tx.SubmitSuccess -> liftIO $ Text.putStrLn "Transaction successfully submitted."
+      Net.Tx.SubmitSuccess -> Api.liftIO $ Text.putStrLn "Transaction successfully submitted."
       Net.Tx.SubmitFail reason ->
         case reason of
-          TxValidationErrorInCardanoMode err -> left . TxCmdTxSubmitError . Text.pack $ show err
-          TxValidationEraMismatch mismatchErr -> left $ TxCmdTxSubmitErrorEraMismatch mismatchErr
+          TxValidationErrorInCardanoMode err -> Api.left . TxCmdTxSubmitError . Text.pack $ show err
+          TxValidationEraMismatch mismatchErr -> Api.left $ TxCmdTxSubmitErrorEraMismatch mismatchErr
 
 -- ----------------------------------------------------------------------------
 -- Transaction fee calculation
@@ -1861,9 +2022,9 @@ runTransactionCalculateMinFeeCmd
     -- , outputFormat
     -- , outFile
     } = do
-    txbodyFile <- liftIO $ CLI.fileOrPipe txbodyFilePath
+    txbodyFile <- Api.liftIO $ CLI.fileOrPipe txbodyFilePath
     IncompleteCddlTxBody { .. } <-
-      firstExceptT TxCmdTextEnvCddlError . newExceptT $
+      Api.firstExceptT TxCmdTextEnvCddlError . Api.newExceptT $
         CLI.readFileTxBody txbodyFile
 
     let nShelleyKeyWitW32 = fromIntegral nShelleyKeyWitnesses
@@ -1871,13 +2032,13 @@ runTransactionCalculateMinFeeCmd
     InAnyShelleyBasedEra sbe txbody <- pure unIncompleteCddlTxBody
 
     lpparams <-
-      firstExceptT TxCmdProtocolParamsError $
+      Api.firstExceptT TxCmdProtocolParamsError $
         CLI.readProtocolParameters sbe protocolParamsFile
 
-    let shelleyfee = evaluateTransactionFee sbe lpparams txbody nShelleyKeyWitW32 0 sReferenceScript
+    let shelleyfee = Api.evaluateTransactionFee sbe lpparams txbody nShelleyKeyWitW32 0 sReferenceScript
 
     let byronfee =
-          shelleyBasedEraConstraints sbe $
+          Api.shelleyBasedEraConstraints sbe $
             calculateByronWitnessFees (lpparams ^. Ledger.ppMinFeeAL) nByronKeyWitnesses
 
     let Coin fee = shelleyfee + byronfee
@@ -1888,21 +2049,21 @@ runTransactionCalculateMinFeeCmd
     -- link against the new cardano-cli.
     -- This whole code block can't really be used until the update works.
     -- What used to be there before the above was:
-    liftIO $ Text.putStrLn textToWrite
+    Api.liftIO $ Text.putStrLn textToWrite
     {-
     case (newOutputFormat outputFormat outFile, outFile) of
       (OutputFormatText, Nothing) ->
-        liftIO $ Text.putStrLn textToWrite
+        Api.liftIO $ Text.putStrLn textToWrite
       (OutputFormatText, Just file) ->
-        firstExceptT TxCmdWriteFileError . newExceptT $ writeTextFile file textToWrite
+        Api.firstExceptT TxCmdWriteFileError . Api.newExceptT $ writeTextFile file textToWrite
       (OutputFormatJson, Nothing) ->
-        liftIO $ LBS8.putStrLn jsonToWrite
+        Api.liftIO $ LBS8.putStrLn jsonToWrite
       (OutputFormatJson, Just file) ->
-        firstExceptT TxCmdWriteFileError . newExceptT $ writeLazyByteStringFile file jsonToWrite
+        Api.firstExceptT TxCmdWriteFileError . Api.newExceptT $ writeLazyByteStringFile file jsonToWrite
     -}
 
 -- Extra logic to handle byron witnesses.
--- TODO: move this to Cardano.API.Fee.evaluateTransactionFee.
+-- TODO: move this to Cardano.API.Fee.Api.evaluateTransactionFee.
 calculateByronWitnessFees
   :: ()
   => Coin
@@ -1958,11 +2119,11 @@ runTransactionCalculateMinValueCmd
     , protocolParamsFile
     , txOut
     } = do
-    pp <- firstExceptT TxCmdProtocolParamsError (CLI.readProtocolParameters eon protocolParamsFile)
+    pp <- Api.firstExceptT TxCmdProtocolParamsError (CLI.readProtocolParameters eon protocolParamsFile)
     out <- toTxOutInShelleyBasedEra eon txOut
 
-    let minValue = calculateMinimumUTxO eon out pp
-    liftIO . IO.print $ minValue
+    let minValue = Api.calculateMinimumUTxO eon out pp
+    Api.liftIO . IO.print $ minValue
 
 runTransactionPolicyIdCmd
   :: ()
@@ -1973,9 +2134,9 @@ runTransactionPolicyIdCmd
     { scriptFile = File sFile
     } = do
     ScriptInAnyLang _ script <-
-      firstExceptT TxCmdScriptFileError $
+      Api.firstExceptT TxCmdScriptFileError $
         CLI.readFileScriptInAnyLang sFile
-    liftIO . Text.putStrLn . serialiseToRawBytesHexText $ hashScript script
+    Api.liftIO . Text.putStrLn . Api.serialiseToRawBytesHexText $ Api.hashScript script
 
 partitionSomeWitnesses
   :: [ByronOrShelleyWitness]
@@ -2006,9 +2167,9 @@ mkShelleyBootstrapWitness
 mkShelleyBootstrapWitness _ Nothing _ (ShelleyBootstrapWitnessSigningKeyData _ Nothing) =
   Left MissingNetworkIdOrByronAddressError
 mkShelleyBootstrapWitness sbe (Just nw) txBody (ShelleyBootstrapWitnessSigningKeyData skey Nothing) =
-  Right $ makeShelleyBootstrapWitness sbe (Byron.WitnessNetworkId nw) txBody skey
+  Right $ Api.makeShelleyBootstrapWitness sbe (Byron.WitnessNetworkId nw) txBody skey
 mkShelleyBootstrapWitness sbe _ txBody (ShelleyBootstrapWitnessSigningKeyData skey (Just addr)) =
-  Right $ makeShelleyBootstrapWitness sbe (Byron.WitnessByronAddress addr) txBody skey
+  Right $ Api.makeShelleyBootstrapWitness sbe (Byron.WitnessByronAddress addr) txBody skey
 
 -- | Attempt to construct Shelley bootstrap witnesses until an error is
 -- encountered.
@@ -2034,8 +2195,8 @@ runTransactionHashScriptDataCmd
   Cmd.TransactionHashScriptDataCmdArgs
     { scriptDataOrFile
     } = do
-    d <- firstExceptT TxCmdScriptDataError $ CLI.readScriptDataOrFile scriptDataOrFile
-    liftIO $ BS8.putStrLn $ serialiseToRawBytesHex (hashScriptDataBytes d)
+    d <- Api.firstExceptT TxCmdScriptDataError $ CLI.readScriptDataOrFile scriptDataOrFile
+    Api.liftIO $ BS8.putStrLn $ Api.serialiseToRawBytesHex (Api.hashScriptDataBytes d)
 
 runTransactionTxIdCmd
   :: ()
@@ -2048,17 +2209,17 @@ runTransactionTxIdCmd
     InAnyShelleyBasedEra _era txbody <-
       case inputTxBodyOrTxFile of
         InputTxBodyFile (File txbodyFilePath) -> do
-          txbodyFile <- liftIO $ CLI.fileOrPipe txbodyFilePath
+          txbodyFile <- Api.liftIO $ CLI.fileOrPipe txbodyFilePath
           IncompleteCddlTxBody { .. } <-
-            firstExceptT TxCmdTextEnvCddlError . newExceptT $
+            Api.firstExceptT TxCmdTextEnvCddlError . Api.newExceptT $
               CLI.readFileTxBody txbodyFile
           pure unIncompleteCddlTxBody
         InputTxFile (File txFilePath) -> do
-          txFile <- liftIO $ CLI.fileOrPipe txFilePath
-          InAnyShelleyBasedEra era tx <- lift (CLI.readFileTx txFile) & onLeft (left . TxCmdTextEnvCddlError)
-          return . InAnyShelleyBasedEra era $ getTxBody tx
+          txFile <- Api.liftIO $ CLI.fileOrPipe txFilePath
+          InAnyShelleyBasedEra era tx <- Api.lift (CLI.readFileTx txFile) & Api.onLeft (Api.left . TxCmdTextEnvCddlError)
+          return . InAnyShelleyBasedEra era $ Api.getTxBody tx
 
-    liftIO $ BS8.putStrLn $ serialiseToRawBytesHex (getTxId txbody)
+    Api.liftIO $ BS8.putStrLn $ Api.serialiseToRawBytesHex (Api.getTxId txbody)
 
 runTransactionViewCmd
   :: ()
@@ -2072,26 +2233,26 @@ runTransactionViewCmd
     } =
     case inputTxBodyOrTxFile of
       InputTxBodyFile (File txbodyFilePath) -> do
-        txbodyFile <- liftIO $ CLI.fileOrPipe txbodyFilePath
+        txbodyFile <- Api.liftIO $ CLI.fileOrPipe txbodyFilePath
         IncompleteCddlTxBody { unIncompleteCddlTxBody = InAnyShelleyBasedEra era txbody } <-
-          firstExceptT TxCmdTextEnvCddlError . newExceptT $
+          Api.firstExceptT TxCmdTextEnvCddlError . Api.newExceptT $
             CLI.readFileTxBody txbodyFile
         -- Why are we differentiating between a transaction body and a transaction?
-        -- In the case of a transaction body, we /could/ simply call @makeSignedTransaction []@
+        -- In the case of a transaction body, we /could/ simply call @Api.makeSignedTransaction []@
         -- to get a transaction which would allow us to reuse friendlyTxBS. However,
         -- this would mean that we'd have an empty list of witnesses mentioned in the output, which
         -- is arguably not part of the transaction body.
-        firstExceptT TxCmdWriteFileError . newExceptT $
+        Api.firstExceptT TxCmdWriteFileError . Api.newExceptT $
           case outputFormat of
-            ViewOutputFormatYaml -> friendlyTxBody FriendlyYaml mOutFile (toCardanoEra era) txbody
-            ViewOutputFormatJson -> friendlyTxBody FriendlyJson mOutFile (toCardanoEra era) txbody
+            ViewOutputFormatYaml -> friendlyTxBody FriendlyYaml mOutFile (Api.toCardanoEra era) txbody
+            ViewOutputFormatJson -> friendlyTxBody FriendlyJson mOutFile (Api.toCardanoEra era) txbody
       InputTxFile (File txFilePath) -> do
-        txFile <- liftIO $ CLI.fileOrPipe txFilePath
-        InAnyShelleyBasedEra era tx <- lift (CLI.readFileTx txFile) & onLeft (left . TxCmdTextEnvCddlError)
-        firstExceptT TxCmdWriteFileError . newExceptT $
+        txFile <- Api.liftIO $ CLI.fileOrPipe txFilePath
+        InAnyShelleyBasedEra era tx <- Api.lift (CLI.readFileTx txFile) & Api.onLeft (Api.left . TxCmdTextEnvCddlError)
+        Api.firstExceptT TxCmdWriteFileError . Api.newExceptT $
           case outputFormat of
-            ViewOutputFormatYaml -> friendlyTx FriendlyYaml mOutFile (toCardanoEra era) tx
-            ViewOutputFormatJson -> friendlyTx FriendlyJson mOutFile (toCardanoEra era) tx
+            ViewOutputFormatYaml -> friendlyTx FriendlyYaml mOutFile (Api.toCardanoEra era) tx
+            ViewOutputFormatJson -> friendlyTx FriendlyJson mOutFile (Api.toCardanoEra era) tx
 
 -- ----------------------------------------------------------------------------
 -- Witness commands
@@ -2108,27 +2269,27 @@ runTransactionWitnessCmd
     , mNetworkId
     , outFile
     } = do
-    txbodyFile <- liftIO $ CLI.fileOrPipe txbodyFilePath
+    txbodyFile <- Api.liftIO $ CLI.fileOrPipe txbodyFilePath
     IncompleteCddlTxBody { unIncompleteCddlTxBody = InAnyShelleyBasedEra sbe txbody } <-
-      firstExceptT TxCmdTextEnvCddlError . newExceptT $
+      Api.firstExceptT TxCmdTextEnvCddlError . Api.newExceptT $
         CLI.readFileTxBody txbodyFile
     someWit <-
-      firstExceptT TxCmdReadWitnessSigningDataError
-        . newExceptT
+      Api.firstExceptT TxCmdReadWitnessSigningDataError
+        . Api.newExceptT
         $ CLI.readWitnessSigningData witnessSigningData
     witness <-
       case CLI.categoriseSomeSigningWitness someWit :: ByronOrShelleyWitness of
         -- Byron witnesses require the network ID. This can either be provided
         -- directly or derived from a provided Byron address.
         AByronWitness bootstrapWitData ->
-          firstExceptT TxCmdBootstrapWitnessError
-            . hoistEither
+          Api.firstExceptT TxCmdBootstrapWitnessError
+            . Api.hoistEither
             $ mkShelleyBootstrapWitness sbe mNetworkId txbody bootstrapWitData
         AShelleyKeyWitness skShelley ->
-          pure $ makeShelleyKeyWitness sbe txbody skShelley
+          pure $ Api.makeShelleyKeyWitness sbe txbody skShelley
 
-    firstExceptT TxCmdWriteFileError . newExceptT $
-      writeTxWitnessFileTextEnvelopeCddl sbe outFile witness
+    Api.firstExceptT TxCmdWriteFileError . Api.newExceptT $
+      Api.writeTxWitnessFileTextEnvelopeCddl sbe outFile witness
 
 runTransactionSignWitnessCmd
   :: ()
@@ -2140,26 +2301,26 @@ runTransactionSignWitnessCmd
     , witnessFiles = witnessFiles
     , outFile = outFile
     } = do
-    txbodyFile <- liftIO $ CLI.fileOrPipe txbodyFilePath
-    IncompleteCddlTxBody { unIncompleteCddlTxBody = InAnyShelleyBasedEra era txbody } <- lift (CLI.readFileTxBody txbodyFile) & onLeft (left . TxCmdTextEnvCddlError)
+    txbodyFile <- Api.liftIO $ CLI.fileOrPipe txbodyFilePath
+    IncompleteCddlTxBody { unIncompleteCddlTxBody = InAnyShelleyBasedEra era txbody } <- Api.lift (CLI.readFileTxBody txbodyFile) & Api.onLeft (Api.left . TxCmdTextEnvCddlError)
     -- TODO: Left off here. Remember we were never reading byron key witnesses anyways!
     witnesses <-
       sequence
         [ do
             InAnyShelleyBasedEra era' witness <-
-              lift (CLI.readFileTxKeyWitness file) & onLeft (left . TxCmdCddlWitnessError)
+              Api.lift (CLI.readFileTxKeyWitness file) & Api.onLeft (Api.left . TxCmdCddlWitnessError)
 
             case testEquality era era' of
               Nothing ->
-                left $
+                Api.left $
                   TxCmdWitnessEraMismatch
-                    (AnyCardanoEra $ toCardanoEra era)
-                    (AnyCardanoEra $ toCardanoEra era')
+                    (AnyCardanoEra $ Api.toCardanoEra era)
+                    (AnyCardanoEra $ Api.toCardanoEra era')
                     witnessFile
               Just Refl -> return witness
         | witnessFile@(WitnessFile file) <- witnessFiles
         ]
 
-    let tx = makeSignedTransaction witnesses txbody
+    let tx = Api.makeSignedTransaction witnesses txbody
 
-    lift (writeTxFileTextEnvelopeCddl era outFile tx) & onLeft (left . TxCmdWriteFileError)
+    Api.lift (Api.writeTxFileTextEnvelopeCddl era outFile tx) & Api.onLeft (Api.left . TxCmdWriteFileError)

--- a/bench/tx-generator/src/Cardano/TxGenerator/Setup/NixService.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Setup/NixService.hs
@@ -53,6 +53,7 @@ data NixServiceOptions = NixServiceOptions {
   , _nix_era              :: AnyCardanoEra
   , _nix_plutus           :: Maybe TxGenPlutusParams
   , _nix_keepalive        :: Maybe Integer
+  , _nix_drep_voting      :: Maybe Bool
   , _nix_nodeConfigFile       :: Maybe FilePath
   , _nix_cardanoTracerSocket  :: Maybe FilePath
   , _nix_sigKey               :: SigningKeyFile In

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -25,7 +25,7 @@ common with-library
   -- This is the inverse to the "buildable" GHC version constraint in plutus-scripts-bench.
   -- It makes sure, we only depend on that package if it is buildable.
   -- The tx-generator will fall back to pre-serialized Plutus scripts if this package is not present.
-  if !(impl(ghc <9.6) || impl(ghc >=9.7))
+  if !(impl(ghc <9.6) || impl(ghc >=9.9))
     build-depends:      plutus-scripts-bench ^>= 1.0.4
     cpp-options:        -DWITH_LIBRARY
 
@@ -117,6 +117,7 @@ library
                       , cardano-ledger-alonzo
                       , cardano-ledger-api
                       , cardano-ledger-byron
+                      , cardano-ledger-conway
                       , cardano-ledger-core
                       , cardano-node
                       , cardano-prelude

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -79,6 +79,7 @@ library
                         Cardano.TxGenerator.FundQueue
                         Cardano.TxGenerator.Genesis
                         Cardano.TxGenerator.PureExample
+                        Cardano.TxGenerator.GovExample
                         Cardano.TxGenerator.Script.Types
                         Cardano.TxGenerator.Setup.NixService
                         Cardano.TxGenerator.Setup.NodeConfig

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   tx-generator
-version:                2.14.1
+version:                2.14.2
 synopsis:               A transaction workload generator for Cardano clusters
 description:            A transaction workload generator for Cardano clusters.
 category:               Cardano,
@@ -25,7 +25,7 @@ common with-library
   -- This is the inverse to the "buildable" GHC version constraint in plutus-scripts-bench.
   -- It makes sure, we only depend on that package if it is buildable.
   -- The tx-generator will fall back to pre-serialized Plutus scripts if this package is not present.
-  if !(impl(ghc <9.6) || impl(ghc >=9.9))
+  if !(impl(ghc <9.6) || impl(ghc >=9.7))
     build-depends:      plutus-scripts-bench ^>= 1.0.4
     cpp-options:        -DWITH_LIBRARY
 
@@ -131,6 +131,7 @@ library
                       , generic-monoid
                       , ghc-prim
                       , io-classes
+                      , microlens >= 0.4.13.1
                       , mtl
                       , network
                       , network-mux

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -125,6 +125,7 @@ library
                       , cborg >= 0.2.2 && < 0.3
                       , containers
                       , constraints-extras
+                      , data-default-class
                       , dlist
                       , extra
                       , formatting

--- a/nix/nixos/tx-generator-service.nix
+++ b/nix/nixos/tx-generator-service.nix
@@ -99,6 +99,8 @@ in pkgs.commonLib.defServiceModule
           redeemer            = mayOpt attrs "Plutus script redeemer.";
         };
 
+        drep_voting           = mayOpt bool "Activate DRep voting workload (mutually excl. with plutus)";
+
         # Overrides the usage of Nix Store paths by default.
         plutusRedeemerFile = mayOpt str "Plutus redeemer file path.";
         plutusDatumFile    = mayOpt str "Plutus datum file path.";

--- a/nix/workbench/genesis/genesis.sh
+++ b/nix/workbench/genesis/genesis.sh
@@ -693,8 +693,14 @@ genesis-create-testnet-data() {
     info genesis "removing delegator keys."
     rm "$dir/stake-delegators" -rf
 
-    info genesis "removing dreps keys."
-    rm "$dir"/drep-keys -rf
+    local is_voting
+    is_voting=$(jq --raw-output '.generator.drep_voting' "$profile_json")
+    if [[ "$is_voting" == "true" ]];
+    then info genesis "voting workload specified - skipping deletion of DRep keys"
+    else
+      info genesis "removing dreps keys."
+      rm "$dir"/drep-keys -rf
+    fi
 
     info genesis "moving keys"
     Massage_the_key_file_layout_to_match_AWS "$profile_json" "$node_specs" "$dir"

--- a/nix/workbench/profile/prof1-variants.jq
+++ b/nix/workbench/profile/prof1-variants.jq
@@ -427,6 +427,14 @@ def all_profile_variants:
       }
     }) as $plutus_base
   |
+    ({ extra_desc: "with DRep voting workload"
+    , generator:
+      { inputs_per_tx:                  1
+      , outputs_per_tx:                 1
+      , drep_voting:                    true
+      }
+    }) as $voting_base
+  |
    ({ generator:
       { plutus:
           { type:                       "LimitSaturationLoop"
@@ -1397,6 +1405,11 @@ def all_profile_variants:
     }
   , $scenario_chainsync * $chaindb_early_alonzo * $p2p *
     { name: "chainsync-early-alonzo-p2p"
+    }
+
+  ## development profile for voting workload: PV9, Conways costmodel, 10 DReps injected
+  , $cibench_base * $voting_base * $double_plus_tps_saturation_plutus * $costmodel_v9_preview * $dreps_tiny *
+    { name: "development-voting"
     }
 
   ## Last, but not least, the profile used by "nix-shell -A devops":


### PR DESCRIPTION
# Description

This passes -j options down from MAKEFLAGS down to nix and cabal in order to help with parallel builds. There could be some tweaking depending on how people want the semantics to be e.g. not parallelising when JOBS is unset vs. passing some sort of value etc. It's all easy enough. It's a little less to carry around in terms of things to git cherry-pick. I threw ERA=coay into the Makefile, too. 

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
I don't think CI uses the Makefile, so this likely doesn't affect it. 
