### PR TITLE
cardano-testnet | Remove redundant functions used for starting a process

### DIFF
--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -85,7 +85,6 @@ library
                       , tasty-expected-failure
                       , tasty-hedgehog
                       , template-haskell
-                      , temporary
                       , text
                       , time
                       , transformers

--- a/cardano-testnet/src/Testnet/Property/Util.hs
+++ b/cardano-testnet/src/Testnet/Property/Util.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MonoLocalBinds #-}
-{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -16,23 +15,14 @@ module Testnet.Property.Util
 
 import           Cardano.Api
 
-import           Control.Exception.Safe
-import           Control.Monad
-import           Control.Monad.Trans.Resource
-import qualified Control.Retry as R
 import qualified Data.Aeson as Aeson
 import           GHC.Stack
-import qualified System.Directory as IO
 import qualified System.Environment as IO
-import           System.FilePath ((</>))
 import           System.Info (os)
-import qualified System.IO as IO
-import qualified System.IO.Temp as IO
 import qualified System.IO.Unsafe as IO
 
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras as H
-import qualified Hedgehog.Extras.Stock.CallStack as H
 import           Hedgehog.Internal.Property (MonadTest)
 
 
@@ -53,52 +43,16 @@ integrationRetryWorkspace n workspaceName f = withFrozenCallStack $
   if disableRetries
     then
       integration $
-        H.runFinallies $ workspace (workspaceName <> "-no-retries") f
+        H.runFinallies $ H.workspace (workspaceName <> "-no-retries") f
     else
       integration $ H.retry n $ \i ->
-        H.runFinallies $ workspace (workspaceName <> "-" <> show i) f
-
--- | Create a workspace directory which will exist for at least the duration of
--- the supplied block.
---
--- The directory will have the supplied prefix but contain a generated random
--- suffix to prevent interference between tests
---
--- The directory will be deleted if the block succeeds, but left behind if
--- the block fails.
--- TODO: this is a version which retries deleting of a workspace on exception - upstream to hedgehog-extras
-workspace
-  :: MonadTest m
-  => HasCallStack
-  => MonadResource m
-  => FilePath
-  -> (FilePath -> m ())
-  -> m ()
-workspace prefixPath f = withFrozenCallStack $ do
-  systemTemp <- H.evalIO IO.getCanonicalTemporaryDirectory
-  maybeKeepWorkspace <- H.evalIO $ IO.lookupEnv "KEEP_WORKSPACE"
-  ws <- H.evalIO $ IO.createTempDirectory systemTemp $ prefixPath <> "-test"
-  H.annotate $ "Workspace: " <> ws
-  H.evalIO $ IO.writeFile (ws </> "module") H.callerModuleName
-  f ws
-  when (os /= "mingw32" && maybeKeepWorkspace /= Just "1") $ do
-    -- try to delete the directory 5 times, 100ms apart
-    let retryPolicy = R.constantDelay 100_000 <> R.limitRetries 10
-        -- retry only on IOExceptions
-        ioExH _ = Handler $ \(_ :: IOException) -> pure True
-    -- For some reason, the temporary directory removal sometimes fails.
-    -- Lets wrap this in MonadResource try multiple times before we fail.
-    void
-      . register
-      . R.recovering retryPolicy [ioExH]
-      . const
-      $ IO.removePathForcibly ws
+        H.runFinallies $ H.workspace (workspaceName <> "-" <> show i) f
 
 -- | The 'FilePath' in '(FilePath -> H.Integration ())' is the work space directory.
 -- This is created (and returned) via 'H.workspace'.
 integrationWorkspace :: HasCallStack => FilePath -> (FilePath -> H.Integration ()) -> H.Property
 integrationWorkspace workspaceName f = withFrozenCallStack $
-  integration $ H.runFinallies $ workspace workspaceName f
+  integration $ H.runFinallies $ H.workspace workspaceName f
 
 isLinux :: Bool
 isLinux = os == "linux"

--- a/cardano-testnet/src/Testnet/Runtime.hs
+++ b/cardano-testnet/src/Testnet/Runtime.hs
@@ -60,7 +60,7 @@ import qualified Hedgehog.Extras.Test.Concurrent as H
 
 data NodeStartFailure
   = ProcessRelatedFailure ProcessError
-  | ExecutableRelatedFailure ExecutableError
+  | ExecutableRelatedFailure SomeException
   | FileRelatedFailure IOException
   | NodeExecutableError (Doc Ann)
   | NodeAddressAlreadyInUseError (Doc Ann)
@@ -144,8 +144,8 @@ startNode tp node ipv4 port _testnetMagic nodeCmd = GHC.withFrozenCallStack $ do
     let socketAbsPath = H.sprocketSystemName sprocket
 
     nodeProcess
-      <- firstExceptT ExecutableRelatedFailure
-           $ hoistExceptT liftIO $ procNode $ mconcat
+      <- newExceptT . fmap (first ExecutableRelatedFailure) . try
+           $ procNode $ mconcat
                          [ nodeCmd
                          , [ "--socket-path", H.sprocketArgumentName sprocket
                            , "--port", show port

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Node/Shutdown.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Node/Shutdown.hs
@@ -145,17 +145,16 @@ hprop_shutdown = integrationRetryWorkspace 2 "shutdown" $ \tempAbsBasePath' -> H
 
   -- Run cardano-node with pipe as stdin.  Use 0 file descriptor as shutdown-ipc
 
-  eRes <- H.evalIO . runExceptT $ procNode
-                         [ "run"
-                         , "--config", tempAbsPath' </> "configuration.yaml"
-                         , "--topology", tempAbsPath' </> "mainnet-topology.json"
-                         , "--database-path", tempAbsPath' </> "db"
-                         , "--socket-path", IO.sprocketArgumentName sprocket
-                         , "--host-addr", "127.0.0.1"
-                         , "--port", show @Int port
-                         , "--shutdown-ipc", "0"
-                         ]
-  res <- H.evalEither eRes
+  res <- procNode
+           [ "run"
+           , "--config", tempAbsPath' </> "configuration.yaml"
+           , "--topology", tempAbsPath' </> "mainnet-topology.json"
+           , "--database-path", tempAbsPath' </> "db"
+           , "--socket-path", IO.sprocketArgumentName sprocket
+           , "--host-addr", "127.0.0.1"
+           , "--port", show @Int port
+           , "--shutdown-ipc", "0"
+           ]
   let process = res { IO.std_in = IO.CreatePipe
                     , IO.std_out = IO.UseHandle hNodeStdout
                     , IO.std_err = IO.UseHandle hNodeStderr


### PR DESCRIPTION
# Description

Requires:
- https://github.com/input-output-hk/hedgehog-extras/pull/74

Removes `hedgehog-extras` functions vendored in:
- https://github.com/IntersectMBO/cardano-node/pull/5494

while still maintaining error reporting functionality in case of node start failure.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
