### PR TITLE
Bump `iohk-monitoring` - drop dependency on `snap`

### DIFF
--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -169,17 +169,17 @@ library
                       , deepseq
                       , directory
                       , dns
-                      , ekg
+                      , ekg-wai
                       , ekg-core
                       , filepath
                       , formatting
                       , generic-data
                       , hostname
                       , io-classes >= 1.4
-                      , iohk-monitoring < 0.2
+                      , iohk-monitoring ^>= 0.2
                       , iproute
                       , lobemo-backend-aggregation
-                      , lobemo-backend-ekg < 0.2
+                      , lobemo-backend-ekg ^>= 0.2
                       , lobemo-backend-monitoring
                       , lobemo-backend-trace-forwarder
                       , mtl

--- a/cardano-node/src/Cardano/Node/Configuration/Logging.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/Logging.hs
@@ -48,7 +48,7 @@ import           Data.Version (showVersion)
 import           System.Metrics.Counter (Counter)
 import           System.Metrics.Gauge (Gauge)
 import           System.Metrics.Label (Label)
-import qualified System.Remote.Monitoring as EKG
+import qualified System.Remote.Monitoring.Wai as EKG
 
 import           Cardano.BM.Backend.Aggregation (plugin)
 import           Cardano.BM.Backend.EKGView (plugin)

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -135,7 +135,7 @@ import           GHC.TypeLits (KnownNat, Nat, natVal)
 import qualified System.Metrics.Counter as Counter
 import qualified System.Metrics.Gauge as Gauge
 import qualified System.Metrics.Label as Label
-import qualified System.Remote.Monitoring as EKG
+import qualified System.Remote.Monitoring.Wai as EKG
 
 
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}

--- a/trace-dispatcher/bench/trace-dispatcher-bench.hs
+++ b/trace-dispatcher/bench/trace-dispatcher-bench.hs
@@ -6,7 +6,7 @@ import           Cardano.Logging.Test.Tracer
 import           Cardano.Logging.Test.Types
 
 import           Data.IORef
-import           System.Remote.Monitoring (forkServer)
+import           System.Remote.Monitoring.Wai (forkServer)
 
 import           Criterion.Main
 

--- a/trace-dispatcher/src/Cardano/Logging/Tracer/EKG.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Tracer/EKG.hs
@@ -19,7 +19,7 @@ import qualified System.Metrics as Metrics
 import qualified System.Metrics.Counter as Counter
 import qualified System.Metrics.Gauge as Gauge
 import qualified System.Metrics.Label as Label
-import           System.Remote.Monitoring (Server, getCounter, getGauge, getLabel)
+import           System.Remote.Monitoring.Wai (Server, getCounter, getGauge, getLabel)
 
 
 -- | It is mandatory to construct only one standard tracer in any application!

--- a/trace-dispatcher/trace-dispatcher.cabal
+++ b/trace-dispatcher/trace-dispatcher.cabal
@@ -54,7 +54,7 @@ library
                       , containers
                       , contra-tracer
                       , deepseq
-                      , ekg
+                      , ekg-wai
                       , ekg-core
                       , ekg-forward >= 0.5
                       , hostname
@@ -116,7 +116,6 @@ test-suite trace-dispatcher-test
                       , cardano-prelude
                       , containers
                       , deepseq
-                      , ekg
                       , ekg-core
                       , generic-data
                       , hostname
@@ -164,7 +163,7 @@ benchmark trace-dispatcher-bench
                       , aeson
                       , containers
                       , criterion
-                      , ekg
+                      , ekg-wai
                       , text
                       , time
                       , trace-dispatcher


### PR DESCRIPTION
# Description

This PR:
1. bumps `iohk-monitoring` to a version that replaces the `snap` server beckend with `wai / warp`.
2. switches all remaining build targets in the repo from `snap`-based `ekg` to `ekg-wai`.
3. sensibly constrains `ekg-forward` (0.5 contains a space leak, and 0.7 will contain breaking changes).

This ultimately removes `snap-server` from node dependency graph entirely.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff
