### PR TITLE
bump: iohkNix for MinNodeVersion to 10.1.4

### DIFF
--- a/configuration/cardano/mainnet-config.json
+++ b/configuration/cardano/mainnet-config.json
@@ -10,7 +10,7 @@
   "LastKnownBlockVersion-Major": 3,
   "LastKnownBlockVersion-Minor": 0,
   "MaxKnownMajorProtocolVersion": 2,
-  "MinNodeVersion": "8.12.0",
+  "MinNodeVersion": "10.1.4",
   "PeerSharing": true,
   "Protocol": "Cardano",
   "RequiresNetworkMagic": "RequiresNoMagic",

--- a/configuration/cardano/mainnet-config.yaml
+++ b/configuration/cardano/mainnet-config.yaml
@@ -42,7 +42,7 @@ TargetNumberOfRootPeers: 60
 
 ##### Version Information #####
 
-MinNodeVersion: 8.12.0
+MinNodeVersion: 10.1.4
 
 ##### Logging configuration #####
 

--- a/configuration/cardano/shelley_qa-config.json
+++ b/configuration/cardano/shelley_qa-config.json
@@ -11,7 +11,7 @@
   "LastKnownBlockVersion-Alt": 0,
   "LastKnownBlockVersion-Major": 3,
   "LastKnownBlockVersion-Minor": 1,
-  "MinNodeVersion": "8.12.0",
+  "MinNodeVersion": "10.1.4",
   "PeerSharing": true,
   "Protocol": "Cardano",
   "RequiresNetworkMagic": "RequiresMagic",

--- a/flake.lock
+++ b/flake.lock
@@ -839,11 +839,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1734618971,
-        "narHash": "sha256-5StB/VhWHOj3zlBxshqVFa6cwAE0Mk/wxRo3eEfcy74=",
+        "lastModified": 1738874249,
+        "narHash": "sha256-oyPD/zIhs5AUEdYXZHluMAOmT5ynJSgjV2bNIXt5aKE=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "dc900a3448e805243b0ed196017e8eb631e32240",
+        "rev": "e26038d47df5d17187288fd7c8f5b915c9447b2e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Description

Bumps iohk-nix flake pin for an update to `MinNodeVersion` to `10.1.4` in nix generated configuration files.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] CI passes. See note on CI.  The following CI checks are required:
- [X] Self-reviewed the diff