### PR TITLE
cardano-testnet | Add correct contents for proposal anchor and constitution

### DIFF
--- a/cardano-testnet/src/Testnet/Process/Cli/DRep.hs
+++ b/cardano-testnet/src/Testnet/Process/Cli/DRep.hs
@@ -362,7 +362,9 @@ makeActivityChangeProposal execConfig epochStateView ceo work
   baseDir <- H.createDirectoryIfMissing work
 
   proposalAnchorFile <- H.note $ baseDir </> "sample-proposal-anchor"
-  H.writeFile proposalAnchorFile "dummy anchor data"
+  H.writeFile proposalAnchorFile $
+    unlines [ "These are the reasons:  " , "" , "1. First" , "2. Second " , "3. Third" ]
+
 
   proposalAnchorDataHash <- execCli' execConfig
     [ "hash", "anchor-data", "--file-text", proposalAnchorFile

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/CommitteeAddNew.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/CommitteeAddNew.hs
@@ -110,7 +110,8 @@ hprop_constitutional_committee_add_new = integrationWorkspace "constitutional-co
   proposalDataFp <- H.note $ gov </> "sample-proposal-data"
   updateCommitteeFp <- H.note $ gov </> "update-cc.action"
 
-  H.writeFile proposalAnchorFp "dummy anchor data"
+  H.writeFile proposalAnchorFp $
+    unlines [ "These are the reasons:  " , "" , "1. First" , "2. Second " , "3. Third" ]
   H.writeFile proposalDataFp "dummy proposal data"
 
   proposalAnchorDataHash <- execCli' execConfig

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/InfoAction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/InfoAction.hs
@@ -88,7 +88,9 @@ hprop_ledger_events_info_action = integrationRetryWorkspace 2 "info-hash" $ \tem
   proposalAnchorFile <- H.note $ work </> gov </> "sample-proposal-anchor"
   infoActionFp <- H.note $ work </> gov </> "info.action"
 
-  H.writeFile proposalAnchorFile "dummy anchor data"
+  -- pls configure your editors to trim trailing whitespace >.>
+  H.writeFile proposalAnchorFile $
+    unlines [ "These are the reasons:  " , "" , "1. First" , "2. Second " , "3. Third" ]
 
   proposalAnchorDataHash <- execCli' execConfig
     [ "hash", "anchor-data", "--file-text", proposalAnchorFile

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs
@@ -145,7 +145,8 @@ hprop_gov_no_confidence = integrationWorkspace "no-confidence" $ \tempAbsBasePat
   -- Create proposal to add a new member to the committee
 
   proposalAnchorFile <- H.note $ work </> "sample-proposal-anchor"
-  H.writeFile proposalAnchorFile "dummy anchor data"
+  H.writeFile proposalAnchorFile $
+    unlines [ "These are the reasons:  " , "" , "1. First" , "2. Second " , "3. Third" ]
 
   proposalAnchorDataHash <- H.execCli' execConfig
     [ "hash", "anchor-data", "--file-text", proposalAnchorFile

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
@@ -244,7 +244,8 @@ makeDesiredPoolNumberChangeProposal execConfig epochStateView ceo work prefix
               }
 
   proposalAnchorFile <- H.note $ baseDir </> "sample-proposal-anchor"
-  H.writeFile proposalAnchorFile "dummy anchor data"
+  H.writeFile proposalAnchorFile $
+    unlines [ "These are the reasons:  " , "" , "1. First" , "2. Second " , "3. Third" ]
 
   proposalAnchorDataHash <- H.execCli' execConfig
     [ "hash", "anchor-data", "--file-text", proposalAnchorFile

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitution.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitution.hs
@@ -46,6 +46,7 @@ import           Testnet.Start.Types
 import           Testnet.Types
 
 import           Hedgehog
+import qualified Hedgehog as H
 import qualified Hedgehog.Extras as H
 
 -- | Execute me with:
@@ -102,13 +103,16 @@ hprop_ledger_events_propose_new_constitution = integrationWorkspace "propose-new
   -- Create Conway constitution
   gov <- H.createDirectoryIfMissing $ work </> "governance"
   proposalAnchorFile <- H.note $ gov </> "sample-proposal-anchor"
-  consitutionFile <- H.note $ gov </> "sample-constitution"
+  constitutionFile <- H.note $ gov </> "sample-constitution"
   constitutionActionFp <- H.note $ gov </> "constitution.action"
 
-  H.writeFile proposalAnchorFile "dummy anchor data"
-  H.writeFile consitutionFile "dummy constitution data"
+  H.writeFile proposalAnchorFile $
+    unlines [ "These are the reasons:  " , "" , "1. First" , "2. Second " , "3. Third" ]
+  H.copyFile
+    "test/cardano-testnet-test/files/input/sample-constitution.txt"
+    constitutionFile
   constitutionHash <- execCli' execConfig
-    [ "hash", "anchor-data", "--file-text", consitutionFile
+    [ "hash", "anchor-data", "--file-text", constitutionFile
     ]
 
   proposalAnchorDataHash <- execCli' execConfig
@@ -232,7 +236,7 @@ hprop_ledger_events_propose_new_constitution = integrationWorkspace "propose-new
   length votes === fromIntegral numVotes
 
   -- We check that constitution was succcessfully ratified
-  void . H.leftFailM . evalIO . runExceptT $
+  void . H.leftFailM . H.evalIO . runExceptT $
     foldEpochState
       configurationFile
       socketPath

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitutionSPO.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitutionSPO.hs
@@ -91,8 +91,12 @@ hprop_ledger_events_propose_new_constitution_spo = integrationWorkspace "propose
   constitutionFile <- H.note $ work </> gov </> "sample-constitution"
   constitutionActionFp <- H.note $ work </> gov </> "constitution.action"
 
-  H.writeFile proposalAnchorFile "dummy anchor data"
-  H.writeFile constitutionFile "dummy constitution data"
+  H.writeFile proposalAnchorFile $
+    unlines [ "These are the reasons:  " , "" , "1. First" , "2. Second " , "3. Third" ]
+
+  H.copyFile
+    "test/cardano-testnet-test/files/input/sample-constitution.txt"
+    constitutionFile
   constitutionHash <- execCli' execConfig
     [ "hash", "anchor-data", "--file-text", constitutionFile
     ]

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryWithdrawal.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryWithdrawal.hs
@@ -91,7 +91,9 @@ hprop_ledger_events_treasury_withdrawal = integrationRetryWorkspace 2  "treasury
   proposalAnchorFile <- H.note $ work </> gov </> "sample-proposal-anchor"
   treasuryWithdrawalActionFp <- H.note $ work </> gov </> "treasury-withdrawal.action"
 
-  H.writeFile proposalAnchorFile "dummy anchor data"
+  -- pls configure your editors to trim trailing whitespace >.>
+  H.writeFile proposalAnchorFile $
+    unlines [ "These are the reasons:  " , "" , "1. First" , "2. Second " , "3. Third" ]
 
   proposalAnchorDataHash <- execCli' execConfig
     [ "hash", "anchor-data", "--file-text", proposalAnchorFile

--- a/cardano-testnet/test/cardano-testnet-test/files/input/sample-constitution.txt
+++ b/cardano-testnet/test/cardano-testnet-test/files/input/sample-constitution.txt
@@ -1,0 +1,50 @@
+Preamble
+
+We, the zaniest inhabitants of the peculiar and bewildering land of Barataria, in honor of our illustrious Governor, Sancho Panza, renowned for his comically charming ordinances, do hereby present this Constitution to tickle your fancy and uphold the values of laughter, merriment, and the pursuit of hilarity for all our citizens.
+
+Article I: The Right to Absurdity
+
+Wine-Watering Rights: Every Baratarian shall have the inalienable right to water down their wine as they see fit, provided they can still manage a tipsy jig.
+
+Fashion Freedom: Citizens are encouraged to dress inappropriately for the sheer joy of it, as long as it does not involve the use of sharp objects, poisonous animals, or explosives.
+
+Article II: The Role of Government: Keeping It Lighthearted
+
+Official Clown: There shall be an official court jester whose duty is to make the Governor laugh at least once a day. Failure to amuse may result in banishment to a neighboring kingdom.
+
+Puns and Pranks: All government proceedings shall include at least one pun and one harmless prank per session to maintain the mirthful spirit of Barataria.
+
+Article III: The Economic Circus
+
+Foolish Redistribution: The government shall engage in a monthly "wealth lottery," redistributing riches by catapulting bags of gold into the air and letting them fall where they may.
+
+Tax Deductions for Silly Hats: Citizens who wear absurd hats shall receive generous tax deductions, fostering creativity and fashion-forward thinking.
+
+Article IV: Justice, Comedy, and the Absurd
+
+Trial by Tickling: In the interest of justice and merriment, all trials shall include a "tickle test" to determine guilt or innocence. Giggles are considered a sign of innocence.
+
+Innocent Until Proven Clueless: It shall be presumed that every Baratarian is innocent of any wrongdoing until they can convincingly demonstrate their utter cluelessness in court.
+
+Article V: Education and Clown Colleges
+
+Clown Colleges for All: Barataria shall establish Clown Colleges to ensure that every citizen has the opportunity to master the art of clowning and perform slapstick humor.
+
+Silly Science: Research grants shall be awarded to projects that explore the science of whoopee cushions, banana peels, and rubber chickens.
+
+Article VI: Defense and Pranks
+
+Pillow Fort Defense: Barataria's defense strategy shall revolve around building impregnable pillow forts and inviting would-be invaders to epic pillow fights to resolve conflicts.
+
+War Declarations through Whoopie Cushions: Before declaring war, Barataria shall send a diplomatic envoy to the offending nation armed only with whoopee cushions to express our discontent.
+
+Article VII: Amendments and Clown-novations
+
+Whimsical Amendments: Amendments to this Constitution shall be proposed in the form of a joke or a riddle, and they must receive a hearty laugh from at least three-quarters of the citizens to be adopted.
+Article VIII: Final Pratfalls
+
+Ratification with a Pie in the Face: This Constitution shall be ratified in a grand ceremony involving a pie in the face of the official ratifier, ensuring a silly and sticky beginning for Barataria.
+
+Effective Clowning Date: This Constitution shall come into effect immediately upon the eruption of the first uncontrollable fit of laughter.
+
+In witness whereof, we, the undersigned jesters, pranksters, and merrymakers, do hereby establish and adopt this Constitution to make Barataria a haven of hilarity, where laughter reigns supreme, and seriousness is only allowed on April Fool's Day.

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -210,6 +210,7 @@ let
                 "cardano-testnet/test/cardano-testnet-golden/files/golden/shelley_node_default_config.json"
                 "cardano-testnet/test/cardano-testnet-golden/files/golden/shelley_node_default_config.json"
                 "cardano-testnet/test/cardano-testnet-test/files/golden/tx.failed.response.json.golden"
+                "cardano-testnet/test/cardano-testnet-test/files/input/sample-constitution.txt"
                 "cardano-testnet/files/data/alonzo/genesis.alonzo.spec.json"
                 "cardano-testnet/files/data/conway/genesis.conway.spec.json"
               ];


### PR DESCRIPTION
# Description

Adds correct contents for proposal anchor and the constitution located at urls used in tests.

Otherwise, those tests will fail with cardano-cli 10.1.1.0.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
