### PR TITLE
Integrate ledger snapshot checksum

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -72,8 +72,8 @@ source-repository-package
   type: git
   location: https://github.com/IntersectMBO/ouroboros-consensus
   -- use branch geo2a/issue-892-checksum-snaphot-file-release-ouroboros-consensus-0.21.0.0-backport
-  tag: 0ff4c0445
-  --sha256: xWBEq9kq2eUTlOnMBkSftH8NUUGbpwpamu1G1TgGETU=
+  tag: bc9f10c0a
+  --sha256: JGuQlFgW46mck545klipsiajhkr9A51JYXVRvmr0KYI=
   subdir:
     ouroboros-consensus
     ouroboros-consensus-cardano

--- a/cabal.project
+++ b/cabal.project
@@ -68,3 +68,16 @@ allow-newer:
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
+source-repository-package
+  type: git
+  location: https://github.com/IntersectMBO/ouroboros-consensus
+  -- use branch geo2a/issue-892-checksum-snaphot-file-release-ouroboros-consensus-0.21.0.0-backport
+  tag: 0ff4c0445
+  --sha256: xWBEq9kq2eUTlOnMBkSftH8NUUGbpwpamu1G1TgGETU=
+  subdir:
+    ouroboros-consensus
+    ouroboros-consensus-cardano
+    ouroboros-consensus-diffusion
+    ouroboros-consensus-protocol
+    sop-extras
+    strict-sop-core

--- a/cardano-node/src/Cardano/Node/Orphans.hs
+++ b/cardano-node/src/Cardano/Node/Orphans.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE StandaloneDeriving #-}
 
@@ -8,6 +10,7 @@ module Cardano.Node.Orphans () where
 
 import           Cardano.Api ()
 
+import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy (Flag(..))
 import           Ouroboros.Consensus.Node
 import qualified Data.Text as Text
 import           Ouroboros.Network.NodeToNode (AcceptedConnectionsLimit (..))
@@ -46,11 +49,14 @@ instance FromJSON AcceptedConnectionsLimit where
       <*> v .: "delay"
 
 instance FromJSON NodeDatabasePaths where
-  parseJSON o@(Object{})= 
-    withObject "NodeDatabasePaths" 
+  parseJSON o@(Object{})=
+    withObject "NodeDatabasePaths"
      (\v -> MultipleDbPaths
               <$> v .: "ImmutableDbPath"
               <*> v .: "VolatileDbPath"
      ) o
   parseJSON (String s) = return . OnePathForAllDbs $ Text.unpack s
   parseJSON _ = fail "NodeDatabasePaths must be an object or a string"
+
+deriving newtype instance FromJSON (Flag symbol)
+deriving newtype instance ToJSON (Flag symbol)

--- a/cardano-node/src/Cardano/Node/Parsers.hs
+++ b/cardano-node/src/Cardano/Node/Parsers.hs
@@ -92,6 +92,7 @@ nodeRunParser = do
            , pncDiffusionMode = mempty
            , pncNumOfDiskSnapshots = numOfDiskSnapshots
            , pncSnapshotInterval = snapshotInterval
+           , pncDoDiskSnapshotChecksum = mempty
            , pncExperimentalProtocolsEnabled = mempty
            , pncProtocolFiles = Last $ Just ProtocolFilepaths
              { byronCertFile

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ExplicitNamespaces #-}
@@ -63,7 +64,7 @@ import           Cardano.Tracing.Config (TraceOptions (..), TraceSelection (..))
 import           Cardano.Tracing.Tracers
 import qualified Ouroboros.Consensus.Config as Consensus
 import           Ouroboros.Consensus.Config.SupportsNode (ConfigSupportsNode (..))
-import           Ouroboros.Consensus.Node (DiskPolicyArgs (..), NetworkP2PMode (..),
+import           Ouroboros.Consensus.Node (DiskPolicyArgs (..), pattern DoDiskSnapshotChecksum, pattern NoDoDiskSnapshotChecksum, NetworkP2PMode (..),
                    NodeDatabasePaths (..), RunNodeArgs (..), StdRunNodeArgs (..))
 import qualified Ouroboros.Consensus.Node as Node (NodeDatabasePaths (..), getChainDB, run)
 import           Ouroboros.Consensus.Node.Genesis
@@ -650,6 +651,7 @@ handleSimpleNode blockType runP p2pMode tracers nc onKernel = do
     DiskPolicyArgs
       (ncSnapshotInterval nc)
       (ncNumOfDiskSnapshots nc)
+      (ncDoDiskSnapshotChecksum nc)
 
 --------------------------------------------------------------------------------
 -- SIGHUP Handlers

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
@@ -1522,6 +1522,8 @@ instance ( StandardHash blk
              " This is most likely an expected change in the serialization format,"
           <> " which currently requires a chain replay"
         _ -> ""
+  forHuman (LedgerDB.SnapshotMissingChecksum snap) =
+      "Checksum file is missing for snapshot " <> showT snap
 
   forMachine dtals (LedgerDB.TookSnapshot snap pt enclosedTiming) =
     mconcat [ "kind" .= String "TookSnapshot"
@@ -1535,15 +1537,21 @@ instance ( StandardHash blk
     mconcat [ "kind" .= String "InvalidSnapshot"
              , "snapshot" .= forMachine dtals snap
              , "failure" .= show failure ]
+  forMachine dtals (LedgerDB.SnapshotMissingChecksum snap) =
+      mconcat [ "kind" .= String "SnapshotMissingChecksum"
+               , "snapshot" .= forMachine dtals snap
+               ]
 
 instance MetaTrace (LedgerDB.TraceSnapshotEvent blk) where
     namespaceFor LedgerDB.TookSnapshot {} = Namespace [] ["TookSnapshot"]
     namespaceFor LedgerDB.DeletedSnapshot {} = Namespace [] ["DeletedSnapshot"]
     namespaceFor LedgerDB.InvalidSnapshot {} = Namespace [] ["InvalidSnapshot"]
+    namespaceFor LedgerDB.SnapshotMissingChecksum {} = Namespace [] ["SnapshotMissingChecksum"]
 
     severityFor  (Namespace _ ["TookSnapshot"]) _ = Just Info
     severityFor  (Namespace _ ["DeletedSnapshot"]) _ = Just Debug
     severityFor  (Namespace _ ["InvalidSnapshot"]) _ = Just Error
+    severityFor  (Namespace _ ["SnapshotMissingChecksum"]) _ = Just Warning
     severityFor _ _ = Nothing
 
     documentFor (Namespace _ ["TookSnapshot"]) = Just $ mconcat
@@ -1555,12 +1563,15 @@ instance MetaTrace (LedgerDB.TraceSnapshotEvent blk) where
           "A snapshot was deleted from the disk."
     documentFor (Namespace _ ["InvalidSnapshot"]) = Just
           "An on disk snapshot was invalid. Unless it was suffixed, it will be deleted"
+    documentFor (Namespace _ ["SnapshotMissingChecksum"]) = Just
+          "Checksum file was missing for snapshot."
     documentFor _ = Nothing
 
     allNamespaces =
       [ Namespace [] ["TookSnapshot"]
       , Namespace [] ["DeletedSnapshot"]
       , Namespace [] ["InvalidSnapshot"]
+      , Namespace [] ["SnapshotMissingChecksum"]
       ]
 
 

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
@@ -1507,15 +1507,27 @@ instance ( StandardHash blk
          , ConvertRawHash blk)
          => LogFormatting (LedgerDB.TraceSnapshotEvent blk) where
   forHuman (LedgerDB.TookSnapshot snap pt RisingEdge) =
-      "Taking ledger snapshot " <> showT snap <>
-        " at " <> renderRealPointAsPhrase pt
+    Text.unwords [ "Taking ledger snapshot"
+                 , showT snap
+                 , "at"
+                 , renderRealPointAsPhrase pt
+                 ]
   forHuman (LedgerDB.TookSnapshot snap pt (FallingEdgeWith t)) =
-      "Took ledger snapshot " <> showT snap <>
-        " at " <> renderRealPointAsPhrase pt <> ", duration: " <> showT t
+    Text.unwords [ "Took ledger snapshot"
+                 , showT snap
+                 , "at"
+                 , renderRealPointAsPhrase pt
+                 , ", duration:"
+                 , showT t
+                 ]
   forHuman (LedgerDB.DeletedSnapshot snap) =
-      "Deleted old snapshot " <> showT snap
+    Text.unwords ["Deleted old snapshot", showT snap]
   forHuman (LedgerDB.InvalidSnapshot snap failure) =
-      "Invalid snapshot " <> showT snap <> showT failure <> context
+    Text.unwords [ "Invalid snapshot"
+                 , showT snap
+                 , showT failure
+                 , context
+                 ]
     where
       context = case failure of
         LedgerDB.InitFailureRead{} ->

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
@@ -175,6 +175,7 @@ instance HasSeverityAnnotation (ChainDB.TraceEvent blk) where
     LedgerDB.TookSnapshot {} -> Info
     LedgerDB.DeletedSnapshot {} -> Debug
     LedgerDB.InvalidSnapshot {} -> Error
+    LedgerDB.SnapshotMissingChecksum {} -> Warning
 
   getSeverityAnnotation (ChainDB.TraceCopyToImmutableDBEvent ev) = case ev of
     ChainDB.CopiedBlockToImmutableDB {} -> Debug
@@ -615,6 +616,8 @@ instance ( ConvertRawHash blk
                    " This is most likely an expected change in the serialization format,"
                 <> " which currently requires a chain replay"
               _ -> ""
+        LedgerDB.SnapshotMissingChecksum snap ->
+          "Checksum file is missing for snapshot " <> showT snap
 
         LedgerDB.TookSnapshot snap pt RisingEdge ->
           "Taking ledger snapshot " <> showT snap <>
@@ -1101,6 +1104,10 @@ instance ( ConvertRawHash blk
       mconcat [ "kind" .= String "TraceSnapshotEvent.InvalidSnapshot"
                , "snapshot" .= toObject verb snap
                , "failure" .= show failure ]
+    LedgerDB.SnapshotMissingChecksum snap ->
+      mconcat [ "kind" .= String "TraceSnapshotEvent.SnapshotMissingChecksum"
+               , "snapshot" .= toObject verb snap
+               ]
 
   toObject verb (ChainDB.TraceCopyToImmutableDBEvent ev) = case ev of
     ChainDB.CopiedBlockToImmutableDB pt ->

--- a/cardano-node/test/Test/Cardano/Node/POM.hs
+++ b/cardano-node/test/Test/Cardano/Node/POM.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Test.Cardano.Node.POM
@@ -15,7 +16,7 @@ import           Cardano.Tracing.Config (PartialTraceOptions (..), defaultPartia
 import           Ouroboros.Consensus.Node (NodeDatabasePaths (..))
 import qualified Ouroboros.Consensus.Node as Consensus (NetworkP2PMode (..))
 import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy (NumOfDiskSnapshots (..),
-                   SnapshotInterval (..))
+                   SnapshotInterval (..), pattern DoDiskSnapshotChecksum)
 import           Ouroboros.Network.Block (SlotNo (..))
 import           Ouroboros.Network.NodeToNode (AcceptedConnectionsLimit (..),
                    DiffusionMode (InitiatorAndResponderDiffusionMode))
@@ -119,6 +120,7 @@ testPartialYamlConfig =
     , pncDiffusionMode = Last Nothing
     , pncNumOfDiskSnapshots = Last Nothing
     , pncSnapshotInterval = mempty
+    , pncDoDiskSnapshotChecksum = Last . Just $ DoDiskSnapshotChecksum
     , pncExperimentalProtocolsEnabled = Last Nothing
     , pncMaxConcurrencyBulkSync = Last Nothing
     , pncMaxConcurrencyDeadline = Last Nothing
@@ -161,6 +163,7 @@ testPartialCliConfig =
     , pncDiffusionMode = mempty
     , pncNumOfDiskSnapshots = Last Nothing
     , pncSnapshotInterval = Last . Just . RequestedSnapshotInterval $ secondsToDiffTime 100
+    , pncDoDiskSnapshotChecksum = Last . Just $ DoDiskSnapshotChecksum
     , pncExperimentalProtocolsEnabled = Last $ Just True
     , pncProtocolFiles = Last . Just $ ProtocolFilepaths Nothing Nothing Nothing Nothing Nothing Nothing
     , pncValidateDB = Last $ Just True
@@ -205,6 +208,7 @@ eExpectedConfig = do
     , ncDiffusionMode = InitiatorAndResponderDiffusionMode
     , ncNumOfDiskSnapshots = DefaultNumOfDiskSnapshots
     , ncSnapshotInterval = RequestedSnapshotInterval $ secondsToDiffTime 100
+    , ncDoDiskSnapshotChecksum = DoDiskSnapshotChecksum
     , ncExperimentalProtocolsEnabled = True
     , ncMaxConcurrencyBulkSync = Nothing
     , ncMaxConcurrencyDeadline = Nothing


### PR DESCRIPTION
# Description

https://github.com/IntersectMBO/ouroboros-consensus/pull/1319, when merged, will checksum the ledger state snapshots to detect data corruption. This PR integrates this change into `cardano-node`.


In addition to the snapshot file itself, a `.checksum` file is written to dist, which contains the `CRC32` checksum of the snapshot data:
```bash
> ls mainnet/db/ledger
2223  2223.checksum

> cat mainnet/db/ledger/2223.checksum
8b578fb4
```

To preserve backwards compatibility, the absence of the checksum file does not block the node from starting up. Instead, a warning is issued when restoring from a snapshot that is missing the checksum file:

```bash
...
Listening on http://127.0.0.1:12798
[geo2a-la:cardano.node.ChainDB:Warning:5] [2024-12-04 13:09:30.72 UTC] Checksum file is missing for snapshot DiskSnapshot {dsNumber = 2223, dsSuffix = Nothing}
...
```

If the checksum differs from the file, there's a number of scenarios that all ultimately lead to the deletion of the snapshot and an attempt to restore from an older one:

- Data corruption of the snapshot file:
  ```
  [geo2a-la:cardano.node.ChainDB:Error:5] [2024-12-04 13:18:42.93 UTC] Invalid snapshot DiskSnapshot {dsNumber = 2223, dsSuffix = Nothing}InitFailureRead ReadSnapshotDataCorruption This is most likely an expected change in the serialization format, which currently requires a chain replay
  ```
  To model data corruption for testing purposes, one could use `dd`, i.e.:
  ```bash
  printf '\x0\x0' | dd of=mainnet/db/ledger/2223 bs=1 seek=100 count=3 conv=notrunc
  ```
- The `.checksum` file is invalid:
  ```
  [geo2a-la:cardano.node.ChainDB:Error:5] [2024-12-04 13:12:29.41 UTC] Invalid snapshot DiskSnapshot {dsNumber = 2223, dsSuffix = Nothing}InitFailureRead (ReadSnapshotInvalidChecksumFile 21127.checksum) This is most likely an expected change in the serialization format, which currently requires a chain replay
  ```
  that means violated the following condition: `length str == 8 && all isHexDigit str`

The feature is on by default and can be disabled by the following configuration option:
```yaml
DoDiskSnapshotChecksum: false
```