### PR TITLE
cardano-tesnet: allow to specify output directory

### DIFF
--- a/cardano-testnet/src/Parsers/Cardano.hs
+++ b/cardano-testnet/src/Parsers/Cardano.hs
@@ -57,6 +57,11 @@ pCardanoTestnetCliOptions envCli = CardanoTestnetOptions
       <>  OA.help "Enable new epoch state logging to logs/ledger-epoch-state.log"
       <>  OA.showDefault
       )
+  <*> optional (OA.strOption
+      (   OA.long "output-dir"
+      <>  OA.help "Directory where to store files, sockets, and so on. It is created if it doesn't exist. If unset, a temporary directory is used."
+      <>  OA.metavar "DIRECTORY"
+      ))
   where
     pAnyShelleyBasedEra' :: Parser AnyShelleyBasedEra
     pAnyShelleyBasedEra' =

--- a/cardano-testnet/src/Parsers/Run.hs
+++ b/cardano-testnet/src/Parsers/Run.hs
@@ -53,4 +53,4 @@ runTestnetCmd = \case
 
 runCardanoOptions :: CardanoTestnetCliOptions -> IO ()
 runCardanoOptions (CardanoTestnetCliOptions testnetOptions shelleyOptions) =
-  runTestnet $ cardanoTestnetDefault testnetOptions shelleyOptions
+  runTestnet testnetOptions $ cardanoTestnetDefault testnetOptions shelleyOptions

--- a/cardano-testnet/src/Testnet/Filepath.hs
+++ b/cardano-testnet/src/Testnet/Filepath.hs
@@ -25,6 +25,8 @@ makeSprocket
 makeSprocket tmpAbsPath node
   = Sprocket (makeTmpBaseAbsPath tmpAbsPath) (makeSocketDir tmpAbsPath </> node)
 
+-- TODO rename me: since the introduction of --output-dir in the cardano-testnet
+-- executable, this is a directory that can persist after the test ends.
 -- Temporary path used at runtime
 newtype TmpAbsolutePath = TmpAbsolutePath
   { unTmpAbsPath :: FilePath

--- a/cardano-testnet/src/Testnet/Start/Types.hs
+++ b/cardano-testnet/src/Testnet/Start/Types.hs
@@ -74,6 +74,7 @@ data CardanoTestnetOptions = CardanoTestnetOptions
   , cardanoNodeLoggingFormat :: NodeLoggingFormat
   , cardanoNumDReps :: NumDReps -- ^ The number of DReps to generate at creation
   , cardanoEnableNewEpochStateLogging :: Bool -- ^ if epoch state logging is enabled
+  , cardanoOutputDir :: Maybe FilePath -- ^ The output directory where to store files, sockets, and so on. If unset, a temporary directory is used.
   } deriving (Eq, Show)
 
 cardanoNumPools :: CardanoTestnetOptions -> NumPools
@@ -105,6 +106,7 @@ instance Default CardanoTestnetOptions where
     , cardanoNodeLoggingFormat = NodeLoggingFormatAsJson
     , cardanoNumDReps = 3
     , cardanoEnableNewEpochStateLogging = True
+    , cardanoOutputDir = Nothing
     }
 
 -- | Options that are implemented by writing fields in the Shelley genesis file.

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
@@ -13,6 +13,7 @@ Usage: cardano-testnet cardano [--num-pool-nodes COUNT]
   [--nodeLoggingFormat LOGGING_FORMAT]
   [--num-dreps NUMBER]
   [--enable-new-epoch-state-logging]
+  [--output-dir DIRECTORY]
   --testnet-magic INT
   [--epoch-length SLOTS]
   [--slot-length SECONDS]

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/cardano.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/cardano.cli
@@ -11,6 +11,7 @@ Usage: cardano-testnet cardano [--num-pool-nodes COUNT]
   [--nodeLoggingFormat LOGGING_FORMAT]
   [--num-dreps NUMBER]
   [--enable-new-epoch-state-logging]
+  [--output-dir DIRECTORY]
   --testnet-magic INT
   [--epoch-length SLOTS]
   [--slot-length SECONDS]
@@ -44,6 +45,9 @@ Available options:
   --enable-new-epoch-state-logging
                            Enable new epoch state logging to
                            logs/ledger-epoch-state.log
+  --output-dir DIRECTORY   Directory where to store files, sockets, and so on.
+                           It is created if it doesn't exist. If unset, a
+                           temporary directory is used.
   --testnet-magic INT      Specify a testnet magic id.
   --epoch-length SLOTS     Epoch length, in number of slots (default: 500)
   --slot-length SECONDS    Slot length (default: 0.1)


### PR DESCRIPTION
# Description

Adds the `--output-dir` to the `cardano-testnet` executable

Fixes https://github.com/IntersectMBO/cardano-node/issues/6078

# How trust this PR

Use the new flag:

```shell
> ls /tmp > tmp-before # for checking data afterwards
> cabal run cardano-testnet -- cardano --testnet-magic 44 --output-dir output-dir
```

Witness that the output directory gets populated:

```
> tree output-dir
output-dir/
├── alonzo-genesis.json
├── byron-gen-command
│   └── genesis-keys.000.key
├── byron-genesis.json
├── byron.genesis.spec.json
├── configuration.yaml
├── conway-genesis.json
├── delegate-keys
│   ├── delegate1
│   │   ├── kes.skey
│   │   ├── kes.vkey
│   │   ├── key.skey
│   │   ├── key.vkey
...
```

You can check that the `/tmp` directory wasn't used, by comparing its current state with the state before:

```shell
> ls /tmp > tmp-after
> diff tmp-before tmp-after
# nothing gets printed
```

Now test that you can omit the flag:

```shell
> ls /tmp > tmp-before-2
> cabal run cardano-testnet -- cardano --testnet-magic 44
```

Observe that the testnet's log mentions a workspace in `/tmp` like before this PR:

```
    forAll77 =
      /tmp/nix-shell.hc4ID6/testnet-test-dc5d67c2dd8545dd
    
    forAll78 =
      Workspace: /tmp/nix-shell.hc4ID6/testnet-test-dc5d67c2dd8545dd
```

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff