### PR TITLE
cardano-testnet: remove possibility to programmatically pass a custom node configuration file (it was unused)

### DIFF
--- a/cardano-testnet/src/Parsers/Cardano.hs
+++ b/cardano-testnet/src/Parsers/Cardano.hs
@@ -79,7 +79,7 @@ pNumSpoNodes =
     <>  OA.showDefault
     <>  OA.value 1)
   where
-    defaultSpoOptions = SpoNodeOptions Nothing []
+    defaultSpoOptions = SpoNodeOptions []
 
 pGenesisOptions :: Parser GenesisOptions
 pGenesisOptions =

--- a/cardano-testnet/src/Testnet/Start/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Start/Cardano.hs
@@ -42,7 +42,6 @@ import           Data.Bifunctor (first)
 import qualified Data.ByteString.Lazy as LBS
 import           Data.Either
 import           Data.Functor
-import           Data.Maybe
 import           Data.MonoTraversable (Element, MonoFunctor, omap)
 import qualified Data.Text as Text
 import           Data.Time (diffUTCTime)
@@ -218,13 +217,6 @@ cardanoTestnet
   testMinimumConfigurationRequirements testnetOptions
 
   H.note_ OS.os
-
-  when (all (isJust . testnetNodeCfgFile) cardanoNodes) $
-    -- TODO: We need a very simple non-obscure way of generating the files necessary
-    -- to run a testnet. "create-staked" is not a good way to do this especially because it
-    -- makes assumptions about where things should go and where genesis template files should be.
-    -- See all of the ad hoc file creation/renaming/dir creation etc below.
-    H.failMessage GHC.callStack "Specifying node configuration files per node not supported yet."
 
   -- Write specification files. Those are the same as the genesis files
   -- used for launching the nodes, but omitting the content regarding stake, utxos, etc.

--- a/cardano-testnet/src/Testnet/Start/Types.hs
+++ b/cardano-testnet/src/Testnet/Start/Types.hs
@@ -19,7 +19,6 @@ module Testnet.Start.Types
   , eraToString
 
   , TestnetNodeOptions(..)
-  , testnetNodeCfgFile
   , testnetNodeExtraCliArgs
   , isSpoNodeOptions
   , isRelayNodeOptions
@@ -128,8 +127,8 @@ instance Default GenesisOptions where
 
 -- | Specify a SPO (Shelley era onwards only) or a Relay node
 data TestnetNodeOptions
-  = SpoNodeOptions (Maybe NodeConfigurationYaml) [String]
-  | RelayNodeOptions (Maybe NodeConfigurationYaml) [String]
+  = SpoNodeOptions [String]
+  | RelayNodeOptions [String]
     -- ^ These arguments will be appended to the default set of CLI options when
     -- starting the node.
   deriving (Eq, Show)
@@ -142,13 +141,8 @@ data UserNodeConfig =
 
 -- | Get extra CLI arguments passed to the node executable
 testnetNodeExtraCliArgs :: TestnetNodeOptions -> [String]
-testnetNodeExtraCliArgs (SpoNodeOptions _ args) = args
-testnetNodeExtraCliArgs (RelayNodeOptions _ args) = args
-
--- | Get node-specific configuration file path
-testnetNodeCfgFile :: TestnetNodeOptions -> Maybe NodeConfigurationYaml
-testnetNodeCfgFile (SpoNodeOptions mFp _) = mFp
-testnetNodeCfgFile (RelayNodeOptions mFp _) = mFp
+testnetNodeExtraCliArgs (SpoNodeOptions args) = args
+testnetNodeExtraCliArgs (RelayNodeOptions args) = args
 
 isSpoNodeOptions :: TestnetNodeOptions -> Bool
 isSpoNodeOptions SpoNodeOptions{} = True
@@ -160,9 +154,9 @@ isRelayNodeOptions RelayNodeOptions{} = True
 
 cardanoDefaultTestnetNodeOptions :: [TestnetNodeOptions]
 cardanoDefaultTestnetNodeOptions =
-  [ SpoNodeOptions Nothing []
-  , RelayNodeOptions Nothing []
-  , RelayNodeOptions Nothing []
+  [ SpoNodeOptions []
+  , RelayNodeOptions []
+  , RelayNodeOptions []
   ]
 
 data NodeLoggingFormat = NodeLoggingFormatAsJson | NodeLoggingFormatAsText deriving (Eq, Show)

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/LeadershipSchedule.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/LeadershipSchedule.hs
@@ -67,9 +67,9 @@ hprop_leadershipSchedule = integrationRetryWorkspace 2 "leadership-schedule" $ \
       cTestnetOptions = def
         { cardanoNodeEra = asbe
         , cardanoNodes =
-          [ SpoNodeOptions Nothing []
-          , SpoNodeOptions Nothing []
-          , SpoNodeOptions Nothing []
+          [ SpoNodeOptions []
+          , SpoNodeOptions []
+          , SpoNodeOptions []
           ]
         }
       eraString = eraToString sbe

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitutionSPO.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitutionSPO.hs
@@ -58,9 +58,9 @@ hprop_ledger_events_propose_new_constitution_spo = integrationWorkspace "propose
       fastTestnetOptions = def
         { cardanoNodeEra = AnyShelleyBasedEra sbe
         , cardanoNodes =
-          [ SpoNodeOptions Nothing []
-          , SpoNodeOptions Nothing []
-          , SpoNodeOptions Nothing []
+          [ SpoNodeOptions []
+          , SpoNodeOptions []
+          , SpoNodeOptions []
           ]
         }
       shelleyOptions = def { genesisEpochLength = 100 }

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Node/Shutdown.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Node/Shutdown.hs
@@ -198,7 +198,7 @@ hprop_shutdownOnSlotSynced = integrationRetryWorkspace 2 "shutdown-on-slot-synce
       slotLen = 0.01
   let fastTestnetOptions = def
         { cardanoNodes =
-          [ SpoNodeOptions Nothing ["--shutdown-on-slot-synced", show maxSlot]
+          [ SpoNodeOptions ["--shutdown-on-slot-synced", show maxSlot]
           ]
         }
       shelleyOptions = def


### PR DESCRIPTION
# Description

* This is a subset of what #6103 does, but it's a valid change on its own; so I rather merge it sooner than the entire #6103.
* Part of fixing https://github.com/IntersectMBO/cardano-node/issues/6069

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [ ] CI passes. See note on CI.  The following CI checks are required:
- [X] Self-reviewed the diff