### PR TITLE
cardano-testnet | Reenable chairman test

### DIFF
--- a/cardano-node-chairman/app/Cardano/Chairman.hs
+++ b/cardano-node-chairman/app/Cardano/Chairman.hs
@@ -253,7 +253,12 @@ runChairman ::
                 (Anchor (Header (CardanoBlock StandardCrypto)))
                 (Header (CardanoBlock StandardCrypto))))
 runChairman tracer networkId runningTime socketPaths cModeParams secParam = do
-    let initialChains :: Map SocketPath (AF.AnchoredSeq (WithOrigin SlotNo) (Anchor (Header (CardanoBlock StandardCrypto))) (Header (CardanoBlock StandardCrypto)))
+    let initialChains :: Map
+          SocketPath
+          (AF.AnchoredSeq
+            (WithOrigin SlotNo)
+            (Anchor (Header (CardanoBlock StandardCrypto)))
+            (Header (CardanoBlock StandardCrypto)))
         initialChains = Map.fromList
           [ (socketPath, AF.Empty AF.AnchorGenesis)
           | socketPath <- socketPaths]

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -68,7 +68,8 @@ test-suite chairman-tests
 
   type:                 exitcode-stdio-1.0
 
-  build-depends:        cardano-testnet
+  build-depends:      , cardano-api
+                      , cardano-testnet
                       , cardano-crypto-class ^>= 2.1.2
                       , data-default-class
                       , filepath
@@ -79,7 +80,6 @@ test-suite chairman-tests
                       , random
                       , resourcet
                       , tasty
-                      , tasty-hedgehog
                       , unliftio
 
   other-modules:        Spec.Chairman.Chairman

--- a/cardano-node-chairman/test/Main.hs
+++ b/cardano-node-chairman/test/Main.hs
@@ -8,27 +8,27 @@ import qualified Cardano.Crypto.Init as Crypto
 
 import           Prelude
 
-import           Data.String (IsString (..))
 import qualified System.Environment as E
 import           System.IO (BufferMode (LineBuffering), hSetBuffering, hSetEncoding, stdout, utf8)
 
+import           Testnet.Property.Run (ignoreOnWindows)
+
 import qualified Test.Tasty as T
-import qualified Test.Tasty.Hedgehog as H
 import qualified Test.Tasty.Ingredients as T
 
+import qualified Spec.Chairman.Cardano
 import qualified Spec.Network
 
 tests :: IO T.TestTree
 tests = do
-  let t0 = H.testPropertyNamed "isPortOpen False" (fromString "isPortOpen False") Spec.Network.hprop_isPortOpen_False
-  let t1 = H.testPropertyNamed "isPortOpen True"  (fromString "isPortOpen True" ) Spec.Network.hprop_isPortOpen_True
-  -- TODO: Conway broken in conway
-  -- let t2 = H.testPropertyNamed "chairman"         (fromString "chairman"        ) Spec.Chairman.Cardano.hprop_chairman
+  let t0 = ignoreOnWindows "isPortOpen False" Spec.Network.hprop_isPortOpen_False
+  let t1 = ignoreOnWindows "isPortOpen True"  Spec.Network.hprop_isPortOpen_True
+  let t2 = ignoreOnWindows "chairman"         Spec.Chairman.Cardano.hprop_chairman
 
   pure $ T.testGroup "test/Spec.hs"
     [ T.testGroup "Spec"
       [ T.testGroup "Chairman"
-        [ T.testGroup "Cardano" [] -- [t2]
+        [ T.testGroup "Cardano" [t2]
         ]
       , T.testGroup "Network" [t0, t1]
       ]

--- a/cardano-node-chairman/test/Spec/Chairman/Cardano.hs
+++ b/cardano-node-chairman/test/Spec/Chairman/Cardano.hs
@@ -4,21 +4,20 @@
 
 module Spec.Chairman.Cardano where
 
-import           Cardano.Testnet (NodeRuntime (nodeName), allNodes,
-                   cardanoTestnetDefault, mkConf)
+import           Cardano.Testnet (allNodes, cardanoTestnetDefault, mkConf)
 
 import           Data.Default.Class
+
 import           Testnet.Property.Util (integrationRetryWorkspace)
 
 import qualified Hedgehog as H
 
 import           Spec.Chairman.Chairman (chairmanOver)
 
--- TODO: Conway broken in conway
 hprop_chairman :: H.Property
 hprop_chairman = integrationRetryWorkspace 2 "cardano-chairman" $ \tempAbsPath' -> do
   conf <- mkConf tempAbsPath'
 
-  allNodes' <- fmap nodeName . allNodes <$> cardanoTestnetDefault def def conf
+  allNodes' <- allNodes <$> cardanoTestnetDefault def def conf
 
   chairmanOver 120 50 conf allNodes'

--- a/cardano-node-chairman/test/Spec/Chairman/Chairman.hs
+++ b/cardano-node-chairman/test/Spec/Chairman/Chairman.hs
@@ -6,44 +6,41 @@ module Spec.Chairman.Chairman
   ( chairmanOver
   ) where
 
+import           Cardano.Api (unFile)
+
 import           Cardano.Testnet (TmpAbsolutePath (TmpAbsolutePath), makeLogDir)
 import qualified Cardano.Testnet as H
 
 import           Control.Monad (when)
 import           Data.Functor ((<&>))
+import           GHC.Stack
 import qualified System.Environment as IO
 import           System.Exit (ExitCode (..))
 import           System.FilePath.Posix ((</>))
 import qualified System.IO as IO
 import qualified System.Process as IO
 
+import           Testnet.Types (NodeRuntime, nodeSocketPath)
+
 import qualified Hedgehog as H
-import           Hedgehog.Extras.Stock.IO.Network.Sprocket (Sprocket (..))
-import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
 import           Hedgehog.Extras.Test.Base (Integration)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 import qualified Hedgehog.Extras.Test.Process as H
 
-{- HLINT ignore "Reduce duplication" -}
 {- HLINT ignore "Redundant <&>" -}
-{- HLINT ignore "Redundant flip" -}
 
-mkSprocket :: FilePath -> FilePath -> String -> Sprocket
-mkSprocket tempBaseAbsPath socketDir node = Sprocket tempBaseAbsPath (socketDir </> node)
-
-chairmanOver :: Int -> Int -> H.Conf -> [String] -> Integration ()
+chairmanOver :: HasCallStack => Int -> Int -> H.Conf -> [NodeRuntime] -> Integration ()
 chairmanOver timeoutSeconds requiredProgress H.Conf {H.tempAbsPath} allNodes = do
   maybeChairman <- H.evalIO $ IO.lookupEnv "DISABLE_CHAIRMAN"
   let tempAbsPath' = H.unTmpAbsPath tempAbsPath
       logDir = makeLogDir $ TmpAbsolutePath tempAbsPath'
       tempBaseAbsPath = H.makeTmpBaseAbsPath $ TmpAbsolutePath tempAbsPath'
-      socketDir = H.makeSocketDir $ TmpAbsolutePath tempAbsPath'
   when (maybeChairman /= Just "1") $ do
     nodeStdoutFile <- H.noteTempFile logDir $ "chairman" <> ".stdout.log"
     nodeStderrFile <- H.noteTempFile logDir $ "chairman" <> ".stderr.log"
 
-    sprockets <- H.noteEach $ fmap (mkSprocket tempBaseAbsPath socketDir) allNodes
+    sprockets <- H.noteEach $ unFile . nodeSocketPath <$> allNodes
 
     hNodeStdout <- H.evalIO $ IO.openFile nodeStdoutFile IO.WriteMode
     hNodeStderr <- H.evalIO $ IO.openFile nodeStderrFile IO.WriteMode
@@ -54,7 +51,7 @@ chairmanOver timeoutSeconds requiredProgress H.Conf {H.tempAbsPath} allNodes = d
           , "--config", tempAbsPath' </> "configuration.yaml"
           , "--require-progress", show @Int requiredProgress
           ]
-        <> (sprockets >>= (\sprocket -> ["--socket-path", IO.sprocketArgumentName sprocket]))
+        <> (sprockets >>= (\sprocket -> ["--socket-path", sprocket]))
         ) <&>
         ( \cp -> cp
           { IO.std_in = IO.CreatePipe

--- a/cardano-testnet/src/Testnet/Start/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Start/Cardano.hs
@@ -71,8 +71,8 @@ import qualified Hedgehog.Extras.Stock.OS as OS
 
 -- | There are certain conditions that need to be met in order to run
 -- a valid node cluster.
-testnetMinimumConfigurationRequirements :: MonadTest m => NumPools -> m ()
-testnetMinimumConfigurationRequirements (NumPools n) =
+testnetMinimumConfigurationRequirements :: HasCallStack => MonadTest m => NumPools -> m ()
+testnetMinimumConfigurationRequirements (NumPools n) = withFrozenCallStack $
   when (n < 2) $ do
      H.noteShow_ ("Need at least two nodes to run a cluster, but got: " <> show n)
      H.failure
@@ -347,6 +347,8 @@ cardanoTestnet
     unless (null failedNodes) $ do
       H.noteShow_ . vsep $ prettyError <$> failedNodes
       H.failure
+
+    H.annotateShow $ nodeSprocket . poolRuntime <$> poolNodes
 
     -- FIXME: use foldEpochState waiting for chain extensions
     now <- H.noteShowIO DTC.getCurrentTime

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -228,11 +228,16 @@ let
                   # This define files included in the directory that will be passed to `H.getProjectBase` for this test:
                   filteredProjectBase = incl ../. cardanoTestnetGoldenFiles;
                 in
+                # work around 104 chars socket path limit by using a different temporary directory
                 ''
                   ${exportCliPath}
                   ${exportNodePath}
                   ${exportChairmanPath}
                   export CARDANO_NODE_SRC=${filteredProjectBase}
+                  # unset TMPDIR, otherwise mktemp will use that as a base
+                  unset TMPDIR
+                  export TMPDIR=$(mktemp -d)
+                  export TMP=$TMPDIR
                 '';
               # cardano-testnet depends on cardano-node, cardano-cli, cardano-submit-api and some config files
               packages.cardano-node.components.tests.cardano-node-test.preCheck =
@@ -259,13 +264,13 @@ let
                   ${exportSubmitApiPath}
                   export CARDANO_NODE_SRC=${filteredProjectBase}
                 ''
-                # the cardano-testnet-tests, use sockets stored in a temporary directory
+                # the cardano-testnet-tests and chairman-tests, use sockets stored in a temporary directory
                 # however on macOS the socket path's max is 104 chars. The package name
                 # is already long, and as such the constructed socket path
                 #
                 #   /private/tmp/nix-build-cardano-testnet-test-cardano-testnet-tests-1.36.0-check.drv-1/chairman-test-93c5d9288dd8e6bc/socket/node-bft1
                 #
-                # exceeds taht limit easily. We therefore set a different tmp directory
+                # exceeds that limit easily. We therefore set a different tmp directory
                 # during the preBuild phase.
                 + ''
                   # unset TMPDIR, otherwise mktemp will use that as a base


### PR DESCRIPTION
# Description

Reenables chairman test.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
