### PR TITLE
tx-generator: stop supporting Byron and use more recent API way to handle eras

### DIFF
--- a/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx.hs
@@ -110,14 +110,14 @@ handleTxSubmissionClientError
       LogErrors   -> traceWith traceSubmit $
         TraceBenchTxSubError (pack errDesc)
 
-walletBenchmark :: forall era. IsShelleyBasedEra era
-  => Trace IO (TraceBenchTxSubmit TxId)
+walletBenchmark :: ()
+  => ShelleyBasedEra era
+  -> Trace IO (TraceBenchTxSubmit TxId)
   -> Trace IO NodeToNodeSubmissionTrace
   -> ConnectClient
   -> NonEmpty NodeDescription
   -> TPSRate
   -> SubmissionErrorPolicy
-  -> AsType era
 -- this is used in newTpsThrottle to limit the tx-count !
 -- This should not be needed, the stream should do it itself (but it does not!)
   -> NumberOfTxs
@@ -128,13 +128,13 @@ walletBenchmark :: forall era. IsShelleyBasedEra era
   -> TxStream IO era
   -> ExceptT TxGenError IO AsyncBenchmarkControl
 walletBenchmark
+  sbe
   traceSubmit
   traceN2N
   connectClient
   targets
   tpsRate
   errorPolicy
-  _era
   count
   txSource
   = liftIO $ do
@@ -157,6 +157,7 @@ walletBenchmark
   abcWorkers <- forM asyncList \(reportRef, remoteInfo@(remoteName, remoteAddrInfo)) -> do
     let errorHandler = handleTxSubmissionClientError traceSubmit remoteInfo reportRef errorPolicy
         client = txSubmissionClient
+                     sbe
                      traceN2N
                      traceSubmit
                      (txStreamSource txStreamRef tpsThrottle)

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Action.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Action.hs
@@ -13,6 +13,8 @@ module Cardano.Benchmarking.Script.Action
        )
        where
 
+import           Cardano.Api
+
 import           Cardano.Benchmarking.OuroborosImports as Core (protocolToNetworkId)
 import           Cardano.Benchmarking.Script.Core
 import           Cardano.Benchmarking.Script.Env
@@ -21,8 +23,6 @@ import           Cardano.Benchmarking.Tracer
 import           Cardano.TxGenerator.Setup.NodeConfig
 import           Cardano.TxGenerator.Types (TxGenError)
 
-import           Control.Monad.IO.Class
-import           Control.Monad.Trans.Except.Extra
 import qualified Data.Text as Text (unpack)
 
 
@@ -43,9 +43,9 @@ action a = case a of
   StartProtocol configFile cardanoTracerSocket -> startProtocol configFile cardanoTracerSocket
   ReadSigningKey name filePath -> readSigningKey name filePath
   DefineSigningKey name descr -> defineSigningKey name descr
-  AddFund era wallet txIn lovelace keyName -> addFund era wallet txIn lovelace keyName
+  AddFund (AnyShelleyBasedEra sbe) wallet txIn lovelace keyName -> addFund sbe wallet txIn lovelace keyName
   Delay t -> delay t
-  Submit era submitMode txParams generator -> submitAction era submitMode generator txParams
+  Submit (AnyShelleyBasedEra sbe) submitMode txParams generator -> submitAction sbe submitMode generator txParams
   WaitBenchmark -> waitBenchmark
   CancelBenchmark -> cancelBenchmark
   WaitForEra era -> waitForEra era

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Selftest.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Selftest.hs
@@ -75,7 +75,7 @@ testScript protocolFile submitMode =
   , InitWallet splitWallet3
   , InitWallet doneWallet
   , DefineSigningKey key skey
-  , AddFund era genesisWallet
+  , AddFund sbe genesisWallet
     (TxIn "900fc5da77a0747da53f7675cbb7d149d46779346dea2f879ab811ccc72a2162" (TxIx 0))
     (L.Coin 90000000000000) key
   , createChange genesisWallet splitWallet1 1 10
@@ -88,7 +88,7 @@ testScript protocolFile submitMode =
   , createChange splitWallet3 splitWallet3 300 30
 -}
 
-  , Submit era submitMode txParams $ Take 4000 $ Cycle
+  , Submit sbe submitMode txParams $ Take 4000 $ Cycle
       $ NtoM splitWallet3 (PayToAddr key doneWallet) 2 2 Nothing Nothing
   ]
   where
@@ -99,7 +99,7 @@ testScript protocolFile submitMode =
           , teDescription = fromString "Genesis Initial UTxO Signing Key"
           , teRawCBOR = "X \vl1~\182\201v(\152\250A\202\157h0\ETX\248h\153\171\SI/m\186\242D\228\NAK\182(&\162"
           }
-    era = AnyCardanoEra AllegraEra
+    sbe = AnyShelleyBasedEra ShelleyBasedEraAllegra
     txParams = defaultTxGenTxParams {txParamFee = 1000000}
     genesisWallet = "genesisWallet"
     splitWallet1 = "SplitWallet-1"
@@ -109,4 +109,4 @@ testScript protocolFile submitMode =
     key = "pass-partout"
     createChange :: String -> String -> Int -> Int -> Action
     createChange src dest txCount outputs
-      = Submit era submitMode txParams $ Take txCount $ Cycle $ SplitN src (PayToAddr key dest) outputs
+      = Submit sbe submitMode txParams $ Take txCount $ Cycle $ SplitN src (PayToAddr key dest) outputs

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Types.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Types.hs
@@ -96,7 +96,7 @@ data Action where
   -- 'Cardano.Benchmarking.Wallet.walletRefInsertFund' which in turn
   -- is just 'Control.Concurrent.modifyMVar' around
   -- 'Cardano.TxGenerator.FundQueue.insert'.
-  AddFund            :: !AnyCardanoEra -> !String -> !TxIn -> !L.Coin -> !String -> Action
+  AddFund            :: !AnyShelleyBasedEra -> !String -> !TxIn -> !L.Coin -> !String -> Action
   -- | 'WaitBenchmark' signifies a 'Control.Concurrent.Async.waitCatch'
   -- on the 'Cardano.Benchmarking.GeneratorTx.AsyncBenchmarkControl'
   -- for the environment and also folds tracers into the completion.
@@ -108,7 +108,7 @@ data Action where
   -- in turn wraps
   -- 'Cardano.Benchmarking.GeneratorTx.SubmissionClient.txSubmissionClient'
   -- and functions local to that like @requestTxs@.
-  Submit             :: !AnyCardanoEra -> !SubmitMode -> !TxGenTxParams -> !Generator -> Action
+  Submit             :: !AnyShelleyBasedEra -> !SubmitMode -> !TxGenTxParams -> !Generator -> Action
   -- | 'CancelBenchmark' wraps a callback from the
   -- 'Cardano.Benchmarking.GeneratorTx.AsyncBenchmarkControl' type,
   -- which is a shutdown action.

--- a/bench/tx-generator/src/Cardano/TxGenerator/Fund.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Fund.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-|
 Module      : Cardano.TxGenerator.Fund
 Description : A type for funds to build transactions with.
@@ -76,15 +75,14 @@ getFundCoin (Fund (InAnyCardanoEra _ a)) = case _fundVal a of
 -- TODO: facilitate casting KeyWitnesses between eras -- Note [Era transitions]
 -- | The `Fund` alternative is checked against `cardanoEra`, but
 -- `getFundWitness` otherwise wraps `_fundWitness`.
-getFundWitness :: forall era. IsShelleyBasedEra era => Fund -> Witness WitCtxTxIn era
-getFundWitness fund = case (cardanoEra @era, fund) of
-  (ByronEra   , Fund (InAnyCardanoEra ByronEra   a)) -> _fundWitness a
-  (ShelleyEra , Fund (InAnyCardanoEra ShelleyEra a)) -> _fundWitness a
-  (AllegraEra , Fund (InAnyCardanoEra AllegraEra a)) -> _fundWitness a
-  (MaryEra    , Fund (InAnyCardanoEra MaryEra    a)) -> _fundWitness a
-  (AlonzoEra  , Fund (InAnyCardanoEra AlonzoEra  a)) -> _fundWitness a
-  (BabbageEra , Fund (InAnyCardanoEra BabbageEra a)) -> _fundWitness a
-  (ConwayEra  , Fund (InAnyCardanoEra ConwayEra  a)) -> _fundWitness a
+getFundWitness :: ShelleyBasedEra era -> Fund -> Witness WitCtxTxIn era
+getFundWitness sbe fund = case (sbe, fund) of
+  (ShelleyBasedEraShelley , Fund (InAnyCardanoEra ShelleyEra a)) -> _fundWitness a
+  (ShelleyBasedEraAllegra , Fund (InAnyCardanoEra AllegraEra a)) -> _fundWitness a
+  (ShelleyBasedEraMary    , Fund (InAnyCardanoEra MaryEra    a)) -> _fundWitness a
+  (ShelleyBasedEraAlonzo  , Fund (InAnyCardanoEra AlonzoEra  a)) -> _fundWitness a
+  (ShelleyBasedEraBabbage , Fund (InAnyCardanoEra BabbageEra a)) -> _fundWitness a
+  (ShelleyBasedEraConway  , Fund (InAnyCardanoEra ConwayEra  a)) -> _fundWitness a
   _                                                  -> error "getFundWitness: era mismatch"
 
 {-

--- a/bench/tx-generator/src/Cardano/TxGenerator/PureExample.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/PureExample.hs
@@ -102,11 +102,13 @@ generateTx TxEnvironment{..}
   where
     TxFeeExplicit _ fee = txEnvFee
 
+    sbe = ShelleyBasedEraBabbage
+
     generator :: TxGenerator BabbageEra
     generator =
-        case convertToLedgerProtocolParameters shelleyBasedEra txEnvProtocolParams of
+        case convertToLedgerProtocolParameters sbe txEnvProtocolParams of
           Right ledgerParameters ->
-            genTx ShelleyBasedEraBabbage ledgerParameters collateralFunds txEnvFee txEnvMetadata
+            genTx sbe ledgerParameters collateralFunds txEnvFee txEnvMetadata
           Left err -> \_ _ -> Left (ApiError err)
       where
         -- collateralFunds are needed for Plutus transactions
@@ -127,7 +129,7 @@ generateTx TxEnvironment{..}
     computeOutputValues = inputsToOutputsWithFee fee numOfOutputs
       where numOfOutputs = 2
 
-    computeUTxO = mkUTxOVariant txEnvNetworkId signingKey
+    computeUTxO = mkUTxOVariant sbe txEnvNetworkId signingKey
 
 
 generateTxM ::
@@ -153,9 +155,11 @@ generateTxPure TxEnvironment{..} inQueue
     inputs = toList inQueue
     TxFeeExplicit _ fee = txEnvFee
 
+    sbe = ShelleyBasedEraBabbage
+
     generator :: TxGenerator BabbageEra
     generator =
-        case convertToLedgerProtocolParameters shelleyBasedEra txEnvProtocolParams of
+        case convertToLedgerProtocolParameters sbe txEnvProtocolParams of
           Right ledgerParameters ->
             genTx ShelleyBasedEraBabbage ledgerParameters collateralFunds txEnvFee txEnvMetadata
           Left err -> \_ _ -> Left (ApiError err)
@@ -171,4 +175,4 @@ generateTxPure TxEnvironment{..} inQueue
     computeOutputValues = inputsToOutputsWithFee fee numOfOutputs
       where numOfOutputs = 2
 
-    computeUTxO = mkUTxOVariant txEnvNetworkId signingKey
+    computeUTxO = mkUTxOVariant sbe txEnvNetworkId signingKey

--- a/bench/tx-generator/src/Cardano/TxGenerator/Tx.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Tx.hs
@@ -172,7 +172,7 @@ genTx sbe ledgerParameters (collateral, collFunds) fee metadata inFunds outputs
  where
   allKeys = mapMaybe getFundKey $ inFunds ++ collFunds
   txBodyContent = shelleyBasedEraConstraints sbe $ defaultTxBodyContent sbe
-    & setTxIns (map (\f -> (getFundTxIn f, BuildTxWith $ getFundWitness f)) inFunds)
+    & setTxIns (map (\f -> (getFundTxIn f, BuildTxWith $ getFundWitness sbe f)) inFunds)
     & setTxInsCollateral collateral
     & setTxOuts outputs
     & setTxFee fee

--- a/bench/tx-generator/src/Cardano/TxGenerator/UTxO.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/UTxO.hs
@@ -26,22 +26,23 @@ makeToUTxOList fkts values
       = let (o, f ) = toUTxO value
          in  (o, f idx)
 
-mkUTxOVariant :: forall era. IsShelleyBasedEra era
-  => NetworkId
+mkUTxOVariant :: ()
+  => ShelleyBasedEra era
+  -> NetworkId
   -> SigningKey PaymentKey
   -> ToUTxO era
-mkUTxOVariant networkId key value
+mkUTxOVariant sbe networkId key value
   = ( mkTxOut value
     , mkNewFund value
     )
  where
-  mkTxOut v = TxOut (keyAddress @era networkId key) (lovelaceToTxOutValue (shelleyBasedEra @era) v) TxOutDatumNone ReferenceScriptNone
+  mkTxOut v = TxOut (keyAddress sbe networkId key) (lovelaceToTxOutValue sbe v) TxOutDatumNone ReferenceScriptNone
 
   mkNewFund :: L.Coin -> TxIx -> TxId -> Fund
-  mkNewFund val txIx txId = Fund $ InAnyCardanoEra (cardanoEra @era) $ FundInEra {
+  mkNewFund val txIx txId = shelleyBasedEraConstraints sbe $ Fund $ InAnyCardanoEra (toCardanoEra sbe) $ FundInEra {
       _fundTxIn = TxIn txId txIx
     , _fundWitness = KeyWitness KeyWitnessForSpending
-    , _fundVal = lovelaceToTxOutValue (shelleyBasedEra @era ) val
+    , _fundVal = lovelaceToTxOutValue sbe val
     , _fundSigningKey = Just key
     }
 

--- a/bench/tx-generator/src/Cardano/TxGenerator/Utils.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Utils.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 
 {-
 Module      : Cardano.TxGenerator.Utils
@@ -74,8 +72,3 @@ mkTxFee = TxFeeExplicit
 mkTxValidityUpperBound :: ShelleyBasedEra era -> SlotNo -> TxValidityUpperBound era
 mkTxValidityUpperBound sbe slotNo =
   TxValidityUpperBound (fromJust $ forShelleyBasedEraMaybeEon sbe) (Just slotNo)
-
--- | `mkTxInModeCardano` never uses the `TxInByronSpecial` constructor
--- because its type enforces it being a Shelley-based era.
-mkTxInModeCardano :: IsShelleyBasedEra era => Tx era -> TxInMode
-mkTxInModeCardano = TxInMode shelleyBasedEra

--- a/bench/tx-generator/src/Cardano/TxGenerator/Utils.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Utils.hs
@@ -32,10 +32,10 @@ liftAnyEra f x = case x of
   InAnyCardanoEra ConwayEra a  ->   InAnyCardanoEra ConwayEra $ f a
 
 -- | `keyAddress` determines an address for the relevant era.
-keyAddress :: forall era. IsShelleyBasedEra era => NetworkId -> SigningKey PaymentKey -> AddressInEra era
-keyAddress networkId k
+keyAddress :: ShelleyBasedEra era -> NetworkId -> SigningKey PaymentKey -> AddressInEra era
+keyAddress sbe networkId k
   = makeShelleyAddressInEra
-      (shelleyBasedEra @era)
+      sbe
       networkId
       (PaymentCredentialByKey $ verificationKeyHash $ getVerificationKey k)
       NoStakeAddress
@@ -66,14 +66,14 @@ includeChange fee spend have = case compare changeValue 0 of
 
 -- | `mkTxFee` reinterprets the `Either` returned by
 -- `txFeesExplicitInEra` with `TxFee` constructors.
-mkTxFee :: IsShelleyBasedEra era => L.Coin -> TxFee era
-mkTxFee = TxFeeExplicit shelleyBasedEra
+mkTxFee :: ShelleyBasedEra era -> L.Coin -> TxFee era
+mkTxFee = TxFeeExplicit
 
 -- | `mkTxValidityUpperBound` rules out needing the
--- `TxValidityNoUpperBound` with the constraint of `IsShelleyBasedEra`.
-mkTxValidityUpperBound :: forall era. IsShelleyBasedEra era => SlotNo -> TxValidityUpperBound era
-mkTxValidityUpperBound slotNo =
-  TxValidityUpperBound (fromJust $ forEraMaybeEon (cardanoEra @era)) (Just slotNo)
+-- `TxValidityNoUpperBound` with the `ShelleyBasedEra` witness.
+mkTxValidityUpperBound :: ShelleyBasedEra era -> SlotNo -> TxValidityUpperBound era
+mkTxValidityUpperBound sbe slotNo =
+  TxValidityUpperBound (fromJust $ forShelleyBasedEraMaybeEon sbe) (Just slotNo)
 
 -- | `mkTxInModeCardano` never uses the `TxInByronSpecial` constructor
 -- because its type enforces it being a Shelley-based era.

--- a/bench/tx-generator/test/ApiTest.hs
+++ b/bench/tx-generator/test/ApiTest.hs
@@ -131,18 +131,18 @@ checkFund ::
   -> String
 checkFund nixService shelleyGenesis signingKey
   | AnyCardanoEra BabbageEra <- _nix_era nixService
-  = showBabbage $ checkFundCore shelleyGenesis signingKey
+  = showBabbage $ checkFundCore ShelleyBasedEraBabbage shelleyGenesis signingKey
   | AnyCardanoEra ConwayEra <- _nix_era nixService
-  = showConway $ checkFundCore shelleyGenesis signingKey
+  = showConway $ checkFundCore ShelleyBasedEraConway shelleyGenesis signingKey
   | otherwise
   = "ApiTest: unrecognized era"
 
 checkFundCore ::
-  IsShelleyBasedEra era
-  => ShelleyGenesis
+  ShelleyBasedEra era
+  -> ShelleyGenesis
   -> SigningKey PaymentKey
   -> Maybe (AddressInEra era, Api.Coin)
-checkFundCore = genesisInitialFundForKey Mainnet
+checkFundCore sbe = genesisInitialFundForKey sbe Mainnet
 
 checkPlutusBuiltin :: FilePath -> IO ()
 #ifndef WITH_LIBRARY


### PR DESCRIPTION
# Description

* Stop using `IsShelleyBasedEra`, which is not the usual way to interact with `cardano-api` anymore.
* Use a `ShelleyBasedEra era` witness instead.
* As a consequence, this avoids picking the era in many places with `shelleyBasedEra`. Passing the witness around makes sure the era being used is consistent.
* This also simplifies the code, as you don't need type applications anymore.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [X] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [X] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
- [X] Self-reviewed the diff