### PR TITLE
cardano-testnet: use new output of "transaction submit"

### DIFF
--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction.hs
@@ -12,7 +12,10 @@ import           Cardano.Api
 import qualified Cardano.Api.Ledger as L
 import           Cardano.Api.Shelley
 
+import           Cardano.CLI.Types.Common
+import           Cardano.Crypto.Hash.Class (hashToStringAsHex)
 import qualified Cardano.Ledger.Core as L
+
 import           Cardano.Testnet
 
 import           Prelude
@@ -28,7 +31,7 @@ import qualified System.Info as SYS
 import           Testnet.Components.Configuration
 import           Testnet.Components.Query (findLargestUtxoWithAddress, findUtxosWithAddress,
                    getEpochStateView, waitForBlocks)
-import           Testnet.Process.Run (execCli', mkExecConfig)
+import           Testnet.Process.Run
 import           Testnet.Property.Util (integrationRetryWorkspace)
 import           Testnet.Types
 
@@ -108,10 +111,11 @@ hprop_transaction = integrationRetryWorkspace 2 "simple transaction build" $ \te
     , "--out-file", txbodySignedFp
     ]
 
-  void $ execCli' execConfig
+  txSubmissionResult :: TxSubmissionResult <- execCliStdoutToJson execConfig
     [ anyEraToString cEra, "transaction", "submit"
     , "--tx-file", txbodySignedFp
     ]
+  let TxId txHash = txhash txSubmissionResult
 
   H.noteShowM_ $ waitForBlocks epochStateView 1
 
@@ -120,6 +124,12 @@ hprop_transaction = integrationRetryWorkspace 2 "simple transaction build" $ \te
     txouts2 <- H.noteShow $ L.unCoin . txOutValueToLovelace . txOutValue . snd <$> toList utxo2
     H.assertWith txouts2 $ \txouts2' ->
       [transferAmount, initialAmount - transferAmount - txFee] == txouts2'
+
+    -- Check that the transaction output exists, when querying by id:
+    void $ execCli' execConfig
+      [ anyEraToString cEra, "query", "utxo"
+      , "--tx-in", hashToStringAsHex txHash <> "#0"
+      ]
 
 txOutValue :: TxOut ctx era -> TxOutValue era
 txOutValue (TxOut _ v _ _) = v


### PR DESCRIPTION
# Description

Test this new additional output of `transaction submit`: https://github.com/IntersectMBO/cardano-cli/pull/925

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] New tests are added if needed and existing tests are updated.
- [X] Self-reviewed the diff