### PR TITLE
cardano-testnet | Add stake address registration/deregistration test

### DIFF
--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -183,30 +183,31 @@ test-suite cardano-testnet-test
 
   main-is:              cardano-testnet-test.hs
 
-  other-modules:        Cardano.Testnet.Test.Cli.LeadershipSchedule
-                        Cardano.Testnet.Test.Cli.StakeSnapshot
-                        Cardano.Testnet.Test.Cli.Transaction
-                        Cardano.Testnet.Test.Cli.Conway.Plutus
+  other-modules:        Cardano.Testnet.Test.Cli.Conway.Plutus
                         Cardano.Testnet.Test.Cli.Conway.StakeSnapshot
                         Cardano.Testnet.Test.Cli.KesPeriodInfo
+                        Cardano.Testnet.Test.Cli.LeadershipSchedule
                         Cardano.Testnet.Test.Cli.Query
                         Cardano.Testnet.Test.Cli.QuerySlotNumber
+                        Cardano.Testnet.Test.Cli.StakeSnapshot
+                        Cardano.Testnet.Test.Cli.Transaction
+                        Cardano.Testnet.Test.Cli.Transaction.RegisterDeregisterStakeAddress
                         Cardano.Testnet.Test.FoldEpochState
                         Cardano.Testnet.Test.Gov.CommitteeAddNew
                         Cardano.Testnet.Test.Gov.DRepActivity
                         Cardano.Testnet.Test.Gov.DRepDeposit
                         Cardano.Testnet.Test.Gov.DRepRetirement
+                        Cardano.Testnet.Test.Gov.GovActionTimeout
                         Cardano.Testnet.Test.Gov.InfoAction
                         Cardano.Testnet.Test.Gov.NoConfidence
                         Cardano.Testnet.Test.Gov.PParamChangeFailsSPO
+                        Cardano.Testnet.Test.Gov.PredefinedAbstainDRep
                         Cardano.Testnet.Test.Gov.ProposeNewConstitution
                         Cardano.Testnet.Test.Gov.ProposeNewConstitutionSPO
-                        Cardano.Testnet.Test.Gov.GovActionTimeout
                         Cardano.Testnet.Test.Gov.TreasuryDonation
                         Cardano.Testnet.Test.Gov.TreasuryGrowth
                         Cardano.Testnet.Test.Gov.TreasuryWithdrawal
                         Cardano.Testnet.Test.Misc
-                        Cardano.Testnet.Test.Gov.PredefinedAbstainDRep
                         Cardano.Testnet.Test.Node.Shutdown
                         Cardano.Testnet.Test.SanityCheck
                         Cardano.Testnet.Test.SubmitApi.Transaction

--- a/cardano-testnet/src/Testnet/Components/Query.hs
+++ b/cardano-testnet/src/Testnet/Components/Query.hs
@@ -49,7 +49,6 @@ import           Cardano.Ledger.Api (ConwayGovState)
 import qualified Cardano.Ledger.Api as L
 import qualified Cardano.Ledger.Coin as L
 import qualified Cardano.Ledger.Conway.Governance as L
-import           Cardano.Ledger.Conway.PParams (ConwayEraPParams)
 import qualified Cardano.Ledger.Conway.PParams as L
 import qualified Cardano.Ledger.Shelley.LedgerState as L
 import qualified Cardano.Ledger.UTxO as L

--- a/cardano-testnet/src/Testnet/Defaults.hs
+++ b/cardano-testnet/src/Testnet/Defaults.hs
@@ -44,7 +44,6 @@ import qualified Cardano.Api.Shelley as Api
 import           Cardano.Ledger.Alonzo.Core (PParams (..))
 import           Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis)
 import qualified Cardano.Ledger.Alonzo.Genesis as Ledger
-import qualified Cardano.Ledger.Api as L
 import           Cardano.Ledger.BaseTypes
 import qualified Cardano.Ledger.BaseTypes as Ledger
 import           Cardano.Ledger.Binary.Version ()

--- a/cardano-testnet/src/Testnet/Defaults.hs
+++ b/cardano-testnet/src/Testnet/Defaults.hs
@@ -388,8 +388,7 @@ defaultShelleyGenesis asbe startTime maxSupply options = do
       -- TODO: find out why this actually degrates network stability - turned off for now
       -- securityParam = ceiling $ fromIntegral epochLength * cardanoActiveSlotsCoeff / 10
       pVer = eraToProtocolVersion asbe
-      -- TODO: Remove after merging https://github.com/IntersectMBO/cardano-node/pull/6017
-      protocolParams = Api.sgProtocolParams Api.shelleyGenesisDefaults & L.ppKeyDepositL .~ 0
+      protocolParams = Api.sgProtocolParams Api.shelleyGenesisDefaults
       protocolParamsWithPVer = protocolParams & ppProtocolVersionL' .~ pVer
   Api.shelleyGenesisDefaults
         { Api.sgActiveSlotsCoeff = unsafeBoundedRational activeSlotsCoeff

--- a/cardano-testnet/src/Testnet/Process/Cli/DRep.hs
+++ b/cardano-testnet/src/Testnet/Process/Cli/DRep.hs
@@ -17,6 +17,7 @@ module Testnet.Process.Cli.DRep
   ) where
 
 import           Cardano.Api hiding (Certificate, TxBody)
+import           Cardano.Api.Experimental (Some (..))
 import           Cardano.Api.Ledger (EpochInterval (EpochInterval, unEpochInterval))
 
 import           Cardano.Testnet (maybeExtractGovernanceActionIndex)
@@ -239,7 +240,7 @@ registerDRep execConfig epochStateView ceo work prefix wallet = do
   drepRegTxBody <- createCertificatePublicationTxBody execConfig epochStateView sbe baseDir "reg-cert-txbody"
                                                        drepRegCert wallet
   drepSignedRegTx <- signTx execConfig cEra baseDir "signed-reg-tx"
-                             drepRegTxBody [SomeKeyPair drepKeyPair, SomeKeyPair $ paymentKeyInfoPair wallet]
+                             drepRegTxBody [Some drepKeyPair, Some $ paymentKeyInfoPair wallet]
   submitTx execConfig cEra drepSignedRegTx
 
   return drepKeyPair
@@ -286,8 +287,8 @@ delegateToDRep execConfig epochStateView sbe work prefix
 
   -- Sign transaction
   repRegSignedRegTx1 <- signTx execConfig cEra baseDir "signed-reg-tx"
-                               repRegTxBody1 [ SomeKeyPair $ paymentKeyInfoPair payingWallet
-                                             , SomeKeyPair skeyPair]
+                               repRegTxBody1 [ Some $ paymentKeyInfoPair payingWallet
+                                             , Some skeyPair]
 
   -- Submit transaction
   submitTx execConfig cEra repRegSignedRegTx1
@@ -398,7 +399,7 @@ makeActivityChangeProposal execConfig epochStateView ceo work
     ]
 
   signedProposalTx <- signTx execConfig cEra baseDir "signed-proposal"
-                             (File proposalBody) [SomeKeyPair $ paymentKeyInfoPair wallet]
+                             (File proposalBody) [Some $ paymentKeyInfoPair wallet]
 
   submitTx execConfig cEra signedProposalTx
 

--- a/cardano-testnet/src/Testnet/Process/Cli/SPO.hs
+++ b/cardano-testnet/src/Testnet/Process/Cli/SPO.hs
@@ -52,10 +52,10 @@ checkStakePoolRegistered
   :: (MonadTest m, MonadCatch m, MonadIO m, HasCallStack)
   => TmpAbsolutePath
   -> ExecConfig
-  -> FilePath -- ^ Stake pool cold verification key file
+  -> File (VKey StakeKey) In -- ^ Stake pool cold verification key file
   -> FilePath -- ^ Output file path of stake pool info
   -> m String -- ^ Stake pool ID
-checkStakePoolRegistered tempAbsP execConfig poolColdVkeyFp outputFp =
+checkStakePoolRegistered tempAbsP execConfig (File poolColdVkeyFp) outputFp =
   GHC.withFrozenCallStack $ do
     let tempAbsPath' = unTmpAbsPath tempAbsP
         oFpAbs = tempAbsPath' </> outputFp
@@ -160,11 +160,11 @@ createStakeDelegationCertificate
   :: (MonadTest m, MonadCatch m, MonadIO m, HasCallStack)
   => TmpAbsolutePath
   -> ShelleyBasedEra era
-  -> FilePath -- ^ Delegate stake verification key file
+  -> File (VKey StakeKey) In -- ^ Delegate stake verification key file
   -> String -- ^ Pool id
   -> FilePath
   -> m ()
-createStakeDelegationCertificate tempAbsP sbe delegatorStakeVerKey poolId outputFp =
+createStakeDelegationCertificate tempAbsP sbe (File delegatorStakeVerKey) poolId outputFp =
   GHC.withFrozenCallStack $ do
     let tempAbsPath' = unTmpAbsPath tempAbsP
     execCli_
@@ -179,11 +179,11 @@ createStakeKeyRegistrationCertificate
   :: (MonadTest m, MonadCatch m, MonadIO m, HasCallStack)
   => TmpAbsolutePath
   -> AnyShelleyBasedEra
-  -> FilePath -- ^ Stake verification key file
+  -> File (VKey StakeKey) In -- ^ Stake verification key file
   -> Int -- ^ deposit amount used only in Conway
   -> FilePath -- ^ Output file path
   -> m ()
