### PR TITLE
cardano-testnet | Fix redundant error in creation of artifacts from failed test workspaces

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -174,7 +174,7 @@ jobs:
         TMP: ${{ runner.temp }}
       run: |
         cd $TMP
-        find . -name 'module' -type f -exec dirname {} \; | xargs -L1 basename | sort -u | xargs tar -czvf workspaces.tgz
+        find . -name 'module' -type f -exec dirname {} \; | xargs -I "{}" basename "{}" | sort -u | xargs -I "{}" tar -czvf workspaces.tgz "{}"
 
     - name: Upload workspaces on tests failure
       if: ${{ failure() }}


### PR DESCRIPTION
# Description

Sometimes after tests in cardano-testnet fail, workspace tar-ing fails as well with this cryptic error:
```
basename: extra operand ‘build-0-test-baf6b13ac090f575’
```
(see for example this build log https://github.com/IntersectMBO/cardano-node/actions/runs/11024038455/job/30616484791#step:16:14 )

This is annoying because you have to scroll through multiple lines of tar output to get to the actual test failures.

This PR aims to fix that.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
