### PR TITLE
cardano-testnet: make call to query stake-address-info a golden test

### DIFF
--- a/cardano-testnet/test/cardano-testnet-test/files/golden/queries/stakeAddressInfoOut.json
+++ b/cardano-testnet/test/cardano-testnet-test/files/golden/queries/stakeAddressInfoOut.json
@@ -1,0 +1,9 @@
+[
+    {
+        "address": "<redacted>",
+        "delegationDeposit": 0,
+        "rewardAccountBalance": 0,
+        "stakeDelegation": "<redacted>",
+        "voteDelegation": "<redacted>"
+    }
+]


### PR DESCRIPTION
# Description

* Keep track of the output of `query stake-address-info` with a golden file
* Will help check that https://github.com/IntersectMBO/cardano-cli/issues/592 is properly done

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] New tests are added if needed and existing tests are updated.
- [X] Self-reviewed the diff