-createStakeKeyRegistrationCertificate tempAbsP asbe stakeVerKey deposit outputFp = GHC.withFrozenCallStack $ do
+createStakeKeyRegistrationCertificate tempAbsP asbe (File stakeVerKey) deposit outputFp = GHC.withFrozenCallStack $ do
   AnyShelleyBasedEra sbe <- return asbe
   let tempAbsPath' = unTmpAbsPath tempAbsP
       extraArgs = monoidForEraInEon @ConwayEraOnwards (toCardanoEra sbe) $
@@ -251,16 +251,12 @@ registerSingleSpo
   -> ExecConfig
   -> (TxIn, FilePath, String)
   -> m ( String
-       , FilePath
-       , FilePath
-       , FilePath
-       , FilePath
+       , KeyPair StakeKey
+       , KeyPair VrfKey
        ) -- ^ Result tuple:
          --   1. String: Registered stake pool ID
-         --   2. FilePath: Stake pool cold signing key
-         --   3. FilePath: Stake pool cold verification key
-         --   4. FilePath: Stake pool VRF signing key
-         --   5. FilePath: Stake pool VRF verification key
+         --   2. Stake pool cold keys
+         --   3. Stake pool VRF keys
 registerSingleSpo asbe identifier tap@(TmpAbsolutePath tempAbsPath') nodeConfigFile socketPath termEpoch testnetMag execConfig
                   (fundingInput, fundingSigninKey, changeAddr) = GHC.withFrozenCallStack $ do
   workDir <- H.note tempAbsPath'
@@ -276,48 +272,53 @@ registerSingleSpo asbe identifier tap@(TmpAbsolutePath tempAbsPath') nodeConfigF
   let spoReqDir = workDir </>  "spo-"<> show identifier <> "-requirements"
 
   H.createDirectoryIfMissing_ spoReqDir
-  let poolOwnerstakeVkeyFp = spoReqDir </> "pool-owner-stake.vkey"
-      poolOwnerstakeSKeyFp = spoReqDir </> "pool-owner-stake.skey"
+  let poolOwnerStakeKeys = KeyPair
+        { verificationKey = File $ spoReqDir </> "pool-owner-stake.vkey"
+        , signingKey = File $ spoReqDir </> "pool-owner-stake.skey"
+        }
 
-  cliStakeAddressKeyGen
-    $ KeyPair (File poolOwnerstakeVkeyFp) (File poolOwnerstakeSKeyFp)
+  cliStakeAddressKeyGen poolOwnerStakeKeys
 
   poolownerstakeaddr <- filter (/= '\n')
                           <$> execCli
                                 [ "latest", "stake-address", "build"
-                                , "--stake-verification-key-file", poolOwnerstakeVkeyFp
+                                , "--stake-verification-key-file", verificationKeyFp poolOwnerStakeKeys
                                 , "--testnet-magic", show @Int testnetMag
                                 ]
 
   -- 2. Generate stake pool owner payment key pair
-  let poolOwnerPaymentVkeyFp = spoReqDir </> "pool-owner-payment.vkey"
-      poolOwnerPaymentSkeyFp = spoReqDir </> "pool-owner-payment.skey"
-  cliAddressKeyGen
-     $ KeyPair (File poolOwnerPaymentVkeyFp) (File poolOwnerPaymentSkeyFp)
+  let poolOwnerPaymentKeys = KeyPair
+        { verificationKey = File $ spoReqDir </> "pool-owner-payment.vkey"
+        , signingKey = File $ spoReqDir </> "pool-owner-payment.skey"
+        }
+  cliAddressKeyGen poolOwnerPaymentKeys
 
   poolowneraddresswstakecred <-
     execCli [ "latest", "address", "build"
-              , "--payment-verification-key-file", poolOwnerPaymentVkeyFp
-              , "--stake-verification-key-file",  poolOwnerstakeVkeyFp
+              , "--payment-verification-key-file", verificationKeyFp poolOwnerPaymentKeys
+              , "--stake-verification-key-file",  verificationKeyFp poolOwnerStakeKeys
               , "--testnet-magic", show @Int testnetMag
               ]
 
   -- 3. Generate pool cold keys
-  let poolColdVkeyFp = spoReqDir </> "pool-cold.vkey"
-      poolColdSkeyFp = spoReqDir </> "pool-cold.skey"
+  let poolColdKeys = KeyPair
+        { verificationKey = File $ spoReqDir </> "pool-cold.vkey"
+        , signingKey = File $ spoReqDir </> "pool-cold.skey"
+        }
 
   execCli_
     [ "latest", "node", "key-gen"
-    , "--cold-verification-key-file", poolColdVkeyFp
-    , "--cold-signing-key-file", poolColdSkeyFp
+    , "--cold-verification-key-file", verificationKeyFp poolColdKeys
+    , "--cold-signing-key-file", signingKeyFp poolColdKeys
     , "--operational-certificate-issue-counter-file", spoReqDir </> "operator.counter"
     ]
 
   -- 4. Generate VRF keys
-  let vrfVkeyFp = spoReqDir </> "pool-vrf.vkey"
-      vrfSkeyFp = spoReqDir </> "pool-vrf.skey"
-  cliNodeKeyGenVrf
-     $ KeyPair (File vrfVkeyFp) (File vrfSkeyFp)
+  let vrfKeys = KeyPair
+        { verificationKey = File $ spoReqDir </> "pool-vrf.vkey"
+        , signingKey = File $ spoReqDir </> "pool-vrf.skey"
+        }
+  cliNodeKeyGenVrf vrfKeys
 
   -- 5. Create registration certificate
   let poolRegCertFp = spoReqDir </> "registration.cert"
@@ -330,10 +331,10 @@ registerSingleSpo asbe identifier tap@(TmpAbsolutePath tempAbsPath') nodeConfigF
     , "--pool-pledge", "0"
     , "--pool-cost", "0"
     , "--pool-margin", "0"
-    , "--cold-verification-key-file", poolColdVkeyFp
-    , "--vrf-verification-key-file", vrfVkeyFp
-    , "--reward-account-verification-key-file", poolOwnerstakeVkeyFp
-    , "--pool-owner-stake-verification-key-file", poolOwnerstakeVkeyFp
+    , "--cold-verification-key-file", verificationKeyFp poolColdKeys
+    , "--vrf-verification-key-file", verificationKeyFp vrfKeys
+    , "--reward-account-verification-key-file", verificationKeyFp poolOwnerStakeKeys
+    , "--pool-owner-stake-verification-key-file", verificationKeyFp poolOwnerStakeKeys
     , "--out-file", poolRegCertFp
     ]
 
@@ -342,7 +343,7 @@ registerSingleSpo asbe identifier tap@(TmpAbsolutePath tempAbsPath') nodeConfigF
 
   -- Create pledger registration certificate
   createStakeKeyRegistrationCertificate tap asbe
-    poolOwnerstakeVkeyFp
+    (verificationKey poolOwnerStakeKeys)
     400_000
     (workDir </> "pledger.regcert")
 
@@ -365,8 +366,8 @@ registerSingleSpo asbe identifier tap@(TmpAbsolutePath tempAbsPath') nodeConfigF
     , "--tx-body-file", workDir </> "pledge-registration-cert.txbody"
     , "--testnet-magic", show @Int testnetMag
     , "--signing-key-file", fundingSigninKey
-    , "--signing-key-file", poolOwnerstakeSKeyFp
-    , "--signing-key-file", poolColdSkeyFp
+    , "--signing-key-file", signingKeyFp poolOwnerStakeKeys
+    , "--signing-key-file", signingKeyFp poolColdKeys
     , "--out-file", pledgeAndPoolRegistrationTx
     ]
 
@@ -397,9 +398,9 @@ registerSingleSpo asbe identifier tap@(TmpAbsolutePath tempAbsPath') nodeConfigF
   poolId <- checkStakePoolRegistered
               tap
               execConfig
-              poolColdVkeyFp
+              (verificationKey poolColdKeys)
               currentRegistedPoolsJson
-  return (poolId, poolColdSkeyFp, poolColdVkeyFp, vrfSkeyFp, vrfVkeyFp)
+  return (poolId, poolColdKeys, vrfKeys)
 
 -- | Generates Stake Pool Operator (SPO) voting files, using @cardano-cli@.
 --

--- a/cardano-testnet/src/Testnet/Process/Cli/SPO.hs
+++ b/cardano-testnet/src/Testnet/Process/Cli/SPO.hs
@@ -341,10 +341,9 @@ registerSingleSpo asbe identifier tap@(TmpAbsolutePath tempAbsPath') nodeConfigF
   -- NB: Pledger and owner can be the same
 
   -- Create pledger registration certificate
-
   createStakeKeyRegistrationCertificate tap asbe
     poolOwnerstakeVkeyFp
-    0
+    400_000
     (workDir </> "pledger.regcert")
 
   void $ execCli' execConfig

--- a/cardano-testnet/src/Testnet/Process/Cli/SPO.hs
+++ b/cardano-testnet/src/Testnet/Process/Cli/SPO.hs
@@ -200,10 +200,10 @@ createScriptStakeRegistrationCertificate
   => TmpAbsolutePath
   -> AnyCardanoEra
   -> FilePath -- ^ Script file
-  -> Int -- ^ Registration deposit amount used only in Conway
+  -> L.Coin -- ^ Registration deposit amount used only in Conway
   -> FilePath -- ^ Output file path
   -> m ()
-createScriptStakeRegistrationCertificate tempAbsP (AnyCardanoEra cEra) scriptFile deposit outputFp =
+createScriptStakeRegistrationCertificate tempAbsP (AnyCardanoEra cEra) scriptFile (L.Coin deposit) outputFp =
   GHC.withFrozenCallStack $ do
     let tempAbsPath' = unTmpAbsPath tempAbsP
         extraArgs = monoidForEraInEon @ConwayEraOnwards cEra $
@@ -221,10 +221,10 @@ createStakeKeyDeregistrationCertificate
   => TmpAbsolutePath
   -> ShelleyBasedEra era
   -> File (VKey StakeKey) In -- ^ Stake verification key file
-  -> Int -- ^ deposit amount used only in Conway
+  -> L.Coin -- ^ deposit amount used only in Conway
   -> FilePath -- ^ Output file path
   -> m ()
-createStakeKeyDeregistrationCertificate tempAbsP sbe (File stakeVerKey) deposit outputFp =
+createStakeKeyDeregistrationCertificate tempAbsP sbe (File stakeVerKey) (L.Coin deposit) outputFp =
   GHC.withFrozenCallStack $ do
     let tempAbsPath' = unTmpAbsPath tempAbsP
         extraArgs = monoidForEraInEon @ConwayEraOnwards (toCardanoEra sbe) $

--- a/cardano-testnet/src/Testnet/Process/Cli/Transaction.hs
+++ b/cardano-testnet/src/Testnet/Process/Cli/Transaction.hs
@@ -15,6 +15,7 @@ module Testnet.Process.Cli.Transaction
   ) where
 
 import           Cardano.Api hiding (Certificate, TxBody)
+import           Cardano.Api.Experimental (Some (..))
 import           Cardano.Api.Ledger (Coin (unCoin))
 
 import           Prelude
@@ -146,14 +147,14 @@ signTx
   -> FilePath -- ^ Base directory path where the signed transaction file will be stored.
   -> String -- ^ Prefix for the output signed transaction file name. The extension will be @.tx@.
   -> File TxBody In -- ^ Transaction body to be signed, obtained using 'createCertificatePublicationTxBody' or similar.
-  -> [SomeKeyPair] -- ^ List of key pairs used for signing the transaction.
+  -> [Some KeyPair] -- ^ List of key pairs used for signing the transaction.
   -> m (File SignedTx In)
 signTx execConfig cEra work prefix txBody signatoryKeyPairs = do
   let signedTx = File (work </> prefix <> ".tx")
   void $ execCli' execConfig $
     [ anyEraToString cEra, "transaction", "sign"
     , "--tx-body-file", unFile txBody
-    ] ++ (concat [["--signing-key-file", signingKeyFp kp] | SomeKeyPair kp <- signatoryKeyPairs]) ++
+    ] ++ (concat [["--signing-key-file", signingKeyFp kp] | Some kp <- signatoryKeyPairs]) ++
     [ "--out-file", unFile signedTx
     ]
   return signedTx

--- a/cardano-testnet/src/Testnet/Types.hs
+++ b/cardano-testnet/src/Testnet/Types.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
@@ -26,7 +27,6 @@ module Testnet.Types
   , KeyPair(..)
   , verificationKeyFp
   , signingKeyFp
-  , SomeKeyPair(..)
   , VKey
   , SKey
   , VrfKey
@@ -43,6 +43,7 @@ module Testnet.Types
   ) where
 
 import           Cardano.Api
+import           Cardano.Api.Experimental (Some (..))
 import           Cardano.Api.Shelley (VrfKey)
 
 import qualified Cardano.Chain.Genesis as G
@@ -91,14 +92,19 @@ instance MonoFunctor (KeyPair k) where
 deriving instance Show (KeyPair k)
 deriving instance Eq (KeyPair k)
 
+instance {-# OVERLAPPING #-} Show (Some KeyPair) where
+  show (Some kp) = show kp
+
+instance {-# OVERLAPPING #-} Eq (Some KeyPair) where
+  (Some KeyPair{verificationKey=File vk1, signingKey=File sk1})
+    == (Some KeyPair{verificationKey=File vk2, signingKey=File sk2}) =
+      vk1 == vk2 && sk1 == sk2
+
 verificationKeyFp :: KeyPair k -> FilePath
 verificationKeyFp = unFile . verificationKey
 
 signingKeyFp :: KeyPair k -> FilePath
 signingKeyFp = unFile . signingKey
-
-data SomeKeyPair = forall a. SomeKeyPair (KeyPair a)
-deriving instance Show SomeKeyPair
 
 -- | Verification key tag
 data VKey k

--- a/cardano-testnet/src/Testnet/Types.hs
+++ b/cardano-testnet/src/Testnet/Types.hs
@@ -29,7 +29,6 @@ module Testnet.Types
   , SomeKeyPair(..)
   , VKey
   , SKey
-  , ColdPoolKey
   , VrfKey
   , StakingKey
   , PaymentKey
@@ -143,7 +142,6 @@ isTestnetNodeSpo = isJust . poolKeys
 nodeSocketPath :: TestnetNode -> SocketPath
 nodeSocketPath = File . H.sprocketSystemName . nodeSprocket
 
-data ColdPoolKey
 data StakingKey
 data SpoColdKey
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/KesPeriodInfo.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/KesPeriodInfo.hs
@@ -94,7 +94,7 @@ hprop_kes_period_info = integrationRetryWorkspace 2 "kes-period-info" $ \tempAbs
   let node1SocketPath = Api.File $ IO.sprocketSystemName node1sprocket
       termEpoch = EpochNo 3
   epochStateView <- getEpochStateView configurationFile node1SocketPath
-  (stakePoolId, stakePoolColdSigningKey, stakePoolColdVKey, _, _)
+  (stakePoolId, KeyPair{signingKey=File stakePoolColdSigningKey, verificationKey=File stakePoolColdVKey}, _)
     <- registerSingleSpo asbe 1 tempAbsPath
          configurationFile
          node1SocketPath

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/LeadershipSchedule.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/LeadershipSchedule.hs
@@ -15,7 +15,6 @@ module Cardano.Testnet.Test.Cli.LeadershipSchedule
 
 import           Cardano.Api
 import qualified Cardano.Api as Api
-import           Cardano.Api.Ledger (Coin (..))
 
 import           Cardano.Node.Configuration.Topology
 import           Cardano.Testnet
@@ -87,7 +86,7 @@ hprop_leadershipSchedule = integrationRetryWorkspace 2 "leadership-schedule" $ \
 
   ----------------Need to register an SPO------------------
   let utxoAddr = Text.unpack $ paymentKeyInfoAddr wallet0
-      utxoSKeyFile = signingKeyFp $ paymentKeyInfoPair wallet0
+      utxoSKeyFile = signingKey $ paymentKeyInfoPair wallet0
   void $ execCli' execConfig
     [ eraString, "query", "utxo"
     , "--address", utxoAddr
@@ -101,12 +100,14 @@ hprop_leadershipSchedule = integrationRetryWorkspace 2 "leadership-schedule" $ \
   let node1SocketPath = Api.File $ IO.sprocketSystemName node1sprocket
       termEpoch = EpochNo 15
   epochStateView <- getEpochStateView configurationFile node1SocketPath
+  keyDeposit <- getKeyDeposit epochStateView ceo
   (stakePoolIdNewSpo, KeyPair{signingKey=File stakePoolColdSigningKey, verificationKey=File stakePoolColdVKey}, KeyPair{signingKey=File vrfSkey})
     <- registerSingleSpo asbe 1 tempAbsPath
          configurationFile
          node1SocketPath
          (EpochNo 10)
          testnetMagic
+         keyDeposit
          execConfig
          (txin1, utxoSKeyFile, utxoAddr)
 
@@ -146,7 +147,6 @@ hprop_leadershipSchedule = integrationRetryWorkspace 2 "leadership-schedule" $ \
                , "--testnet-magic", show @Int testnetMagic
                ]
 
-  keyDeposit <- fromIntegral . unCoin <$> getKeyDeposit epochStateView ceo
   -- Test stake address registration cert
   createStakeKeyRegistrationCertificate
     tempAbsPath
@@ -198,7 +198,7 @@ hprop_leadershipSchedule = integrationRetryWorkspace 2 "leadership-schedule" $ \
     [ "latest", "transaction", "sign"
     , "--tx-body-file", delegRegTestDelegatorTxBodyFp
     , "--testnet-magic", show @Int testnetMagic
-    , "--signing-key-file", utxoSKeyFile
+    , "--signing-key-file", unFile utxoSKeyFile
     , "--signing-key-file", signingKeyFp testDelegatorKeys
     , "--out-file", delegRegTestDelegatorTxFp
     ]

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Query.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Query.hs
@@ -14,6 +14,7 @@ module Cardano.Testnet.Test.Cli.Query
   ) where
 
 import           Cardano.Api
+import           Cardano.Api.Experimental (Some (..))
 import qualified Cardano.Api.Genesis as Api
 import           Cardano.Api.Ledger (Coin (Coin), EpochInterval (EpochInterval), StandardCrypto,
                    extractHash, unboundRational)
@@ -327,7 +328,7 @@ hprop_cli_queries = integrationWorkspace "cli-queries" $ \tempAbsBasePath' -> H.
         -- Now we create a transaction and check if it exists in the mempool
         mempoolWork <- H.createDirectoryIfMissing $ work </> "mempool-test"
         txBody <- mkSimpleSpendOutputsOnlyTx execConfig epochStateView sbe mempoolWork "tx-body" wallet0 wallet1 10_000_000
-        signedTx <- signTx execConfig cEra mempoolWork "signed-tx" txBody [SomeKeyPair $ paymentKeyInfoPair wallet0]
+        signedTx <- signTx execConfig cEra mempoolWork "signed-tx" txBody [Some $ paymentKeyInfoPair wallet0]
         submitTx execConfig cEra signedTx
         txId <- retrieveTransactionId execConfig signedTx
         -- And we check
@@ -349,7 +350,7 @@ hprop_cli_queries = integrationWorkspace "cli-queries" $ \tempAbsBasePath' -> H.
         -- Submit a transaction to publish the reference script
         txBody <- mkSpendOutputsOnlyTx execConfig epochStateView sbe refScriptSizeWork "tx-body" wallet1
                     [(ReferenceScriptAddress plutusV3Script, transferAmount)]
-        signedTx <- signTx execConfig cEra refScriptSizeWork "signed-tx" txBody [SomeKeyPair $ paymentKeyInfoPair wallet1]
+        signedTx <- signTx execConfig cEra refScriptSizeWork "signed-tx" txBody [Some $ paymentKeyInfoPair wallet1]
         submitTx execConfig cEra signedTx
         -- Wait until transaction is on chain and obtain transaction identifier
         txId <- retrieveTransactionId execConfig signedTx

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction/RegisterDeregisterStakeAddress.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction/RegisterDeregisterStakeAddress.hs
@@ -59,8 +59,6 @@ hprop_tx_register_deregister_stake_address = integrationWorkspace "register-dere
 
   let ceo = ConwayEraOnwardsConway
       sbe = conwayEraOnwardsToShelleyBasedEra ceo
-      era = toCardanoEra sbe
-      cEra = AnyCardanoEra era
       eraName = eraToString sbe
       fastTestnetOptions = def { cardanoNodeEra = AnyShelleyBasedEra sbe }
       shelleyOptions = def { genesisEpochLength = 200 }
@@ -144,7 +142,6 @@ hprop_tx_register_deregister_stake_address = integrationWorkspace "register-dere
     ]
 
   H.noteShowM_ $ waitForBlocks epochStateView 1
-  -- H.noteShowM_ $ waitForEpochs epochStateView (EpochInterval 2)
 
   do
     (_, stdout', stderr') <- execCliAny execConfig

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction/RegisterDeregisterStakeAddress.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction/RegisterDeregisterStakeAddress.hs
@@ -1,0 +1,194 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Cardano.Testnet.Test.Cli.Transaction.RegisterDeregisterStakeAddress
+  ( hprop_tx_register_deregister_stake_address
+  ) where
+
+import           Cardano.Api as Api
+import           Cardano.Api.Ledger (Coin (..), EpochInterval (..))
+
+import qualified Cardano.Crypto.Hash as L
+import qualified Cardano.Ledger.Conway.Governance as L
+import qualified Cardano.Ledger.Conway.Governance as Ledger
+import qualified Cardano.Ledger.Hashes as L
+import qualified Cardano.Ledger.Shelley.LedgerState as L
+import           Cardano.Testnet
+
+import           Prelude
+
+import           Control.Monad
+import           Control.Monad.State.Strict (StateT)
+import           Data.Default.Class
+import           Data.Maybe
+import           Data.Maybe.Strict
+import           Data.String
+import qualified Data.Text as Text
+import           GHC.Exts (IsList (..))
+import           Lens.Micro
+import           System.FilePath ((</>))
+
+import           Testnet.Components.Configuration
+import           Testnet.Components.Query
+import           Testnet.Defaults
+import           Testnet.EpochStateProcessing (waitForGovActionVotes)
+import           Testnet.Process.Cli.DRep
+import           Testnet.Process.Cli.Keys
+import           Testnet.Process.Cli.Transaction
+import           Testnet.Process.Run (execCli', execCliAny, mkExecConfig)
+import           Testnet.Property.Util (integrationWorkspace)
+import           Testnet.Start.Types
+import           Testnet.Types
+
+import           Hedgehog
+import qualified Hedgehog.Extras as H
+
+-- | Execute me with:
+-- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/register deregister stake address in transaction build/"'@
+hprop_tx_register_deregister_stake_address :: Property
+hprop_tx_register_deregister_stake_address = integrationWorkspace "register-deregister-stake-address" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
+  -- Start a local test net
+  conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
+  let tempAbsPath' = unTmpAbsPath tempAbsPath
+      tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
+
+  work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
+
+  let ceo = ConwayEraOnwardsConway
+      sbe = conwayEraOnwardsToShelleyBasedEra ceo
+      era = toCardanoEra sbe
+      cEra = AnyCardanoEra era
+      eraName = eraToString sbe
+      fastTestnetOptions = def { cardanoNodeEra = AnyShelleyBasedEra sbe }
+      shelleyOptions = def { genesisEpochLength = 200 }
+
+  TestnetRuntime
+    { testnetMagic
+    , testnetNodes
+    , wallets=wallet0:wallet1:_
+    , configurationFile
+    }
+    <- cardanoTestnetDefault fastTestnetOptions shelleyOptions conf
+
+  node <- H.headM testnetNodes
+  poolSprocket1 <- H.noteShow $ nodeSprocket node
+  execConfig <- mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
+  let socketPath = nodeSocketPath node
+
+  epochStateView <- getEpochStateView configurationFile socketPath
+
+  H.note_ $ "Sprocket: " <> show poolSprocket1
+  H.note_ $ "Abs path: " <> tempAbsBasePath'
+  H.note_ $ "Socketpath: " <> unFile socketPath
+  H.note_ $ "Foldblocks config file: " <> unFile configurationFile
+
+  -- Create Conway constitution
+  gov <- H.createDirectoryIfMissing $ work </> "governance"
+
+  let stakeVkeyFp = gov </> "stake.vkey"
+      stakeSKeyFp = gov </> "stake.skey"
+      stakeCertFp = gov </> "stake.regcert"
+      stakeCertDeregFp = gov </> "stake.deregcert"
+      stakeKeys = KeyPair { verificationKey = File stakeVkeyFp
+                          , signingKey = File stakeSKeyFp
+                          }
+
+  cliStakeAddressKeyGen stakeKeys
+
+  keyDepositStr <- show . unCoin <$> getKeyDeposit epochStateView ceo
+  -- Register stake address
+  void $ execCli' execConfig
+    [ eraName, "stake-address", "registration-certificate"
+    , "--stake-verification-key-file", stakeVkeyFp
+    , "--key-reg-deposit-amt", keyDepositStr
+    , "--out-file", stakeCertFp
+    ]
+
+  stakeAddress <- H.noteM $ execCli' execConfig
+    [ eraName, "stake-address", "build"
+    , "--stake-verification-key-file", stakeVkeyFp
+    , "--out-file", "/dev/stdout"
+    ]
+
+  stakeCertTxBodyFp <- H.note $ work </> "stake.registration.txbody"
+  stakeCertTxSignedFp <- H.note $ work </> "stake.registration.tx"
+
+  txin1 <- findLargestUtxoForPaymentKey epochStateView sbe wallet0
+
+  (_, stdout, stderr) <- execCliAny execConfig
+    [ eraName, "transaction", "build"
+    , "--change-address", Text.unpack $ paymentKeyInfoAddr wallet0
+    , "--tx-in", Text.unpack $ renderTxIn txin1
+    , "--tx-out", Text.unpack (paymentKeyInfoAddr wallet1) <> "+" <> show @Int 10_000_000
+    , "--certificate-file", stakeCertFp
+    , "--witness-override", show @Int 2
+    , "--out-file", stakeCertTxBodyFp
+    ]
+  H.note_ stdout
+  H.note_ stderr
+
+  void $ execCli' execConfig
+    [ eraName, "transaction", "sign"
+    , "--tx-body-file", stakeCertTxBodyFp
+    , "--signing-key-file", signingKeyFp $ paymentKeyInfoPair wallet0
+    , "--signing-key-file", stakeSKeyFp
+    , "--out-file", stakeCertTxSignedFp
+    ]
+
+  void $ execCli' execConfig
+    [ eraName, "transaction", "submit"
+    , "--tx-file", stakeCertTxSignedFp
+    ]
+
+  H.noteShowM_ $ waitForBlocks epochStateView 1
+  -- H.noteShowM_ $ waitForEpochs epochStateView (EpochInterval 2)
+
+  do
+    (_, stdout', stderr') <- execCliAny execConfig
+      [ eraName, "query", "stake-address-info"
+      , "--address", stakeAddress
+      , "--out-file", "/dev/stdout"
+      ]
+    H.note_ stdout'
+    H.note_ stderr'
+
+  -- deregister stake address
+  void $ execCli' execConfig
+    [ eraName, "stake-address", "deregistration-certificate"
+    , "--stake-verification-key-file", stakeVkeyFp
+    , "--key-reg-deposit-amt", keyDepositStr
+    , "--out-file", stakeCertDeregFp
+    ]
+
+  stakeCertDeregTxBodyFp <- H.note $ work </> "stake.deregistration.txbody"
+  stakeCertDeregTxSignedFp <- H.note $ work </> "stake.deregistration.tx"
+
+  txin2 <- findLargestUtxoForPaymentKey epochStateView sbe wallet1
+
+  (_, stdout', stderr') <- execCliAny execConfig
+    [ eraName, "transaction", "build"
+    , "--change-address", Text.unpack $ paymentKeyInfoAddr wallet1
+    , "--tx-in", Text.unpack $ renderTxIn txin2
+    , "--tx-out", Text.unpack (paymentKeyInfoAddr wallet0) <> "+" <> show @Int 10_000_000
+    , "--certificate-file", stakeCertDeregFp
+    , "--witness-override", show @Int 2
+    , "--out-file", stakeCertDeregTxBodyFp
+    ]
+  H.note_ stdout'
+  H.note_ stderr'
+
+  void $ execCli' execConfig
+    [ eraName, "transaction", "sign"
+    , "--tx-body-file", stakeCertDeregTxBodyFp
+    , "--signing-key-file", signingKeyFp $ paymentKeyInfoPair wallet1
+    , "--signing-key-file", stakeSKeyFp
+    , "--out-file", stakeCertDeregTxSignedFp
+    ]
+
+  void $ execCli' execConfig
+    [ eraName, "transaction", "submit"
+    , "--tx-file", stakeCertDeregTxSignedFp
+    ]

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/CommitteeAddNew.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/CommitteeAddNew.hs
@@ -127,12 +127,12 @@ hprop_constitutional_committee_add_new = integrationWorkspace "constitutional-co
               , signingKey = File stakeSKeyFp
               }
 
+  keyDepositStr <- show . L.unCoin <$> getKeyDeposit epochStateView ceo
   -- Register stake address
-
   void $ execCli' execConfig
     [ eraName, "stake-address", "registration-certificate"
     , "--stake-verification-key-file", stakeVkeyFp
-    , "--key-reg-deposit-amt", show @Int 0 -- TODO: why this needs to be 0????
+    , "--key-reg-deposit-amt", keyDepositStr
     , "--out-file", stakeCertFp
     ]
 
@@ -163,7 +163,6 @@ hprop_constitutional_committee_add_new = integrationWorkspace "constitutional-co
     [ eraName, "transaction", "submit"
     , "--tx-file", stakeCertTxSignedFp
     ]
-
 
   minGovActDeposit <- getMinGovActionDeposit epochStateView ceo
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/CommitteeAddNew.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/CommitteeAddNew.hs
@@ -11,6 +11,7 @@ module Cardano.Testnet.Test.Gov.CommitteeAddNew
   ) where
 
 import           Cardano.Api as Api
+import           Cardano.Api.Experimental (Some (..))
 import qualified Cardano.Api.Ledger as L
 import           Cardano.Api.Shelley (ShelleyLedgerEra)
 
@@ -214,7 +215,7 @@ hprop_constitutional_committee_add_new = integrationWorkspace "constitutional-co
   committeeMembers `H.assertWith` null
 
   signedProposalTx <-
-    signTx execConfig cEra work "signed-proposal" (File txbodyFp) [SomeKeyPair $ paymentKeyInfoPair wallet0]
+    signTx execConfig cEra work "signed-proposal" (File txbodyFp) [Some $ paymentKeyInfoPair wallet0]
   submitTx execConfig cEra signedProposalTx
 
   governanceActionTxId <- H.noteM $ retrieveTransactionId execConfig signedProposalTx
@@ -245,7 +246,7 @@ hprop_constitutional_committee_add_new = integrationWorkspace "constitutional-co
         , verificationKey = error "unused"
         }
       drepSKeys = map (defaultDRepKeyPair . snd) drepVotes
-      signingKeys = SomeKeyPair <$> paymentKeyInfoPair wallet0:poolNodePaymentKeyPair:drepSKeys
+      signingKeys = Some <$> paymentKeyInfoPair wallet0:poolNodePaymentKeyPair:drepSKeys
   voteTxFp <- signTx
     execConfig cEra gov "signed-vote-tx" voteTxBodyFp signingKeys
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepActivity.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepActivity.hs
@@ -12,6 +12,7 @@ module Cardano.Testnet.Test.Gov.DRepActivity
 
 import           Cardano.Api as Api
 import           Cardano.Api.Eon.ShelleyBasedEra (ShelleyLedgerEra)
+import           Cardano.Api.Experimental (Some (..))
 import           Cardano.Api.Ledger (EpochInterval (EpochInterval, unEpochInterval), drepExpiry)
 
 import           Cardano.Ledger.Conway.Core (EraGov, curPParamsGovStateL)
@@ -286,7 +287,7 @@ voteChangeProposal execConfig epochStateView sbe work prefix governanceActionTxI
   voteTxBodyFp <- createVotingTxBody execConfig epochStateView sbe baseDir "vote-tx-body"
                                      voteFiles wallet
 
-  let signingKeys = SomeKeyPair <$> (paymentKeyInfoPair wallet:(defaultDRepKeyPair . snd <$> votes))
+  let signingKeys = Some <$> (paymentKeyInfoPair wallet:(defaultDRepKeyPair . snd <$> votes))
   voteTxFp <- signTx execConfig cEra baseDir "signed-vote-tx" voteTxBodyFp signingKeys
 
   submitTx execConfig cEra voteTxFp

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepDeposit.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepDeposit.hs
@@ -5,6 +5,7 @@ module Cardano.Testnet.Test.Gov.DRepDeposit
   ) where
 
 import           Cardano.Api
+import           Cardano.Api.Experimental (Some (..))
 import qualified Cardano.Api.Ledger as L
 
 import           Cardano.Testnet
@@ -84,7 +85,7 @@ hprop_ledger_events_drep_deposits = integrationWorkspace "drep-deposits" $ \temp
   drepRegTxBody1 <- createCertificatePublicationTxBody execConfig epochStateView sbe drepDir1 "reg-cert-txbody"
                                                        drepRegCert1 wallet0
   drepSignedRegTx1 <- signTx execConfig cEra drepDir1 "signed-reg-tx"
-                             drepRegTxBody1 [SomeKeyPair drepKeyPair1, SomeKeyPair $ paymentKeyInfoPair wallet0]
+                             drepRegTxBody1 [Some drepKeyPair1, Some $ paymentKeyInfoPair wallet0]
 
   failToSubmitTx execConfig cEra drepSignedRegTx1 "ConwayDRepIncorrectDeposit"
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/GovActionTimeout.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/GovActionTimeout.hs
@@ -11,7 +11,7 @@ module Cardano.Testnet.Test.Gov.GovActionTimeout
   ) where
 
 import           Cardano.Api as Api
-import           Cardano.Api.Ledger (EpochInterval (EpochInterval, unEpochInterval))
+import           Cardano.Api.Ledger (Coin (..), EpochInterval (EpochInterval, unEpochInterval))
 
 import           Cardano.Testnet
 
@@ -94,12 +94,12 @@ hprop_check_gov_action_timeout = integrationWorkspace "gov-action-timeout" $ \te
 
   cliStakeAddressKeyGen stakeKeys
 
+  keyDepositStr <- show . unCoin <$> getKeyDeposit epochStateView ceo
   -- Register stake address
-
   void $ execCli' execConfig
     [ eraName, "stake-address", "registration-certificate"
     , "--stake-verification-key-file", stakeVkeyFp
-    , "--key-reg-deposit-amt", show @Int 0 -- TODO: why this needs to be 0????
+    , "--key-reg-deposit-amt", keyDepositStr
     , "--out-file", stakeCertFp
     ]
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/InfoAction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/InfoAction.hs
@@ -13,7 +13,7 @@ module Cardano.Testnet.Test.Gov.InfoAction
 
 import           Cardano.Api as Api
 import           Cardano.Api.Error (displayError)
-import           Cardano.Api.Ledger (EpochInterval (EpochInterval))
+import           Cardano.Api.Ledger (Coin (..), EpochInterval (EpochInterval))
 import           Cardano.Api.Shelley
 
 import           Cardano.Ledger.Conway.Governance (RatifyState (..))
@@ -103,11 +103,11 @@ hprop_ledger_events_info_action = integrationRetryWorkspace 2 "info-hash" $ \tem
   cliStakeAddressKeyGen stakeKeys
 
   -- Register stake address
-
+  keyDepositStr <- show . unCoin <$> getKeyDeposit epochStateView ceo
   void $ execCli' execConfig
     [ eraName, "stake-address", "registration-certificate"
     , "--stake-verification-key-file", stakeVkeyFp
-    , "--key-reg-deposit-amt", show @Int 0 -- TODO: why this needs to be 0????
+    , "--key-reg-deposit-amt", keyDepositStr
     , "--out-file", stakeCertFp
     ]
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs
@@ -9,6 +9,7 @@ module Cardano.Testnet.Test.Gov.NoConfidence
   ) where
 
 import           Cardano.Api as Api
+import           Cardano.Api.Experimental (Some (..))
 import           Cardano.Api.Ledger
 import           Cardano.Api.Shelley
 
@@ -184,7 +185,7 @@ hprop_gov_no_confidence = integrationWorkspace "no-confidence" $ \tempAbsBasePat
     ]
 
   signedProposalTx <- signTx execConfig cEra work "signed-proposal"
-                           (File txbodyFp) [SomeKeyPair $ paymentKeyInfoPair wallet0]
+                           (File txbodyFp) [Some $ paymentKeyInfoPair wallet0]
 
   submitTx execConfig cEra signedProposalTx
 
@@ -216,12 +217,12 @@ hprop_gov_no_confidence = integrationWorkspace "no-confidence" $ \tempAbsBasePat
   -- Submit votes
   voteTxBodyFp <- DRep.createVotingTxBody execConfig epochStateView sbe work "vote-tx-body"
                                      allVoteFiles wallet0
-  let spoSigningKeys = [SomeKeyPair $ defaultSpoColdKeyPair n | (_, n) <- spoVotes]
-      drepSigningKeys = [SomeKeyPair $ defaultDRepKeyPair n | (_, n) <- drepVotes]
+  let spoSigningKeys = [Some $ defaultSpoColdKeyPair n | (_, n) <- spoVotes]
+      drepSigningKeys = [Some $ defaultDRepKeyPair n | (_, n) <- drepVotes]
       allVoteSigningKeys = spoSigningKeys ++ drepSigningKeys
 
   voteTxFp <- signTx execConfig cEra work "signed-vote-tx" voteTxBodyFp
-                (SomeKeyPair (paymentKeyInfoPair wallet0) : allVoteSigningKeys)
+                (Some (paymentKeyInfoPair wallet0) : allVoteSigningKeys)
 
   submitTx execConfig cEra voteTxFp
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PParamChangeFailsSPO.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PParamChangeFailsSPO.hs
@@ -12,7 +12,7 @@ module Cardano.Testnet.Test.Gov.PParamChangeFailsSPO
 
 import           Cardano.Api as Api
 import           Cardano.Api.Experimental (Some (..))
-import           Cardano.Api.Ledger (Coin (..), EpochInterval (EpochInterval))
+import           Cardano.Api.Ledger (EpochInterval (..))
 
 import           Cardano.Testnet
 
@@ -31,6 +31,7 @@ import           Testnet.Defaults (defaultSpoColdKeyPair, defaultSpoKeys)
 import           Testnet.Process.Cli.DRep
 import           Testnet.Process.Cli.Keys (cliStakeAddressKeyGen)
 import qualified Testnet.Process.Cli.SPO as SPO
+import           Testnet.Process.Cli.SPO (createStakeKeyRegistrationCertificate)
 import           Testnet.Process.Cli.Transaction (failToSubmitTx, signTx)
 import           Testnet.Process.Run (execCli', mkExecConfig)
 import           Testnet.Property.Util (integrationWorkspace)
@@ -87,23 +88,15 @@ hprop_check_pparam_fails_spo = integrationWorkspace "test-pparam-spo" $ \tempAbs
 
   baseDir <- H.createDirectoryIfMissing $ gov </> "output"
 
-  let stakeVkeyFp = gov </> "stake.vkey"
-      stakeSKeyFp = gov </> "stake.skey"
-      stakeCertFp = gov </> "stake.regcert"
-      stakingKeys = KeyPair { verificationKey = File stakeVkeyFp
-                            , signingKey= File stakeSKeyFp
-                            }
-
-  cliStakeAddressKeyGen stakingKeys
-
-  keyDepositStr <- show . unCoin <$> getKeyDeposit epochStateView ceo
   -- Register stake address
-  void $ execCli' execConfig
-    [ eraName, "stake-address", "registration-certificate"
-    , "--stake-verification-key-file", stakeVkeyFp
-    , "--key-reg-deposit-amt", keyDepositStr
-    , "--out-file", stakeCertFp
-    ]
+  let stakeCertFp = gov </> "stake.regcert"
+      stakeKeys =  KeyPair { verificationKey = File $ gov </> "stake.vkey"
+                           , signingKey = File $ gov </> "stake.skey"
+                           }
+  cliStakeAddressKeyGen stakeKeys
+  keyDeposit <- getKeyDeposit epochStateView ceo
+  createStakeKeyRegistrationCertificate
+    tempAbsPath (AnyShelleyBasedEra sbe) (verificationKey stakeKeys) keyDeposit stakeCertFp
 
   stakeCertTxBodyFp <- H.note $ work </> "stake.registration.txbody"
   stakeCertTxSignedFp <- H.note $ work </> "stake.registration.tx"
@@ -124,7 +117,7 @@ hprop_check_pparam_fails_spo = integrationWorkspace "test-pparam-spo" $ \tempAbs
     [ eraName, "transaction", "sign"
     , "--tx-body-file", stakeCertTxBodyFp
     , "--signing-key-file", signingKeyFp $ paymentKeyInfoPair wallet1
-    , "--signing-key-file", stakeSKeyFp
+    , "--signing-key-file", signingKeyFp stakeKeys
     , "--out-file", stakeCertTxSignedFp
     ]
 
@@ -144,7 +137,7 @@ hprop_check_pparam_fails_spo = integrationWorkspace "test-pparam-spo" $ \tempAbs
 
   (governanceActionTxId, governanceActionIndex) <-
     makeActivityChangeProposal execConfig epochStateView ceo (baseDir </> "proposal")
-                               Nothing (EpochInterval 3) stakingKeys wallet0 (EpochInterval 2)
+                               Nothing (EpochInterval 3) stakeKeys wallet0 (EpochInterval 2)
 
   failToVoteChangeProposalWithSPOs ceo execConfig epochStateView baseDir "vote"
                                    governanceActionTxId governanceActionIndex propVotes wallet1

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PParamChangeFailsSPO.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PParamChangeFailsSPO.hs
@@ -11,7 +11,7 @@ module Cardano.Testnet.Test.Gov.PParamChangeFailsSPO
   ) where
 
 import           Cardano.Api as Api
-import           Cardano.Api.Ledger (EpochInterval (EpochInterval))
+import           Cardano.Api.Ledger (Coin (..), EpochInterval (EpochInterval))
 
 import           Cardano.Testnet
 
@@ -95,12 +95,12 @@ hprop_check_pparam_fails_spo = integrationWorkspace "test-pparam-spo" $ \tempAbs
 
   cliStakeAddressKeyGen stakingKeys
 
+  keyDepositStr <- show . unCoin <$> getKeyDeposit epochStateView ceo
   -- Register stake address
-
   void $ execCli' execConfig
     [ eraName, "stake-address", "registration-certificate"
     , "--stake-verification-key-file", stakeVkeyFp
-    , "--key-reg-deposit-amt", show @Int 0 -- TODO: why this needs to be 0????
+    , "--key-reg-deposit-amt", keyDepositStr
     , "--out-file", stakeCertFp
     ]
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PParamChangeFailsSPO.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PParamChangeFailsSPO.hs
@@ -11,6 +11,7 @@ module Cardano.Testnet.Test.Gov.PParamChangeFailsSPO
   ) where
 
 import           Cardano.Api as Api
+import           Cardano.Api.Experimental (Some (..))
 import           Cardano.Api.Ledger (Coin (..), EpochInterval (EpochInterval))
 
 import           Cardano.Testnet
@@ -180,7 +181,7 @@ failToVoteChangeProposalWithSPOs ceo execConfig epochStateView work prefix
   voteTxBodyFp <- createVotingTxBody execConfig epochStateView sbe baseDir "vote-tx-body"
                                      voteFiles wallet
 
-  let signingKeys = SomeKeyPair (paymentKeyInfoPair wallet):(SomeKeyPair . defaultSpoColdKeyPair . snd <$> votes)
+  let signingKeys = Some (paymentKeyInfoPair wallet):(Some . defaultSpoColdKeyPair . snd <$> votes)
   voteTxFp <- signTx execConfig cEra baseDir "signed-vote-tx" voteTxBodyFp signingKeys
 
   failToSubmitTx execConfig cEra voteTxFp "DisallowedVoters"

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
@@ -11,6 +11,7 @@ module Cardano.Testnet.Test.Gov.PredefinedAbstainDRep
 
 import           Cardano.Api as Api
 import           Cardano.Api.Eon.ShelleyBasedEra (ShelleyLedgerEra)
+import           Cardano.Api.Experimental (Some (..))
 import           Cardano.Api.Ledger (EpochInterval (EpochInterval))
 
 import           Cardano.Ledger.Conway.Core (ppNOptL)
@@ -42,8 +43,7 @@ import qualified Testnet.Process.Run as H
 import qualified Testnet.Property.Util as H
 import           Testnet.Start.Types
 import           Testnet.Types (KeyPair (..),
-                   PaymentKeyInfo (paymentKeyInfoAddr, paymentKeyInfoPair),
-                   SomeKeyPair (SomeKeyPair), StakingKey)
+                   PaymentKeyInfo (paymentKeyInfoAddr, paymentKeyInfoPair), StakingKey)
 
 import           Hedgehog
 import qualified Hedgehog.Extras as H
@@ -158,8 +158,8 @@ delegateToAlwaysAbstain execConfig epochStateView sbe work prefix
 
   -- Sign transaction
   repRegSignedRegTx1 <- signTx execConfig cEra baseDir "signed-reg-tx"
-                               repRegTxBody1 [ SomeKeyPair (paymentKeyInfoPair payingWallet)
-                                             , SomeKeyPair skeyPair]
+                               repRegTxBody1 [ Some (paymentKeyInfoPair payingWallet)
+                                             , Some skeyPair]
 
   -- Submit transaction
   submitTx execConfig cEra repRegSignedRegTx1
@@ -281,7 +281,7 @@ makeDesiredPoolNumberChangeProposal execConfig epochStateView ceo work prefix
     ]
 
   signedProposalTx <- signTx execConfig cEra baseDir "signed-proposal"
-                             (File proposalBody) [SomeKeyPair $ paymentKeyInfoPair wallet]
+                             (File proposalBody) [Some $ paymentKeyInfoPair wallet]
 
   submitTx execConfig cEra signedProposalTx
 
@@ -326,7 +326,7 @@ voteChangeProposal execConfig epochStateView sbe work prefix
                                      voteFiles wallet
 
   voteTxFp <- signTx execConfig cEra baseDir "signed-vote-tx" voteTxBodyFp
-                     (SomeKeyPair (paymentKeyInfoPair wallet):[SomeKeyPair $ defaultDRepKeyPair n | (_, n) <- votes])
+                     (Some (paymentKeyInfoPair wallet):[Some $ defaultDRepKeyPair n | (_, n) <- votes])
   submitTx execConfig cEra voteTxFp
 
 -- | Obtains the @desiredPoolNumberValue@ from the protocol parameters.

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitution.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitution.hs
@@ -10,7 +10,7 @@ module Cardano.Testnet.Test.Gov.ProposeNewConstitution
 
 import           Cardano.Api as Api
 import           Cardano.Api.Experimental (Some (..))
-import           Cardano.Api.Ledger (Coin (..), EpochInterval (..))
+import           Cardano.Api.Ledger (EpochInterval (..))
 
 import qualified Cardano.Crypto.Hash as L
 import qualified Cardano.Ledger.Conway.Governance as L
@@ -38,6 +38,7 @@ import           Testnet.Defaults
 import           Testnet.EpochStateProcessing (waitForGovActionVotes)
 import           Testnet.Process.Cli.DRep
 import           Testnet.Process.Cli.Keys
+import           Testnet.Process.Cli.SPO (createStakeKeyRegistrationCertificate)
 import           Testnet.Process.Cli.Transaction
 import           Testnet.Process.Run (execCli', mkExecConfig)
 import           Testnet.Property.Util (integrationWorkspace)
@@ -114,22 +115,15 @@ hprop_ledger_events_propose_new_constitution = integrationWorkspace "propose-new
     [ "hash", "anchor-data", "--file-text", proposalAnchorFile
     ]
 
-  let stakeVkeyFp = gov </> "stake.vkey"
-      stakeSKeyFp = gov </> "stake.skey"
-      stakeCertFp = gov </> "stake.regcert"
-
-  cliStakeAddressKeyGen
-    $ KeyPair { verificationKey = File stakeVkeyFp
-              , signingKey = File stakeSKeyFp
-              }
-  keyDepositStr <- show . unCoin <$> getKeyDeposit epochStateView ceo
   -- Register stake address
-  void $ execCli' execConfig
-    [ eraName, "stake-address", "registration-certificate"
-    , "--stake-verification-key-file", stakeVkeyFp
-    , "--key-reg-deposit-amt", keyDepositStr
-    , "--out-file", stakeCertFp
-    ]
+  let stakeCertFp = gov </> "stake.regcert"
+      stakeKeys =  KeyPair { verificationKey = File $ gov </> "stake.vkey"
+                           , signingKey = File $ gov </> "stake.skey"
+                           }
+  cliStakeAddressKeyGen stakeKeys
+  keyDeposit <- getKeyDeposit epochStateView ceo
+  createStakeKeyRegistrationCertificate
+    tempAbsPath (AnyShelleyBasedEra sbe) (verificationKey stakeKeys) keyDeposit stakeCertFp
 
   stakeCertTxBodyFp <- H.note $ work </> "stake.registration.txbody"
   stakeCertTxSignedFp <- H.note $ work </> "stake.registration.tx"
@@ -150,7 +144,7 @@ hprop_ledger_events_propose_new_constitution = integrationWorkspace "propose-new
     [ eraName, "transaction", "sign"
     , "--tx-body-file", stakeCertTxBodyFp
     , "--signing-key-file", signingKeyFp $ paymentKeyInfoPair wallet1
-    , "--signing-key-file", stakeSKeyFp
+    , "--signing-key-file", signingKeyFp stakeKeys
     , "--out-file", stakeCertTxSignedFp
     ]
 
@@ -176,7 +170,7 @@ hprop_ledger_events_propose_new_constitution = integrationWorkspace "propose-new
     [ "conway", "governance", "action", "create-constitution"
     , "--testnet"
     , "--governance-action-deposit", show minDRepDeposit
-    , "--deposit-return-stake-verification-key-file", stakeVkeyFp
+    , "--deposit-return-stake-verification-key-file", verificationKeyFp stakeKeys
     , "--anchor-url", "https://tinyurl.com/3wrwb2as"
     , "--anchor-data-hash", proposalAnchorDataHash
     , "--constitution-url", "https://tinyurl.com/2pahcy6z"

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitution.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitution.hs
@@ -9,6 +9,7 @@ module Cardano.Testnet.Test.Gov.ProposeNewConstitution
   ) where
 
 import           Cardano.Api as Api
+import           Cardano.Api.Experimental (Some (..))
 import           Cardano.Api.Ledger (Coin (..), EpochInterval (..))
 
 import qualified Cardano.Crypto.Hash as L
@@ -199,7 +200,7 @@ hprop_ledger_events_propose_new_constitution = integrationWorkspace "propose-new
     ]
 
   signedProposalTx <- signTx execConfig cEra gov "signed-proposal"
-                           (File txbodyFp) [SomeKeyPair $ paymentKeyInfoPair wallet1]
+                           (File txbodyFp) [Some $ paymentKeyInfoPair wallet1]
 
   submitTx execConfig cEra signedProposalTx
 
@@ -218,7 +219,7 @@ hprop_ledger_events_propose_new_constitution = integrationWorkspace "propose-new
   voteTxBodyFp <- createVotingTxBody execConfig epochStateView sbe work "vote-tx-body"
                                      voteFiles wallet0
 
-  let signingKeys = SomeKeyPair <$> (paymentKeyInfoPair wallet0:(defaultDRepKeyPair . snd <$> allVotes))
+  let signingKeys = Some <$> (paymentKeyInfoPair wallet0:(defaultDRepKeyPair . snd <$> allVotes))
   voteTxFp <- signTx execConfig cEra gov "signed-vote-tx" voteTxBodyFp signingKeys
 
   submitTx execConfig cEra voteTxFp

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitution.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitution.hs
@@ -9,7 +9,7 @@ module Cardano.Testnet.Test.Gov.ProposeNewConstitution
   ) where
 
 import           Cardano.Api as Api
-import           Cardano.Api.Ledger (EpochInterval (..))
+import           Cardano.Api.Ledger (Coin (..), EpochInterval (..))
 
 import qualified Cardano.Crypto.Hash as L
 import qualified Cardano.Ledger.Conway.Governance as L
@@ -121,12 +121,12 @@ hprop_ledger_events_propose_new_constitution = integrationWorkspace "propose-new
     $ KeyPair { verificationKey = File stakeVkeyFp
               , signingKey = File stakeSKeyFp
               }
+  keyDepositStr <- show . unCoin <$> getKeyDeposit epochStateView ceo
   -- Register stake address
-
   void $ execCli' execConfig
     [ eraName, "stake-address", "registration-certificate"
     , "--stake-verification-key-file", stakeVkeyFp
-    , "--key-reg-deposit-amt", show @Int 0 -- TODO: why this needs to be 0????
+    , "--key-reg-deposit-amt", keyDepositStr
     , "--out-file", stakeCertFp
     ]
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitutionSPO.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitutionSPO.hs
@@ -9,6 +9,7 @@ module Cardano.Testnet.Test.Gov.ProposeNewConstitutionSPO
   ) where
 
 import           Cardano.Api
+import           Cardano.Api.Experimental (Some (..))
 import           Cardano.Api.Ledger
 
 import qualified Cardano.Ledger.Conway.Governance as L
@@ -135,7 +136,7 @@ hprop_ledger_events_propose_new_constitution_spo = integrationWorkspace "propose
     , "--out-file", txBodyFp
     ]
 
-  txBodySigned <- signTx execConfig cEra work "proposal-signed-tx" (File txBodyFp) [SomeKeyPair $ paymentKeyInfoPair wallet0]
+  txBodySigned <- signTx execConfig cEra work "proposal-signed-tx" (File txBodyFp) [Some $ paymentKeyInfoPair wallet0]
 
   submitTx execConfig cEra txBodySigned
 
@@ -160,8 +161,8 @@ hprop_ledger_events_propose_new_constitution_spo = integrationWorkspace "propose
   votesTxBody <- createVotingTxBody execConfig epochStateView sbe work "vote-tx-body" votes wallet0
 
   votesSignedTx <- signTx execConfig cEra work "vote-signed-tx"
-                     votesTxBody (SomeKeyPair (paymentKeyInfoPair wallet0)
-                                  :[SomeKeyPair $ defaultSpoColdKeyPair n | n <- [1..3]])
+                     votesTxBody (Some (paymentKeyInfoPair wallet0)
+                                  :[Some $ defaultSpoColdKeyPair n | n <- [1..3]])
 
   -- Call should fail, because SPOs are unallowed to vote on the constitution
   failToSubmitTx execConfig cEra votesSignedTx "DisallowedVoters"

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryWithdrawal.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryWithdrawal.hs
@@ -108,10 +108,11 @@ hprop_ledger_events_treasury_withdrawal = integrationRetryWorkspace 2  "treasury
                , signingKey= File stakeSKeyFp
                }
 
+  keyDepositStr <- show . L.unCoin <$> getKeyDeposit epochStateView ceo
   void $ execCli' execConfig
     [ eraName, "stake-address", "registration-certificate"
     , "--stake-verification-key-file", stakeVkeyFp
-    , "--key-reg-deposit-amt", show @Int 0 -- TODO: why this needs to be 0????
+    , "--key-reg-deposit-amt", keyDepositStr
     , "--out-file", stakeCertFp
     ]
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryWithdrawal.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryWithdrawal.hs
@@ -40,6 +40,7 @@ import           System.FilePath ((</>))
 import           Testnet.Components.Query
 import           Testnet.Defaults
 import           Testnet.Process.Cli.Keys (cliStakeAddressKeyGen)
+import           Testnet.Process.Cli.SPO (createStakeKeyRegistrationCertificate)
 import           Testnet.Process.Run (execCli', mkExecConfig)
 import           Testnet.Property.Util (integrationRetryWorkspace)
 import           Testnet.Start.Types
@@ -99,22 +100,15 @@ hprop_ledger_events_treasury_withdrawal = integrationRetryWorkspace 2  "treasury
   txin2 <- findLargestUtxoForPaymentKey epochStateView sbe wallet1
 
   -- {{{ Register stake address
-  let stakeVkeyFp = gov </> "stake.vkey"
-      stakeSKeyFp = gov </> "stake.skey"
-      stakeCertFp = gov </> "stake.regcert"
+  let stakeCertFp = gov </> "stake.regcert"
+      stakeKeys =  KeyPair { verificationKey = File $ gov </> "stake.vkey"
+                           , signingKey = File $ gov </> "stake.skey"
+                           }
+  cliStakeAddressKeyGen stakeKeys
+  keyDeposit <- getKeyDeposit epochStateView ceo
+  createStakeKeyRegistrationCertificate
+    tempAbsPath (AnyShelleyBasedEra sbe) (verificationKey stakeKeys) keyDeposit stakeCertFp
 
-  cliStakeAddressKeyGen
-     $ KeyPair { verificationKey = File stakeVkeyFp
-               , signingKey= File stakeSKeyFp
-               }
-
-  keyDepositStr <- show . L.unCoin <$> getKeyDeposit epochStateView ceo
-  void $ execCli' execConfig
-    [ eraName, "stake-address", "registration-certificate"
-    , "--stake-verification-key-file", stakeVkeyFp
-    , "--key-reg-deposit-amt", keyDepositStr
-    , "--out-file", stakeCertFp
-    ]
 
   stakeCertTxBodyFp <- H.note $ work </> "stake.registration.txbody"
   stakeCertTxSignedFp <- H.note $ work </> "stake.registration.tx"
@@ -133,7 +127,7 @@ hprop_ledger_events_treasury_withdrawal = integrationRetryWorkspace 2  "treasury
     [ eraName, "transaction", "sign"
     , "--tx-body-file", stakeCertTxBodyFp
     , "--signing-key-file", signingKeyFp $ paymentKeyInfoPair wallet1
-    , "--signing-key-file", stakeSKeyFp
+    , "--signing-key-file", signingKeyFp stakeKeys
     , "--out-file", stakeCertTxSignedFp
     ]
 
@@ -152,9 +146,9 @@ hprop_ledger_events_treasury_withdrawal = integrationRetryWorkspace 2  "treasury
     , "--anchor-url", "https://tinyurl.com/3wrwb2as"
     , "--anchor-data-hash", proposalAnchorDataHash
     , "--governance-action-deposit", show govActionDeposit
-    , "--deposit-return-stake-verification-key-file", stakeVkeyFp
+    , "--deposit-return-stake-verification-key-file", verificationKeyFp stakeKeys
     , "--transfer", show withdrawalAmount
-    , "--funds-receiving-stake-verification-key-file", stakeVkeyFp
+    , "--funds-receiving-stake-verification-key-file", verificationKeyFp stakeKeys
     , "--out-file", treasuryWithdrawalActionFp
     ]
 

--- a/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
+++ b/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
@@ -11,6 +11,7 @@ import qualified Cardano.Testnet.Test.Cli.Query
 import qualified Cardano.Testnet.Test.Cli.QuerySlotNumber
 import qualified Cardano.Testnet.Test.Cli.StakeSnapshot
 import qualified Cardano.Testnet.Test.Cli.Transaction
+import qualified Cardano.Testnet.Test.Cli.Transaction.RegisterDeregisterStakeAddress
 import qualified Cardano.Testnet.Test.FoldEpochState
 import qualified Cardano.Testnet.Test.Gov.CommitteeAddNew as Gov
 import qualified Cardano.Testnet.Test.Gov.DRepDeposit as Gov
@@ -76,9 +77,10 @@ tests = do
           -- ShutdownOnSigint fails on Mac with
           -- "Log file: /private/tmp/tmp.JqcjW7sLKS/kes-period-info-2-test-30c2d0d8eb042a37/logs/test-spo.stdout.log had no logs indicating the relevant node has minted blocks."
           , ignoreOnMacAndWindows "Shutdown On Sigint" Cardano.Testnet.Test.Node.Shutdown.hprop_shutdownOnSigint
-          , ignoreOnWindows "ShutdownOnSlotSynced" Cardano.Testnet.Test.Node.Shutdown.hprop_shutdownOnSlotSynced
-          , ignoreOnWindows "stake-snapshot" Cardano.Testnet.Test.Cli.StakeSnapshot.hprop_stakeSnapshot
+          , ignoreOnWindows "Shutdown On SlotSynced" Cardano.Testnet.Test.Node.Shutdown.hprop_shutdownOnSlotSynced
+          , ignoreOnWindows "stake snapshot" Cardano.Testnet.Test.Cli.StakeSnapshot.hprop_stakeSnapshot
           , ignoreOnWindows "simple transaction build" Cardano.Testnet.Test.Cli.Transaction.hprop_transaction
+          , ignoreOnWindows "register deregister stake address in transaction build"  Cardano.Testnet.Test.Cli.Transaction.RegisterDeregisterStakeAddress.hprop_tx_register_deregister_stake_address
           -- FIXME
           -- , ignoreOnMacAndWindows "leadership-schedule" Cardano.Testnet.Test.Cli.LeadershipSchedule.hprop_leadershipSchedule
 

--- a/cardano-testnet/test/cardano-testnet-test/files/golden/queries/govStateOut.json
+++ b/cardano-testnet/test/cardano-testnet-test/files/golden/queries/govStateOut.json
@@ -652,7 +652,7 @@
             "major": 10,
             "minor": 0
         },
-        "stakeAddressDeposit": 0,
+        "stakeAddressDeposit": 400000,
         "stakePoolDeposit": 0,
         "stakePoolTargetNum": 100,
         "treasuryCut": 0.1,
@@ -1320,7 +1320,7 @@
                     "major": 10,
                     "minor": 0
                 },
-                "stakeAddressDeposit": 0,
+                "stakeAddressDeposit": 400000,
                 "stakePoolDeposit": 0,
                 "stakePoolTargetNum": 100,
                 "treasuryCut": 0.1,
@@ -1977,7 +1977,7 @@
                     "major": 10,
                     "minor": 0
                 },
-                "stakeAddressDeposit": 0,
+                "stakeAddressDeposit": 400000,
                 "stakePoolDeposit": 0,
                 "stakePoolTargetNum": 100,
                 "treasuryCut": 0.1,
@@ -2631,7 +2631,7 @@
             "major": 10,
             "minor": 0
         },
-        "stakeAddressDeposit": 0,
+        "stakeAddressDeposit": 400000,
         "stakePoolDeposit": 0,
         "stakePoolTargetNum": 100,
         "treasuryCut": 0.1,

--- a/cardano-testnet/test/cardano-testnet-test/files/golden/queries/protocolParametersFileOut.json
+++ b/cardano-testnet/test/cardano-testnet-test/files/golden/queries/protocolParametersFileOut.json
@@ -641,7 +641,7 @@
         "major": 10,
         "minor": 0
     },
-    "stakeAddressDeposit": 0,
+    "stakeAddressDeposit": 400000,
     "stakePoolDeposit": 0,
     "stakePoolTargetNum": 100,
     "treasuryCut": 0.1,

--- a/cardano-testnet/test/cardano-testnet-test/files/golden/queries/protocolParametersOut.txt
+++ b/cardano-testnet/test/cardano-testnet-test/files/golden/queries/protocolParametersOut.txt
@@ -641,7 +641,7 @@
         "major": 10,
         "minor": 0
     },
-    "stakeAddressDeposit": 0,
+    "stakeAddressDeposit": 400000,
     "stakePoolDeposit": 0,
     "stakePoolTargetNum": 100,
     "treasuryCut": 0.1,


### PR DESCRIPTION
# Description

Reproducer for: https://github.com/IntersectMBO/cardano-cli/issues/942

Adds also a few refactors:
* Use `KeyPair k` type in more places
* Replace `SomeKeyPair` with `Some KeyPair`
* Read required key deposit from protocol parameters instead of hardcoding it
* Use `createStakeKeyDeregistrationCertificate` and `createStakeKeyRegistrationCertificate` instead of manually building cardano-cli command.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
