### PR TITLE
Fix and update hlint GitHub CI workflow

### DIFF
--- a/.github/workflows/check-hlint.yml
+++ b/.github/workflows/check-hlint.yml
@@ -14,11 +14,7 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v3
-
-    - name: Install dependencies
-      run: |
-        sudo apt-get -y install libtinfo5
+    - uses: actions/checkout@v4
 
     - name: 'Set up HLint'
       uses: rwe/actions-hlint-setup@v1


### PR DESCRIPTION
# Description

GitHub just updated the `ubuntu-latest` runner image from `22.04` to `24.04` and `libtinfo5` is no longer in the image. However, the binary releases of `hlint` that are used no longer require `libtinfo` at any version.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff