### PR TITLE
Enhancements and fixes related to logging, metrics, and testing

### DIFF
--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -729,7 +729,7 @@ updateBlockForging startupTracer blockType nodeKernel nc = do
                     (BlockForgingUpdate (if isNonProducing || null blockForging
                                           then DisabledBlockForging
                                           else EnabledBlockForging))
-          unless (ncStartAsNonProducingNode nc) $
+          unless isNonProducing $
             setBlockForging nodeKernel blockForging
         Nothing ->
           traceWith startupTracer

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -729,8 +729,7 @@ updateBlockForging startupTracer blockType nodeKernel nc = do
                     (BlockForgingUpdate (if isNonProducing || null blockForging
                                           then DisabledBlockForging
                                           else EnabledBlockForging))
-          unless isNonProducing $
-            setBlockForging nodeKernel blockForging
+          setBlockForging nodeKernel blockForging
         Nothing ->
           traceWith startupTracer
             $ BlockForgingBlockTypeMismatch

--- a/cardano-node/src/Cardano/Node/TraceConstraints.hs
+++ b/cardano-node/src/Cardano/Node/TraceConstraints.hs
@@ -44,6 +44,7 @@ type TraceConstraints blk =
     , HasKESInfo blk
     , GetKESInfo blk
     , RunNode blk
+    , HasIssuer blk
 
     , ToObject (ApplyTxErr blk)
     , ToObject (GenTx blk)

--- a/cardano-node/src/Cardano/Node/TraceConstraints.hs
+++ b/cardano-node/src/Cardano/Node/TraceConstraints.hs
@@ -44,7 +44,6 @@ type TraceConstraints blk =
     , HasKESInfo blk
     , GetKESInfo blk
     , RunNode blk
-    , HasIssuer blk
 
     , ToObject (ApplyTxErr blk)
     , ToObject (GenTx blk)

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
@@ -507,7 +507,7 @@ instance ( LogFormatting (Header blk)
                | not (null events) ]
             ++ [ "tipBlockHash" .= tipBlockHash
                , "tipBlockParentHash" .= tipBlockParentHash
-               , "tipBlockIssuerVerificationKeyHash" .= tipBlockIssuerVkHashText]
+               , "tipBlockIssuerVKeyHash" .= tipBlockIssuerVkHashText]
   forMachine dtal (ChainDB.AddedToCurrentChain events selChangedInfo _base extended) =
       mconcat $
                [ "kind" .=  String "AddedToCurrentChain"
@@ -542,7 +542,7 @@ instance ( LogFormatting (Header blk)
                | not (null events) ]
             ++ [ "tipBlockHash" .= tipBlockHash
                , "tipBlockParentHash" .= tipBlockParentHash
-               , "tipBlockIssuerVerificationKeyHash" .= tipBlockIssuerVkHashText]
+               , "tipBlockIssuerVKeyHash" .= tipBlockIssuerVkHashText]
   forMachine dtal (ChainDB.SwitchedToAFork events selChangedInfo _old new) =
       mconcat $
                [ "kind" .= String "TraceAddBlockEvent.SwitchedToAFork"
@@ -606,8 +606,8 @@ instance ( LogFormatting (Header blk)
         , IntM    "epoch" (fromIntegral (unEpochNo epoch))
         , CounterM "forks" (Just (if forkIt then 1 else 0))
         , PrometheusM "tipBlock" [("hash",tipBlockHash)
-                                 ,("parent hash",tipBlockParentHash)
-                                 ,("issuer verification key hash", tipBlockIssuerVkHashText)]
+                                 ,("parent_hash",tipBlockParentHash)
+                                 ,("issuer_VKey_hash", tipBlockIssuerVkHashText)]
         ]
   asMetrics (ChainDB.AddedToCurrentChain _warnings selChangedInfo oldChain newChain) =
     let ChainInformation { .. } =
@@ -745,7 +745,14 @@ instance MetaTrace  (ChainDB.TraceAddBlockEvent blk) where
         , ( "epoch"
           , "In which epoch is the tip of the current chain."
           )
+        , ( "forks"
+          , "counter for forks"
+          )
+        , ( "tipBlock"
+          , "Hash vallues for tipBlockHash, tipBlockParentHash and tipBlockIssuerVkHashText"
+          )
         ]
+
   metricsDocFor (Namespace _ ["AddedToCurrentChain"]) =
         [ ( "density"
           , mconcat
@@ -767,6 +774,9 @@ instance MetaTrace  (ChainDB.TraceAddBlockEvent blk) where
           )
         , ( "epoch"
           , "In which epoch is the tip of the current chain."
+          )
+        , ( "tipBlock"
+          , "Hash vallues for tipBlockHash, tipBlockParentHash and tipBlockIssuerVkHashText"
           )
         ]
   metricsDocFor _ = []

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
@@ -504,9 +504,9 @@ instance ( LogFormatting (Header blk)
                | dtal == DDetailed ]
             ++ [ "events" .= toJSON (map (forMachine dtal) events)
                | not (null events) ]
-            ++ [ "tipBlockHash" .= tipBlockHash]
-            ++ [ "tipBlockParentHash" .= tipBlockParentHash]
-            ++ [ "tipBlockIssuerVerificationKeyHash" .= tipBlockIssuerVkHashText]
+            ++ [ "tipBlockHash" .= tipBlockHash
+               , "tipBlockParentHash" .= tipBlockParentHash
+               , "tipBlockIssuerVerificationKeyHash" .= tipBlockIssuerVkHashText]
   forMachine dtal (ChainDB.SwitchedToAFork events selChangedInfo old new) =
       let ChainInformation { .. } = chainInformation selChangedInfo old new 0
           tipBlockIssuerVkHashText :: Text
@@ -527,9 +527,9 @@ instance ( LogFormatting (Header blk)
                | dtal == DDetailed ]
             ++ [ "events" .= toJSON (map (forMachine dtal) events)
                | not (null events) ]
-            ++ [ "tipBlockHash" .= tipBlockHash]
-            ++ [ "tipBlockParentHash" .= tipBlockParentHash]
-            ++ [ "tipBlockIssuerVerificationKeyHash" .= tipBlockIssuerVkHashText]
+            ++ [ "tipBlockHash" .= tipBlockHash
+               , "tipBlockParentHash" .= tipBlockParentHash
+               , "tipBlockIssuerVerificationKeyHash" .= tipBlockIssuerVkHashText]
 
   forMachine dtal (ChainDB.AddBlockValidation ev') =
     forMachine dtal ev'
@@ -2152,13 +2152,7 @@ chainInformation selChangedInfo oldFrag frag blocksUncoupledDelta = ChainInforma
     }
   where
     tipIssuerVkHash :: BlockIssuerVerificationKeyHash
-    tipIssuerVkHash =
-      case AF.head frag of
-        Left AF.AnchorGenesis ->
-          NoBlockIssuer
-        Left (AF.Anchor _s _h _b) ->
-          NoBlockIssuer
-        Right blk -> getIssuerVerificationKeyHash blk
+    tipIssuerVkHash = either (const NoBlockIssuer) getIssuerVerificationKeyHash (AF.head frag)
 
 fragmentChainDensity ::
   HasHeader (Header blk)

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
@@ -749,7 +749,7 @@ instance MetaTrace  (ChainDB.TraceAddBlockEvent blk) where
           , "counter for forks"
           )
         , ( "tipBlock"
-          , "Hash vallues for tipBlockHash, tipBlockParentHash and tipBlockIssuerVkHashText"
+          , "Values for hash, parent hash and issuer verification key hash"
           )
         ]
 
@@ -776,7 +776,7 @@ instance MetaTrace  (ChainDB.TraceAddBlockEvent blk) where
           , "In which epoch is the tip of the current chain."
           )
         , ( "tipBlock"
-          , "Hash vallues for tipBlockHash, tipBlockParentHash and tipBlockIssuerVkHashText"
+          , "Values for hash, parent hash and issuer verification key hash"
           )
         ]
   metricsDocFor _ = []

--- a/cardano-node/test/Test/Cardano/Tracing/NewTracing/Consistency.hs
+++ b/cardano-node/test/Test/Cardano/Tracing/NewTracing/Consistency.hs
@@ -16,27 +16,32 @@ tests = H.checkSequential
       $ H.Group "Configuration Consistency tests"
       $ test
      <$> [ (  []
-           , "goodConfig.yaml")
+           , "mainnet-config-new-tracing.json"
+           , configPrefix)
+         , (  []
+           , "goodConfig.yaml"
+           , testPrefix)
          , (  [ "Config namespace error: Illegal namespace ChainDB.CopyToImmutableDBEvent2.CopiedBlockToImmutableDB"
               , "Config namespace error: Illegal namespace SubscriptionDNS"
               ]
-           , "badConfig.yaml")
-           -- TODO: add mainnet config as good
+           , "badConfig.yaml"
+           , testPrefix)
          ]
   where
-    test (actualValue, goldenBaseName) =
-        (PropertyName goldenBaseName, goldenTestJSON actualValue goldenBaseName)
+    test (actualValue, goldenBaseName, prefix) =
+        (PropertyName goldenBaseName, goldenTestJSON actualValue goldenBaseName prefix)
 
 
-goldenTestJSON :: [Text] -> FilePath -> Property
-goldenTestJSON expectedOutcome goldenFileBaseName =
+goldenTestJSON :: [Text] -> FilePath -> FilePath -> Property
+goldenTestJSON expectedOutcome goldenFileBaseName prefix =
     H.withTests 1 $ H.withShrinks 0 $ H.property $ do
-      goldenFp    <- H.Base.note $ addPrefix goldenFileBaseName
+      goldenFp    <- H.Base.note $ prefix <> goldenFileBaseName
       actualValue <- liftIO $ checkNodeTraceConfiguration goldenFp
       actualValue H.=== expectedOutcome
 
 
--- | NB: this function is only used in 'goldenTestJSON' but it is defined at the
--- top level so that we can refer to it in the documentation of this module.
-addPrefix :: FilePath -> FilePath
-addPrefix fname = "test/Test/Cardano/Tracing/NewTracing/data/" <> fname
+configPrefix :: FilePath
+configPrefix = "../configuration/cardano/"
+
+testPrefix :: FilePath
+testPrefix = "test/Test/Cardano/Tracing/NewTracing/data/"

--- a/cardano-node/test/Test/Cardano/Tracing/NewTracing/Consistency.hs
+++ b/cardano-node/test/Test/Cardano/Tracing/NewTracing/Consistency.hs
@@ -16,6 +16,7 @@ tests = H.checkSequential
       $ H.Group "Configuration Consistency tests"
       $ test
      <$> [ (  []
+              -- This file name shoud reference the current standard config with new tracing
            , "mainnet-config-new-tracing.json"
            , configPrefix)
          , (  []

--- a/cardano-node/test/Test/Cardano/Tracing/NewTracing/Consistency.hs
+++ b/cardano-node/test/Test/Cardano/Tracing/NewTracing/Consistency.hs
@@ -1,48 +1,59 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+
 -- | Check namespace consistencies agains configurations
 module Test.Cardano.Tracing.NewTracing.Consistency (tests) where
 
 import           Cardano.Node.Tracing.Consistency (checkNodeTraceConfiguration)
 
-import           Control.Monad.IO.Class (liftIO)
+import           Control.Monad.IO.Class (MonadIO, liftIO)
 import           Data.Text
+import           System.Directory (canonicalizePath)
+import           System.FilePath ((</>))
 
 import           Hedgehog (Property)
 import qualified Hedgehog as H
-import qualified Hedgehog.Extras.Test.Base as H.Base
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.Process as H
 import           Hedgehog.Internal.Property (PropertyName (PropertyName))
 
-tests :: IO Bool
-tests = H.checkSequential
+tests :: MonadIO m => m Bool
+tests = do
+  H.checkSequential
       $ H.Group "Configuration Consistency tests"
-      $ test
-     <$> [ (  []
-              -- This file name shoud reference the current standard config with new tracing
-           , "mainnet-config-new-tracing.json"
-           , configPrefix)
-         , (  []
-           , "goodConfig.yaml"
-           , testPrefix)
-         , (  [ "Config namespace error: Illegal namespace ChainDB.CopyToImmutableDBEvent2.CopiedBlockToImmutableDB"
-              , "Config namespace error: Illegal namespace SubscriptionDNS"
-              ]
-           , "badConfig.yaml"
-           , testPrefix)
-         ]
+      $ Prelude.map test
+            [ (  []
+                  -- This file name shoud reference the current standard config with new tracing
+              , "mainnet-config-new-tracing.json"
+              , configPrefix)
+            , (  []
+              , "goodConfig.yaml"
+              , testPrefix)
+            , (  [ "Config namespace error: Illegal namespace ChainDB.CopyToImmutableDBEvent2.CopiedBlockToImmutableDB"
+                  , "Config namespace error: Illegal namespace SubscriptionDNS"
+                  ]
+              , "badConfig.yaml"
+              , testPrefix)
+            ]
   where
     test (actualValue, goldenBaseName, prefix) =
         (PropertyName goldenBaseName, goldenTestJSON actualValue goldenBaseName prefix)
 
 
-goldenTestJSON :: [Text] -> FilePath -> FilePath -> Property
-goldenTestJSON expectedOutcome goldenFileBaseName prefix =
+goldenTestJSON :: [Text] -> FilePath -> (FilePath -> IO FilePath) -> Property
+goldenTestJSON expectedOutcome goldenFileBaseName prefixFunc =
     H.withTests 1 $ H.withShrinks 0 $ H.property $ do
-      goldenFp    <- H.Base.note $ prefix <> goldenFileBaseName
+      basePath <- H.getProjectBase
+      prefixPath <- liftIO $ prefixFunc basePath
+      goldenFp    <- H.note $ prefixPath </> goldenFileBaseName
       actualValue <- liftIO $ checkNodeTraceConfiguration goldenFp
       actualValue H.=== expectedOutcome
 
 
-configPrefix :: FilePath
-configPrefix = "../configuration/cardano/"
+configPrefix :: FilePath -> IO FilePath
+configPrefix projectBase = do
+  base <- canonicalizePath projectBase
+  return $ base </> "configuration/cardano"
 
-testPrefix :: FilePath
-testPrefix = "test/Test/Cardano/Tracing/NewTracing/data/"
+testPrefix :: FilePath ->  IO FilePath
+testPrefix _ = pure "test/Test/Cardano/Tracing/NewTracing/data/"

--- a/configuration/cardano/update-config-files.sh
+++ b/configuration/cardano/update-config-files.sh
@@ -20,6 +20,7 @@ copyFile "mainnet-alonzo-genesis.json"
 copyFile "mainnet-byron-genesis.json"
 copyFile "mainnet-conway-genesis.json"
 copyFile "mainnet-config.json"
+copyFile "mainnet-config-new-tracing.json"
 copyFile "mainnet-shelley-genesis.json"
 copyFile "mainnet-topology.json"
 

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -194,6 +194,7 @@ let
               mainnetConfigFiles = [
                 "configuration/cardano/mainnet-config.yaml"
                 "configuration/cardano/mainnet-config.json"
+                "configuration/cardano/mainnet-config-new-tracing.json"
                 "configuration/cardano/mainnet-byron-genesis.json"
                 "configuration/cardano/mainnet-shelley-genesis.json"
                 "configuration/cardano/mainnet-alonzo-genesis.json"


### PR DESCRIPTION
#### **Summary**
This pull request addresses multiple enhancements and fixes related to logging, metrics, and testing in the project.

---

#### **Changes**
1. **Let the Forging Mode metrics respect the command line config**  
   - Resolves [#5751](https://github.com/project/repo/issues/5751).  
   - Fixes a metric to track the **current forging mode** on a block producer node.  
   - Ensures visibility into the forging mode to improve monitoring and debugging.

2. **Enhanced Logging for Chain Events**  
   - Added the following fields to log messages for better traceability:  
     - **`tipBlockHash`**: Hash of the current tip block.  
     - **`tipBlockParentHash`**: Hash of the parent block of the tip.  
     - **`tipBlockIssuerVerificationKeyHash`**: Hash of the verification key of the tip block issuer.  
   - Affected log messages:  
     - `SwitchedToAFork`  
     - `AddedToCurrentChain`

3. **Consistency Testing for Mainnet Configuration**  
   - Added a **test case** to ensure **mainnet configuration consistency**.  
   - Validates the correctness of the mainnet configuration to prevent misconfigurations.

#### **Testing**
- Verified the new metric appears correctly in monitoring systems during runtime.  
- Confirmed the additional fields are included in the logs for the relevant events (`SwitchedToAFork`, `AddedToCurrentChain`).  
- Successfully ran the new mainnet configuration test case.

---
#### **Checklist**
- [x] Corrected metric for current forging mode.  
- [x] Updated log messages with additional fields.  
- [x] Implemented and verified the mainnet configuration consistency test.  
- [x] Updated relevant documentation if necessary.  

---

#### **Linked Issue**
Closes #5751
