### PR TITLE
cardano-testnet: rename ShelleyTestnetOptions into GenesisOptions

### DIFF
--- a/cardano-testnet/src/Parsers/Cardano.hs
+++ b/cardano-testnet/src/Parsers/Cardano.hs
@@ -110,7 +110,7 @@ pGenesisOptions =
         <>  OA.help "Epoch length, in number of slots"
         <>  OA.metavar "SLOTS"
         <>  OA.showDefault
-        <>  OA.value (shelleyEpochLength def)
+        <>  OA.value (genesisEpochLength def)
         )
     pSlotLength =
       OA.option auto
@@ -118,7 +118,7 @@ pGenesisOptions =
         <>  OA.help "Slot length"
         <>  OA.metavar "SECONDS"
         <>  OA.showDefault
-        <>  OA.value (shelleySlotLength def)
+        <>  OA.value (genesisSlotLength def)
         )
     pActiveSlotCoeffs =
       OA.option auto
@@ -126,7 +126,7 @@ pGenesisOptions =
         <>  OA.help "Active slots co-efficient"
         <>  OA.metavar "DOUBLE"
         <>  OA.showDefault
-        <>  OA.value (shelleyActiveSlotsCoeff def)
+        <>  OA.value (genesisActiveSlotsCoeff def)
         )
 
 cmdCardano :: EnvCli -> Mod CommandFields CardanoTestnetCliOptions

--- a/cardano-testnet/src/Parsers/Cardano.hs
+++ b/cardano-testnet/src/Parsers/Cardano.hs
@@ -24,7 +24,7 @@ import           Testnet.Types (readNodeLoggingFormat)
 optsTestnet :: EnvCli -> Parser CardanoTestnetCliOptions
 optsTestnet envCli = CardanoTestnetCliOptions
   <$> pCardanoTestnetCliOptions envCli
-  <*> pShelleyTestnetOptions
+  <*> pGenesisOptions
 
 pCardanoTestnetCliOptions :: EnvCli -> Parser CardanoTestnetOptions
 pCardanoTestnetCliOptions envCli = CardanoTestnetOptions
@@ -96,9 +96,9 @@ parseNodeConfigFile = NodeConfigurationYaml <$>
                , "Or use num-pool-nodes to use cardano-testnet's default configuration."
                ]
 
-pShelleyTestnetOptions :: Parser ShelleyTestnetOptions
-pShelleyTestnetOptions =
-  ShelleyTestnetOptions
+pGenesisOptions :: Parser GenesisOptions
+pGenesisOptions =
+  GenesisOptions
     <$> pNetworkId
     <*> pEpochLength
     <*> pSlotLength

--- a/cardano-testnet/src/Testnet/Defaults.hs
+++ b/cardano-testnet/src/Testnet/Defaults.hs
@@ -420,10 +420,10 @@ defaultShelleyGenesis
   :: AnyShelleyBasedEra
   -> UTCTime
   -> Word64
-  -> ShelleyTestnetOptions
+  -> GenesisOptions
   -> Api.ShelleyGenesis StandardCrypto
 defaultShelleyGenesis asbe startTime maxSupply options = do
-  let ShelleyTestnetOptions
+  let GenesisOptions
         { shelleyTestnetMagic = magic
         , shelleySlotLength = slotLength
         , shelleyEpochLength = epochLength

--- a/cardano-testnet/src/Testnet/Defaults.hs
+++ b/cardano-testnet/src/Testnet/Defaults.hs
@@ -424,13 +424,13 @@ defaultShelleyGenesis
   -> Api.ShelleyGenesis StandardCrypto
 defaultShelleyGenesis asbe startTime maxSupply options = do
   let GenesisOptions
-        { shelleyTestnetMagic = magic
-        , shelleySlotLength = slotLength
-        , shelleyEpochLength = epochLength
-        , shelleyActiveSlotsCoeff
+        { genesisTestnetMagic = magic
+        , genesisSlotLength = slotLength
+        , genesisEpochLength = epochLength
+        , genesisActiveSlotsCoeff
         } = options
       -- f
-      activeSlotsCoeff = round (shelleyActiveSlotsCoeff * 100) % 100
+      activeSlotsCoeff = round (genesisActiveSlotsCoeff * 100) % 100
       -- make security param k satisfy: epochLength = 10 * k / f
       -- TODO: find out why this actually degrates network stability - turned off for now
       -- securityParam = ceiling $ fromIntegral epochLength * cardanoActiveSlotsCoeff / 10

--- a/cardano-testnet/src/Testnet/Start/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Start/Cardano.hs
@@ -88,14 +88,14 @@ data ForkPoint
 startTimeOffsetSeconds :: DTC.NominalDiffTime
 startTimeOffsetSeconds = if OS.isWin32 then 90 else 15
 
--- | Like 'cardanoTestnet', but using 'ShelleyTestnetOptions' to obtain
+-- | Like 'cardanoTestnet', but using 'GenesisOptions' to obtain
 -- the genesis files, instead of passing them directly.
 -- See 'cardanoTestnet' for additional documentation.
 cardanoTestnetDefault
   :: ()
   => HasCallStack
   => CardanoTestnetOptions
-  -> ShelleyTestnetOptions
+  -> GenesisOptions
   -> Conf
   -> H.Integration TestnetRuntime
 cardanoTestnetDefault testnetOptions shelleyOptions conf = do
@@ -121,7 +121,7 @@ getDefaultShelleyGenesis :: ()
   => MonadTest m
   => AnyShelleyBasedEra
   -> Word64 -- ^ The max supply
-  -> ShelleyTestnetOptions
+  -> GenesisOptions
   -> m (ShelleyGenesis StandardCrypto)
 getDefaultShelleyGenesis asbe maxSupply opts = do
   currentTime <- H.noteShowIO DTC.getCurrentTime

--- a/cardano-testnet/src/Testnet/Start/Types.hs
+++ b/cardano-testnet/src/Testnet/Start/Types.hs
@@ -78,18 +78,18 @@ instance Default CardanoTestnetOptions where
 
 -- | Options that are implemented by writing fields in the Shelley genesis file.
 data GenesisOptions = GenesisOptions
-  { shelleyTestnetMagic :: Int -- TODO Use the NetworkMagic type from API
-  , shelleyEpochLength :: Int -- ^ An epoch's duration, in number of slots
-  , shelleySlotLength :: Double -- ^ Slot length, in seconds
-  , shelleyActiveSlotsCoeff :: Double
+  { genesisTestnetMagic :: Int -- TODO Use the NetworkMagic type from API
+  , genesisEpochLength :: Int -- ^ An epoch's duration, in number of slots
+  , genesisSlotLength :: Double -- ^ Slot length, in seconds
+  , genesisActiveSlotsCoeff :: Double
   } deriving (Eq, Show)
 
 instance Default GenesisOptions where
   def = GenesisOptions
-    { shelleyTestnetMagic = 42
-    , shelleyEpochLength = 500
-    , shelleySlotLength = 0.1
-    , shelleyActiveSlotsCoeff = 0.05
+    { genesisTestnetMagic = 42
+    , genesisEpochLength = 500
+    , genesisSlotLength = 0.1
+    , genesisActiveSlotsCoeff = 0.05
     }
 
 -- | Specify a BFT node (Pre-Babbage era only) or an SPO (Shelley era onwards only)

--- a/cardano-testnet/src/Testnet/Start/Types.hs
+++ b/cardano-testnet/src/Testnet/Start/Types.hs
@@ -13,7 +13,7 @@ module Testnet.Start.Types
   , TestnetNodeOptions(..)
   , extraSpoNodeCliArgs
   , cardanoDefaultTestnetNodeOptions
-  , ShelleyTestnetOptions(..)
+  , GenesisOptions(..)
 
   , NodeLoggingFormat(..)
   , Conf(..)
@@ -38,19 +38,19 @@ import qualified Hedgehog.Extras as H
 
 -- | Command line options for the @cardano-testnet@ executable. They are used
 -- in the parser, and then get split into 'CardanoTestnetOptions' and
--- 'ShelleyTestnetOptions'
+-- 'GenesisOptions'
 data CardanoTestnetCliOptions = CardanoTestnetCliOptions
   { cliTestnetOptions :: CardanoTestnetOptions
-  , cliShelleyOptions :: ShelleyTestnetOptions
+  , cliGenesisOptions :: GenesisOptions
   } deriving (Eq, Show)
 
 instance Default CardanoTestnetCliOptions where
   def = CardanoTestnetCliOptions
     { cliTestnetOptions = def
-    , cliShelleyOptions = def
+    , cliGenesisOptions = def
     }
 
--- | Options which, contrary to 'ShelleyTestnetOptions' are not implemented
+-- | Options which, contrary to 'GenesisOptions' are not implemented
 -- by tuning the genesis files.
 data CardanoTestnetOptions = CardanoTestnetOptions
   { -- | List of node options. Each option will result in a single node being
@@ -58,7 +58,7 @@ data CardanoTestnetOptions = CardanoTestnetOptions
     cardanoNodes :: [TestnetNodeOptions]
   , cardanoNodeEra :: AnyShelleyBasedEra -- ^ The era to start at
   , cardanoMaxSupply :: Word64 -- ^ The amount of Lovelace you are starting your testnet with (forwarded to shelley genesis)
-                               -- TODO move me to ShelleyTestnetOptions when https://github.com/IntersectMBO/cardano-cli/pull/874 makes it to cardano-node
+                               -- TODO move me to GenesisOptions when https://github.com/IntersectMBO/cardano-cli/pull/874 makes it to cardano-node
   , cardanoEnableP2P :: Bool
   , cardanoNodeLoggingFormat :: NodeLoggingFormat
   , cardanoNumDReps :: Int -- ^ The number of DReps to generate at creation
@@ -77,15 +77,15 @@ instance Default CardanoTestnetOptions where
     }
 
 -- | Options that are implemented by writing fields in the Shelley genesis file.
-data ShelleyTestnetOptions = ShelleyTestnetOptions
+data GenesisOptions = GenesisOptions
   { shelleyTestnetMagic :: Int -- TODO Use the NetworkMagic type from API
   , shelleyEpochLength :: Int -- ^ An epoch's duration, in number of slots
   , shelleySlotLength :: Double -- ^ Slot length, in seconds
   , shelleyActiveSlotsCoeff :: Double
   } deriving (Eq, Show)
 
-instance Default ShelleyTestnetOptions where
-  def = ShelleyTestnetOptions
+instance Default GenesisOptions where
+  def = GenesisOptions
     { shelleyTestnetMagic = 42
     , shelleyEpochLength = 500
     , shelleySlotLength = 0.1

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Query.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Query.hs
@@ -69,7 +69,7 @@ import           Testnet.Process.Cli.Transaction (
 import           Testnet.Process.Run (execCli', execCliStdoutToJson, mkExecConfig)
 import           Testnet.Property.Assert (assertErasEqual)
 import           Testnet.Property.Util (integrationWorkspace)
-import           Testnet.Start.Types (ShelleyTestnetOptions(..))
+import           Testnet.Start.Types (GenesisOptions(..))
 import           Testnet.TestQueryCmds (TestQueryCmds (..), forallQueryCommands)
 import           Testnet.Types
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Query.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Query.hs
@@ -97,10 +97,10 @@ hprop_cli_queries = integrationWorkspace "cli-queries" $ \tempAbsBasePath' -> H.
       eraName = eraToString era
       fastTestnetOptions = def { cardanoNodeEra = asbe }
       shelleyOptions = def
-        { shelleyEpochLength = 100
+        { genesisEpochLength = 100
         -- We change slotCoeff because epochLength must be equal to:
         -- securityParam * 10 / slotCoeff
-        , shelleyActiveSlotsCoeff = 0.5
+        , genesisActiveSlotsCoeff = 0.5
         }
 
   TestnetRuntime

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/CommitteeAddNew.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/CommitteeAddNew.hs
@@ -79,7 +79,7 @@ hprop_constitutional_committee_add_new = integrationWorkspace "constitutional-co
         { cardanoNodeEra = AnyShelleyBasedEra sbe
         , cardanoNumDReps = nDrepVotes
         }
-      shelleyOptions = def { shelleyEpochLength = 200 }
+      shelleyOptions = def { genesisEpochLength = 200 }
 
   TestnetRuntime
     { testnetMagic

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/CommitteeAddNew.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/CommitteeAddNew.hs
@@ -45,7 +45,7 @@ import           Testnet.Process.Cli.Transaction
 import           Testnet.Process.Run (execCli', mkExecConfig)
 import           Testnet.Property.Util (integrationWorkspace)
 import           Testnet.Types
-import           Testnet.Start.Types (ShelleyTestnetOptions(..))
+import           Testnet.Start.Types (GenesisOptions(..))
 
 import           Hedgehog
 import qualified Hedgehog.Extras as H

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepActivity.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepActivity.hs
@@ -59,7 +59,7 @@ hprop_check_drep_activity = integrationWorkspace "test-activity" $ \tempAbsBaseP
         { cardanoNodeEra = AnyShelleyBasedEra sbe
         , cardanoNumDReps = 1
         }
-      shelleyOptions = def { shelleyEpochLength = 200 }
+      shelleyOptions = def { genesisEpochLength = 200 }
 
   TestnetRuntime
     { testnetMagic

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepDeposit.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepDeposit.hs
@@ -48,7 +48,7 @@ hprop_ledger_events_drep_deposits = integrationWorkspace "drep-deposits" $ \temp
         { cardanoNodeEra = AnyShelleyBasedEra sbe
         , cardanoNumDReps = 0
         }
-      shelleyOptions = def { shelleyEpochLength = 100 }
+      shelleyOptions = def { genesisEpochLength = 100 }
 
   TestnetRuntime
     { testnetMagic

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepRetirement.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepRetirement.hs
@@ -49,7 +49,7 @@ hprop_drep_retirement = integrationRetryWorkspace 2 "drep-retirement" $ \tempAbs
 
   let cardanoNodeEra = AnyShelleyBasedEra sbe
       fastTestnetOptions = def { cardanoNodeEra }
-      shelleyOptions = def { shelleyEpochLength = 50 } -- 50 * (1/10s) length, i.e. 5 seconds
+      shelleyOptions = def { genesisEpochLength = 50 } -- 50 * (1/10s) length, i.e. 5 seconds
 
   TestnetRuntime
     { testnetMagic

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/GovActionTimeout.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/GovActionTimeout.hs
@@ -49,7 +49,7 @@ hprop_check_gov_action_timeout = integrationWorkspace "gov-action-timeout" $ \te
       sbe = conwayEraOnwardsToShelleyBasedEra ceo
       asbe = AnyShelleyBasedEra sbe
       fastTestnetOptions = def { cardanoNodeEra = asbe }
-      shelleyOptions = def { shelleyEpochLength = 200 }
+      shelleyOptions = def { genesisEpochLength = 200 }
 
   TestnetRuntime
     { testnetMagic

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/InfoAction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/InfoAction.hs
@@ -60,7 +60,7 @@ hprop_ledger_events_info_action = integrationRetryWorkspace 0 "info-hash" $ \tem
       sbe = conwayEraOnwardsToShelleyBasedEra ceo
       asbe = AnyShelleyBasedEra sbe
       fastTestnetOptions = def { cardanoNodeEra = asbe }
-      shelleyOptions = def { shelleyEpochLength = 200 }
+      shelleyOptions = def { genesisEpochLength = 200 }
 
   TestnetRuntime
     { testnetMagic

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs
@@ -68,7 +68,7 @@ hprop_gov_no_confidence = integrationWorkspace "no-confidence" $ \tempAbsBasePat
       era = toCardanoEra sbe
       cEra = AnyCardanoEra era
       fastTestnetOptions = def { cardanoNodeEra = asbe  }
-      shelleyOptions = def { shelleyEpochLength = 200 }
+      shelleyOptions = def { genesisEpochLength = 200 }
 
   execConfigOffline <- H.mkExecConfigOffline tempBaseAbsPath
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PParamChangeFailsSPO.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PParamChangeFailsSPO.hs
@@ -54,7 +54,7 @@ hprop_check_pparam_fails_spo = integrationWorkspace "test-pparam-spo" $ \tempAbs
       sbe = conwayEraOnwardsToShelleyBasedEra ceo
       asbe = AnyShelleyBasedEra sbe
       fastTestnetOptions = def { cardanoNodeEra = asbe }
-      shelleyOptions = def { shelleyEpochLength = 200 }
+      shelleyOptions = def { genesisEpochLength = 200 }
 
   TestnetRuntime
     { testnetMagic

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
@@ -79,7 +79,7 @@ hprop_check_predefined_abstain_drep = H.integrationWorkspace "test-activity" $ \
         { cardanoNodeEra = AnyShelleyBasedEra sbe
         , cardanoNumDReps = 3
         }
-      shelleyOptions = def { shelleyEpochLength = 200 }
+      shelleyOptions = def { genesisEpochLength = 200 }
 
   TestnetRuntime
     { testnetMagic

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitution.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitution.hs
@@ -74,7 +74,7 @@ hprop_ledger_events_propose_new_constitution = integrationWorkspace "propose-new
         { cardanoNodeEra = AnyShelleyBasedEra sbe
         , cardanoNumDReps = numVotes
         }
-      shelleyOptions = def { shelleyEpochLength = 200 }
+      shelleyOptions = def { genesisEpochLength = 200 }
 
   TestnetRuntime
     { testnetMagic

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitutionSPO.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitutionSPO.hs
@@ -55,7 +55,7 @@ hprop_ledger_events_propose_new_constitution_spo = integrationWorkspace "propose
       era = toCardanoEra sbe
       cEra = AnyCardanoEra era
       fastTestnetOptions = def { cardanoNodeEra = AnyShelleyBasedEra sbe }
-      shelleyOptions = def { shelleyEpochLength = 100 }
+      shelleyOptions = def { genesisEpochLength = 100 }
 
   TestnetRuntime
     { testnetMagic

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryDonation.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryDonation.hs
@@ -47,7 +47,7 @@ hprop_ledger_events_treasury_donation = integrationWorkspace "treasury-donation"
   let ceo = ConwayEraOnwardsConway
       sbe = conwayEraOnwardsToShelleyBasedEra ceo
       fastTestnetOptions = def { cardanoNodeEra = AnyShelleyBasedEra sbe }
-      shelleyOptions = def { shelleyEpochLength = 100 }
+      shelleyOptions = def { genesisEpochLength = 100 }
 
   TestnetRuntime
     { testnetMagic

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryGrowth.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryGrowth.hs
@@ -43,8 +43,8 @@ prop_check_if_treasury_is_growing = integrationRetryWorkspace 0 "growing-treasur
   let era = ConwayEra
       sbe = ShelleyBasedEraConway
       options = def { cardanoNodeEra = AnyShelleyBasedEra sbe } -- TODO: We should only support the latest era and the upcoming era
-      shelleyOptions = def { shelleyEpochLength = 100
-                           , shelleyActiveSlotsCoeff = 0.3
+      shelleyOptions = def { genesisEpochLength = 100
+                           , genesisActiveSlotsCoeff = 0.3
                            }
 
   TestnetRuntime{testnetMagic, configurationFile, poolNodes} <- cardanoTestnetDefault options shelleyOptions conf

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryWithdrawal.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryWithdrawal.hs
@@ -62,8 +62,8 @@ hprop_ledger_events_treasury_withdrawal = integrationRetryWorkspace 1  "treasury
       eraName = eraToString era
 
       fastTestnetOptions = def { cardanoNodeEra = AnyShelleyBasedEra sbe }
-      shelleyOptions = def { shelleyEpochLength = 200
-                           , shelleyActiveSlotsCoeff = 0.3
+      shelleyOptions = def { genesisEpochLength = 200
+                           , genesisActiveSlotsCoeff = 0.3
                            }
 
   TestnetRuntime

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Node/Shutdown.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Node/Shutdown.hs
@@ -202,8 +202,8 @@ hprop_shutdownOnSlotSynced = integrationRetryWorkspace 2 "shutdown-on-slot-synce
           ]
         }
       shelleyOptions = def
-        { shelleyEpochLength = 300
-        , shelleySlotLength = slotLen
+        { genesisEpochLength = 300
+        , genesisSlotLength = slotLen
         }
   testnetRuntime <- cardanoTestnetDefault fastTestnetOptions shelleyOptions conf
   let allNodes' = poolNodes testnetRuntime
@@ -244,7 +244,7 @@ hprop_shutdownOnSigint = integrationRetryWorkspace 2 "shutdown-on-sigint" $ \tem
   conf <- mkConf tempAbsBasePath'
 
   let fastTestnetOptions = def
-      shelleyOptions = def { shelleyEpochLength = 300 }
+      shelleyOptions = def { genesisEpochLength = 300 }
   testnetRuntime
     <- cardanoTestnetDefault fastTestnetOptions shelleyOptions conf
   node@NodeRuntime{nodeProcessHandle} <- H.headM $ poolRuntime <$> poolNodes testnetRuntime

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SanityCheck.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SanityCheck.hs
@@ -47,8 +47,8 @@ hprop_ledger_events_sanity_check = integrationWorkspace "ledger-events-sanity-ch
 
   let fastTestnetOptions = def
       shelleyOptions = def
-        { shelleyEpochLength = 100
-        , shelleySlotLength = 0.1
+        { genesisEpochLength = 100
+        , genesisSlotLength = 0.1
         }
 
   TestnetRuntime{configurationFile, poolNodes}


### PR DESCRIPTION
# Description

Doing a renaming agreed here: https://github.com/IntersectMBO/cardano-node/pull/5976#discussion_r1761109187

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff