### PR TITLE
Optionally support lightweight checkpointing

### DIFF
--- a/bench/tx-generator/src/Cardano/TxGenerator/Setup/NodeConfig.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Setup/NodeConfig.hs
@@ -42,15 +42,15 @@ getGenesis (SomeConsensusProtocol CardanoBlockType proto)
 getGenesisPath :: NodeConfiguration -> Maybe GenesisFile
 getGenesisPath nodeConfig =
   case ncProtocolConfig nodeConfig of
-    NodeProtocolConfigurationCardano _ shelleyConfig _ _ _ ->
+    NodeProtocolConfigurationCardano _ shelleyConfig _ _ _ _ ->
       Just $ npcShelleyGenesisFile shelleyConfig
 
 mkConsensusProtocol :: NodeConfiguration -> IO (Either TxGenError SomeConsensusProtocol)
 mkConsensusProtocol nodeConfig =
   case ncProtocolConfig nodeConfig of
-    NodeProtocolConfigurationCardano byronConfig shelleyConfig alonzoConfig conwayConfig hardforkConfig ->
+    NodeProtocolConfigurationCardano byronConfig shelleyConfig alonzoConfig conwayConfig hardforkConfig checkpointsConfig ->
       first ProtocolError
-        <$> runExceptT (mkSomeConsensusProtocolCardano byronConfig shelleyConfig alonzoConfig conwayConfig hardforkConfig Nothing)
+        <$> runExceptT (mkSomeConsensusProtocolCardano byronConfig shelleyConfig alonzoConfig conwayConfig hardforkConfig checkpointsConfig Nothing)
 
 -- | Creates a NodeConfiguration from a config file;
 --   the result is devoid of any keys/credentials

--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -1,5 +1,30 @@
 # Changelog for cardano-node
 
+## Next version
+
+- Optionally support lightweight checkpointing.
+
+  This PR adds optional support for *lightweight checkpointing*. Concretely, a file can contain a list of checkpoints (each consisting of a block number and a corresponding block hash). When validating a header/block with a block number with a corresponding checkpoint, we consider the header/block to be invalid if their actual hash does not coincide with the hash from the checkpoint.
+
+  This is only expected to be used in certain disaster recovery scenarios, so ideally never. See [CIP-0135](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0135/README.md) for more details.
+
+  > ⚠️ Specifying a checkpoints file requires great care; incorrect entries can lead the node to be stuck on adversarial chains forever!
+
+  Concretely, the node configuration file has two new optional entries:
+  ```yaml
+  CheckpointsFile: "/path/to/checkpoints.json"
+  CheckpointsFileHash: "a71c47262163947daaefb6aa1112acf34cb5ded6841d51e27dd642eb2de355a3"
+  ```
+
+  The `checkpoints.json` file has the following format:
+  ```json
+  {
+    "checkpoints": [
+      {"blockNo": 3, "hash": "52b7912de176ab76c233d6e08ccdece53ac1863c08cc59d3c5dec8d924d9b536"}
+    ]
+  }
+  ```
+
 ## 10.2 -- January 2025
 
 - Use p2p network stack by default, warn when using the legacy network stack.

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -82,6 +82,7 @@ library
                         Cardano.Node.Protocol.Alonzo
                         Cardano.Node.Protocol.Byron
                         Cardano.Node.Protocol.Cardano
+                        Cardano.Node.Protocol.Checkpoints
                         Cardano.Node.Protocol.Conway
                         Cardano.Node.Protocol.Shelley
                         Cardano.Node.Protocol.Types

--- a/cardano-node/src/Cardano/Node/Configuration/POM.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/POM.hs
@@ -325,6 +325,7 @@ instance FromJSON PartialNodeConfiguration where
                 <*> parseAlonzoProtocol v
                 <*> parseConwayProtocol v
                 <*> parseHardForkProtocol v
+                <*> parseCheckpoints v
       pncMaybeMempoolCapacityOverride <- Last <$> parseMempoolCapacityBytesOverride v
 
       -- Network timeouts
@@ -543,6 +544,14 @@ instance FromJSON PartialNodeConfiguration where
 
           , npcTestConwayHardForkAtEpoch
           , npcTestConwayHardForkAtVersion
+          }
+
+      parseCheckpoints v = do
+        npcCheckpointsFile     <- v .:? "CheckpointsFile"
+        npcCheckpointsFileHash <- v .:? "CheckpointsFileHash"
+        pure NodeCheckpointsConfiguration
+          { npcCheckpointsFile
+          , npcCheckpointsFileHash
           }
 
 -- | Default configuration is mainnet

--- a/cardano-node/src/Cardano/Node/Protocol.hs
+++ b/cardano-node/src/Cardano/Node/Protocol.hs
@@ -30,7 +30,8 @@ mkConsensusProtocol ncProtocolConfig mProtocolFiles =
         shelleyConfig
         alonzoConfig
         conwayConfig
-        hardForkConfig ->
+        hardForkConfig
+        checkpointsConfig ->
       firstExceptT CardanoProtocolInstantiationError $
         mkSomeConsensusProtocolCardano
           byronConfig
@@ -38,6 +39,7 @@ mkConsensusProtocol ncProtocolConfig mProtocolFiles =
           alonzoConfig
           conwayConfig
           hardForkConfig
+          checkpointsConfig
           mProtocolFiles
 
 ------------------------------------------------------------------------------

--- a/cardano-node/src/Cardano/Node/Protocol/Checkpoints.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Checkpoints.hs
@@ -1,0 +1,115 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | Configuration for lightweight checkpointing.
+module Cardano.Node.Protocol.Checkpoints
+  ( CheckpointsReadError(..)
+  , readCheckpointsMap
+  ) where
+
+import           Cardano.Api
+
+import qualified Cardano.Crypto.Hash.Class as Crypto
+import           Cardano.Ledger.Crypto (StandardCrypto)
+import           Cardano.Node.Types
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Cardano
+import           Ouroboros.Consensus.Config (CheckpointsMap (..), emptyCheckpointsMap)
+
+import           Control.Exception (IOException)
+import           Control.Monad (forM, unless, when)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Types as Aeson
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base16 as B16
+import           Data.Foldable (forM_)
+import qualified Data.Map.Strict as Map
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+
+data CheckpointsReadError =
+       CheckpointsReadFileError !FilePath !IOException
+     | CheckpointsHashMismatch
+         !FilePath
+         -- | Actual
+         !CheckpointsHash
+         -- | Expected
+         !CheckpointsHash
+     | CheckpointsDecodeError !FilePath !String
+   deriving Show
+
+instance Error CheckpointsReadError where
+  prettyError (CheckpointsReadFileError fp err) =
+        "There was an error reading the checkpoints file: "
+     <> pshow fp <> " Error: " <> pshow err
+
+  prettyError (CheckpointsHashMismatch fp actual expected) =
+        "Hash mismatch for checkpoints file " <> pshow fp <> ": "
+     <> "the actual hash is " <> pshow actual <> ", but the expected "
+     <> "hash given in the node configuration file is " <> pshow expected
+
+  prettyError (CheckpointsDecodeError fp err) =
+        "There was an error parsing the checkpoints file: "
+     <> pshow fp <> " Error: " <> pshow err
+
+readCheckpointsMap
+  :: NodeCheckpointsConfiguration
+  -> ExceptT CheckpointsReadError IO (CheckpointsMap (CardanoBlock StandardCrypto))
+readCheckpointsMap NodeCheckpointsConfiguration {
+                       npcCheckpointsFile,
+                       npcCheckpointsFileHash = mExpectedHash
+                     } = case npcCheckpointsFile of
+    Nothing -> pure emptyCheckpointsMap
+    Just (CheckpointsFile file) -> do
+      content <-
+        handleIOExceptT (CheckpointsReadFileError file) $ BS.readFile file
+
+      let actualHash = CheckpointsHash $ Crypto.hashWith id content
+      forM_ mExpectedHash $ \expectedHash ->
+        when (actualHash /= expectedHash) $
+          throwError (CheckpointsHashMismatch file actualHash expectedHash)
+
+      WrapCheckpointsMap checkpointsMap <-
+        firstExceptT (CheckpointsDecodeError file) $ hoistEither $
+          Aeson.eitherDecodeStrict' content
+      pure checkpointsMap
+
+newtype WrapCheckpointsMap =
+        WrapCheckpointsMap (CheckpointsMap (CardanoBlock StandardCrypto))
+
+instance Aeson.FromJSON WrapCheckpointsMap where
+  parseJSON = Aeson.withObject "CheckpointsMap" $ \o -> do
+      checkpointList :: [Aeson.Object] <- o Aeson..: "checkpoints"
+
+      checkpoints :: [(BlockNo, HeaderHash (CardanoBlock StandardCrypto))] <-
+        forM checkpointList $ \c -> do
+          bno <- c Aeson..: "blockNo"
+          hash <- parseCardanoHash =<< c Aeson..: "hash"
+          pure (bno, hash)
+
+      let duplicates :: Set BlockNo
+          duplicates =
+            Map.keysSet $ Map.filter (> 1) $ Map.fromListWith (+) $
+              (\(bno, _) -> (bno, 1 :: Int)) <$> checkpoints
+      unless (Set.null duplicates) $
+        fail $ "Duplicate checkpoints for block numbers "
+            <> show (Set.toList duplicates)
+
+      pure $ WrapCheckpointsMap $ CheckpointsMap $ Map.fromList checkpoints
+    where
+      parseCardanoHash
+        :: Aeson.Value
+        -> Aeson.Parser (HeaderHash (CardanoBlock StandardCrypto))
+      parseCardanoHash = Aeson.withText "CheckpointHash" $ \t ->
+          case B16.decode $ Text.encodeUtf8 t of
+            Right h -> do
+              when (BS.length h /= fromIntegral (hashSize p)) $
+                fail $ "Invalid hash size for " <> Text.unpack t
+              pure $ fromRawHash p h
+            Left e  ->
+              fail $ "Invalid base16 for " <> Text.unpack t <> ": " <> e
+        where
+          p = Proxy @(CardanoBlock StandardCrypto)

--- a/cardano-node/test/Test/Cardano/Node/POM.hs
+++ b/cardano-node/test/Test/Cardano/Node/POM.hs
@@ -98,6 +98,13 @@ testNodeHardForkProtocolConfiguration =
     , npcTestConwayHardForkAtVersion  = Nothing
     }
 
+testNodeCheckpointsConfiguration :: NodeCheckpointsConfiguration
+testNodeCheckpointsConfiguration =
+  NodeCheckpointsConfiguration
+    { npcCheckpointsFile     = Nothing
+    , npcCheckpointsFileHash = Nothing
+    }
+
 testNodeProtocolConfiguration :: NodeProtocolConfiguration
 testNodeProtocolConfiguration =
   NodeProtocolConfigurationCardano
@@ -106,6 +113,7 @@ testNodeProtocolConfiguration =
     testNodeAlonzoProtocolConfiguration
     testNodeConwayProtocolConfiguration
     testNodeHardForkProtocolConfiguration
+    testNodeCheckpointsConfiguration
 
 -- | Example partial configuration theoretically created from a
 -- config yaml file.

--- a/cardano-testnet/src/Testnet/Types.hs
+++ b/cardano-testnet/src/Testnet/Types.hs
@@ -194,7 +194,7 @@ getStartTime
 getStartTime tempRootPath TestnetRuntime{configurationFile} = withFrozenCallStack $ H.evalEither <=< H.evalIO . runExceptT $ do
   byronGenesisFile <-
     decodeNodeConfiguration configurationFile >>= \case
-      NodeProtocolConfigurationCardano NodeByronProtocolConfiguration{npcByronGenesisFile} _ _ _ _ ->
+      NodeProtocolConfigurationCardano NodeByronProtocolConfiguration{npcByronGenesisFile} _ _ _ _ _ ->
         pure $ unGenesisFile npcByronGenesisFile
   let byronGenesisFilePath = tempRootPath </> byronGenesisFile
   G.gdStartTime . G.configGenesisData <$> decodeGenesisFile byronGenesisFilePath


### PR DESCRIPTION
# Description

Closes #5730 

This PR adds optional support for *lightweight checkpointing*. Concretely, a file can contain a list of checkpoints (each consisting of a block number and a corresponding block hash). When validating a header/block with a block number with a corresponding checkpoint, we consider the header/block to be invalid if their actual hash does not coincide with the hash from the checkpoint.

This is only expected to be used in certain disaster recovery scenarios, so ideally never. See [CIP-0135](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0135/README.md) for more details.

> [!WARNING]  
> Specifying a checkpoints file requires great care; incorrect entries can lead the node to be stuck on adversarial chains forever!

Concretely, the node configuration file has two new optional entries:
```yaml
CheckpointsFile: "/path/to/checkpoints.json"
CheckpointsFileHash: "a71c47262163947daaefb6aa1112acf34cb5ded6841d51e27dd642eb2de355a3"
```

The `checkpoints.json` file has the following format:
```json
{
  "checkpoints": [
    {"blockNo": 3, "hash": "52b7912de176ab76c233d6e08ccdece53ac1863c08cc59d3c5dec8d924d9b536"}
  ]
}
```

### Testing

Component-level tests for this feature already exist in Consensus, but end-to-end tests might still be useful. I manually tested this PR locally, but a test in CI would be nice. I am not familiar with the various tests in this repo; maybe a test under `Cardano.Testnet.Test` could work?

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
