### PR TITLE
Drop legacy relay bootstrap filtering in nixos node svc

### DIFF
--- a/configuration/cardano/mainnet-topology.json
+++ b/configuration/cardano/mainnet-topology.json
@@ -5,11 +5,11 @@
       "port": 3001
     },
     {
-      "address": "backbone.mainnet.emurgornd.com",
+      "address": "backbone.mainnet.cardanofoundation.org",
       "port": 3001
     },
     {
-      "address": "backbone.mainnet.cardanofoundation.org",
+      "address": "backbone.mainnet.emurgornd.com",
       "port": 3001
     }
   ],

--- a/flake.lock
+++ b/flake.lock
@@ -856,11 +856,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1721825987,
-        "narHash": "sha256-PPcma4tjozwXJAWf+YtHUQUulmxwulVlwSQzKItx/n8=",
+        "lastModified": 1728687575,
+        "narHash": "sha256-38uD8SqT557eh5yyRYuthKm1yTtiWzAN0FH7L/01QKM=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "eb61f2c14e1f610ec59117ad40f8690cddbf80cb",
+        "rev": "86c2bd46e8a08f62ea38ffe77cb4e9c337b42217",
         "type": "github"
       },
       "original": {

--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -546,17 +546,7 @@ in {
 
       bootstrapPeers = mkOption {
         type = types.nullOr (types.listOf types.attrs);
-        default =
-          # Until legacy mainnet relays are deprecated and replaced by IOG bootstrap peers for relaysNew,
-          # filter the legacy relaysNew definition from the mainnet bootstrapPeers list.
-          #
-          # All other envs can use the edgeNodes list as bootstrapPeers.
-          if envConfig.name == "mainnet"
-          then
-            map (e: {address = e.addr; inherit (e) port;})
-              (builtins.filter (e: e.addr != envConfig.relaysNew) envConfig.edgeNodes)
-          else
-            map (e: {address = e.addr; inherit (e) port;}) envConfig.edgeNodes;
+        default = map (e: {address = e.addr; inherit (e) port;}) envConfig.edgeNodes;
         description = ''
           If set, it will enable bootstrap peers.
           To disable, set this to null.


### PR DESCRIPTION
# Description
* Removes legacy mainnet relay filter for bootstrap attr generation
* Bumps the iohkNix pin for similarly updated topology generation
* Updates mainnet topology config to match updated iohk-nix topology ordering

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] CI passes. See note on CI.  The following CI checks are required:
- [X] Self-reviewed the diff