### PR TITLE
prepare for garnix

### DIFF
--- a/garnix.yaml
+++ b/garnix.yaml
@@ -1,0 +1,3 @@
+builds:
+  include:
+  - 'checks.*.*'


### PR DESCRIPTION
# Description

- Add garnix cache to the flake nix config.
- Add `garnix.yaml` that builds only `.#checks`.
- Adjust the flake outputs to make garnix build everything that Hydra did.

Garnix does not build the `hydraJobs` output
so move them all into the `checks` output,
adhering to the flake output schema
because garnix does not build nested attrsets.

Note that this replaces the layout of the `checks` output
but it should still include all the checks that it had previously.
So no checks are removed, they just have a different name.
I hope that's ok and no checks are referred to by name somewhere.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- ~~New tests are added if needed and existing tests are updated.~~
- ~~Any changes are noted in the `CHANGELOG.md` for affected package~~
- ~~The version bounds in `.cabal` files are updated~~
- [x] CI passes
- [x] Self-reviewed the diff