### PR TITLE
cardano-testnet | Remove `NodeRuntime` type

### DIFF
--- a/cardano-node-chairman/test/Spec/Chairman/Cardano.hs
+++ b/cardano-node-chairman/test/Spec/Chairman/Cardano.hs
@@ -4,7 +4,7 @@
 
 module Spec.Chairman.Cardano where
 
-import           Cardano.Testnet (allNodes, cardanoTestnetDefault, mkConf)
+import           Cardano.Testnet (cardanoTestnetDefault, mkConf, testnetNodes)
 
 import           Data.Default.Class
 
@@ -19,6 +19,6 @@ hprop_chairman :: H.Property
 hprop_chairman = integrationRetryWorkspace 2 "cardano-chairman" $ \tempAbsPath' -> H.runWithDefaultWatchdog_ $ do
   conf <- mkConf tempAbsPath'
 
-  allNodes' <- allNodes <$> cardanoTestnetDefault def def conf
+  allNodes <- testnetNodes <$> cardanoTestnetDefault def def conf
 
-  chairmanOver 120 50 conf allNodes'
+  chairmanOver 120 50 conf allNodes

--- a/cardano-node-chairman/test/Spec/Chairman/Chairman.hs
+++ b/cardano-node-chairman/test/Spec/Chairman/Chairman.hs
@@ -20,7 +20,7 @@ import           System.FilePath.Posix ((</>))
 import qualified System.IO as IO
 import qualified System.Process as IO
 
-import           Testnet.Types (NodeRuntime, nodeSocketPath)
+import           Testnet.Types (TestnetNode, nodeSocketPath)
 
 import qualified Hedgehog as H
 import           Hedgehog.Extras.Test.Base (Integration)
@@ -30,7 +30,7 @@ import qualified Hedgehog.Extras.Test.Process as H
 
 {- HLINT ignore "Redundant <&>" -}
 
-chairmanOver :: HasCallStack => Int -> Int -> H.Conf -> [NodeRuntime] -> Integration ()
+chairmanOver :: HasCallStack => Int -> Int -> H.Conf -> [TestnetNode] -> Integration ()
 chairmanOver timeoutSeconds requiredProgress H.Conf {H.tempAbsPath} allNodes = do
   maybeChairman <- H.evalIO $ IO.lookupEnv "DISABLE_CHAIRMAN"
   let tempAbsPath' = H.unTmpAbsPath tempAbsPath

--- a/cardano-testnet/src/Cardano/Testnet.hs
+++ b/cardano-testnet/src/Cardano/Testnet.hs
@@ -37,9 +37,14 @@ module Cardano.Testnet (
   waitForEpochs,
 
   -- * Runtime
-  NodeRuntime(..),
-  allNodes,
+  TestnetRuntime(..),
+  testnetSprockets,
+  spoNodes,
+  relayNodes,
 
+  TestnetNode(..),
+  isTestnetNodeSpo,
+  nodeSocketPath,
   ) where
 
 import           Testnet.Components.Query

--- a/cardano-testnet/src/Testnet/Types.hs
+++ b/cardano-testnet/src/Testnet/Types.hs
@@ -15,15 +15,12 @@ module Testnet.Types
   , NodeLoggingFormat(..)
   , PaymentKeyInfo(..)
   , TestnetRuntime(..)
-  , allNodes
   , spoNodes
   , relayNodes
   , testnetSprockets
-  , NodeRuntime(..)
-  , nodeSocketPath
   , TestnetNode(..)
+  , nodeSocketPath
   , isTestnetNodeSpo
-  , testnetNodeStdout
   , SpoNodeKeys(..)
   , Delegator(..)
   , KeyPair(..)
@@ -120,31 +117,17 @@ data TestnetRuntime = TestnetRuntime
   }
 
 testnetSprockets :: TestnetRuntime -> [Sprocket]
-testnetSprockets = fmap (nodeSprocket . testnetNodeRuntime) . testnetNodes
+testnetSprockets = fmap nodeSprocket . testnetNodes
 
