### PR TITLE
cardano-testnet: modify API to accept user-provided configuration file

### DIFF
--- a/cardano-testnet/src/Testnet/Start/Types.hs
+++ b/cardano-testnet/src/Testnet/Start/Types.hs
@@ -10,6 +10,7 @@ module Testnet.Start.Types
   , NumDReps(..)
   , NumPools(..)
   , NumRelays(..)
+  , UserNodeConfig(..)
   , cardanoNumPools
   , cardanoNumRelays
 
@@ -132,6 +133,12 @@ data TestnetNodeOptions
     -- ^ These arguments will be appended to the default set of CLI options when
     -- starting the node.
   deriving (Eq, Show)
+
+-- | Type used to track whether the user is using its own node configuration file,
+-- or whether it is programmatically generated.
+data UserNodeConfig =
+  UserNodeConfigNotSubmitted
+  | UserNodeConfig FilePath
 
 -- | Get extra CLI arguments passed to the node executable
 testnetNodeExtraCliArgs :: TestnetNodeOptions -> [String]

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs
@@ -120,7 +120,7 @@ hprop_gov_no_confidence = integrationWorkspace "no-confidence" $ \tempAbsBasePat
     , configurationFile
     } <- cardanoTestnet
            fastTestnetOptions
-           conf shelleyGenesis'
+           conf UserNodeConfigNotSubmitted shelleyGenesis'
            alonzoGenesis conwayGenesisWithCommittee
 
   poolNode1 <- H.headM testnetNodes


### PR DESCRIPTION
# Description

* Allow to pass a custom node configuration file at the Haskell level of `cardano-testnet`
* Unused for now, but is a step towards this: https://github.com/IntersectMBO/cardano-node/issues/6069, because to implement #6069 we'll need to call `cardanoTestnet` with a custom node configuration file.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [ ] CI passes.
- [X] Self-reviewed the diff