### PR TITLE
tracer-forwarder: Update to typed-protocols-0.3

### DIFF
--- a/trace-forward/src/Trace/Forward/Protocol/DataPoint/Acceptor.hs
+++ b/trace-forward/src/Trace/Forward/Protocol/DataPoint/Acceptor.hs
@@ -14,7 +14,8 @@ module Trace.Forward.Protocol.DataPoint.Acceptor
   , dataPointAcceptorPeer
   ) where
 
-import           Network.TypedProtocol.Core (Peer (..), PeerHasAgency (..), PeerRole (..))
+import           Network.TypedProtocol.Peer.Client
+-- import           Network.TypedProtocol.Core (Peer (..), PeerHasAgency (..), PeerRole (..))
 
 import           Trace.Forward.Protocol.DataPoint.Type
 
@@ -33,15 +34,15 @@ data DataPointAcceptor m a where
 dataPointAcceptorPeer
   :: Monad m
   => DataPointAcceptor m a
-  -> Peer DataPointForward 'AsClient 'StIdle m a
+  -> Client DataPointForward 'NonPipelined 'StIdle m a
 dataPointAcceptorPeer = \case
   SendMsgDataPointsRequest request next ->
     -- Send our message (request for new 'DataPoint's from the forwarder).
-    Yield (ClientAgency TokIdle) (MsgDataPointsRequest request) $
+    Yield (MsgDataPointsRequest request) $
       -- We're now into the 'StBusy' state, and now we'll wait for a reply
       -- from the forwarder. It is assuming that the forwarder will reply
       -- immediately (even there are no 'DataPoint's).
-      Await (ServerAgency TokBusy) $ \(MsgDataPointsReply reply) ->
+      Await $ \(MsgDataPointsReply reply) ->
         Effect $
           dataPointAcceptorPeer <$> next reply
 
@@ -50,5 +51,5 @@ dataPointAcceptorPeer = \case
     -- 'StDone' state. Once in the 'StDone' state we can actually stop using
     -- 'done', with a return value.
     Effect $
-      Yield (ClientAgency TokIdle) MsgDone . Done TokDone
+      Yield MsgDone . Done 
         <$> getResult

--- a/trace-forward/src/Trace/Forward/Protocol/DataPoint/Codec.hs
+++ b/trace-forward/src/Trace/Forward/Protocol/DataPoint/Codec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
@@ -13,8 +14,9 @@ import qualified Codec.CBOR.Encoding as CBOR
 import           Codec.CBOR.Read (DeserialiseFailure)
 import           Control.Monad.Class.MonadST (MonadST)
 import qualified Data.ByteString.Lazy as LBS
-import           Network.TypedProtocol.Codec (Codec, PeerHasAgency (..), PeerRole (..),
-                   SomeMessage (..))
+import           Network.TypedProtocol.Codec
+-- import           Network.TypedProtocol.Codec (Codec, PeerHasAgency (..), PeerRole (..),
+--                    SomeMessage (..))
 import           Network.TypedProtocol.Codec.CBOR (mkCodecCborLazyBS)
 import           Text.Printf (printf)
 
@@ -35,48 +37,46 @@ codecDataPointForward encodeRequest   decodeRequest
  where
   -- Encode messages.
   encode
-    :: forall (pr  :: PeerRole)
-              (st  :: DataPointForward)
+    :: forall (st  :: DataPointForward)
               (st' :: DataPointForward).
-       PeerHasAgency pr st
-    -> Message DataPointForward st st'
+       Message DataPointForward st st'
     -> CBOR.Encoding
 
-  encode (ClientAgency TokIdle) (MsgDataPointsRequest request) =
+  encode (MsgDataPointsRequest request) =
        CBOR.encodeListLen 2
     <> CBOR.encodeWord 1
     <> encodeRequest request
 
-  encode (ClientAgency TokIdle) MsgDone =
+  encode MsgDone =
        CBOR.encodeListLen 1
     <> CBOR.encodeWord 2
 
-  encode (ServerAgency TokBusy) (MsgDataPointsReply reply) =
+  encode (MsgDataPointsReply reply) =
        CBOR.encodeListLen 2
     <> CBOR.encodeWord 3
     <> encodeReplyList reply
 
   -- Decode messages
   decode
-    :: forall (pr :: PeerRole)
-              (st :: DataPointForward) s.
-       PeerHasAgency pr st
+    :: forall (st :: DataPointForward) s.
+       ActiveState st 
+    => StateToken st
     -> CBOR.Decoder s (SomeMessage st)
-  decode stok = do
+  decode stateToken = do
     len <- CBOR.decodeListLen
     key <- CBOR.decodeWord
-    case (key, len, stok) of
-      (1, 2, ClientAgency TokIdle) ->
+    case (key, len, stateToken) of
+      (1, 2, SingIdle) ->
         SomeMessage . MsgDataPointsRequest <$> decodeRequest
 
-      (2, 1, ClientAgency TokIdle) ->
+      (2, 1, SingIdle) ->
         return $ SomeMessage MsgDone
 
-      (3, 2, ServerAgency TokBusy) ->
+      (3, 2, SingBusy) ->
         SomeMessage . MsgDataPointsReply <$> decodeReplyList
 
       -- Failures per protocol state
-      (_, _, ClientAgency TokIdle) ->
-        fail (printf "codecDataPointForward (%s) unexpected key (%d, %d)" (show stok) key len)
-      (_, _, ServerAgency TokBusy) ->
-        fail (printf "codecDataPointForward (%s) unexpected key (%d, %d)" (show stok) key len)
+      (_, _, SingIdle) ->
+        fail (printf "codecDataPointForward (%s) unexpected key (%d, %d)" (show stateToken) key len)
+      (_, _, SingBusy) ->
+        fail (printf "codecDataPointForward (%s) unexpected key (%d, %d)" (show stateToken) key len)

--- a/trace-forward/src/Trace/Forward/Protocol/DataPoint/Forwarder.hs
+++ b/trace-forward/src/Trace/Forward/Protocol/DataPoint/Forwarder.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
@@ -9,7 +10,7 @@ module Trace.Forward.Protocol.DataPoint.Forwarder
   , dataPointForwarderPeer
   ) where
 
-import           Network.TypedProtocol.Core (Peer (..), PeerHasAgency (..), PeerRole (..))
+import           Network.TypedProtocol.Peer.Server
 
 import           Trace.Forward.Protocol.DataPoint.Type
 
@@ -29,22 +30,21 @@ data DataPointForwarder m a = DataPointForwarder
 dataPointForwarderPeer
   :: Monad m
   => DataPointForwarder m a
-  -> Peer DataPointForward 'AsServer 'StIdle m a
+  -> Server DataPointForward 'NonPipelined 'StIdle m a
 dataPointForwarderPeer DataPointForwarder{recvMsgDataPointsRequest, recvMsgDone} = go
   where
     go =
       -- In the 'StIdle' state the forwarder is awaiting a request message
       -- from the acceptor.
-      Await (ClientAgency TokIdle) $ \case
+      Await \case
         -- The acceptor sent us a request for new 'DataPoint's, so now we're
         -- in the 'StBusy' state which means it's the forwarder's turn to send
         -- a reply.
-        MsgDataPointsRequest request -> Effect $ do
+        MsgDataPointsRequest request -> Effect do
           reply <- recvMsgDataPointsRequest request
-          return $ Yield (ServerAgency TokBusy)
-                         (MsgDataPointsReply reply)
+          return $ Yield (MsgDataPointsReply reply)
                          go
 
         -- The acceptor sent the done transition, so we're in the 'StDone' state
         -- so all we can do is stop using 'done', with a return value.
-        MsgDone -> Effect $ Done TokDone <$> recvMsgDone
+        MsgDone -> Effect $ Done <$> recvMsgDone

--- a/trace-forward/src/Trace/Forward/Protocol/DataPoint/Type.hs
+++ b/trace-forward/src/Trace/Forward/Protocol/DataPoint/Type.hs
@@ -3,6 +3,8 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- | The type of the 'DataPoint' forwarding/accepting protocol.
@@ -14,16 +16,16 @@ module Trace.Forward.Protocol.DataPoint.Type
   , DataPointValues
   , DataPointForward (..)
   , Message (..)
-  , ClientHasAgency (..)
-  , ServerHasAgency (..)
-  , NobodyHasAgency (..)
+  , SingDataPointForward (..)
   ) where
 
+import           Data.Singletons
+import           Network.TypedProtocol.Core
 import           Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
 
 import qualified Data.ByteString.Lazy as LBS
+import           Data.Kind (Type)
 import           Data.Text (Text)
-import           Network.TypedProtocol.Core (Protocol (..))
 
 -- | A kind to identify our protocol, and the types of the states in the state
 -- transition diagram of the protocol.
@@ -62,6 +64,25 @@ data DataPointForward where
 instance ShowProxy DataPointForward where
   showProxy _ = "DataPointForward"
 
+-- | Singleton type of DataPointForward. Same as:
+--
+-- @
+-- type SingDataPointForward :: DataPointForward -> Type
+-- type SingDataPointForward = TypeRep
+-- @
+type SingDataPointForward :: DataPointForward -> Type
+data SingDataPointForward dataPoint where
+  SingIdle :: SingDataPointForward 'StIdle
+  SingBusy :: SingDataPointForward 'StBusy
+  SingDone :: SingDataPointForward 'StDone
+
+type instance Sing = SingDataPointForward
+
+deriving instance Show (SingDataPointForward st)
+instance StateTokenI 'StIdle where stateToken = SingIdle
+instance StateTokenI 'StBusy where stateToken = SingBusy
+instance StateTokenI 'StDone where stateToken = SingDone
+
 instance Protocol DataPointForward where
 
   -- | The messages in the trace forwarding/accepting protocol.
@@ -95,27 +116,11 @@ instance Protocol DataPointForward where
   -- 1. ClientHasAgency (from 'Network.TypedProtocol.Core') corresponds to acceptor's agency.
   -- 3. ServerHasAgency (from 'Network.TypedProtocol.Core') corresponds to forwarder's agency.
   --
-  data ClientHasAgency st where
-    TokIdle :: ClientHasAgency 'StIdle
+  type StateAgency 'StIdle = 'ClientAgency
+  type StateAgency 'StBusy = 'ServerAgency
+  type StateAgency 'StDone = 'NobodyAgency
 
-  data ServerHasAgency st where
-    TokBusy :: ServerHasAgency 'StBusy
+  type StateToken = SingDataPointForward
 
-  data NobodyHasAgency st where
-    TokDone :: NobodyHasAgency 'StDone
-
-  -- | Impossible cases.
-  exclusionLemma_ClientAndServerHaveAgency TokIdle tok = case tok of {}
-  exclusionLemma_NobodyAndClientHaveAgency TokDone tok = case tok of {}
-  exclusionLemma_NobodyAndServerHaveAgency TokDone tok = case tok of {}
-
-instance Show (Message DataPointForward from to) where
-  show MsgDataPointsRequest{} = "MsgDataPointsRequest"
-  show MsgDataPointsReply{}   = "MsgDataPointsReply"
-  show MsgDone{}              = "MsgDone"
-
-instance Show (ClientHasAgency (st :: DataPointForward)) where
-  show TokIdle = "TokIdle"
-
-instance Show (ServerHasAgency (st :: DataPointForward)) where
-  show TokBusy{} = "TokBusy"
+deriving 
+  instance Show (Message DataPointForward from to)

--- a/trace-forward/src/Trace/Forward/Protocol/TraceObject/Forwarder.hs
+++ b/trace-forward/src/Trace/Forward/Protocol/TraceObject/Forwarder.hs
@@ -1,15 +1,20 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Trace.Forward.Protocol.TraceObject.Forwarder
   ( TraceObjectForwarder (..)
   , traceObjectForwarderPeer
   ) where
 
-import           Network.TypedProtocol.Core (Peer (..), PeerHasAgency (..), PeerRole (..))
+import           Data.Singletons
+import           Network.TypedProtocol.Peer.Server
+-- import           Network.TypedProtocol.Core (Peer (..), PeerHasAgency (..), PeerRole (..))
 
 import           Trace.Forward.Protocol.TraceObject.Type
 
@@ -30,24 +35,27 @@ data TraceObjectForwarder lo m a = TraceObjectForwarder
 -- | Interpret a particular action sequence into the server side of the protocol.
 --
 traceObjectForwarderPeer
-  :: Monad m
+  :: forall m lo a
+   . Monad m
   => TraceObjectForwarder lo m a
-  -> Peer (TraceObjectForward lo) 'AsServer 'StIdle m a
+  -> Server (TraceObjectForward lo) 'NonPipelined 'StIdle m a
 traceObjectForwarderPeer TraceObjectForwarder{recvMsgTraceObjectsRequest, recvMsgDone} = go
   where