-allNodes :: TestnetRuntime -> [NodeRuntime]
-allNodes = fmap testnetNodeRuntime . testnetNodes
+spoNodes :: TestnetRuntime -> [TestnetNode]
+spoNodes = filter isTestnetNodeSpo . testnetNodes
 
-spoNodes :: TestnetRuntime -> [NodeRuntime]
-spoNodes = fmap testnetNodeRuntime . filter isTestnetNodeSpo . testnetNodes
-
-relayNodes :: TestnetRuntime -> [NodeRuntime]
-relayNodes = fmap testnetNodeRuntime . filter (not . isTestnetNodeSpo) . testnetNodes
+relayNodes :: TestnetRuntime -> [TestnetNode]
+relayNodes = filter (not . isTestnetNodeSpo) . testnetNodes
 
 data TestnetNode = TestnetNode
-  { testnetNodeRuntime :: !NodeRuntime
-  , poolKeys :: Maybe SpoNodeKeys -- ^ Keys are only present for SPO nodes
-  }
-
-testnetNodeStdout :: TestnetNode -> FilePath
-testnetNodeStdout = nodeStdout . testnetNodeRuntime
-
-isTestnetNodeSpo :: TestnetNode -> Bool
-isTestnetNodeSpo = isJust . poolKeys
-
--- | Node process runtime parameters
-data NodeRuntime = NodeRuntime
   { nodeName :: !String
+  , poolKeys :: Maybe SpoNodeKeys -- ^ Keys are only present for SPO nodes
   , nodeIpv4 :: !HostAddress
   , nodePort :: !PortNumber
   , nodeSprocket :: !Sprocket
@@ -154,7 +137,10 @@ data NodeRuntime = NodeRuntime
   , nodeProcessHandle :: !IO.ProcessHandle
   }
 
-nodeSocketPath :: NodeRuntime -> SocketPath
+isTestnetNodeSpo :: TestnetNode -> Bool
+isTestnetNodeSpo = isJust . poolKeys
+
+nodeSocketPath :: TestnetNode -> SocketPath
 nodeSocketPath = File . H.sprocketSystemName . nodeSprocket
 
 data ColdPoolKey

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/Plutus.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/Plutus.hs
@@ -65,14 +65,14 @@ hprop_plutus_v3 = integrationWorkspace "all-plutus-script-purposes" $ \tempAbsBa
     , wallets=wallet0:wallet1:_
     } <- cardanoTestnetDefault options def conf
 
-  TestnetNode{testnetNodeRuntime} <- H.headM testnetNodes
-  poolSprocket1 <- H.noteShow $ nodeSprocket testnetNodeRuntime
+  node <- H.headM testnetNodes
+  poolSprocket1 <- H.noteShow $ nodeSprocket node
   execConfig <- mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
   H.noteShow_ wallet0
   let utxoAddr = Text.unpack $ paymentKeyInfoAddr wallet0
       utxoSKeyFile = signingKeyFp $ paymentKeyInfoPair wallet0
       utxoSKeyFile2 = signingKeyFp $ paymentKeyInfoPair wallet1
-      socketPath = nodeSocketPath testnetNodeRuntime
+      socketPath = nodeSocketPath node
 
   epochStateView <- getEpochStateView configurationFile socketPath
   txin1 <- findLargestUtxoForPaymentKey epochStateView sbe wallet0

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/StakeSnapshot.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/StakeSnapshot.hs
@@ -21,7 +21,6 @@ import qualified System.Info as SYS
 
 import           Testnet.Process.Run (execCliStdoutToJson, mkExecConfig)
 import           Testnet.Property.Util (integrationRetryWorkspace)
-import           Testnet.Types
 
 import           Hedgehog (Property, (===))
 import qualified Hedgehog as H
@@ -43,7 +42,7 @@ hprop_stakeSnapshot = integrationRetryWorkspace 2 "conway-stake-snapshot" $ \tem
     } <- cardanoTestnetDefault def def conf
 
   poolNode1 <- H.headM testnetNodes
-  poolSprocket1 <- H.noteShow $ nodeSprocket $ testnetNodeRuntime poolNode1
+  poolSprocket1 <- H.noteShow $ nodeSprocket poolNode1
   execConfig <- mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
 
   void $ waitUntilEpoch configurationFile

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/KesPeriodInfo.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/KesPeriodInfo.hs
@@ -215,7 +215,7 @@ hprop_kes_period_info = integrationRetryWorkspace 2 "kes-period-info" $ \tempAbs
   H.createDirectoryIfMissing_ testSpoDir
   let valency = 1
       topology = RealNodeTopology $
-        flip map testnetNodes $ \TestnetNode{testnetNodeRuntime=NodeRuntime{nodeIpv4,nodePort}} ->
+        flip map testnetNodes $ \TestnetNode{nodeIpv4,nodePort} ->
             RemoteAddress (showIpv4Address nodeIpv4) nodePort valency
   H.lbsWriteFile topologyFile $ Aeson.encode topology
 
@@ -260,7 +260,7 @@ hprop_kes_period_info = integrationRetryWorkspace 2 "kes-period-info" $ \tempAbs
         , "--shelley-vrf-key", testSpoVrfSKey
         , "--shelley-operational-certificate", testSpoOperationalCertFp
         ]
-  NodeRuntime{ nodeStdout } <- H.evalEither eRuntime
+  TestnetNode{nodeStdout} <- H.evalEither eRuntime
 
   threadDelay 5_000_000
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/LeadershipSchedule.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/LeadershipSchedule.hs
@@ -222,7 +222,7 @@ hprop_leadershipSchedule = integrationRetryWorkspace 2 "leadership-schedule" $ \
   H.createDirectoryIfMissing_ testSpoDir
   let valency = 1
       topology = RealNodeTopology $
-        flip map testnetNodes $ \TestnetNode{testnetNodeRuntime=NodeRuntime{nodeIpv4,nodePort}} ->
+        flip map testnetNodes $ \TestnetNode{nodeIpv4,nodePort} ->
           RemoteAddress (showIpv4Address nodeIpv4) nodePort valency
   H.lbsWriteFile topologyFile $ Aeson.encode topology
   let testSpoKesVKey = work </> "kes.vkey"

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Query.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Query.hs
@@ -114,10 +114,10 @@ hprop_cli_queries = integrationWorkspace "cli-queries" $ \tempAbsBasePath' -> H.
 
   let shelleyGeneisFile = work </> Defaults.defaultGenesisFilepath ShelleyEra
 
-  TestnetNode{testnetNodeRuntime} <- H.headM testnetNodes
-  poolSprocket1 <- H.noteShow $ nodeSprocket testnetNodeRuntime
+  node <- H.headM testnetNodes
+  poolSprocket1 <- H.noteShow $ nodeSprocket node
   execConfig <- mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
-  let socketPath = nodeSocketPath testnetNodeRuntime
+  let socketPath = nodeSocketPath node
 
   epochStateView <- getEpochStateView configurationFile socketPath
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/QuerySlotNumber.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/QuerySlotNumber.hs
@@ -56,7 +56,7 @@ hprop_querySlotNumber = integrationRetryWorkspace 2 "query-slot-number" $ \tempA
       epochSize = fromIntegral (unEpochSize sgEpochLength) :: Int
 
   poolNode1 <- H.headM testnetNodes
-  poolSprocket1 <- H.noteShow $ nodeSprocket $ testnetNodeRuntime poolNode1
+  poolSprocket1 <- H.noteShow $ nodeSprocket poolNode1
   execConfig <- mkExecConfig tempBaseAbsPath' poolSprocket1 testnetMagic
 
   id do

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/StakeSnapshot.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/StakeSnapshot.hs
@@ -22,7 +22,6 @@ import qualified System.Info as SYS
 
 import           Testnet.Process.Run (execCliStdoutToJson, mkExecConfig)
 import           Testnet.Property.Util (integrationRetryWorkspace)
-import           Testnet.Types
 
 import           Hedgehog (Property, (===))
 import qualified Hedgehog as H
@@ -45,7 +44,7 @@ hprop_stakeSnapshot = integrationRetryWorkspace 2 "stake-snapshot" $ \tempAbsBas
 
   let nSpoNodes = length $ spoNodes runtime
   poolNode1 <- H.headM testnetNodes
-  poolSprocket1 <- H.noteShow $ nodeSprocket $ testnetNodeRuntime poolNode1
+  poolSprocket1 <- H.noteShow $ nodeSprocket poolNode1
   execConfig <- mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
 
   void $ waitUntilEpoch configurationFile

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction.hs
@@ -65,7 +65,7 @@ hprop_transaction = integrationRetryWorkspace 2 "simple transaction build" $ \te
     } <- cardanoTestnetDefault options def conf
 
   poolNode1 <- H.headM testnetNodes
-  poolSprocket1 <- H.noteShow $ nodeSprocket $ testnetNodeRuntime poolNode1
+  poolSprocket1 <- H.noteShow $ nodeSprocket poolNode1
   execConfig <- mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
 
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/FoldEpochState.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/FoldEpochState.hs
@@ -17,7 +17,6 @@ import qualified System.Directory as IO
 import           System.FilePath ((</>))
 
 import           Testnet.Property.Util (integrationWorkspace)
-import           Testnet.Types
 
 import           Hedgehog ((===))
 import qualified Hedgehog as H

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/CommitteeAddNew.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/CommitteeAddNew.hs
@@ -91,10 +91,10 @@ hprop_constitutional_committee_add_new = integrationWorkspace "constitutional-co
     }
     <- cardanoTestnetDefault fastTestnetOptions shelleyOptions conf
 
-  TestnetNode{testnetNodeRuntime, poolKeys=Just poolKeys} <- H.headM . filter isTestnetNodeSpo $ testnetNodes runtime
-  poolSprocket1 <- H.noteShow $ nodeSprocket testnetNodeRuntime
+  node@TestnetNode{poolKeys=Just poolKeys} <- H.headM . filter isTestnetNodeSpo $ testnetNodes runtime
+  poolSprocket1 <- H.noteShow $ nodeSprocket node
   execConfig <- mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
-  let socketPath = nodeSocketPath testnetNodeRuntime
+  let socketPath = nodeSocketPath node
 
   epochStateView <- getEpochStateView configurationFile socketPath
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepActivity.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepActivity.hs
@@ -69,10 +69,10 @@ hprop_check_drep_activity = integrationWorkspace "test-activity" $ \tempAbsBaseP
     }
     <- cardanoTestnetDefault fastTestnetOptions shelleyOptions conf
 
-  TestnetNode{testnetNodeRuntime} <- H.headM testnetNodes
-  poolSprocket1 <- H.noteShow $ nodeSprocket testnetNodeRuntime
+  node <- H.headM testnetNodes
+  poolSprocket1 <- H.noteShow $ nodeSprocket node
   execConfig <- mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
-  let socketPath = nodeSocketPath testnetNodeRuntime
+  let socketPath = nodeSocketPath node
 
   epochStateView <- getEpochStateView configurationFile socketPath
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepDeposit.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepDeposit.hs
@@ -58,10 +58,10 @@ hprop_ledger_events_drep_deposits = integrationWorkspace "drep-deposits" $ \temp
     }
     <- cardanoTestnetDefault fastTestnetOptions shelleyOptions conf
 
-  TestnetNode{testnetNodeRuntime} <- H.headM testnetNodes
-  poolSprocket1 <- H.noteShow $ nodeSprocket testnetNodeRuntime
+  node <- H.headM testnetNodes
+  poolSprocket1 <- H.noteShow $ nodeSprocket node
   execConfig <- mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
-  let socketPath = nodeSocketPath testnetNodeRuntime
+  let socketPath = nodeSocketPath node
 
   epochStateView <- getEpochStateView configurationFile socketPath
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepRetirement.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepRetirement.hs
@@ -59,10 +59,10 @@ hprop_drep_retirement = integrationRetryWorkspace 2 "drep-retirement" $ \tempAbs
     }
     <- cardanoTestnetDefault fastTestnetOptions shelleyOptions conf
 
-  TestnetNode{testnetNodeRuntime} <- H.headM testnetNodes
-  poolSprocket1 <- H.noteShow $ nodeSprocket testnetNodeRuntime
+  node <- H.headM testnetNodes
+  poolSprocket1 <- H.noteShow $ nodeSprocket node
   execConfig <- mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
-  let socketPath = nodeSocketPath testnetNodeRuntime
+  let socketPath = nodeSocketPath node
 
   epochStateView <- getEpochStateView configurationFile socketPath
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/GovActionTimeout.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/GovActionTimeout.hs
@@ -25,7 +25,6 @@ import           Testnet.Process.Cli.DRep (makeActivityChangeProposal)
 import           Testnet.Process.Run (mkExecConfig)
 import           Testnet.Property.Util (integrationWorkspace)
 import           Testnet.Start.Types
-import           Testnet.Types
 
 import           Hedgehog (Property)
 import qualified Hedgehog as H
@@ -59,10 +58,10 @@ hprop_check_gov_action_timeout = integrationWorkspace "gov-action-timeout" $ \te
     }
     <- cardanoTestnetDefault fastTestnetOptions shelleyOptions conf
 
-  TestnetNode{testnetNodeRuntime} <- H.headM testnetNodes
-  poolSprocket1 <- H.noteShow $ nodeSprocket testnetNodeRuntime
+  node <- H.headM testnetNodes
+  poolSprocket1 <- H.noteShow $ nodeSprocket node
   execConfig <- mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
-  let socketPath = nodeSocketPath testnetNodeRuntime
+  let socketPath = nodeSocketPath node
 
   epochStateView <- getEpochStateView configurationFile socketPath
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/InfoAction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/InfoAction.hs
@@ -70,10 +70,10 @@ hprop_ledger_events_info_action = integrationRetryWorkspace 2 "info-hash" $ \tem
     }
     <- cardanoTestnetDefault fastTestnetOptions shelleyOptions conf
 
-  TestnetNode{testnetNodeRuntime} <- H.headM testnetNodes
-  poolSprocket1 <- H.noteShow $ nodeSprocket testnetNodeRuntime
+  node <- H.headM testnetNodes
+  poolSprocket1 <- H.noteShow $ nodeSprocket node
   execConfig <- mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
-  let socketPath = nodeSocketPath testnetNodeRuntime
+  let socketPath = nodeSocketPath node
 
   epochStateView <- getEpochStateView configurationFile socketPath
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs
@@ -123,7 +123,7 @@ hprop_gov_no_confidence = integrationWorkspace "no-confidence" $ \tempAbsBasePat
            alonzoGenesis conwayGenesisWithCommittee
 
   poolNode1 <- H.headM testnetNodes
-  poolSprocket1 <- H.noteShow $ nodeSprocket $ testnetNodeRuntime poolNode1
+  poolSprocket1 <- H.noteShow $ nodeSprocket poolNode1
   execConfig <- H.mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
 
   let socketName' = IO.sprocketName poolSprocket1

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PParamChangeFailsSPO.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PParamChangeFailsSPO.hs
@@ -64,10 +64,10 @@ hprop_check_pparam_fails_spo = integrationWorkspace "test-pparam-spo" $ \tempAbs
     }
     <- cardanoTestnetDefault fastTestnetOptions shelleyOptions conf
 
-  TestnetNode{testnetNodeRuntime} <- H.headM testnetNodes
-  poolSprocket1 <- H.noteShow $ nodeSprocket testnetNodeRuntime
+  node <- H.headM testnetNodes
+  poolSprocket1 <- H.noteShow $ nodeSprocket node
   execConfig <- mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
-  let socketPath = nodeSocketPath testnetNodeRuntime
+  let socketPath = nodeSocketPath node
 
   epochStateView <- getEpochStateView configurationFile socketPath
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
@@ -43,8 +43,7 @@ import qualified Testnet.Property.Util as H
 import           Testnet.Start.Types
 import           Testnet.Types (KeyPair (..),
                    PaymentKeyInfo (paymentKeyInfoAddr, paymentKeyInfoPair),
-                   SomeKeyPair (SomeKeyPair), StakingKey, TestnetNode (..), TestnetRuntime (..),
-                   nodeSocketPath)
+                   SomeKeyPair (SomeKeyPair), StakingKey)
 
 import           Hedgehog
 import qualified Hedgehog.Extras as H
@@ -90,10 +89,10 @@ hprop_check_predefined_abstain_drep = H.integrationWorkspace "test-activity" $ \
     }
     <- cardanoTestnetDefault fastTestnetOptions shelleyOptions conf
 
-  TestnetNode{testnetNodeRuntime} <- H.headM testnetNodes
-  poolSprocket1 <- H.noteShow $ nodeSprocket testnetNodeRuntime
+  node <- H.headM testnetNodes
+  poolSprocket1 <- H.noteShow $ nodeSprocket node
   execConfig <- H.mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
-  let socketPath = nodeSocketPath testnetNodeRuntime
+  let socketPath = nodeSocketPath node
 
   epochStateView <- getEpochStateView configurationFile socketPath
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitution.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitution.hs
@@ -84,10 +84,10 @@ hprop_ledger_events_propose_new_constitution = integrationWorkspace "propose-new
     }
     <- cardanoTestnetDefault fastTestnetOptions shelleyOptions conf
 
-  TestnetNode{testnetNodeRuntime} <- H.headM testnetNodes
-  poolSprocket1 <- H.noteShow $ nodeSprocket testnetNodeRuntime
+  node <- H.headM testnetNodes
+  poolSprocket1 <- H.noteShow $ nodeSprocket node
   execConfig <- mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
-  let socketPath = nodeSocketPath testnetNodeRuntime
+  let socketPath = nodeSocketPath node
 
   epochStateView <- getEpochStateView configurationFile socketPath
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitutionSPO.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitutionSPO.hs
@@ -72,10 +72,10 @@ hprop_ledger_events_propose_new_constitution_spo = integrationWorkspace "propose
     }
     <- cardanoTestnetDefault fastTestnetOptions shelleyOptions conf
 
-  TestnetNode{testnetNodeRuntime} <- H.headM testnetNodes
-  poolSprocket1 <- H.noteShow $ nodeSprocket testnetNodeRuntime
+  node <- H.headM testnetNodes
+  poolSprocket1 <- H.noteShow $ nodeSprocket node
   execConfig <- mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
-  let socketPath = nodeSocketPath testnetNodeRuntime
+  let socketPath = nodeSocketPath node
 
   epochStateView <- getEpochStateView configurationFile socketPath
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryGrowth.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryGrowth.hs
@@ -26,7 +26,6 @@ import           System.FilePath ((</>))
 import           Testnet.Process.Run (execCli', mkExecConfig)
 import           Testnet.Property.Util (integrationRetryWorkspace)
 import           Testnet.Start.Types
-import           Testnet.Types
 
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as H
@@ -50,8 +49,8 @@ prop_check_if_treasury_is_growing = integrationRetryWorkspace 2 "growing-treasur
   TestnetRuntime{testnetMagic, configurationFile, testnetNodes} <- cardanoTestnetDefault options shelleyOptions conf
 
   (execConfig, socketPathAbs) <- do
-    TestnetNode{testnetNodeRuntime} <- H.headM testnetNodes
-    poolSprocket1 <- H.noteShow $ nodeSprocket testnetNodeRuntime
+    TestnetNode{nodeSprocket} <- H.headM testnetNodes
+    poolSprocket1 <- H.noteShow nodeSprocket
     let socketPath' = H.sprocketArgumentName poolSprocket1
     socketPathAbs <- Api.File <$> H.noteIO (IO.canonicalizePath $ tempAbsPath' </> socketPath')
     execConfig <- mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryWithdrawal.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryWithdrawal.hs
@@ -49,7 +49,7 @@ import           Hedgehog
 import qualified Hedgehog.Extras as H
 
 hprop_ledger_events_treasury_withdrawal:: Property
-hprop_ledger_events_treasury_withdrawal = integrationRetryWorkspace 1  "treasury-withdrawal" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
+hprop_ledger_events_treasury_withdrawal = integrationRetryWorkspace 2  "treasury-withdrawal" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   conf@Conf { tempAbsPath } <- H.noteShowM $ mkConf tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
       tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
@@ -74,10 +74,10 @@ hprop_ledger_events_treasury_withdrawal = integrationRetryWorkspace 1  "treasury
     }
     <- cardanoTestnetDefault fastTestnetOptions shelleyOptions conf
 
