### PR TITLE
cardano-node-chairman | Wrap tests in watchdog to avoid endlessly waiting on hanged up test

### DIFF
--- a/cardano-node-chairman/test/Spec/Chairman/Cardano.hs
+++ b/cardano-node-chairman/test/Spec/Chairman/Cardano.hs
@@ -11,11 +11,12 @@ import           Data.Default.Class
 import           Testnet.Property.Util (integrationRetryWorkspace)
 
 import qualified Hedgehog as H
+import qualified Hedgehog.Extras as H
 
 import           Spec.Chairman.Chairman (chairmanOver)
 
 hprop_chairman :: H.Property
-hprop_chairman = integrationRetryWorkspace 2 "cardano-chairman" $ \tempAbsPath' -> do
+hprop_chairman = integrationRetryWorkspace 2 "cardano-chairman" $ \tempAbsPath' -> H.runWithDefaultWatchdog_ $ do
   conf <- mkConf tempAbsPath'
 
   allNodes' <- allNodes <$> cardanoTestnetDefault def def conf

--- a/cardano-node-chairman/test/Spec/Network.hs
+++ b/cardano-node-chairman/test/Spec/Network.hs
@@ -27,23 +27,22 @@ import qualified System.Random as IO
 
 import           Hedgehog (Property, (===))
 import qualified Hedgehog as H
+import qualified Hedgehog.Extras as H
 import qualified Hedgehog.Extras.Stock.IO.Network.Socket as IO
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.Network as H
 
 import qualified UnliftIO.Exception as IO
 
 hprop_isPortOpen_False :: Property
-hprop_isPortOpen_False = H.propertyOnce . H.workspace "temp-network" $ \_ -> do
+hprop_isPortOpen_False = H.propertyOnce . H.workspace "temp-network" $ \_ -> H.runWithDefaultWatchdog_ $ do
   -- Check multiple random ports and assert that one is closed.
   -- Multiple random ports are checked because there is a remote possibility a random
   -- port is actually open by another program
   ports <- H.evalIO $ fmap (L.take 10 . IO.randomRs @Int (5000, 9000)) IO.getStdGen
   results <- forM ports H.isPortOpen
-  H.assert (False `L.elem` results)
+  H.assertWith results (False `L.elem`)
 
 hprop_isPortOpen_True :: Property
-hprop_isPortOpen_True = H.propertyOnce . H.workspace "temp-network" $ \_ -> do
+hprop_isPortOpen_True = H.propertyOnce . H.workspace "temp-network" $ \_ -> H.runWithDefaultWatchdog_ $ do
   -- Check first random port from multiple possible ports to be successfully bound is open
   -- Multiple random ports are checked because there is a remote possibility a random
   -- port is actually open by another program


### PR DESCRIPTION
# Description

If for some reason chairman test becomes flaky, this makes the test fail after 10 minutes instead of waiting for hours for it to complete, blocking GHA runner.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