-    go =
-      -- In the 'StIdle' state the forwarder is awaiting a request message
-      -- from the acceptor.
-      Await (ClientAgency TokIdle) $ \case
-        -- The acceptor sent us a request for new 'TraceObject's, so now we're
-        -- in the 'StBusy' state which means it's the forwarder's turn to send
-        -- a reply.
-        MsgTraceObjectsRequest blocking request -> Effect $ do
-          reply <- recvMsgTraceObjectsRequest blocking request
-          return $ Yield (ServerAgency (TokBusy blocking))
-                         (MsgTraceObjectsReply reply)
-                         go
+  go :: Server (TraceObjectForward lo) 'NonPipelined StIdle m a
+  go =
+    -- In the 'StIdle' state the forwarder is awaiting a request message
+    -- from the acceptor.
+    Await \case
+      -- The acceptor sent us a request for new 'TraceObject's, so now we're
+      -- in the 'StBusy' state which means it's the forwarder's turn to send
+      -- a reply.
+      MsgTraceObjectsRequest blocking request -> Effect do
+        reply <- recvMsgTraceObjectsRequest blocking request
+        pure do
+          withSingI blocking do
+            Yield (MsgTraceObjectsReply reply) go
 
-        -- The acceptor sent the done transition, so we're in the 'StDone' state
-        -- so all we can do is stop using 'done', with a return value.
-        MsgDone -> Effect $ Done TokDone <$> recvMsgDone
+      -- The acceptor sent the done transition, so we're in the 'StDone' state
+      -- so all we can do is stop using 'done', with a return value.
+      MsgDone -> Effect do
+        Done <$> recvMsgDone

--- a/trace-forward/src/Trace/Forward/Protocol/TraceObject/Type.hs
+++ b/trace-forward/src/Trace/Forward/Protocol/TraceObject/Type.hs
@@ -1,11 +1,14 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- | The type of the trace forwarding/accepting protocol.
@@ -13,23 +16,23 @@
 
 module Trace.Forward.Protocol.TraceObject.Type
   ( TraceObjectForward (..)
+  , SingTraceObjectForward(..)
   , TokBlockingStyle (..)
   , Message (..)
-  , ClientHasAgency (..)
-  , ServerHasAgency (..)
-  , NobodyHasAgency (..)
   , NumberOfTraceObjects (..)
   , BlockingReplyList (..)
+  , StBlockingStyle(..)
   ) where
 
 import           Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
 
+import           Data.Kind (Type)
+import           Data.Singletons
 import           Codec.Serialise (Serialise (..))
 import           Data.List.NonEmpty (NonEmpty)
-import           Data.Proxy (Proxy (..))
 import           Data.Word (Word16)
 import           GHC.Generics (Generic)
-import           Network.TypedProtocol.Core (Protocol (..))
+import           Network.TypedProtocol.Core -- (Protocol (..))
 
 -- | A kind to identify our protocol, and the types of the states in the state
 -- transition diagram of the protocol.
@@ -49,10 +52,11 @@ import           Network.TypedProtocol.Core (Protocol (..))
 -- | The acceptor will send this request to the forwarder.
 newtype NumberOfTraceObjects = NumberOfTraceObjects
   { nTraceObjects :: Word16
-  } deriving (Eq, Generic, Show)
-
-instance ShowProxy NumberOfTraceObjects
-instance Serialise NumberOfTraceObjects
+  }
+  deriving stock
+    (Eq, Generic, Show)
+  deriving anyclass
+    (ShowProxy, Serialise)
 
 data TraceObjectForward lo where
 
@@ -84,6 +88,13 @@ instance (ShowProxy lo)
     , ")"
     ]
 
+-- | Singleton type of TraceObjectForward.
+type SingTraceObjectForward :: TraceObjectForward lo -> Type
+data SingTraceObjectForward traceObj where
+  SingIdle :: SingTraceObjectForward 'StIdle
+  SingBusy :: TokBlockingStyle blockStyle -> SingTraceObjectForward ('StBusy blockStyle)
+  SingDone :: SingTraceObjectForward 'StDone
+
 data StBlockingStyle where
   -- | In this sub-state the reply need not be prompt. There is no timeout.
   StBlocking    :: StBlockingStyle
@@ -100,6 +111,18 @@ data TokBlockingStyle (k :: StBlockingStyle) where
 
 deriving instance Eq   (TokBlockingStyle b)
 deriving instance Show (TokBlockingStyle b)
+
+type instance Sing = SingTraceObjectForward
+type instance Sing = TokBlockingStyle
+
+deriving stock
+  instance Show (SingTraceObjectForward traceObj)
+instance StateTokenI 'StIdle where stateToken = SingIdle
+instance StateTokenI 'StDone where stateToken = SingDone
+instance SingI blockStyle => StateTokenI ('StBusy blockStyle) where stateToken = SingBusy sing
+
+instance SingI 'StBlocking    where sing = TokBlocking
+instance SingI 'StNonBlocking where sing = TokNonBlocking
 
 -- | We have requests for lists of things. In the blocking case the
 -- corresponding reply must be non-empty, whereas in the non-blocking case
@@ -154,28 +177,33 @@ instance Protocol (TraceObjectForward lo) where
   -- 1. ClientHasAgency (from 'Network.TypedProtocol.Core') corresponds to acceptor's agency.
   -- 3. ServerHasAgency (from 'Network.TypedProtocol.Core') corresponds to forwarder's agency.
   --
-  data ClientHasAgency st where
-    TokIdle :: ClientHasAgency 'StIdle
+  type StateAgency 'StIdle = 'ClientAgency
+  type StateAgency ('StBusy blocking) = 'ServerAgency
+  type StateAgency 'StDone = 'NobodyAgency
 
-  data ServerHasAgency st where
-    TokBusy :: TokBlockingStyle blocking -> ServerHasAgency ('StBusy blocking)
+  type StateToken = SingTraceObjectForward
+  -- data ClientHasAgency st where
+  --   TokIdle :: ClientHasAgency 'StIdle
 
-  data NobodyHasAgency st where
-    TokDone :: NobodyHasAgency 'StDone
+  -- data ServerHasAgency st where
+  --   TokBusy :: TokBlockingStyle blocking -> ServerHasAgency ('StBusy blocking)
 
-  -- | Impossible cases.
-  exclusionLemma_ClientAndServerHaveAgency TokIdle tok = case tok of {}
-  exclusionLemma_NobodyAndClientHaveAgency TokDone tok = case tok of {}
-  exclusionLemma_NobodyAndServerHaveAgency TokDone tok = case tok of {}
+  -- data NobodyHasAgency st where
+  --   TokDone :: NobodyHasAgency 'StDone
 
-instance Show lo
-      => Show (Message (TraceObjectForward lo) from to) where
-  show MsgTraceObjectsRequest{} = "MsgTraceObjectsRequest"
-  show MsgTraceObjectsReply{}   = "MsgTraceObjectsReply"
-  show MsgDone{}                = "MsgDone"
+  -- -- | Impossible cases.
+  -- exclusionLemma_ClientAndServerHaveAgency TokIdle tok = case tok of {}
+  -- exclusionLemma_NobodyAndClientHaveAgency TokDone tok = case tok of {}
+  -- exclusionLemma_NobodyAndServerHaveAgency TokDone tok = case tok of {}
 
-instance Show (ClientHasAgency (st :: TraceObjectForward lo)) where
-  show TokIdle = "TokIdle"
+deriving stock
+  instance Show lo => Show (Message (TraceObjectForward lo) from to)
+  -- show MsgTraceObjectsRequest{} = "MsgTraceObjectsRequest"
+  -- show MsgTraceObjectsReply{}   = "MsgTraceObjectsReply"
+  -- show MsgDone{}                = "MsgDone"
 
-instance Show (ServerHasAgency (st :: TraceObjectForward lo)) where
-  show TokBusy{} = "TokBusy"
+-- instance Show (ClientHasAgency (st :: TraceObjectForward lo)) where
+--   show TokIdle = "TokIdle"
+
+-- instance Show (ServerHasAgency (st :: TraceObjectForward lo)) where
+--   show TokBusy{} = "TokBusy"

--- a/trace-forward/trace-forward.cabal
+++ b/trace-forward/trace-forward.cabal
@@ -64,12 +64,13 @@ library
                       , deepseq
                       , extra
                       , io-classes
-                      , ouroboros-network-api ^>= 0.10
-                      , ouroboros-network-framework
+                      , ouroboros-network-api
+                      , singletons ^>= 3.0
+                      , ouroboros-network-framework ^>= 0.14
                       , serialise
                       , stm
                       , text
-                      , typed-protocols ^>= 0.1
+                      , typed-protocols ^>= 0.3
                       , typed-protocols-cborg
 
 test-suite test


### PR DESCRIPTION
# Description

## This is not intended to build

This is a non-building draft. The `trace-forwarder` has been updated to `typed-protocols-0.3` but the rest of the project has not. 

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
