### PR TITLE
do not merge - for testing txsubmission initial delay

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -65,3 +65,13 @@ allow-newer: katip:Win32
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
+
+source-repository-package
+    type: git
+    location: https://github.com/IntersectMBO/ouroboros-network
+    tag: 539fee242bfb7847c68b77b29c9afc4830c6ba4b
+    subdir: ouroboros-network
+            ouroboros-network-api
+            ouroboros-network-framework
+            ouroboros-network-protocols
+    --sha256: sha256-3Mr+aqjRWEHay53UZN1w6cmG5nD03WasgyhIpT1OKcM=


### PR DESCRIPTION
# Description

Test branch with o-n patch that includes initial delay for node to node tx submission.

A build flag txsubmission-delay determines whether the initial request for transactions is delayed or not. By default, the flag is  True and delay is present. Disable the flag to turn off the delay.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