-  TestnetNode{testnetNodeRuntime} <- H.headM testnetNodes
-  poolSprocket1 <- H.noteShow $ nodeSprocket testnetNodeRuntime
+  node@TestnetNode{nodeSprocket} <- H.headM testnetNodes
+  poolSprocket1 <- H.noteShow nodeSprocket
   execConfig <- mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
-  let socketPath = nodeSocketPath testnetNodeRuntime
+  let socketPath = nodeSocketPath node
 
   epochStateView <- getEpochStateView configurationFile socketPath
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SanityCheck.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SanityCheck.hs
@@ -20,9 +20,8 @@ import           Data.Default.Class
 import           GHC.IO.Exception (IOException)
 import           GHC.Stack
 
-import           Testnet.Property.Util (integrationWorkspace)
+import           Testnet.Property.Util (integrationRetryWorkspace)
 import           Testnet.Start.Types
-import           Testnet.Types
 
 import           Hedgehog
 import qualified Hedgehog.Extras as H
@@ -41,7 +40,7 @@ newtype AdditionalCatcher
 -- This sets the stage for more direct testing of clusters allowing us to avoid querying the node, dealing with serialization to and from disk,
 -- setting timeouts for expected results etc.
 hprop_ledger_events_sanity_check :: Property
-hprop_ledger_events_sanity_check = integrationWorkspace "ledger-events-sanity-check" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
+hprop_ledger_events_sanity_check = integrationRetryWorkspace 2 "ledger-events-sanity-check" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   -- Start a local test net
   conf <- mkConf tempAbsBasePath'
 
@@ -53,7 +52,7 @@ hprop_ledger_events_sanity_check = integrationWorkspace "ledger-events-sanity-ch
 
   TestnetRuntime{configurationFile, testnetNodes}
     <- cardanoTestnetDefault fastTestnetOptions shelleyOptions conf
-  nr@NodeRuntime{nodeSprocket} <- H.headM $ testnetNodeRuntime <$> testnetNodes
+  nr@TestnetNode{nodeSprocket} <- H.headM testnetNodes
   let socketPath = nodeSocketPath nr
 
   H.note_ $ "Sprocket: " <> show nodeSprocket

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SubmitApi/Transaction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SubmitApi/Transaction.hs
@@ -74,7 +74,7 @@ hprop_transaction = integrationRetryWorkspace 2 "submit-api-transaction" $ \temp
 
   poolNode1 <- H.headM testnetNodes
 
-  poolSprocket1 <- H.noteShow $ nodeSprocket $ testnetNodeRuntime poolNode1
+  poolSprocket1 <- H.noteShow $ nodeSprocket poolNode1
 
   execConfig <- mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
 


### PR DESCRIPTION
# Description

Removes `NodeRuntime` type, which was redundant. 

A follow up from https://github.com/IntersectMBO/cardano-node/pull/6007#discussion_r1797086810

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
