### PR TITLE
cardano-testnet: use create-testnet-data's byron genesis generation feature

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -68,3 +68,9 @@ allow-newer:
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
+
+source-repository-package
+   type: git
+   location: https://github.com/IntersectMBO/cardano-cli
+   subdir: cardano-cli
+   tag: 01cb56f621c6ac2469a242e7661d3777af109b37

--- a/cardano-testnet/src/Testnet/Components/Configuration.hs
+++ b/cardano-testnet/src/Testnet/Components/Configuration.hs
@@ -72,7 +72,7 @@ createConfigJson :: ()
   -> ShelleyBasedEra era -- ^ The era used for generating the hard fork configuration toggle
   -> m LBS.ByteString
 createConfigJson (TmpAbsolutePath tempAbsPath) sbe = GHC.withFrozenCallStack $ do
-  byronGenesisHash <- getByronGenesisHash $ tempAbsPath </> "byron/genesis.json"
+  byronGenesisHash <- getByronGenesisHash $ tempAbsPath </> "byron-genesis.json"
   shelleyGenesisHash <- getHash ShelleyEra "ShelleyGenesisHash"
   alonzoGenesisHash  <- getHash AlonzoEra  "AlonzoGenesisHash"
   conwayGenesisHash  <- getHash ConwayEra  "ConwayGenesisHash"
@@ -179,13 +179,8 @@ createSPOGenesisAndFiles nPoolNodes nDelReps maxSupply sbe shelleyGenesis
   -- Remove the input files. We don't need them anymore, since create-testnet-data wrote new versions.
   forM_ [inputGenesisShelleyFp, inputGenesisAlonzoFp, inputGenesisConwayFp] (liftIO . System.removeFile)
 
-  -- Move all genesis related files
-  genesisByronDir <- H.createDirectoryIfMissing $ tempAbsPath </> "byron"
-
   files <- H.listDirectory tempAbsPath
   forM_ files H.note
-
-  H.renameFile (tempAbsPath </> "byron-gen-command" </> "genesis.json") (genesisByronDir </> "genesis.json")
 
   return genesisShelleyDir
   where

--- a/cardano-testnet/src/Testnet/Defaults.hs
+++ b/cardano-testnet/src/Testnet/Defaults.hs
@@ -290,7 +290,7 @@ defaultYamlConfig =
     , ("EnableLogging", Aeson.Bool True)
 
     -- Genesis filepaths
-    , ("ByronGenesisFile", "byron/genesis.json")
+    , ("ByronGenesisFile", genesisPath ByronEra)
     , ("ShelleyGenesisFile", genesisPath ShelleyEra)
     , ("AlonzoGenesisFile",  genesisPath AlonzoEra)
     , ("ConwayGenesisFile",  genesisPath ConwayEra)

--- a/cardano-testnet/src/Testnet/Start/Byron.hs
+++ b/cardano-testnet/src/Testnet/Start/Byron.hs
@@ -7,8 +7,6 @@
 
 module Testnet.Start.Byron
   ( createByronGenesis
-  , createByronUpdateProposal
-  , createByronUpdateProposalVote
   , byronDefaultGenesisOptions
   ) where
 
@@ -66,35 +64,3 @@ createByronGenesis testnetMagic' startTime testnetOptions pParamFp genOutputDir 
     , "--protocol-parameters-file", pParamFp
     , "--genesis-output-dir", genOutputDir
     ]
