### PR TITLE
span-calculation: comment 85% CPU span calculation

### DIFF
--- a/bench/locli/src/Cardano/Analysis/API/Chain.hs
+++ b/bench/locli/src/Cardano/Analysis/API/Chain.hs
@@ -40,6 +40,9 @@ slotStart Genesis{..} =
   . fromIntegral
   . unSlotNo
 
+-- | `impliedSlot` calculates slot numbers from timestamps and genesis
+--   parameters. The fields `systemStart` time and `slotLength` are
+--   both fields of the `Genesis` record.
 impliedSlot :: Genesis -> UTCTime -> SlotNo
 impliedSlot Genesis{..} =
   SlotNo

--- a/bench/locli/src/Cardano/Render.hs
+++ b/bench/locli/src/Cardano/Render.hs
@@ -245,6 +245,9 @@ renderProfilingData rc a flt pd =
      , fDescription = peSrcLoc pe
      }
 
+-- | `renderTimelineWithClass` and `renderTimeline` output textual
+--   representations of timelines for postprocessing with ede, em, and
+--   other such tools for producing benchmark reports.
 renderTimelineWithClass :: forall (a :: Type). TimelineFields a => (Field ISelect I a -> Bool) -> RenderConfig -> Anchor -> [TimelineComments a] -> [a] -> [Text]
 renderTimelineWithClass flt = renderTimeline (filter flt timelineFields) rtCommentary
 

--- a/bench/locli/src/Cardano/Util.hs
+++ b/bench/locli/src/Cardano/Util.hs
@@ -133,6 +133,9 @@ mapSMaybeFB cons f x next = case f x of
   SNothing -> next
   SJust r -> cons r next
 
+-- | `mapConcurrentlyPure` mostly fully forces the list elements
+--   produced in parallel. `evaluate` seems to have mostly to do with
+--   exceptions.
 mapConcurrentlyPure :: NFData b => (a -> b) -> [a] -> IO [b]
 mapConcurrentlyPure f =
   mapConcurrently
@@ -178,6 +181,8 @@ replaceExtension :: FilePath -> String -> FilePath
 replaceExtension f new = F.dropExtension f <> "." <> new
 
 
+-- | `spans` creates a list of `Vector` where each list element is all
+--   of the list elements comprising a span put into a `Vector`.
 spans :: forall a. (a -> Bool) -> [a] -> [Vector a]
 spans f = go []
  where


### PR DESCRIPTION
# Description
Anomalies were seen with 85% CPU span calculations. This is at least trying to figure out what's going on and explain it to everyone else. That said, it appears the trouble is most likely in emitting the traces, given what Micha just spotted instantly upon looking at it today. At the very least, the audit of the reporting calculations produced some comments even if it didn't find the bug.

This consists exclusively of adding comments to the code. There should be no runtime effects. At most I might have to fix up some new haddock warnings.

This was documentation as a by-product of an auditing/debugging effort.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
This consists exclusively of adding comments, so it might at worst trigger some new haddock warnings. I'll fix whatever of those crops up, too, of course.