### PR TITLE
cardano-testnet: call the CLI check-node-configuration to catch configuration errors

### DIFF
--- a/cardano-testnet/src/Testnet/Start/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Start/Cardano.hs
@@ -275,6 +275,10 @@ cardanoTestnet
   -- Add Byron, Shelley and Alonzo genesis hashes to node configuration
   config <- createConfigJson (TmpAbsolutePath tmpAbsPath) sbe
   H.evalIO $ LBS.writeFile (unFile configurationFile) config
+  execCli_
+    [ "debug", "check-node-configuration"
+    , "--node-configuration-file", unFile configurationFile
+    ]
 
   portNumbersWithNodeOptions <- forM cardanoNodes $ \nodeOption -> (nodeOption,) <$> H.randomPort testnetDefaultIpv4Address
   let portNumbers = snd <$> portNumbersWithNodeOptions


### PR DESCRIPTION
# Description

Call the CLI's "new" [check-node-configuration](https://github.com/IntersectMBO/cardano-node/issues/6028) command in `cardano-testnet` setup.

This both serves as a test of `check-node-configuration` and will also help catch configuration errors earlier (and with a nice error message). The latter is particularly important as we will soon release `cardano-testnet` and let users supply genesis files (see [roadmap](https://github.com/IntersectMBO/cardano-node/issues/6080) and [issue about supplying genesis files](https://github.com/IntersectMBO/cardano-node/issues/6069)).

Fixes https://github.com/IntersectMBO/cardano-node/issues/6028

# How to trust this PR

The tests still pass, so the cal is successful

Try to break the genesis files, for example apply this patch:

```diff
--- a/cardano-testnet/src/Testnet/Components/Configuration.hs
+++ b/cardano-testnet/src/Testnet/Components/Configuration.hs
@@ -75,8 +75,8 @@ createConfigJson :: ()
 createConfigJson (TmpAbsolutePath tempAbsPath) sbe = GHC.withFrozenCallStack $ do
   byronGenesisHash <- getByronGenesisHash $ tempAbsPath </> "byron-genesis.json"
   shelleyGenesisHash <- getHash ShelleyEra "ShelleyGenesisHash"
-  alonzoGenesisHash  <- getHash AlonzoEra  "AlonzoGenesisHash"
-  conwayGenesisHash  <- getHash ConwayEra  "ConwayGenesisHash"
+  alonzoGenesisHash  <- getHash ConwayEra  "AlonzoGenesisHash"
+  conwayGenesisHash  <- getHash AlonzoEra  "ConwayGenesisHash"
```

Run `cardano-testnet`'s tests:

```shell
cabal test cardano-testnet-test
```

And observe that, as expected, the tests fail with the expected error:

```shell
              ┃     │ ━━━━ command ━━━━
              ┃     │ /home/churlin/.local/state/cabal/store/ghc-8.10.7/cardano-cli-10.3.0.0-e-cardano-cli-0a5a7130af59b84c2d65c8b4b8cad9fc373753786ec928a2dc0d3f04d5276bf8/bin/cardano-cli debug check-node-configuration --node-configuration-file /tmp/nix-shell.hc4ID6/submit-api-transaction-2-test-63f5646fc9235289/configuration.yaml
              ┃     │ Process exited with non-zero exit-code: 1
              ┃     │ ━━━━ stdout ━━━━
              ┃     │ Checking byron genesis file: /tmp/nix-shell.hc4ID6/submit-api-transaction-2-test-63f5646fc9235289/byron-genesis.json
              ┃     │ 
              ┃     │ ━━━━ stderr ━━━━
              ┃     │ Wrong genesis hash for /tmp/nix-shell.hc4ID6/submit-api-transaction-2-test-63f5646fc9235289/alonzo-genesis.json in /tmp/nix-shell.hc4ID6/submit-api-transaction-2-test-63f5646fc9235289/configuration.yaml: when computing the hash, got: a4844d02149b2c12da7195fdcb82fefc13641d8e78fe5d964d054bf48dee0f1a, but the node configuration files states that this hash is expected: 33aacea1c55c0cab6c9906f2e435cb47ede3eda3f9b7f5d4eaf4ec616e890596
```

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [X] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [X] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
- [X] Self-reviewed the diff