### PR TITLE
GHA push latest tag, bump iohkNix

### DIFF
--- a/.github/workflows/release-ghcr.yaml
+++ b/.github/workflows/release-ghcr.yaml
@@ -67,19 +67,37 @@ jobs:
     - name: Uploading intersectmbo/cardano-node
       run: |
         echo "::group::Downloading from cache"
-        nix build --accept-flake-config --print-out-paths --builders "" --max-jobs 0 ${{ steps.flake-metadata.outputs.LOCKED_URL }}#dockerImage/node
+        nix build --accept-flake-config --print-out-paths --builders "" --max-jobs 0 --out-link ./result-node ${{ steps.flake-metadata.outputs.LOCKED_URL }}#dockerImage/node
         echo "::endgroup::"
 
         echo "::group::Uploading to registry"
-        skopeo copy docker-archive:./result docker://ghcr.io/intersectmbo/cardano-node:$GITHUB_REF_NAME
+        skopeo copy docker-archive:./result-node docker://ghcr.io/intersectmbo/cardano-node:$GITHUB_REF_NAME
         echo "::endgroup::"
 
     - name: Uploading intersectmbo/cardano-submit-api
       run: |
         echo "::group::Downloading from cache"
-        nix build --accept-flake-config --print-out-paths --builders "" --max-jobs 0 ${{ steps.flake-metadata.outputs.LOCKED_URL }}#dockerImage/submit-api
+        nix build --accept-flake-config --print-out-paths --builders "" --max-jobs 0 --out-link ./result-api ${{ steps.flake-metadata.outputs.LOCKED_URL }}#dockerImage/submit-api
         echo "::endgroup::"
 
         echo "::group::Uploading to registry"
-        skopeo copy docker-archive:./result docker://ghcr.io/intersectmbo/cardano-submit-api:$GITHUB_REF_NAME
+        skopeo copy docker-archive:./result-api docker://ghcr.io/intersectmbo/cardano-submit-api:$GITHUB_REF_NAME
+        echo "::endgroup::"
+
+    - name: Obtaining latest release tag
+      id: latest-tag
+      run: |
+        LATEST_TAG=$(gh api repos/$GITHUB_REPOSITORY/releases/latest --jq '.tag_name')
+        echo "LATEST_TAG=$LATEST_TAG" >> "$GITHUB_OUTPUT"
+        echo "Latest release tag is: $LATEST_TAG"
+
+    - name: Tagging intersectmbo container latest
+      if: ${{ github.event.release.tag_name == steps.latest-tag.outputs.LATEST_TAG }}
+      run: |
+        echo "::group::Tagging latest for intersectmbo/cardano-node"
+        skopeo copy docker-archive:./result-node docker://ghcr.io/intersectmbo/cardano-node:latest
+        echo "::endgroup::"
+
+        echo "::group::Tagging latest for intersectmbo/cardano-submit-api"
+        skopeo copy docker-archive:./result-api docker://ghcr.io/intersectmbo/cardano-submit-api:latest
         echo "::endgroup::"

--- a/configuration/cardano/mainnet-config.json
+++ b/configuration/cardano/mainnet-config.json
@@ -17,7 +17,7 @@
   "ShelleyGenesisFile": "mainnet-shelley-genesis.json",
   "ShelleyGenesisHash": "1a3be38bcbb7911969283716ad7aa550250226b76a61fc51cc9a9a35d9276d81",
   "TargetNumberOfActivePeers": 20,
-  "TargetNumberOfEstablishedPeers": 50,
+  "TargetNumberOfEstablishedPeers": 40,
   "TargetNumberOfKnownPeers": 150,
   "TargetNumberOfRootPeers": 60,
   "TraceAcceptPolicy": true,

--- a/configuration/cardano/mainnet-config.yaml
+++ b/configuration/cardano/mainnet-config.yaml
@@ -36,7 +36,7 @@ MaxKnownMajorProtocolVersion: 2
 
 PeerSharing: True
 TargetNumberOfActivePeers: 20
-TargetNumberOfEstablishedPeers: 50
+TargetNumberOfEstablishedPeers: 40
 TargetNumberOfKnownPeers: 150
 TargetNumberOfRootPeers: 60
 

--- a/configuration/cardano/shelley_qa-config.json
+++ b/configuration/cardano/shelley_qa-config.json
@@ -18,7 +18,7 @@
   "ShelleyGenesisFile": "shelley_qa-shelley-genesis.json",
   "ShelleyGenesisHash": "73a9f6bdb0aa97f5e63190a6f14a702bd64a21f2bec831cbfc28f6037128b952",
   "TargetNumberOfActivePeers": 20,
-  "TargetNumberOfEstablishedPeers": 50,
+  "TargetNumberOfEstablishedPeers": 40,
   "TargetNumberOfKnownPeers": 150,
   "TargetNumberOfRootPeers": 60,
   "TestAllegraHardForkAtEpoch": 0,
@@ -65,6 +65,7 @@
   "TracingVerbosity": "NormalVerbosity",
   "TurnOnLogMetrics": true,
   "TurnOnLogging": true,
+  "UseTraceDispatcher": false,
   "defaultBackends": [
     "KatipBK"
   ],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
-version: "3.5"
-
 services:
   cardano-node:
-    image: ghcr.io/intersectmbo/cardano-node:${CARDANO_NODE_VERSION:-10.1.2}
+    image: ghcr.io/intersectmbo/cardano-node:${CARDANO_NODE_VERSION:-latest}
     environment:
       - NETWORK=${NETWORK:-mainnet}
     volumes:
@@ -15,7 +13,7 @@ services:
         max-file: "10"
 
   cardano-submit-api:
-    image: ghcr.io/intersectmbo/cardano-submit-api:${CARDANO_SUBMIT_API_VERSION:-10.1.2}
+    image: ghcr.io/intersectmbo/cardano-submit-api:${CARDANO_SUBMIT_API_VERSION:-latest}
     environment:
       - NETWORK=${NETWORK:-mainnet}
     depends_on:

--- a/flake.lock
+++ b/flake.lock
@@ -839,11 +839,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1732287300,
-        "narHash": "sha256-lURsE6HdJX0alscWhbzCWyLRK8GpAgKuXeIgX31Kfqg=",
+        "lastModified": 1734618971,
+        "narHash": "sha256-5StB/VhWHOj3zlBxshqVFa6cwAE0Mk/wxRo3eEfcy74=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "262cb2aec2ddd914124bab90b06fe24a1a74d02c",
+        "rev": "dc900a3448e805243b0ed196017e8eb631e32240",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Description
* Adds GHA steps to push a `latest` tag for node and api containers on release events where the tag is the latest release
* Updates the docker-compose to default to the latest tag
* Bumps iohk-nix for an updated target number of established peers and adjusts related configs to pass CI checks

# Checklist
- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] CI passes. See note on CI.  The following CI checks are required:
- [X] Self-reviewed the diff