### PR TITLE
bench: improve genesis cache retrieval; maintenance for `locli` and others

### DIFF
--- a/bench/locli/CHANGELOG.md
+++ b/bench/locli/CHANGELOG.md
@@ -5,4 +5,7 @@
 * Add `CHANGELOG.md` for `locli`
 * Discern Plutus RIPEMD-160 workload in reports
 * Remove unused build-depends
-
+* Remove redundant fields from summary report: Perf analysis start/stop spread, Log text lines per host (NB. incompatible for comparison with `summary.org` files created with prior versions)
+* Remove unused CLI commands `list-logobject-keys-legacy` and `list-logobject-keys`
+* Remove unused `HostLogs` SHA256 checksums
+* Disable missing trace detection (temporarily), as raw data isn't properly evaluated to that end at the moment

--- a/bench/locli/CHANGELOG.md
+++ b/bench/locli/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Revision history for locli
+
+## 1.36 -- Nov 2024
+
+* Add `CHANGELOG.md` for `locli`
+* Discern Plutus RIPEMD-160 workload in reports
+* Remove unused build-depends
+

--- a/bench/locli/locli.cabal
+++ b/bench/locli/locli.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   locli
-version:                1.35
+version:                1.36
 synopsis:               Cardano log analysis CLI
 description:            Cardano log analysis CLI.
 category:               Cardano,
@@ -12,6 +12,7 @@ maintainer:             operations@iohk.io
 license:                Apache-2.0
 license-files:          LICENSE
                         NOTICE
+extra-doc-files:        CHANGELOG.md
 build-type:             Simple
 
 common project-config
@@ -95,11 +96,8 @@ library
   autogen-modules:      Paths_locli
 
   build-depends:        aeson
-                      , Histogram
                       , aeson-pretty
                       , async
-                      , attoparsec
-                      , attoparsec-iso8601
                       , bytestring
                       , cardano-git-rev ^>= 0.2.2
                       , cardano-ledger-core
@@ -110,27 +108,16 @@ library
                       , directory
                       , ede
                       , extra
-                      , file-embed
                       , filepath
                       , fingertree
                       , hashable
-                      , gnuplot
-                      , iohk-monitoring
-                      , optparse-applicative-fork
-                      , optparse-generic
+                      , optparse-applicative-fork >= 0.18.1
                       , ouroboros-consensus
-                      -- for Data.SOP.Strict:
-                      , ouroboros-network ^>= 0.17
-                      , ouroboros-network-api
-                      , process
-                      , quiet
-                      , scientific
+                      , ouroboros-network-api ^>= 0.10
                       , sop-core
                       , split
                       , statistics
                       , strict-sop-core
-                      , system-filepath
-                      , template-haskell
                       , text
                       , text-short
                       , time
@@ -139,10 +126,8 @@ library
                       , transformers-except
                       , unix
                       , unordered-containers
-                      , utf8-string
                       , vector
                       , witherable
-                      , cardano-strict-containers ^>= 0.1
 
 executable locli
   import:               project-config
@@ -150,7 +135,6 @@ executable locli
   hs-source-dirs:       app
   main-is:              locli.hs
   ghc-options:          -threaded
-                        -Wall
                         -rtsopts
                         "-with-rtsopts=-T -N7 -A2m -qb -H64m"
 

--- a/bench/locli/src/Cardano/Analysis/API/Metrics.hs
+++ b/bench/locli/src/Cardano/Analysis/API/Metrics.hs
@@ -48,11 +48,10 @@ sumFieldsReport =
   , "plutusScript"
   , "sumHosts", "sumLogObjectsTotal"
   , "sumFilters"
-  , "cdfLogLinesEmitted", "cdfLogObjectsEmitted", "cdfLogObjects"
+  , "cdfLogObjectsEmitted", "cdfLogObjects"
   , "cdfRuntime", "cdfLogLineRate"
   , "ddRawCount.sumDomainTime", "ddFilteredCount.sumDomainTime", "dataDomainFilterRatio.sumDomainTime"
   , "ddRaw.sumStartSpread", "ddRaw.sumStopSpread"
-  , "ddFiltered.sumStartSpread", "ddFiltered.sumStopSpread"
   , "sumDomainSlots", "sumDomainBlocks", "sumBlocksRejected"]
 
 instance (KnownCDF f) => TimelineFields (Summary f)  where
@@ -95,8 +94,8 @@ instance (KnownCDF f) => TimelineFields (Summary f)  where
       ""
 
    <> fScalar "utxo"                   W12 Cnt (IWord64 $           utxo.sumGenesisSpec)
-      "Starting UTxO set size"
-      "Extra UTxO set size at the beginning of the benchmark"
+      "Stuffed UTxO size"
+      "Extra UTxO set entries (from genesis)"
 
    <> fScalar "dreps"                  W12 Cnt (IWord64 $          dreps.sumGenesisSpec)
       "DRep count"
@@ -134,10 +133,6 @@ instance (KnownCDF f) => TimelineFields (Summary f)  where
 
    <> fScalar "sumFilters"             W2  Cnt (IInt   $   length.snd.sumFilters)
       "Number of filters applied"
-      ""
-
-   <> fScalar "cdfLogLinesEmitted"     W12 Cnt (IFloat $ cdfAverageVal.cdfLogLinesEmitted)
-      "Log text lines emitted per host"
       ""
 
    <> fScalar "cdfLogObjectsEmitted"   W12 Cnt (IFloat $ cdfAverageVal.cdfLogObjectsEmitted)
@@ -180,14 +175,6 @@ instance (KnownCDF f) => TimelineFields (Summary f)  where
       "Node stop spread, s"
       ""
 
-   <> fScalar "ddFiltered.sumStartSpread" W9 Sec (IDeltaT$ maybe 0 (intvDurationSec.fmap (fromRUTCTime . arityProj cdfMedian)).ddFiltered.sumStartSpread)
-      "Perf analysis start spread, s"
-      ""
-
-   <> fScalar "ddFiltered.sumStopSpread"  W9 Sec (IDeltaT$ maybe 0 (intvDurationSec.fmap (fromRUTCTime . arityProj cdfMedian)).ddFiltered.sumStopSpread)
-      "Perf analysis stop spread, s"
-      ""
-
    <> fScalar "sumDomainSlots"         W12 Slo (IInt  $ floor.arityProj cdfMedian.cdfAverage.ddFilteredCount.sumDomainSlots)
       "Slots analysed"
       ""
@@ -210,7 +197,6 @@ instance (KnownCDF f) => TimelineFields (Summary f)  where
                        [ manifestPackages <&> pkgVersion
                        , manifestPackages <&> pkgCommit
                        ]
-
 
 -- fieldJSONOverlay f = (:[]) . tryOverlayFieldDescription f
 

--- a/bench/locli/src/Cardano/Analysis/API/Types.hs
+++ b/bench/locli/src/Cardano/Analysis/API/Types.hs
@@ -50,7 +50,6 @@ data Summary f where
     , sumDomainBlocks        :: !(DataDomain f BlockNo)
     , sumProfilingData       :: !(Maybe (ProfilingData (CDF I)))
 
-    , cdfLogLinesEmitted     :: !(CDF f Int)
     , cdfLogObjectsEmitted   :: !(CDF f Int)
     , cdfLogObjects          :: !(CDF f Int)
     , cdfRuntime             :: !(CDF f NominalDiffTime)

--- a/bench/locli/src/Cardano/Analysis/Summary.hs
+++ b/bench/locli/src/Cardano/Analysis/Summary.hs
@@ -71,7 +71,6 @@ summariseMultiSummary sumAnalysisTime centiles xs@(headline:xss) = do
   sumMeta                <- summariseMetadata $ xs <&> sumMeta
   sumFilters             <- allEqOrElse (xs <&> sumFilters) SEIncoherentRunFilters
 
-  cdfLogLinesEmitted     <- sumCDF2 $ xs <&> cdfLogLinesEmitted
   cdfLogObjectsEmitted   <- sumCDF2 $ xs <&> cdfLogObjectsEmitted
   cdfLogObjects          <- sumCDF2 $ xs <&> cdfLogObjects
   cdfRuntime             <- sumCDF2 $ xs <&> cdfRuntime
@@ -172,7 +171,6 @@ computeSummary sumAnalysisTime
   --
   , cdfLogObjects        = cdf stdCentiles (objLists <&> length)
   , cdfLogObjectsEmitted = cdf stdCentiles logObjectsEmitted
-  , cdfLogLinesEmitted   = cdf stdCentiles textLinesEmitted
   , cdfRuntime           = cdf stdCentiles runtimes
   , ..
   }
@@ -183,7 +181,7 @@ computeSummary sumAnalysisTime
     rlHostLogs
     & Map.elems
 
-   (,) logObjectsEmitted textLinesEmitted =
+   (logObjectsEmitted, textLinesEmitted) =
      hostLogs
      & fmap (hlRawLogObjects &&& hlRawLines)
      & unzip
@@ -198,7 +196,7 @@ computeSummary sumAnalysisTime
    lineRates  = zipWith (/) (textLinesEmitted <&> fromIntegral)
                             (runtimes <&> fromIntegral @Int . truncate)
 
-   (,,) sumDomainTime sumStartSpread sumStopSpread =
+   (sumDomainTime, sumStartSpread, sumStopSpread) =
      slotDomains sumGenesis (losFirsts, losLasts) mpDomainSlots
 
    sumChainRejectionStats :: [(ChainFilter, Int)]

--- a/bench/locli/src/Cardano/Report.hs
+++ b/bench/locli/src/Cardano/Report.hs
@@ -80,6 +80,7 @@ data Workload
   | WPlutusLoopCountdown
   | WPlutusLoopSECP
   | WPlutusLoopBLST
+  | WPlutusLoopRipemd
   | WPlutusUnknown
 
 instance ToJSON Workload where
@@ -88,6 +89,7 @@ instance ToJSON Workload where
     WPlutusLoopCountdown -> "Plutus countdown loop"
     WPlutusLoopSECP      -> "Plutus SECP loop"
     WPlutusLoopBLST      -> "Plutus BLST loop"
+    WPlutusLoopRipemd    -> "Plutus RIPEMD-160 loop"
     WPlutusUnknown       -> "Plutus (other)"
 
 filenameInfix :: Workload -> Text
@@ -95,6 +97,7 @@ filenameInfix = \case
   WPlutusLoopCountdown  -> "plutus"
   WPlutusLoopSECP       -> "plutus-secp"
   WPlutusLoopBLST       -> "plutus-blst"
+  WPlutusLoopRipemd     -> "plutus-ripemd"
   WValue                -> "value-only"
   _                     -> "unknown"
 
@@ -150,6 +153,7 @@ liftTmplRun Summary{sumWorkload=generatorProfile
         | script == "EcdsaSecp256k1Loop"    -> WPlutusLoopSECP
         | script == "SchnorrSecp256k1Loop"  -> WPlutusLoopSECP
         | script == "HashOntoG2AndAdd"      -> WPlutusLoopBLST
+        | script == "Ripemd160"             -> WPlutusLoopRipemd
         | otherwise                         -> WPlutusUnknown
   }
 

--- a/bench/locli/src/Cardano/Unlog/LogObject.hs
+++ b/bench/locli/src/Cardano/Unlog/LogObject.hs
@@ -87,11 +87,8 @@ data HostLogs a
   = HostLogs
     { hlRawLogfiles    :: [FilePath]
     , hlRawLines       :: Int
-    , hlRawSha256      :: Hash
     , hlRawTraceFreqs  :: Map Text Int
-    , hlMissingTraces  :: [Text]
     , hlLogs           :: (JsonLogfile, a)
-    , hlFilteredSha256 :: Hash
     , hlProfile        :: [ProfileEntry I]
     , hlRawFirstAt     :: Maybe UTCTime
     , hlRawLastAt      :: Maybe UTCTime
@@ -107,8 +104,6 @@ hlRawLogObjects = sum . Map.elems . hlRawTraceFreqs
 data RunLogs a
   = RunLogs
     { rlHostLogs      :: Map.Map Host (HostLogs a)
-    , rlMissingTraces :: [Text]
-    , rlFilterKeys    :: [Text]
     , rlFilterDate    :: UTCTime
     }
   deriving (Generic, FromJSON, ToJSON)

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
@@ -1311,7 +1311,7 @@ instance MetaTrace (TraceEventMempool blk) where
     severityFor (Namespace _ ["RejectedTx"]) _ = Just Info
     severityFor (Namespace _ ["RemoveTxs"]) _ = Just Info
     severityFor (Namespace _ ["ManuallyRemovedTxs"]) _ = Just Info
-    severityFor (Namespace _ ["Synced"]) _ = Just Info
+    severityFor (Namespace _ ["Synced"]) _ = Just Debug
     severityFor _ _ = Nothing
 
     metricsDocFor (Namespace _ ["AddedTx"]) =
@@ -1331,11 +1331,9 @@ instance MetaTrace (TraceEventMempool blk) where
       , ("mempoolBytes", "Byte size of the mempool")
       , ("txsProcessedNum", "")
       ]
-
     metricsDocFor (Namespace _ ["Synced"]) =
       [ ("txsSyncDuration", "Time to sync the mempool in ms after block adoption")
       ]
-
     metricsDocFor _ = []
 
     documentFor (Namespace _ ["AddedTx"]) = Just
@@ -1358,6 +1356,7 @@ instance MetaTrace (TraceEventMempool blk) where
       , Namespace [] ["RejectedTx"]
       , Namespace [] ["RemoveTxs"]
       , Namespace [] ["ManuallyRemovedTxs"]
+      , Namespace [] ["Synced"]
       ]
 
 --------------------------------------------------------------------------------
@@ -1417,8 +1416,8 @@ instance MetaTrace  (ForgeTracerType blk) where
   privacyFor _ _ = Nothing
 
   metricsDocFor (Namespace _ ["StartLeadershipCheckPlus"]) =
-      [ ("Forge.UtxoSize", "")
-      , ("Forge.DelegMapSize", "")
+      [ ("Forge.UtxoSize", "UTxO set size")
+      , ("Forge.DelegMapSize", "Delegation map size")
       ]
   metricsDocFor ns =
     metricsDocFor (nsCast ns :: Namespace (TraceForgeEvent blk))

--- a/configuration/cardano/mainnet-config-new-tracing.json
+++ b/configuration/cardano/mainnet-config-new-tracing.json
@@ -3,18 +3,106 @@
   "AlonzoGenesisHash": "7e94a15f55d1e82d10f09203fa1d40f8eede58fd8066542cf6566008068ed874",
   "ByronGenesisFile": "mainnet-byron-genesis.json",
   "ByronGenesisHash": "5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb",
+  "ConwayGenesisFile": "mainnet-conway-genesis.json",
+  "ConwayGenesisHash": "15a199f895e461ec0ffc6dd4e4028af28a492ab4e806d39cb674c88f7643ef62",
+  "EnableP2P": true,
   "LastKnownBlockVersion-Alt": 0,
   "LastKnownBlockVersion-Major": 3,
   "LastKnownBlockVersion-Minor": 0,
   "MaxKnownMajorProtocolVersion": 2,
+  "PeerSharing": true,
   "Protocol": "Cardano",
   "RequiresNetworkMagic": "RequiresNoMagic",
   "ShelleyGenesisFile": "mainnet-shelley-genesis.json",
   "ShelleyGenesisHash": "1a3be38bcbb7911969283716ad7aa550250226b76a61fc51cc9a9a35d9276d81",
   "TurnOnLogging": true,
-  "UseTraceDispatcher": true,
-  "TraceOptionPeerFrequency": 3000,
-  "TraceOptionResourceFrequency": 4000,
   "TurnOnLogMetrics": true,
-  "TraceOptions": {}
+  "UseTraceDispatcher": true,
+  "TraceOptionForwarder": null,
+  "TraceOptionMetricsPrefix": null,
+  "TraceOptionNodeName": null,
+  "TraceOptionPeerFrequency": 3000,
+  "TraceOptionResourceFrequency": 5000,
+  "TraceOptions": {
+    "": {
+      "backends": [
+        "Stdout HumanFormatColoured",
+        "EKGBackend",
+        "Forwarder"
+      ],
+      "severity": "Notice"
+    },
+    "BlockFetch.Decision": {
+      "severity": "Silence"
+    },
+    "ChainDB": {
+      "severity": "Info"
+    },
+    "ChainDB.AddBlockEvent.AddBlockValidation": {
+      "severity": "Silence"
+    },
+    "ChainSync.Client": {
+      "severity": "Info"
+    },
+    "Net.ConnectionManager.Remote": {
+      "severity": "Info"
+    },
+    "Net.Subscription.DNS": {
+      "severity": "Info"
+    },
+    "Startup.DiffusionInit": {
+      "severity": "Info"
+    },
+    "Net.ErrorPolicy": {
+      "severity": "Info"
+    },
+    "Forge.Loop": {
+      "severity": "Info"
+    },
+    "Forge.StateInfo": {
+      "severity": "Info"
+    },
+    "Net.InboundGovernor.Remote": {
+      "severity": "Info"
+    },
+    "Net.Subscription.IP": {
+      "severity": "Info"
+    },
+    "Net.ErrorPolicy.Local": {
+      "severity": "Info"
+    },
+    "Mempool": {
+      "severity": "Info"
+    },
+    "Mempool.Synced": {
+      "severity": "Silence"
+    },
+    "Net.Mux.Remote": {
+      "severity": "Info"
+    },
+    "Net.PeerSelection": {
+      "severity": "Info"
+    },
+    "Resources": {
+      "severity": "Info"
+    },
+    "ChainDB.AddBlockEvent.AddedBlockToQueue": {
+      "maxFrequency": 2.0
+    },
+    "ChainDB.AddBlockEvent.AddedBlockToVolatileDB": {
+      "maxFrequency": 2.0
+    },
+    "ChainDB.AddBlockEvent.AddBlockValidation.ValidCandidate": {
+      "maxFrequency": 2.0
+    },
+    "ChainDB.CopyToImmutableDBEvent.CopiedBlockToImmutableDB": {
+      "maxFrequency": 2.0
+    },
+    "ChainSync.Client.DownloadedHeader": {
+      "maxFrequency": 2.0
+    },
+    "BlockFetch.Client.CompletedBlockFetch": {
+      "maxFrequency": 2.0
+    }
+  }
 }

--- a/nix/workbench/env.sh
+++ b/nix/workbench/env.sh
@@ -1,8 +1,9 @@
 WB_ENV_DEFAULT='
-{ "type":         "supervisor"
-, "cacheDir":     "'${XDG_CACHE_HOME:-$HOME/.cache}'/cardano-workbench"
-, "basePort":     30000
-, "staggerPorts": true
+{ "type":           "supervisor"
+, "cacheDir":       "'${XDG_CACHE_HOME:-$HOME/.cache}'/cardano-workbench"
+, "basePort":       30000
+, "basePortTracer": 3000
+, "staggerPorts":   true
 }'
 
 export WB_ENV=$WB_ENV_DEFAULT

--- a/nix/workbench/service/healthcheck.nix
+++ b/nix/workbench/service/healthcheck.nix
@@ -355,8 +355,8 @@ let
             else
               local tip block slot
               # Returns nothing/empty/"" when the node is exiting
-              tip=$(${cardano-cli}/bin/cardano-cli query tip \
-                --testnet-magic "''${network_magic}"         \
+              tip=$(${cardano-cli}/bin/cardano-cli conway query tip \
+                --testnet-magic "''${network_magic}"                \
                 --socket-path "../''${node}/node.socket"
               )
               block=$(${coreutils}/bin/echo "''${tip}" | ${jq}/bin/jq .block)

--- a/nix/workbench/service/tracing.nix
+++ b/nix/workbench/service/tracing.nix
@@ -13,6 +13,7 @@ let
   {
     UseTraceDispatcher   = true;
     TraceOptionResourceFrequency = 1000;
+    TraceOptionNodeName = nodeSpec.name;
 
   ## Please see the generated tracing configuration reference at:
   ##
@@ -130,6 +131,10 @@ let
     TraceBlockFetchServer       = true;
     TraceChainSyncHeaderServer  = true;
     TraceChainSyncClient        = true;
+
+    ## needs to be explicit when new tracing is the node's default
+    UseTraceDispatcher          = false;
+
     options = {
       mapBackends = {
         "cardano.node.resources" = [ "KatipBK" ];

--- a/nix/workbench/service/tracing.nix
+++ b/nix/workbench/service/tracing.nix
@@ -47,6 +47,7 @@ let
       "Forge.Loop".severity = "Debug";
       "Forge.StateInfo".severity = "Debug";
       "Mempool".severity = "Debug";
+      "Mempool.Synced".severity = "Silence";
       "Net".severity = "Notice";
       "Net.AcceptPolicy".severity = "Debug";
       "Net.ConnectionManager.Local".severity = "Debug";

--- a/scripts/lite/mainnet-new-tracing.sh
+++ b/scripts/lite/mainnet-new-tracing.sh
@@ -18,7 +18,8 @@ cabal run exe:cardano-node -- run \
   --topology "${configuration}/mainnet-topology.json" \
   --database-path "${db_dir}" \
   --socket-path "${socket_dir}/node-1-socket" \
-  --host-addr "127.0.0.1" \
+  --tracer-socket-path-connect "${socket_dir}/tracer.socket" \
+  --host-addr "0.0.0.0" \
   --port "3001"
 
 

--- a/scripts/lite/mainnet.sh
+++ b/scripts/lite/mainnet.sh
@@ -18,7 +18,7 @@ cabal run exe:cardano-node -- run \
   --topology "${configuration}/mainnet-topology.json" \
   --database-path "${db_dir}" \
   --socket-path "${socket_dir}/node-1-socket" \
-  --host-addr "127.0.0.1" \
+  --host-addr "0.0.0.0" \
   --port "3001"
 
 


### PR DESCRIPTION
# Description

This PR improves retrieval of huge staked geneses from the workbench cache: small parameter changes shouldn't trigger (lengthy) recreation of a genesis, but can be patched into a retrieved cache hit if they're unrelated to staking itself.

Furthermore, there are various changes to `locli`, including proper handling of Plutus RIPEMD-160 workloads in reporting - and lots of cleanup. Please see `locli`'s brand new changelog for more details.

Then, there's a fix for the `Mempool.Synced` tracer that lacked a proper namespace.

Last not least, several maintenance updates for Nomad healthcheck, workbench console output and adjustments of the `scripts/lite/` to recent P2P.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff
