### PR TITLE
Fix port display

### DIFF
--- a/cardano-node/src/Cardano/Node/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Startup.hs
@@ -250,9 +250,16 @@ prepareNodeInfo nc (SomeConsensusProtocol whichP pForInfo) tc nodeStartTime = do
         -- In this case we should form node's name as "host_port",
         -- where 'host' is the machine's host name and 'port' is taken
         -- from the '--port' CLI-parameter.
-        let SocketConfig{ncNodePortNumber = port} = ncSocketConfig nc
+
+        let suffix :: Text
+            suffix 
+              | SocketConfig{ncNodePortNumber = Last (Just port)} <- ncSocketConfig nc
+              = "_" <> show port
+              | otherwise
+              = ""
+
         hostName <- getHostName
-        return . pack $ hostName <> "_" <> show (getLast port)
+        return (pack (hostName <> suffix))
 
 -- | This information is taken from 'BasicInfoShelleyBased'. It is required for
 --   'cardano-tracer' service (particularly, for RTView).


### PR DESCRIPTION
Fixes the way the port is displayed in the node information (remove an accidental layer of `Maybe`).