### PR TITLE
tx-generator: remove usage of cardano-api's ProtocolParameters (WIP)

### DIFF
--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Aeson.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Aeson.hs
@@ -1,5 +1,6 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -22,7 +23,7 @@ import qualified Data.Attoparsec.ByteString as Atto
 import qualified Data.Yaml as Yaml (encode)
 
 import           Cardano.Api
-import           Cardano.Api.Shelley (ProtocolParameters)
+import qualified Cardano.Ledger.Core as L
 
 import           Cardano.Benchmarking.Script.Types
 import           Cardano.TxGenerator.Internal.Orphans ()
@@ -158,5 +159,9 @@ parseJSONFile parser filePath = do
 parseScriptFileAeson :: FilePath -> IO [Action]
 parseScriptFileAeson = parseJSONFile fromJSON
 
-readProtocolParametersFile :: FilePath -> IO ProtocolParameters
-readProtocolParametersFile = parseJSONFile fromJSON
+readProtocolParametersFile ::
+  ()
+  => L.EraPParams era
+  => FilePath
+  -> IO (L.PParams era)
+readProtocolParametersFile  = parseJSONFile fromJSON

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Types.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Types.hs
@@ -39,8 +39,8 @@ module Cardano.Benchmarking.Script.Types (
 ) where
 
 import           Cardano.Api
-import qualified Cardano.Api.Ledger as L
 import           Cardano.Api.Shelley
+import qualified Cardano.Api.Ledger as L
 
 import           Cardano.Benchmarking.OuroborosImports (SigningKeyFile)
 import           Cardano.Node.Configuration.NodeAddress (NodeIPv4Address)
@@ -214,4 +214,4 @@ newtype TxList era = TxList [Tx era]
 
 data ProtocolParameterMode where
   ProtocolParameterQuery :: ProtocolParameterMode
-  ProtocolParameterLocal :: ProtocolParameters -> ProtocolParameterMode
+  ProtocolParameterLocal :: L.PParams (ShelleyLedgerEra era) -> ProtocolParameterMode

--- a/bench/tx-generator/src/Cardano/TxGenerator/PureExample.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/PureExample.hs
@@ -7,7 +7,6 @@ module  Cardano.TxGenerator.PureExample
         where
 
 import           Cardano.Api
-import           Cardano.Api.Shelley (convertToLedgerProtocolParameters)
 
 import qualified Cardano.Ledger.Coin as L
 import           Cardano.TxGenerator.FundQueue
@@ -105,11 +104,7 @@ generateTx TxEnvironment{..}
     sbe = ShelleyBasedEraBabbage
 
     generator :: TxGenerator BabbageEra
-    generator =
-        case convertToLedgerProtocolParameters sbe txEnvProtocolParams of
-          Right ledgerParameters ->
-            genTx sbe ledgerParameters collateralFunds txEnvFee txEnvMetadata
-          Left err -> \_ _ -> Left (ApiError err)
+    generator = genTx ShelleyBasedEraBabbage txEnvProtocolParams collateralFunds txEnvFee txEnvMetadata
       where
         -- collateralFunds are needed for Plutus transactions
         collateralFunds :: (TxInsCollateral BabbageEra, [Fund])
@@ -158,11 +153,7 @@ generateTxPure TxEnvironment{..} inQueue
     sbe = ShelleyBasedEraBabbage
 
     generator :: TxGenerator BabbageEra
-    generator =
-        case convertToLedgerProtocolParameters sbe txEnvProtocolParams of
-          Right ledgerParameters ->
-            genTx ShelleyBasedEraBabbage ledgerParameters collateralFunds txEnvFee txEnvMetadata
-          Left err -> \_ _ -> Left (ApiError err)
+    generator = genTx ShelleyBasedEraBabbage txEnvProtocolParams collateralFunds txEnvFee txEnvMetadata
       where
         -- collateralFunds are needed for Plutus transactions
         collateralFunds :: (TxInsCollateral BabbageEra, [Fund])

--- a/bench/tx-generator/src/Cardano/TxGenerator/Tx.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Tx.hs
@@ -7,9 +7,10 @@ module  Cardano.TxGenerator.Tx
         where
 
 import           Cardano.Api
-import           Cardano.Api.Shelley (LedgerProtocolParameters)
+import           Cardano.Api.Shelley
 
 import qualified Cardano.Ledger.Coin as L
+import qualified Cardano.Ledger.Core as L
 import           Cardano.TxGenerator.Fund
 import           Cardano.TxGenerator.Types
 import           Cardano.TxGenerator.UTxO (ToUTxOList)
@@ -159,7 +160,7 @@ sourceTransactionPreview txGenerator inputFunds valueSplitter toStore =
 -- for a function type -- of two arguments.
 genTx :: ()
   => ShelleyBasedEra era
-  -> LedgerProtocolParameters era
+  -> L.PParams (ShelleyLedgerEra era)
   -> (TxInsCollateral era, [Fund])
   -> TxFee era
   -> TxMetadataInEra era
@@ -179,7 +180,7 @@ genTx sbe ledgerParameters (collateral, collFunds) fee metadata inFunds outputs
     & setTxValidityLowerBound TxValidityNoLowerBound
     & setTxValidityUpperBound (defaultTxValidityUpperBound sbe)
     & setTxMetadata metadata
-    & setTxProtocolParams (BuildTxWith (Just ledgerParameters))
+    & setTxProtocolParams (BuildTxWith (Just $ LedgerProtocolParameters ledgerParameters))
 
 
 txSizeInBytes ::

--- a/bench/tx-generator/src/Cardano/TxGenerator/Types.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Types.hs
@@ -14,9 +14,10 @@ module  Cardano.TxGenerator.Types
         where
 
 import           Cardano.Api
-import           Cardano.Api.Shelley (ProtocolParameters)
+import           Cardano.Api.Shelley
 
 import qualified Cardano.Ledger.Coin as L
+import qualified Cardano.Ledger.Core as L
 import           Cardano.Ledger.Crypto (StandardCrypto)
 import qualified Cardano.Ledger.Shelley.API as Ledger (ShelleyGenesis)
 import           Cardano.TxGenerator.Fund (Fund)
@@ -67,7 +68,7 @@ data TxEnvironment era = TxEnvironment
   { txEnvNetworkId        :: !NetworkId
   -- , txEnvGenesis          :: !ShelleyGenesis
   -- , txEnvProtocolInfo     :: !SomeConsensusProtocol
-  , txEnvProtocolParams   :: !ProtocolParameters
+  , txEnvProtocolParams   :: !(L.PParams (ShelleyLedgerEra era))
   , txEnvFee              :: TxFee era
   , txEnvMetadata         :: TxMetadataInEra era
   }

--- a/bench/tx-generator/test/ApiTest.hs
+++ b/bench/tx-generator/test/ApiTest.hs
@@ -14,7 +14,7 @@ module Main (module Main) where
 
 import           Cardano.Api
 import qualified Cardano.Api.Ledger as Api
-import           Cardano.Api.Shelley (ProtocolParameters (..), fromPlutusData)
+import           Cardano.Api.Shelley (fromPlutusData)
 
 #ifdef WITH_LIBRARY
 import           Cardano.Benchmarking.PlutusScripts


### PR DESCRIPTION
> [!NOTE]
>
> On top of https://github.com/IntersectMBO/cardano-node/pull/6087 and needs also to be merged after https://github.com/IntersectMBO/cardano-node/pull/6068 (to have more recent `cardano-api` version)

# Description

This PR adapts `tx-generator` to the removal of the `ProtocolParameters` type from `cardano-api` (which has been deprecated, see https://github.com/IntersectMBO/cardano-api/issues/384).

Instead this PR makes `tx-generator` use the ledger type `PParams era` directly. The challenge is that this type is parameterized by the era, as opposed to `ProtocolParameters` (that was hiding it).

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff