### PR TITLE
Test a version of haskell.nix using cabal unit IDs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -485,43 +485,6 @@
         "type": "github"
       }
     },
-    "ghc910X": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1714520650,
-        "narHash": "sha256-4uz6RA1hRr0RheGNDM49a/B3jszqNNU8iHIow4mSyso=",
-        "ref": "ghc-9.10",
-        "rev": "2c6375b9a804ac7fca1e82eb6fcfc8594c67c5f5",
-        "revCount": 62663,
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      },
-      "original": {
-        "ref": "ghc-9.10",
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      }
-    },
-    "ghc911": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1714817013,
-        "narHash": "sha256-m2je4UvWfkgepMeUIiXHMwE6W+iVfUY38VDGkMzjCcc=",
-        "ref": "refs/heads/master",
-        "rev": "fc24c5cf6c62ca9e3c8d236656e139676df65034",
-        "revCount": 62816,
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      },
-      "original": {
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      }
-    },
     "gomod2nix": {
       "inputs": {
         "nixpkgs": "nixpkgs",
@@ -566,8 +529,6 @@
         "cardano-shell": "cardano-shell",
         "flake-compat": "flake-compat_3",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
-        "ghc910X": "ghc910X",
-        "ghc911": "ghc911",
         "hackage": [
           "hackageNix"
         ],
@@ -594,16 +555,17 @@
         "nixpkgs-2211": "nixpkgs-2211",
         "nixpkgs-2305": "nixpkgs-2305",
         "nixpkgs-2311": "nixpkgs-2311",
+        "nixpkgs-2405": "nixpkgs-2405",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1718797200,
-        "narHash": "sha256-ueFxTuZrQ3ZT/Fj5sSeUWlqKa4+OkUU1xW0E+q/XTfw=",
+        "lastModified": 1725927021,
+        "narHash": "sha256-wEatXUV9CL3VU5JdX7d1FN6GY/Vy14n+wJUQ/cRvm2A=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "cb139fa956158397aa398186bb32dd26f7318784",
+        "rev": "4b6ad33f96680917244d8396adb34ba89811750f",
         "type": "github"
       },
       "original": {
@@ -790,7 +752,7 @@
     "hls-2.9": {
       "flake": false,
       "locked": {
-        "lastModified": 1718469202,
+        "lastModified": 1720003792,
         "narHash": "sha256-qnDx8Pk0UxtoPr7BimEsAZh9g2WuTuMB/kGqnmdryKs=",
         "owner": "haskell",
         "repo": "haskell-language-server",
@@ -1202,11 +1164,11 @@
     },
     "nixpkgs-2305": {
       "locked": {
-        "lastModified": 1701362232,
-        "narHash": "sha256-GVdzxL0lhEadqs3hfRLuj+L1OJFGiL/L7gCcelgBlsw=",
+        "lastModified": 1705033721,
+        "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d2332963662edffacfddfad59ff4f709dde80ffe",
+        "rev": "a1982c92d8980a0114372973cbdfe0a307f1bdea",
         "type": "github"
       },
       "original": {
@@ -1218,16 +1180,32 @@
     },
     "nixpkgs-2311": {
       "locked": {
-        "lastModified": 1701386440,
-        "narHash": "sha256-xI0uQ9E7JbmEy/v8kR9ZQan6389rHug+zOtZeZFiDJk=",
+        "lastModified": 1719957072,
+        "narHash": "sha256-gvFhEf5nszouwLAkT9nWsDzocUTqLWHuL++dvNjMp9I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "293822e55ec1872f715a66d0eda9e592dc14419f",
+        "rev": "7144d6241f02d171d25fba3edeaf15e0f2592105",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-23.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2405": {
+      "locked": {
+        "lastModified": 1720122915,
+        "narHash": "sha256-Nby8WWxj0elBu1xuRaUcRjPi/rU3xVbkAt2kj4QwX2U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "835cf2d3f37989c5db6585a28de967a667a75fb1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1250,17 +1228,17 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1694822471,
-        "narHash": "sha256-6fSDCj++lZVMZlyqOe9SIOL8tYSBz1bI8acwovRwoX8=",
+        "lastModified": 1720181791,
+        "narHash": "sha256-i4vJL12/AdyuQuviMMd1Hk2tsGt02hDNhA0Zj1m16N8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
+        "rev": "4284c2b73c8bce4b46a6adf23e16d9e2ec8da4bb",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
-        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
         "type": "github"
       }
     },
@@ -1511,11 +1489,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1718756571,
-        "narHash": "sha256-8rL8viTbuE9/yV1of6SWp2tHmhVMD2UmkOfmN5KDbKg=",
+        "lastModified": 1725840910,
+        "narHash": "sha256-Sv/CQAO0kwg3g8q/Cdy8tzXNAO4dDDtjj8aNRRGRvvY=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "027672fb6fd45828b0e623c8152572d4058429ad",
+        "rev": "61e0766039b352477f8a885faea24f5149019fbf",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -561,11 +561,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1725927021,
-        "narHash": "sha256-wEatXUV9CL3VU5JdX7d1FN6GY/Vy14n+wJUQ/cRvm2A=",
+        "lastModified": 1725945224,
+        "narHash": "sha256-C1DBAZeeDwp+MFYcM4Zs9U8txM19Em/Yw8y7L4dFtBE=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "4b6ad33f96680917244d8396adb34ba89811750f",
+        "rev": "0b10d7a14bebff8361354a220aa9d7dd0405c19b",
         "type": "github"
       },
       "original": {

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -113,6 +113,7 @@ let
           ({ lib, pkgs, ... }: {
             packages.cardano-tracer.package.buildable = with pkgs.stdenv.hostPlatform; lib.mkForce (!isMusl);
             packages.cardano-node-chairman.components.tests.chairman-tests.buildable = lib.mkForce pkgs.stdenv.hostPlatform.isUnix;
+            package-keys = ["plutus-tx-plugin"];
             packages.plutus-tx-plugin.components.library.platforms = with lib.platforms; [ linux darwin ];
             packages.tx-generator.package.buildable = with pkgs.stdenv.hostPlatform; !isMusl;
 
@@ -139,10 +140,6 @@ let
             packages.unix-time.postPatch = ''
               sed -i 's/mingwex//g' unix-time.cabal
             '';
-            # For these two packages the custom setups fail, as we end up with multiple instances of
-            # lib:Cabal. Likely a haskell.nix bug.
-            packages.entropy.package.buildType = lib.mkForce "Simple";
-            packages.HsOpenSSL.package.buildType = lib.mkForce "Simple";
             #packages.plutus-core.components.library.preBuild = ''
             #  export ISERV_ARGS="-v +RTS -Dl"
             #  export PROXY_ARGS=-v
@@ -312,17 +309,18 @@ let
             # <no location info>: error: ghc: ghc-iserv terminated (-11)
             packages.plutus-core.components.library.ghcOptions = [ "-fexternal-interpreter" ];
           })
-          ({ lib, ... }@args: {
-            options.packages = lib.mkOption {
-              type = lib.types.attrsOf (lib.types.submodule (
-                { config, lib, ... }:
-                lib.mkIf config.package.isLocal
-                {
-                  configureFlags = [ "--ghc-option=-Werror"]
-                    ++ lib.optional (args.config.compiler.version == "8.10.7") "--ghc-option=-Wwarn=unused-packages";
-                }
-              ));
-            };
+          ({ config, lib, ... }@args: {
+            options.packages = lib.genAttrs config.package-keys (_:
+              lib.mkOption {
+                type = lib.types.submodule (
+                  { config, lib, ... }:
+                  lib.mkIf config.package.isLocal
+                  {
+                    configureFlags = [ "--ghc-option=-Werror"]
+                      ++ lib.optional (args.config.compiler.version == "8.10.7") "--ghc-option=-Wwarn=unused-packages";
+                  }
+                );
+              });
           })
           ({ lib, pkgs, ... }: lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
             # systemd can't be statically linked
@@ -332,18 +330,19 @@ let
           })
           # disable haddock
           # Musl libc fully static build
-          ({ lib, ... }: {
-            options.packages = lib.mkOption {
-              type = lib.types.attrsOf (lib.types.submodule (
-                { config, lib, pkgs, ...}:
-                lib.mkIf (pkgs.stdenv.hostPlatform.isMusl && config.package.isLocal)
-                {
-                  # Module options which adds GHC flags and libraries for a fully static build
-                  enableShared = true; # TH code breaks if this is false.
-                  enableStatic = true;
-                }
-              ));
-            };
+          ({ config, lib, ... }: {
+            options.packages = lib.genAttrs config.package-keys (_:
+              lib.mkOption {
+                type = lib.types.submodule (
+                  { config, lib, pkgs, ...}:
+                  lib.mkIf (pkgs.stdenv.hostPlatform.isMusl && config.package.isLocal)
+                  {
+                    # Module options which adds GHC flags and libraries for a fully static build
+                    enableShared = true; # TH code breaks if this is false.
+                    enableStatic = true;
+                  }
+                );
+              });
             config =
               lib.mkIf pkgs.stdenv.hostPlatform.isMusl
               {

--- a/nix/workbench/default.nix
+++ b/nix/workbench/default.nix
@@ -11,7 +11,7 @@ let
   # recover CHaP location from cardano's project
   chap = cardanoNodeProject.args.inputMap."https://chap.intersectmbo.org/";
   # build plan as computed by nix
-  nixPlanJson = cardanoNodeProject.plan-nix.json;
+  nixPlanJson = cardanoNodeProject.plan-nix + "/plan.json";
 
   workbench' = tools:
     pkgs.stdenv.mkDerivation {

--- a/nix/workbench/shell.nix
+++ b/nix/workbench/shell.nix
@@ -22,7 +22,7 @@ let
     chap = project.args.inputMap."https://chap.intersectmbo.org/";
 
     # build plan as computed by nix
-    nixPlanJson = project.plan-nix.json;
+    nixPlanJson = project.plan-nix + "/plan.json";
 
 in project.shellFor {
   name = "workbench-shell";


### PR DESCRIPTION
This PR is just to check that https://github.com/input-output-hk/haskell.nix/pull/2239 does not introduce any issues for building `cardano-node`.