### PR TITLE
Allow outbound connections to non-big ledger peers in Genesis

### DIFF
--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -939,10 +939,7 @@ mkP2PArguments NodeConfiguration {
         targetNumberOfEstablishedBigLedgerPeers = ncDeadlineTargetOfEstablishedBigLedgerPeers,
         targetNumberOfActiveBigLedgerPeers      = ncDeadlineTargetOfActiveBigLedgerPeers
     }
-    syncTargets = PeerSelectionTargets {
-      targetNumberOfRootPeers        = 0,
-      targetNumberOfKnownPeers       = 0,
-      targetNumberOfEstablishedPeers = 0,
+    syncTargets = deadlineTargets {
       targetNumberOfActivePeers               = ncSyncTargetOfActivePeers,
       targetNumberOfKnownBigLedgerPeers       = ncSyncTargetOfKnownBigLedgerPeers,
       targetNumberOfEstablishedBigLedgerPeers = ncSyncTargetOfEstablishedBigLedgerPeers,

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -1754,19 +1754,19 @@ instance (Aeson.ToJSONKey peerAddr, ToJSON peerAddr, Ord peerAddr, Show peerAddr
 
 instance ToJSON PeerSelectionTargets where
   toJSON (PeerSelectionTargets
-            nRootLedgerPeers
-            nKnownLedgerPeers
-            nEstablishedLedgerPeers
-            nActiveLedgerPeers
+            nRootPeers
+            nKnownPeers
+            nEstablishedPeers
+            nActivePeers
             nKnownBigLedgerPeers
             nEstablishedBigLedgerPeers
             nActiveBigLedgerPeers
          ) =
     Aeson.object [ "kind" .= String "PeerSelectionTargets"
-                 , "targetRootLedgerPeers" .= nRootLedgerPeers
-                 , "targetKnownLedgerPeers" .= nKnownLedgerPeers
-                 , "targetEstablishedLedgerPeers" .= nEstablishedLedgerPeers
-                 , "targetActiveLedgerPeers" .= nActiveLedgerPeers
+                 , "targetRootPeers" .= nRootPeers
+                 , "targetKnownPeers" .= nKnownPeers
+                 , "targetEstablishedPeers" .= nEstablishedPeers
+                 , "targetActivePeers" .= nActivePeers
 
                  , "targetKnownBigLedgerPeers" .= nKnownBigLedgerPeers
                  , "targetEstablishedBigLedgerPeers" .= nEstablishedBigLedgerPeers


### PR DESCRIPTION
# Description

- Properly handle `SyncTargetOfActivePeers` from configuration.
- Verify at node startup if peer selection targets are valid or stop
- Update peer selection trace tags

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