-
-createByronUpdateProposal
-  :: (MonadTest m, MonadCatch m, MonadIO m, HasCallStack)
-  => Int -> String -> String -> Int -> m ()
-createByronUpdateProposal testnetMagic' signingKeyFp updateProposalFp ptclMajorVersion =
-  withFrozenCallStack $ execCli_
-    [ "byron", "governance", "create-update-proposal"
-    , "--filepath", updateProposalFp
-    , "--testnet-magic", show testnetMagic'
-    , "--signing-key", signingKeyFp
-    , "--protocol-version-major", show ptclMajorVersion
-    , "--protocol-version-minor", "0"
-    , "--protocol-version-alt", "0"
-    , "--application-name", "cardano-sl"
-    , "--software-version-num", "1"
-    , "--system-tag", "linux"
-    , "--installer-hash", "0"
-    ]
-
-createByronUpdateProposalVote
-  :: (MonadTest m, MonadCatch m, MonadIO m, HasCallStack)
-  => Int -> String -> String -> String -> m ()
-createByronUpdateProposalVote testnetMagic' updateProposalFp signingKey outputFp =
-    withFrozenCallStack $ execCli_
-      [ "byron", "governance", "create-proposal-vote"
-      , "--proposal-filepath", updateProposalFp
-      , "--testnet-magic", show testnetMagic'
-      , "--signing-key", signingKey
-      , "--vote-yes"
-      , "--output-filepath", outputFp
-      ]
-

--- a/cardano-testnet/src/Testnet/Start/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Start/Cardano.hs
@@ -54,7 +54,6 @@ import qualified GHC.Stack as GHC
 import qualified System.Directory as IO
 import           System.FilePath ((</>))
 import qualified System.Info as OS
-import           Text.Printf (printf)
 
 import           Testnet.Components.Configuration
 import qualified Testnet.Defaults as Defaults
@@ -62,7 +61,6 @@ import           Testnet.Filepath
 import           Testnet.Process.Run (execCli', execCli_, mkExecConfig)
 import           Testnet.Property.Assert (assertChainExtended, assertExpectedSposInLedgerState)
 import           Testnet.Runtime as TR
-import qualified Testnet.Start.Byron as Byron
 import           Testnet.Start.Types
 import           Testnet.Types as TR hiding (shelleyGenesis)
 
@@ -130,11 +128,7 @@ getDefaultShelleyGenesis asbe maxSupply opts = do
 
 -- | Setup a number of credentials and nodes (SPOs and relays), like this:
 --
--- > ├── byron
--- > │   └── genesis.json
 -- > ├── byron-gen-command
--- > │   ├── delegate-keys.00{1,2}.key
--- > │   ├── delegation-cert.00{1,2}.json
 -- > │   └── genesis-keys.00{0,1,2}.key
 -- > ├── delegate-keys
 -- > │   ├── delegate{1,2,3}
@@ -187,6 +181,7 @@ getDefaultShelleyGenesis asbe maxSupply opts = do
 -- > │   │   └── utxo.{addr,skey,vkey}
 -- > │   └── README.md
 -- > ├── alonzo-genesis.json
+-- > ├── byron.genesis.json
 -- > ├── byron.genesis.spec.json
 -- > ├── configuration.yaml
 -- > ├── conway-genesis.json
@@ -215,7 +210,7 @@ cardanoTestnet
         , cardanoNumDReps=nDReps
         , cardanoNodes
         } = testnetOptions
-      startTime = sgSystemStart shelleyGenesis
+      _startTime = sgSystemStart shelleyGenesis
       testnetMagic = fromIntegral $ sgNetworkMagic shelleyGenesis
       nPools = cardanoNumPools testnetOptions
   AnyShelleyBasedEra sbe <- pure asbe
@@ -230,16 +225,6 @@ cardanoTestnet
     -- makes assumptions about where things should go and where genesis template files should be.
     -- See all of the ad hoc file creation/renaming/dir creation etc below.
     H.failMessage GHC.callStack "Specifying node configuration files per node not supported yet."
-
-  H.lbsWriteFile (tmpAbsPath </> "byron.genesis.spec.json")
-    . encode $ Defaults.defaultByronProtocolParamsJsonValue
-
-  Byron.createByronGenesis
-    testnetMagic
-    startTime
-    Byron.byronDefaultGenesisOptions
-    (tmpAbsPath </> "byron.genesis.spec.json")
-    (tmpAbsPath </> "byron-gen-command")
 
   -- Write specification files. Those are the same as the genesis files
   -- used for launching the nodes, but omitting the content regarding stake, utxos, etc.
@@ -296,16 +281,10 @@ cardanoTestnet
   let portNumbers = snd <$> portNumbersWithNodeOptions
 
   -- Byron related
-  forM_ (zip [1..] portNumbersWithNodeOptions) $ \(i, (nodeOptions, portNumber)) -> do
-    let iStr = printf "%03d" (i - 1)
-        nodeDataDir = tmpAbsPath </> Defaults.defaultNodeDataDir i
-        nodePoolKeysDir = tmpAbsPath </> Defaults.defaultSpoKeysDir i
+  forM_ (zip [1..] portNumbersWithNodeOptions) $ \(i, (_nodeOptions, portNumber)) -> do
+    let nodeDataDir = tmpAbsPath </> Defaults.defaultNodeDataDir i
     H.evalIO $ IO.createDirectoryIfMissing True nodeDataDir
     H.writeFile (nodeDataDir </> "port") (show portNumber)
-    when (isSpoNodeOptions nodeOptions) $ do
-      H.renameFile (tmpAbsPath </> "byron-gen-command" </> "delegate-keys." <> iStr <> ".key") (nodePoolKeysDir </> "byron-delegate.key")
-      H.renameFile (tmpAbsPath </> "byron-gen-command" </> "delegation-cert." <> iStr <> ".json") (nodePoolKeysDir </> "byron-delegation.cert")
-
 
   -- Make Non P2P topology files
   forM_ (zip [1..] portNumbers) $ \(i, myPortNumber) -> do

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Query.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Query.hs
@@ -81,7 +81,7 @@ import qualified Hedgehog.Extras.Test.Golden as H
 
 -- | Test CLI queries
 -- Execute me with:
--- @cabal test cardano-testnet-test --test-options '-p "/CliQueries/"'@
+-- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/CliQueries/"'@
 -- If you want to recreate golden files, run the comment with
 -- RECREATE_GOLDEN_FILES=1 as its prefix
 hprop_cli_queries :: Property

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Node/Shutdown.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Node/Shutdown.hs
@@ -91,13 +91,15 @@ hprop_shutdown = integrationRetryWorkspace 2 "shutdown" $ \tempAbsBasePath' -> H
   H.lbsWriteFile (tempAbsPath' </> "byron.genesis.spec.json")
     . encode $ defaultByronProtocolParamsJsonValue
 
+  let byronGenesisOutputDir = tempAbsPath' </> "byron"
+
   startTime <- H.noteShowIO DTC.getCurrentTime
   createByronGenesis
     testnetMagic'
     startTime
     byronDefaultGenesisOptions
     (tempAbsPath' </> "byron.genesis.spec.json")
-    (tempAbsPath' </> "byron")
+    byronGenesisOutputDir
 
   shelleyDir <- H.createDirectoryIfMissing $ tempAbsPath' </> "shelley"
 
@@ -118,8 +120,9 @@ hprop_shutdown = integrationRetryWorkspace 2 "shutdown" $ \tempAbsBasePath' -> H
     , "--start-time", formatIso8601 startTime
     ]
 
-  byronGenesisHash <- getByronGenesisHash $ tempAbsPath' </> "byron/genesis.json"
+  byronGenesisHash <- getByronGenesisHash $ byronGenesisOutputDir </> "genesis.json"
   -- Move the files to the paths expected by 'defaultYamlHardforkViaConfig' below
+  H.renameFile (byronGenesisOutputDir </> "genesis.json")       (tempAbsPath' </> defaultGenesisFilepath ByronEra)
   H.renameFile (tempAbsPath' </> "shelley/genesis.json")        (tempAbsPath' </> defaultGenesisFilepath ShelleyEra)
   H.renameFile (tempAbsPath' </> "shelley/genesis.alonzo.json") (tempAbsPath' </> defaultGenesisFilepath AlonzoEra)
   H.renameFile (tempAbsPath' </> "shelley/genesis.conway.json") (tempAbsPath' </> defaultGenesisFilepath ConwayEra)


### PR DESCRIPTION
> [!NOTE]
>
> Needs https://github.com/IntersectMBO/cardano-cli/pull/974

# Description

Do not create Byron genesis in `cardano-testnet`. Instead rely on `cardano-cli`'s create-testnet-data doing it: https://github.com/IntersectMBO/cardano-cli/pull/974

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff