### PR TITLE
tx-generator: Core.hs: simplifications + better non-Byron support

### DIFF
--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Core.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Core.hs
@@ -162,19 +162,23 @@ cancelBenchmark = do
 getLocalConnectInfo :: ActionM LocalNodeConnectInfo
 getLocalConnectInfo = makeLocalConnectInfo <$> getEnvNetworkId <*> getEnvSocketPath
 
-queryEra :: ActionM AnyCardanoEra
+queryEra :: ActionM AnyShelleyBasedEra
 queryEra = do
   localNodeConnectInfo <- getLocalConnectInfo
   chainTip  <- getLocalChainTip localNodeConnectInfo
-  mapExceptT liftIO .
+  AnyCardanoEra era <- mapExceptT liftIO .
     modifyError (Env.TxGenError . TxGenError . show) $
       queryNodeLocalState localNodeConnectInfo (SpecificPoint $ chainTipToChainPoint chainTip) QueryCurrentEra
+  caseByronOrShelleyBasedEra
+    (liftTxGenError $ TxGenError "queryEra Byron not supported")
+    (return . AnyShelleyBasedEra)
+    era
 
 queryRemoteProtocolParameters :: ActionM ProtocolParameters
 queryRemoteProtocolParameters = do
   localNodeConnectInfo <- getLocalConnectInfo
   chainTip  <- liftIO $ getLocalChainTip localNodeConnectInfo
-  AnyCardanoEra era <- queryEra
+  AnyShelleyBasedEra sbe <- queryEra
   let
     callQuery :: forall era.
                  QueryInEra era (Ledger.PParams (ShelleyLedgerEra era))
@@ -187,10 +191,7 @@ queryRemoteProtocolParameters = do
       liftIO $ BSL.writeFile pparamsFile $ prettyPrintOrdered pp'
       traceDebug $ "queryRemoteProtocolParameters : query result saved in: " ++ pparamsFile
       return pp'
-  caseByronOrShelleyBasedEra
-    (liftTxGenError $ TxGenError "queryRemoteProtocolParameters Byron not supported")
-    (\sbe -> callQuery $ QueryInShelleyBasedEra sbe QueryProtocolParameters)
-    era
+  callQuery $ QueryInShelleyBasedEra sbe QueryProtocolParameters
 
 getProtocolParameters :: ActionM ProtocolParameters
 getProtocolParameters = do
@@ -198,7 +199,7 @@ getProtocolParameters = do
     ProtocolParameterQuery -> queryRemoteProtocolParameters
     ProtocolParameterLocal parameters -> return parameters
 
-waitForEra :: AnyCardanoEra -> ActionM ()
+waitForEra :: AnyShelleyBasedEra -> ActionM ()
 waitForEra era = do
   currentEra <- queryEra
   if currentEra == era

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Types.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Types.hs
@@ -117,7 +117,7 @@ data Action where
   -- with testing and quick fixes.
   Reserved           :: [String] -> Action
   -- 'WaitForEra' loops doing delays/sleeps until the current era matches.
-  WaitForEra         :: !AnyCardanoEra -> Action
+  WaitForEra         :: !AnyShelleyBasedEra -> Action
   -- | 'SetProtocolParameters' has one option to read from a file and
   -- another to pass directly and just sets a state variable for
   -- the @protoParams@ field of 'Cardano.Benchmarking.Script.Env.Env'.


### PR DESCRIPTION
# Description

As part of my work on adapting `tx-generator` to upcoming changes to API (this is https://github.com/IntersectMBO/cardano-node/commits/smelc/adapt-to-api-removal-of-protocol-parameters-use-ledger-type-instead/), I:

1. found a place where the code could be simplified (this is the first commit)
2. found that Byron was not being supported in this place, and so removed the corresponding error case, by pushing the non-Byron constraints to callers.

Point 1. is good on its own while point 2. will make my life easier for the branch mentioned above, but it is optional (I can live with it).

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [X] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [X] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [X] Self-reviewed the diff