### PR TITLE
bench: analysis quick queries; various maintenance

### DIFF
--- a/bench/locli/CHANGELOG.md
+++ b/bench/locli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Revision history for locli
 
+## 2.1 -- Feb 2025
+
+* New CLI command `dump-tracefreqs` to write out per-host trace frequencies JSON files
+* Introduce `Reducer` type class for `locli-quick` based quick query evaluation
+* Sample `Reducer` instance implmentations: data types `TxsInMempool`, `Silence` and `ResourceMeasure`
+* Add plotting capabilities (experimental) via a heavily modded fork of package `easyplot-1.0` (module `EasyPlot.hs` and its license)
+
 ## 2.0 -- Dec 2024
 
 * New database (DB) persistence backend for log objects using serverless SQLite DBs

--- a/bench/locli/LICENSE_easyplot
+++ b/bench/locli/LICENSE_easyplot
@@ -1,0 +1,17 @@
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/bench/locli/app/locli-quick.hs
+++ b/bench/locli/app/locli-quick.hs
@@ -1,57 +1,179 @@
-import           Cardano.Api (SlotNo (..))
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
+{-# OPTIONS_GHC -Wno-unused-imports -Wno-redundant-constraints -Wno-unused-top-binds #-}
+
+import           Cardano.Api (ExceptT, SlotNo (..), runExceptT)
+
+import           Cardano.Analysis.API.Ground (JsonInputFile (..))
+import           Cardano.Analysis.Reducer
+import           Cardano.Analysis.Reducer.Util
 import           Cardano.Unlog.BackendDB
-import           Cardano.Unlog.LogObject (LOBody (..), LogObject (..))
+import           Cardano.Unlog.BackendFile (readRunLogsBare)
+import           Cardano.Unlog.LogObject (LogObject (..), RunLogs (..), rlLogs)
 import           Cardano.Unlog.LogObjectDB
-import           Cardano.Util
+import           Cardano.Util hiding (toDouble)
 
-import           Prelude hiding (log)
+import           Prelude hiding (log, seq)
 
-import           Data.Bifunctor (second)
-import           Data.List.Split (chop)
-import           Data.Maybe
+import           Data.Bifunctor (first)
+import           Data.Either
+import           Data.Function (on)
+import           Data.List (find, isSuffixOf)
+import           Data.Map.Strict as Map (restrictKeys)
+import           Data.Reducer
+import qualified Data.Set as Set (fromList, null)
+import           Data.Word
 import           System.Environment (getArgs)
 
 import           Database.Sqlite.Easy hiding (Text)
+import           Graphics.EasyPlot
 
 
 main :: IO ()
 main = do
   getArgs >>= \case
-    []     -> putStrLn "please specify DB file"
-    db : _ -> runDB $ fromString db
+    db : _
+      | ".sqlite3"  `isSuffixOf` db -> runDB $ fromString db
+      | ".json"     `isSuffixOf` db -> runManifest db
+      | db == "testplot"            -> void testPlot
+    _ -> putStrLn "please specify DB file or log manifest, or 'testplot'"
+
+-- for testing the EasyPlot module
+testPlot :: IO Bool
+testPlot =
+  plot' [Debug, Interactive] _term3 plotData
+  where
+    _term1 = mkTerminal (PNGCairo "test.png")
+    _term2 = Terminal X11 "test plot" (Just (1024, 768))
+    _term3 = Terminal Qt "test plot" (Just (1024, 768))
+    _term4 = mkTerminal Dumb
+    plotData =
+        [ Data2D [Title "Graph 1", Color Red] [] [(x, x ** 3) | x <- [-4,-3.9 :: Double .. 4]]
+        , Function2D [Title "Function 2", Color Blue] [] (\x -> negate $ x ** 2)
+        , Gnuplot2D [Title "Function Expr", Color Green] [] "x*x"
+        , File2D [Title "from file", Color Yellow] [] "_plot1.dat" Nothing
+        ]
+
+runManifest :: FilePath -> IO ()
+runManifest logManifest = do
+  rls <- withTimingInfo "quick-query" $
+    -- runOnRun (LoadLogObjectsWith selectMempoolTxs) logManifest [] -- ["node-2", "node-12", "node-22"]
+    -- runOnRun LoadHeapData logManifest [] -- ["node-2", "node-12", "node-22"]
+    runOnRun LoadTimestamps logManifest [] -- ["node-2", "node-12", "node-22"]
+
+  {-
+  let
+    perSlot :: RunLogs [ObjectsInSlot]
+    perSlot = bySlotDomain `fmap` rls
+
+    red    = reduceRunLogs (TxsInMempoolPerSlot <-> Changes ((/=) `on` snd)) perSlot
+  -}
+
+  {-
+  let
+    perSlot :: RunLogs [BySlot Word64]
+    perSlot = bySlot
+                (either (const Nothing) Just)
+                (fromLeft undefined)
+                False
+              `fmap` rls
+  -}
+
+  now <- getCurrentTime
+  let
+    res = reduceRunLogs Silence{threshold = 1.2, startTime = now} rls
+
+  mapM_ print (rlLogs res)
+
+runOnRun :: forall l. LoadFromDB l => l -> FilePath -> [String] -> IO (RunLogs [LoadResult l])
+runOnRun loadFromDB logManifest onlyHosts =
+  runExceptT go >>= either error pure
+  where
+    restrictRunLogs rl@RunLogs{rlHostLogs}
+      | null onlyHosts  = rl
+      | otherwise       =
+        let onlyKeys = Set.fromList $ map fromString onlyHosts
+        in rl{ rlHostLogs = Map.restrictKeys rlHostLogs onlyKeys }
+
+    go :: ExceptT String IO (RunLogs [LoadResult l])
+    go = do
+      rl <- restrictRunLogs <$> readRunLogsBare (JsonInputFile logManifest)
+      runLiftLogObjectsDB loadFromDB rl
 
 -- sample case:
 -- we want to know the txns in mempool for each slot
 
 runDB :: ConnectionString -> IO ()
 runDB dbName = do
-  (summary, res2) <-
+  (summary, result) <-
     withTimingInfo "withDb/selectMempoolTxs" $
       withDb dbName $
-        (,) <$> getSummary <*> run selectMempoolTxs
+        (,) <$> getSummary <*> run (sqlOrdered selectMempoolTxs)
 
-  let logObjects = map (sqlToLogObject summary) res2
+  let
+    logObjects = map (sqlToLogObject summary) result
 
-  -- TODO: needs a reducer
-  mapM_ (print . second safeLast) (bySlotDomain logObjects)
-  where
-    safeLast [] = []
-    safeLast xs = [last xs]
+    bySlotOjbs :: [BySlot LogObject]
+    bySlotOjbs = bySlotLogObjects logObjects
 
-bySlotDomain :: [LogObject] -> [(SlotNo, [LogObject])]
-bySlotDomain logObjs =
-  case dropWhile (isNothing . newSlot) logObjs of
-    [] -> []
-    xs -> chop go xs
-  where
-    newSlot LogObject{loBody} = case loBody of { LOTraceStartLeadershipCheck s _ _ -> Just s; _ -> Nothing }
+    res1   = take 1600 $ reduce TxsInMempoolPerSlot bySlotOjbs
+    res2   = reduce changes res1
 
-    go (lo:los) = let (inSlot, rest) = span (isNothing . newSlot) los in ((fromJust $ newSlot lo, inSlot), rest)
-    go []       = error "bySlotDomain/chop: empty list"
+  let
+    toDouble :: SlotNo -> Double
+    toDouble = fromIntegral . unSlotNo
 
-selectMempoolTxs :: SQL
-selectMempoolTxs = sqlOrdered
+    term    = Terminal X11 "Txns in Mempool" (Just (1024, 768))
+    points1 = map (first toDouble) res1
+    points2 = map (first toDouble) res2
+
+  void $ plot' [] term (Data2D [Title "txn count per slot", Color Red, Style Linespoints] [] points1)
+  void $ plot' [] term (Data2D [Title "txn count changes", Color Blue, Style Steps] [] points2)
+
+selectMempoolTxs :: [SQLSelect6Cols]
+selectMempoolTxs =
   [ sqlGetSlot
   , sqlGetTxns `sqlAppend` "WHERE cons='LOMempoolTxs'"
   ]
+
+
+{-
+  This should eventually be part of a QuickQuery typeclass. This class is defined by:
+  - a query + (possibly parametrizable) filter, making use of the LoadFromDB typeclass
+  - a (possibly parametrizable) reducer, making use of the Reducer typeclass
+  - meaningful stdout output
+  - optionally: file output, like e.g. CSV
+  - optionally: a plot / plots
+-}
+
+data LoadHeapData = LoadHeapData
+
+instance LoadFromDB LoadHeapData where
+  type instance LoadResult LoadHeapData = Either Word64 SlotNo
+
+  loadQuery _ = Just "SELECT at, slot, null as heap FROM slot UNION SELECT at, null, heap FROM resource ORDER BY at ASC"
+
+  loadConvert _ _ = \case
+    [_, slot_, heap_] ->
+      let
+        slot :: SMaybe SlotNo
+        slot = fromSqlData slot_
+        heap :: SMaybe Word64
+        heap = fromSqlData heap_
+      in smaybe (Left $ unsafeFromSJust heap) Right slot
+    _ -> error "loadConvert(LoadHeapData): expected 3 result columns"
+
+
+data LoadTimestamps = LoadTimestamps
+
+instance LoadFromDB LoadTimestamps where
+  type instance LoadResult LoadTimestamps = (UTCTime, SMaybe SlotNo)
+
+  loadQuery _ = Just $ "SELECT at, slot FROM slot" <> from "resource" <> from "txns" <> from "event" <> " ORDER BY at ASC"
+    where from t = " UNION SELECT at, null FROM " <> t
+
+  loadConvert _ _ = \case
+    [at, slot] -> (fromSqlData at, fromSqlData slot)
+    _ -> error "loadConvert(LoadTimestamps): expected 2 result columns"

--- a/bench/locli/locli.cabal
+++ b/bench/locli/locli.cabal
@@ -11,12 +11,33 @@ author:                 IOHK
 maintainer:             operations@iohk.io
 license:                Apache-2.0
 license-files:          LICENSE
+                        LICENSE_easyplot
                         NOTICE
+                        -- The module src-quick/Graphics/EasyPlot.hs is a forked, and heavily modded,
+                        -- version of the easyplot-1.0 package by Julian Bertram.
 extra-doc-files:        CHANGELOG.md
 build-type:             Simple
 
 common project-config
   default-language:     Haskell2010
+
+  ghc-options:          -Wall
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wredundant-constraints
+                        -Wpartial-fields
+                        -Wcompat
+                        -Wno-all-missed-specialisations
+
+  if impl(ghc >= 9.8)
+    ghc-options:        -Wno-x-partial
+
+  build-depends:        base >= 4.14 && < 5,
+
+  if os(windows)
+    buildable: False
+
+common extensions
   default-extensions:   BangPatterns
                         BlockArguments
                         DataKinds
@@ -42,24 +63,10 @@ common project-config
                         TypeFamilies
                         ViewPatterns
 
-  ghc-options:          -Wall
-                        -Wincomplete-record-updates
-                        -Wincomplete-uni-patterns
-                        -Wredundant-constraints
-                        -Wpartial-fields
-                        -Wcompat
-                        -Wno-all-missed-specialisations
-
-  if impl(ghc >= 9.8)
-    ghc-options:        -Wno-x-partial
-
-  build-depends:        base >= 4.14 && < 5,
-
-  if os(windows)
-    buildable: False
-
 library
   import:               project-config
+                      , extensions
+
   hs-source-dirs:       src
 
   exposed-modules:      Data.Accum
@@ -138,6 +145,7 @@ library
 
 executable locli
   import:               project-config
+                      , extensions
 
   hs-source-dirs:       app
   main-is:              locli.hs
@@ -157,8 +165,19 @@ executable locli
 executable locli-quick
   import:               project-config
 
+  default-extensions:   NamedFieldPuns
+                        LambdaCase
+                        TypeFamilies
+
   hs-source-dirs:       app
+                        src-quick
   main-is:              locli-quick.hs
+
+  other-modules:        Cardano.Analysis.Reducer
+                        Cardano.Analysis.Reducer.Util
+                        Data.Reducer
+                        Graphics.EasyPlot
+
   ghc-options:          -threaded
                         -rtsopts
                         "-with-rtsopts=-T -N7 -A2m -c -H64m"
@@ -167,9 +186,11 @@ executable locli-quick
                       , aeson
                       , async
                       , bytestring
-                      , containers
                       , cardano-api
+                      , containers
+                      , directory
                       , extra
+                      , process
                       , split
                       , text
                       , text-short
@@ -180,6 +201,7 @@ executable locli-quick
 
 test-suite test-locli
   import:               project-config
+                      , extensions
 
   hs-source-dirs:       test
   main-is:              test-locli.hs

--- a/bench/locli/locli.cabal
+++ b/bench/locli/locli.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   locli
-version:                2.0
+version:                2.1
 synopsis:               Cardano log analysis CLI
 description:            Cardano log analysis CLI.
 category:               Cardano,
@@ -168,6 +168,7 @@ executable locli-quick
   default-extensions:   NamedFieldPuns
                         LambdaCase
                         TypeFamilies
+                        TypeOperators
 
   hs-source-dirs:       app
                         src-quick

--- a/bench/locli/src-quick/Cardano/Analysis/Reducer.hs
+++ b/bench/locli/src-quick/Cardano/Analysis/Reducer.hs
@@ -1,0 +1,72 @@
+
+module Cardano.Analysis.Reducer
+       (module Cardano.Analysis.Reducer)
+       where
+
+import           Cardano.Api (SlotNo)
+
+import           Cardano.Analysis.Reducer.Util
+import           Cardano.Unlog.LogObject (LOBody (..), LogObject (..))
+import           Cardano.Util
+
+import           Prelude hiding (log, seq)
+
+import           Data.Reducer
+import           Data.Word
+
+
+data TxsInMempool = TxsInMempoolPerSlot
+
+instance Reducer TxsInMempool where
+  type instance Elem   TxsInMempool = BySlot LogObject
+  type instance Accum  TxsInMempool = ([(SlotNo, Word64)], Word64)
+  type instance Result TxsInMempool = [(SlotNo, Word64)]
+
+  initialOf _ = ([], 0)
+
+  -- every slot (x-axis) contains one value on the y-axis (ideal for plotting a curve)
+  reducerOf _ (acc, currentTxns) (BySlot (slotNo, objs)) =
+    case safeLast objs of
+      [ LogObject{loBody = LOMempoolTxs txns} ]
+        -> ((slotNo, txns) : acc, txns)
+      _ -> ((slotNo, currentTxns) : acc, currentTxns)
+
+  resultOf _ = reverse . fst
+
+
+data ResourceMeasure = ResourceMeasurePerSlot
+
+instance Reducer ResourceMeasure where
+  type instance Elem   ResourceMeasure = BySlot Word64
+  type instance Accum  ResourceMeasure = [(SlotNo, Word64)]
+  type instance Result ResourceMeasure = [(SlotNo, Word64)]
+
+  initialOf _ = []
+
+  reducerOf _ acc (BySlot (slotNo, objs)) =
+    case safeLast objs of
+      [measurement] -> (slotNo, measurement) : acc
+      _             -> acc
+
+  resultOf _ = reverse
+
+
+data Silence = Silence {threshold :: NominalDiffTime, startTime :: UTCTime}
+
+instance Reducer Silence where
+  type instance Elem   Silence = (UTCTime, SMaybe SlotNo)
+  type instance Accum  Silence = ([(SlotNo, NominalDiffTime)], (UTCTime, SlotNo))
+  type instance Result Silence = [(SlotNo, NominalDiffTime)]
+
+  initialOf Silence{startTime} = ([], (startTime, 0))
+
+  reducerOf Silence{threshold} (acc, (lastHeard, slot)) (now, mSlot) =
+    (acc', (now, slot'))
+    where
+      slot'   = fromSMaybe slot mSlot
+      silence = now `diffUTCTime` lastHeard
+      acc'
+        | silence >= threshold  = (slot', silence) : acc
+        | otherwise             = acc
+
+  resultOf _ = reverse . fst

--- a/bench/locli/src-quick/Cardano/Analysis/Reducer/Util.hs
+++ b/bench/locli/src-quick/Cardano/Analysis/Reducer/Util.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Cardano.Analysis.Reducer.Util
+       (module Cardano.Analysis.Reducer.Util)
+       where
+
+import           Cardano.Api (SlotNo)
+
+import           Cardano.Unlog.LogObject (HostLogs (..), LOBody (..), LogObject (..), RunLogs (..))
+import           Cardano.Util (StrictMaybe (..))
+
+import           Data.List.Split (chop)
+import           Data.Maybe
+import           Data.Reducer
+
+
+newtype BySlot a = BySlot (SlotNo, [a])
+        deriving newtype Show
+
+bySlot :: (a -> Maybe SlotNo) -> (a -> b) -> Bool -> [a] -> [BySlot b]
+bySlot newSlot proj includeSeparator xs =
+  case dropWhile (isNothing . newSlot) xs of
+    [] -> []
+    ys -> chop go ys
+  where
+    go (lo:los) = let
+                    (inSlot_, rest) = span (isNothing . newSlot) los
+                    inSlot          = if includeSeparator then lo:inSlot_ else inSlot_
+                  in (BySlot (fromJust $ newSlot lo, map proj inSlot), rest)
+    go []       = error "bySlot/chop: empty list"
+
+bySlotLogObjects :: [LogObject] -> [BySlot LogObject]
+bySlotLogObjects =
+  bySlot
+    (\LogObject{loBody} -> case loBody of { LOTraceStartLeadershipCheck s _ _ -> Just s; _ -> Nothing })
+    id
+    True
+
+reduceHostLogs ::
+  ( Reducer r
+  , Foldable f
+  , Elem r ~ a
+  , Result r ~ b
+  ) => r -> HostLogs (f a) -> HostLogs b
+reduceHostLogs r HostLogs{hlLogs = (file, logs), ..} =
+  HostLogs{hlLogs = (file, reduce r logs), ..}
+
+reduceRunLogs ::
+  ( Reducer r
+  , Foldable f
+  , Elem r ~ a
+  , Result r ~ b
+  ) => r -> RunLogs (f a) -> RunLogs b
+reduceRunLogs r RunLogs{rlHostLogs = logs, ..} =
+  RunLogs{rlHostLogs = reduceHostLogs r <$> logs, ..}
+
+safeLast :: [a] -> [a]
+safeLast [] = []
+safeLast xs = [last xs]
+
+{-# INLINE unsafeFromSJust #-}
+unsafeFromSJust :: StrictMaybe a -> a
+unsafeFromSJust = \case
+  SJust a   -> a
+  SNothing  -> error "unsafeFromSJust: got SNothing"

--- a/bench/locli/src-quick/Data/Reducer.hs
+++ b/bench/locli/src-quick/Data/Reducer.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Data.Reducer (module Data.Reducer) where
+
+import           Data.Foldable
+import           Data.Function (on)
+import           Data.Kind (Type)
+import           Data.Maybe
+
+
+class Reducer r where
+  type family Elem  r   :: Type
+  type family Accum r   :: Type
+  type family Result r  :: Type
+
+  initialOf :: r -> Accum r
+  reducerOf :: r -> Accum r -> Elem r -> Accum r
+  resultOf  :: r -> Accum r -> Result r
+
+
+reduce :: (Foldable f, Reducer r) => r -> f (Elem r) -> Result r
+reduce r = resultOf r . foldl' (reducerOf r) (initialOf r)
+
+
+data Chain r1 r2 = Chain r1 r2
+
+instance  ( Foldable f2
+          , Reducer r1
+          , Reducer r2
+          , Result r1 ~ f2 (Elem r2)
+          ) => Reducer (Chain r1 r2) where
+
+  type instance Elem    (Chain r1 r2)  = Elem r1
+  type instance Accum   (Chain r1 r2)  = Accum r1
+  type instance Result  (Chain r1 r2)  = Result r2
+
+  initialOf (Chain r1 _)  = initialOf r1
+  reducerOf (Chain r1 _)  = reducerOf r1
+  resultOf  (Chain r1 r2) = reduce r2 . resultOf r1
+
+(<->) :: r1 -> r2 -> Chain r1 r2
+r1 <-> r2 = Chain r1 r2
+
+-- Explicitly chain reducers with a projection function that extracts a Foldable and
+-- an initial accumulator value from the first reducer's reult value
+chainWith ::
+  ( Foldable f1
+  , Foldable f2
+  , Reducer r1
+  , Reducer r2
+  )
+  => (Result r1 -> (Accum r2, f2 (Elem r2))) -> r1 -> r2 -> f1 (Elem r1) -> Result r2
+chainWith f r1 r2 =
+  resultOf r2 . uncurry (foldl' (reducerOf r2)) . f . reduce r1
+
+
+data HigherOrder a where
+  Threshold :: (a -> a -> Bool) -> HigherOrder a  -- a function that - given two data points - classifies them as passing a threshold, causing the reducer to emit a corresponding data point.
+  Scan      :: (a -> a -> a)    -> HigherOrder a  -- prefix sum
+
+instance Reducer (HigherOrder a) where
+  type instance Elem   (HigherOrder a)  = a
+  type instance Accum  (HigherOrder a)  = ([a], Maybe a)
+  type instance Result (HigherOrder a)  = [a]
+
+  initialOf _ = ([], Nothing)
+
+  reducerOf (Threshold f) = go where
+    -- still in intial state? always use the head of the original sequence as first data point
+    go ([], _) h            = ([h], Just h)
+    go (acc@(h:_), _) next
+      | f h next            = (next:acc, Just next)
+      | otherwise           = (acc, Just next)
+  reducerOf (Scan f) = go where
+    go (_, Nothing) h            = ([], Just h)
+    go (acc, Just current) next  = (f current next : acc, Just next)
+
+  resultOf Threshold{} accum = case accum of
+    -- there where no data points in the original sequence
+    ([], _)         -> []
+    -- always use the last data point of the original sequence
+    (acc, lastVal)  -> reverse $ maybeToList lastVal ++ acc
+  resultOf Scan{} acc = case fst acc of
+    [] -> []
+    xs -> reverse xs
+
+-- this extracts deltas from y[x[n]] to y[x[n-1]]; can be sensibly applied to a cumulative measurement like CPU ticks
+deltas :: Num y => HigherOrder (x, y)
+deltas = Scan $ \(_, y) (x', y') -> (x', y' - y)
+
+-- this derives a steps plot from a curve, emitting a data point whenever there's a change on the y-axis
+changes :: Eq y => HigherOrder (x, y)
+changes = Threshold ((/=) `on` snd)

--- a/bench/locli/src-quick/Data/Reducer.hs
+++ b/bench/locli/src-quick/Data/Reducer.hs
@@ -3,7 +3,7 @@
 
 module Data.Reducer (module Data.Reducer) where
 
-import           Data.Foldable
+import qualified Data.Foldable as F (foldl')
 import           Data.Function (on)
 import           Data.Kind (Type)
 import           Data.Maybe
@@ -11,8 +11,8 @@ import           Data.Maybe
 
 class Reducer r where
   type family Elem  r   :: Type
-  type family Accum r   :: Type
   type family Result r  :: Type
+  type family Accum r   :: Type
 
   initialOf :: r -> Accum r
   reducerOf :: r -> Accum r -> Elem r -> Accum r
@@ -20,7 +20,7 @@ class Reducer r where
 
 
 reduce :: (Foldable f, Reducer r) => r -> f (Elem r) -> Result r
-reduce r = resultOf r . foldl' (reducerOf r) (initialOf r)
+reduce r = resultOf r . F.foldl' (reducerOf r) (initialOf r)
 
 
 data Chain r1 r2 = Chain r1 r2
@@ -32,8 +32,8 @@ instance  ( Foldable f2
           ) => Reducer (Chain r1 r2) where
 
   type instance Elem    (Chain r1 r2)  = Elem r1
-  type instance Accum   (Chain r1 r2)  = Accum r1
   type instance Result  (Chain r1 r2)  = Result r2
+  type instance Accum   (Chain r1 r2)  = Accum r1
 
   initialOf (Chain r1 _)  = initialOf r1
   reducerOf (Chain r1 _)  = reducerOf r1
@@ -52,7 +52,7 @@ chainWith ::
   )
   => (Result r1 -> (Accum r2, f2 (Elem r2))) -> r1 -> r2 -> f1 (Elem r1) -> Result r2
 chainWith f r1 r2 =
-  resultOf r2 . uncurry (foldl' (reducerOf r2)) . f . reduce r1
+  resultOf r2 . uncurry (F.foldl' (reducerOf r2)) . f . reduce r1
 
 
 data HigherOrder a where
@@ -61,8 +61,8 @@ data HigherOrder a where
 
 instance Reducer (HigherOrder a) where
   type instance Elem   (HigherOrder a)  = a
-  type instance Accum  (HigherOrder a)  = ([a], Maybe a)
   type instance Result (HigherOrder a)  = [a]
+  type instance Accum  (HigherOrder a)  = (Result (HigherOrder a), Maybe a)
 
   initialOf _ = ([], Nothing)
 

--- a/bench/locli/src-quick/Graphics/EasyPlot.hs
+++ b/bench/locli/src-quick/Graphics/EasyPlot.hs
@@ -1,0 +1,509 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
+
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
+
+-- | A simple wrapper to the gnuplot command line utility.
+--
+-- Typically you will invoke a plot like so:
+--
+-- > plot X11 $ Data2D [Title "Sample Data"] [] [(1, 2), (2, 4), ...]
+--
+-- To plot a function, use the following:
+--
+-- > plot X11 $ Function2D [Title "Sine and Cosine"] [] (\x -> sin x * cos x)
+--
+-- There is also a shortcut available - the following plots the sine function:
+--
+-- > plot X11 sin
+--
+-- Output can go into a file, too (See 'TerminalType'):
+--
+-- > plot (PNG "plot.png") (sin . cos)
+--
+-- Haskell functions are plotted via a set of tuples obtained form the function.
+-- If you want to make use of gnuplots mighty function plotting functions you can
+-- pass a 'Gnuplot2D' or 'Gnuplot3D' object to plot.
+--
+-- > plot X11 $ Gnuplot2D [Color Blue] [] "2**cos(x)"
+--
+-- For 3D-Plots there is a shortcut available by directly passing a String:
+--
+-- > plot X11 "x*y"
+--
+-- Multiple graphs can be shown simply by passing a list of these:
+--
+-- > plot X11 [ Data2D [Title "Graph 1", Color Red] [] [(x, x ** 3) | x <- [-4,-3.9..4]]
+-- >          , Function2D [Title "Function 2", Color Blue] [] (\x -> negate $ x ** 2) ]
+--
+-- For 3D Graphs it is useful to be able to interact with the graph (See 'plot'' and 'GnuplotOption'):
+--
+-- > plot' [Interactive] (mkTerminal X11) $ Gnuplot3D [Color Magenta] [] "x ** 2 + y ** 3"
+--
+-- If you want to inspect the command and datafiles that are used to plot your graph,
+-- turn on debugging - intermediate files will be kept on disk:
+--
+-- > plot' [Debug] (mkTerminal X11) $ Gnuplot3D [Color Magenta] [] "x ** 4 + y ** 3"
+-- > > set term x11 persist; splot x ** 4 + y ** 3 lc rgb "magenta"
+module Graphics.EasyPlot (
+
+    -- * Plotting
+    Plot (plot, plot'),
+
+    -- * Graphs for 2D and 3D plots
+    Graph2D (..), Graph3D (..),
+
+    -- * Configuration and other options
+    Terminal(..), TerminalType (..),
+    defaultOsTerminal, mkTerminal,
+    Color (..), Style (..), Style2D (..),
+    Option (..), Option2D (..), Option3D (..),
+    GnuplotOption (..)
+
+    ) where
+
+import           Control.Monad
+import           Data.Bool (bool)
+import           Data.List (intercalate, nubBy, sortBy)
+import           Data.Maybe (fromMaybe)
+import           Data.Word (Word8)
+import           System.Directory (removeFile)
+import           System.Exit (ExitCode (ExitSuccess))
+import           System.Process (rawSystem)
+import           Text.Printf
+
+-- | TerminalType determines where the output of gnuplot should go.
+data TerminalType =
+    Aqua        -- ^ Output on Mac OS X (Aqua Terminal).
+  | Windows     -- ^ Output for MS Windows.
+  | X11         -- ^ Output to the X Window System.
+  | Dumb        -- ^ Output to text-based user interface.
+  | Qt          -- ^ Output to a Qt window (should be cross-platform)
+
+  | PS FilePath -- ^ Output into a Postscript file.
+  | EPS FilePath -- ^ Output into an EPS file.
+  | PNG FilePath -- ^ Output as Portable Network Graphic into file.
+  | PDF FilePath -- ^ Output as Portable Document Format into a file.
+  | SVG FilePath -- ^ Output as Scalable Vector Graphic into a file.
+  | GIF FilePath -- ^ Output as Graphics Interchange Format into a file.
+  | JPEG FilePath -- ^ Output into a JPEG file.
+  | Latex FilePath -- ^ Output as LaTeX.
+  | PNGCairo FilePath -- ^ Output as Portable Network Graphic into file, using Cairo as rendering backend.
+    deriving (Eq, Show)
+
+data Terminal = Terminal
+  { tType :: TerminalType      -- ^ the terminal type.
+  , tName :: String            -- ^ the terminal name; represents caption for window-based terminal types, output filename for file based ones.
+  , tSize :: Maybe (Int, Int)  -- ^ the terminal size, if other than the default is desired: pixels for pixel-based terminals and formats, inches for PDF, PS, EPS
+  }
+  deriving (Eq, Show)
+  -- TODO: Use fractional size type, for non-pixel based resolution specs?
+
+defaultOsTerminal :: TerminalType
+#if defined(linux_HOST_OS)
+defaultOsTerminal = X11
+#elif defined(mingw32_HOST_OS)
+defaultOsTerminal = Windows
+#elif defined(darwin_HOST_OS)
+defaultOsTerminal = Aqua
+#else
+defaultOsTerminal = Dumb
+#endif
+
+-- this is a little redundant, but keeps backwards compatibility
+mkTerminal :: TerminalType -> Terminal
+mkTerminal tt = Terminal tt defaultName Nothing
+ where
+  defaultName = case tt of
+    PS f          -> f
+    EPS f         -> f
+    PNG f         -> f
+    PDF f         -> f
+    SVG f         -> f
+    GIF f         -> f
+    JPEG f        -> f
+    Latex f       -> f
+    PNGCairo f    -> f
+    _             -> ""
+
+-- | The Style of a graph.
+data Style = Lines  -- ^ points in the plot are interconnected by lines.
+           | Points -- ^ data points are little cross symbols.
+           | Dots   -- ^ data points are real dots (approx the size of a pixel).
+           | Impulses
+           | Linespoints
+           | Steps
+
+-- | The Color of a graph.
+data Color = Red | Blue | Green | Yellow | Orange | Magenta | Cyan
+           | DarkRed | DarkBlue | DarkGreen | DarkYellow | DarkOrange | DarkMagenta | DarkCyan
+           | LightRed | LightBlue | LightGreen | LightMagenta
+           | Violet | White | Brown | Grey | DarkGrey | Black
+           | RGB Word8 Word8 Word8 -- ^ a custom color
+
+data Style2D = Boxerrorbars | Boxes | Boxyerrorbars
+             | Filledcurves | Financebars | Fsteps | Histeps | Histograms
+             | Steps2D | Xerrorbars | Xyerrorbars | Yerrorbars | Xerrorlines
+             | Xyerrorlines | Yerrorlines
+
+-- | Options on how to render a graph.
+data Option = Style Style   -- ^ The style for a graph.
+            | Title String  -- ^ The title for a graph in a plot (or a filename like @plot1.dat@).
+            | Color Color   -- ^ The line-color for the graph (or if it consist of 'Dots' or 'Points' the color of these)
+            | Width Int     -- ^ The line width for a graph.
+
+-- | Options which are exclusively available for 2D plots.
+data Option2D x y = Range x x -- ^ Plots the function for the specified x range
+                  | For [x]   -- ^ Plots the function only for the given x values
+                  | Step x    -- ^ Uses the given step-size for plotting along the x-axis
+
+-- | Options which are exclusively available for 3D plots.
+data Option3D x y z = RangeX x x -- ^ Plots the function for the specified x range
+                    | RangeY y y -- ^ Plots the function for the specified y range
+                    | ForX [x]   -- ^ Plots the function only for the given x values
+                    | ForY [y]   -- ^ Plots the function only for the given y values
+                    | StepX x    -- ^ Uses the given step-size for plotting along the x-axis
+                    | StepY y    -- ^ Uses the given step-size for plotting along the y-axis
+
+-- | A two dimensional set of data to plot.
+data Graph2D x y =
+      Function2D   [Option] [Option2D x y] (x -> y)
+      -- ^ plots a Haskell function @x -> y@
+
+    | Data2D       [Option] [Option2D x y] [(x, y)]
+      -- ^ plots a set of tuples.
+
+    | Gnuplot2D    [Option] [Option2D x y] String
+      -- ^ plots a custom function passed to Gnuplot (like @x**2 + 10@)
+
+    | File2D       [Option] [Option2D x y] FilePath (Maybe (Int, Int))
+      -- ^ plots data read from a file, optionally giving indices of which columns to plot as x and y
+
+-- | A three dimensional set of data to plot.
+data Graph3D x y z =
+      Function3D   [Option] [Option3D x y z] (x -> y -> z)
+      -- ^ plots a Haskell function @x -> y -> z@
+
+    | Data3D       [Option] [Option3D x y z] [(x, y, z)]
+      -- ^ plots a set of triples.
+
+    | Gnuplot3D    [Option] [Option3D x y z] String
+      -- ^ plots a custom function passed to Gnuplot (like @x*y@)
+
+    | File3D       [Option] [Option3D x y z] FilePath (Maybe (Int, Int, Int))
+      -- ^ plots data read from a file, optionally giving indices of which columns to plot as x, y and z
+
+-- | Options which can be used with 'plot''
+data GnuplotOption = Interactive -- ^ keeps gnuplot open, so that you can interact with the plot (only usefull with 'X11')
+                   | Debug       -- ^ keeps intermediate files used to invoke gnuplot, such as the script '_plot.p' and the datafiles '_plot*.dat'.
+    deriving Eq
+
+-- | Provides the plot function for different kinds of graphs (2D and 3D)
+class Plot a where
+
+    -- | Do a plot to the terminal (i.e. a window will open and your plot can be seen)
+    plot :: TerminalType -- ^ The terminal to be used for output.
+            -> a         -- ^ The graph to plot. A 'Graph2D' or 'Graph3D' or a list of these.
+            -> IO Bool   -- ^ Whether the plot was successful or not.
+
+    plot = plot' [] . mkTerminal
+
+    plot' :: [GnuplotOption]
+            -> Terminal
+            -> a
+            -> IO Bool
+
+-- | 'plot' can be used to plot a single 'Graph2D'.
+instance (Fractional x, Enum x, Show x, Num y, Show y) => Plot (Graph2D x y) where
+    plot' options term graph = plot' options term [graph]
+
+-- | 'plot' can be used to plot a list of 'Graph2D'.
+instance (Fractional x, Enum x, Show x, Num y, Show y) => Plot [Graph2D x y] where
+    plot' options term graphs = exec options term "plot" options' datasources
+        where   (options', datasources) = unzip $ map prepare graphs
+                prepare (Gnuplot2D  opt _opt2d g) = (opts $ sanitize opt, DataExpression g)
+                prepare (Data2D     opt _opt2d d) = (opts $ sanitize opt, DataRendered $ toString d)
+                prepare (Function2D opt opt2d f) = (opt', DataRendered plotData)
+                    where   (opt', plotData) = render2D opt opt2d f
+                prepare (File2D     opt _opt2d f ixs) = (opts $ sanitize opt, DataFile f ixs')
+                    where   ixs' = maybe [] (\(ix1, ix2) -> [ix1, ix2]) ixs
+
+-- | 'plot' can be used to plot a single 'Graph3D'.
+instance (Fractional x, Enum x, Show x, Fractional y, Enum y, Show y, Num z, Show z) => Plot (Graph3D x y z) where
+    plot' options term graph = plot' options term [graph]
+
+-- | 'plot' can be used to plot a list of 'Graph3D'
+instance (Fractional x, Enum x, Show x, Fractional y, Enum y, Show y, Num z, Show z) => Plot [Graph3D x y z] where
+    plot' options term graphs = exec options term "splot" options' datasources
+        where   (options', datasources) = unzip $ map prepare graphs
+                prepare (Gnuplot3D  opt _opt3d g) = (opts $ sanitize opt, DataExpression g)
+                prepare (Data3D     opt _opt3d d) = (opts $ sanitize opt, DataRendered $ toString d)
+                prepare (Function3D opt opt3d f) = (opt', DataRendered plotData)
+                    where   (opt', plotData) = render3D opt opt3d f
+                prepare (File3D     opt _opt3d f ixs) = (opts $ sanitize opt, DataFile f ixs')
+                    where   ixs' = maybe [] (\(ix1, ix2, ix3) -> [ix1, ix2, ix3]) ixs
+
+-- | A 2D function can be plotted directly using 'plot'
+instance {-# OVERLAPPABLE #-} (Fractional x, Enum x, Show x, Num y, Show y) => Plot (x -> y) where
+    plot' options term f = plot' options term $ Function2D [] [] f
+
+-- | A list of 2D functions can be plotted directly using 'plot'
+instance {-# OVERLAPPABLE #-} (Fractional x, Enum x, Show x, Num y, Show y) => Plot [x -> y] where
+    plot' options term fs = plot' options term $ map (Function2D [] []) fs
+
+-- | A 3D function can be plotted directly using 'plot'
+instance (Fractional x, Enum x, Show x, Fractional y, Enum y, Show y, Num z, Show z) => Plot (x -> y -> z) where
+    plot' options term f = plot' options term $ Function3D [] [] f
+
+-- | A list of 3D functions can be plotted directly using 'plot'
+instance (Fractional x, Enum x, Show x, Fractional y, Enum y, Show y, Num z, Show z) => Plot [x -> y -> z] where
+    plot' options term fs = plot' options term $ map (Function3D [] []) fs
+
+-- | A list of tuples can be plotted directly using 'plot'
+instance (Fractional x, Enum x, Num x, Show x, Num y, Show y) => Plot [(x, y)] where
+    plot' options term d = plot' options term $ Data2D [] [] d
+
+-- | A list of triples can be plotted directly using 'plot'
+instance (Fractional x, Enum x, Show x, Fractional y, Enum y, Show y, Num z, Show z) => Plot [(x, y, z)] where
+    plot' options term d = plot' options term $ Data3D [] [] d
+
+-- | plot accepts a custom string which is then to be interpreted by gnu plot.
+--   The function will be interpreted as 'Gnuplot3D'.
+instance Plot String where
+    plot' options term g = plot' @(Graph3D Double Double Int) options term $ Gnuplot3D [] [] g
+
+-- | plots mutliple 3D functions using gnuplots native function parser
+--   and renderer. The String will be interpreted as 'Gnuplot3D'.
+instance Plot [String] where
+    plot' options term g = plot' @[Graph3D Double Double Int] options term $ map (Gnuplot3D [] []) g
+
+-- | INTERNAL: Prepares 2D plots of haskell functions.
+render2D :: (Num a, Show a, Fractional x, Show x, Enum x) =>
+                [Option] -> [Option2D x y] -> (x -> a) -> ([Char], String)
+render2D opt opt2d f = (opts $ sanitize (opt ++ [Style Lines]), plot2D f)
+    where   plot2D g = toString [(x, g x) | x <- fromMaybe [x1,sx..x2] $ for opt2d]
+
+            (x1, x2) = range opt2d
+            sx       = x1 + step opt2d
+
+-- | INTERNAL: Prepares 3D plots of haskell functions.
+render3D :: (Num a, Show a, Fractional x, Fractional y, Enum y,
+              Enum x, Show x, Show y) =>
+                [Option] -> [Option3D x y z] -> (x -> y -> a) -> ([Char], String)
+render3D opt opt3d f = (opts $ sanitize opt, plot3D f)
+    where   plot3D g = toString [(x, y, g x y) | x <- xs, y <- ys]
+
+            xs = fromMaybe [x1,sx..x2] $ forX opt3d
+            ys = fromMaybe [y1,sy..y2] $ forY opt3d
+
+            ((x1, x2), (y1, y2)) = (rangeX opt3d, rangeY opt3d)
+            (sx, sy) = (x1 + stepX opt3d, y1 + stepY opt3d)
+
+for :: [Option2D x y] -> Maybe [x]
+for []             = Nothing
+for ((For xs) : _) = Just xs
+for (_ : xs)       = for xs
+
+range :: Num x => [Option2D x y] -> (x, x)
+range []                  = (-5, 5)
+range ((Range x1 x2) : _) = (x1, x2)
+range (_ : xs)            = range xs
+
+step :: Fractional x => [Option2D x y] -> x
+step []             = 0.05
+step ((Step x) : _) = x
+step (_ : xs)       = step xs
+
+forX :: [Option3D x y z] -> Maybe [x]
+forX []              = Nothing
+forX ((ForX xs) : _) = Just xs
+forX (_ : xs)        = forX xs
+
+forY :: [Option3D x y z] -> Maybe [y]
+forY []              = Nothing
+forY ((ForY ys) : _) = Just ys
+forY (_ : ys)        = forY ys
+
+rangeX :: Num x => [Option3D x y z] -> (x, x)
+rangeX []                   = (-5, 5)
+rangeX ((RangeX x1 x2) : _) = (x1, x2)
+rangeX (_ : xs)             = rangeX xs
+
+rangeY :: Num y => [Option3D x y z] -> (y, y)
+rangeY []                   = (-5, 5)
+rangeY ((RangeY y1 y2) : _) = (y1, y2)
+rangeY (_ : ys)             = rangeY ys
+
+stepX :: Fractional x => [Option3D x y z] -> x
+stepX []              = 0.1
+stepX ((StepX x) : _) = x
+stepX (_ : xs)        = stepX xs
+
+stepY :: Fractional y => [Option3D x y z] -> y
+stepY []              = 0.1
+stepY ((StepY y) : _) = y
+stepY (_ : ys)        = stepY ys
+
+-- | INTERNAL: Sanitizes options given via Graph-Objects
+sanitize :: [Option] -> [Option]
+sanitize = sortBy ord . nubBy dup
+    where   ord a b
+                | dup a b   = EQ
+                | otherwise = ord' a b
+            ord' (Style _) (Title _) = LT
+            ord' (Style _) (Color _) = LT
+            ord' (Color _) (Title _) = GT
+            ord' a b
+                | ord' b a == LT = GT
+                | otherwise      = LT
+            dup (Title _) (Title _) = True
+            dup (Style _) (Style _) = True
+            dup (Color _) (Color _) = True
+            dup _ _                 = False
+
+-- | INTERNAL: Translates options into gnuplot commands
+opts :: GnuplotIdiom a => [a] -> [Char]
+opts []     = ""
+opts [x]    = toString x
+opts (x:xs) = toString x ++ " " ++ opts xs
+
+-- | INTERNAL: Guarded values
+infix 7 |?
+(|?) :: Monoid m => m -> Bool -> m
+(|?) = bool mempty
+{-# INLINE (|?) #-}
+
+data DataSource =
+    DataRendered String        -- ^ data rendered by a GnuplotIdiom instance, e.g. "2 0 3\n1 1 2"
+  | DataExpression String      -- ^ expression passed verbatim to gnuplot, such as "sin(x) + cos(y)"
+  | DataFile FilePath [Int]    -- ^ datafile and a (possibly empty) list of indices for a 'using x:y' modifier
+
+writeDataSource :: (DataSource, FilePath) -> IO DataSource
+writeDataSource = \case
+  (DataRendered s, f) -> writeFile f s >> pure (DataRendered f)
+  (s, _)              -> pure s
+
+asPlotCmd :: DataSource -> String
+asPlotCmd = \case
+  DataRendered f   -> quoted f
+  DataExpression e -> e
+  DataFile f ixs   -> quoted f ++ (" using " ++ intercalate ":" (map show ixs)) |? (not . null) ixs
+
+-- | INTERNAL: Invokes gnuplot.
+exec :: [GnuplotOption] -> Terminal -> String -> [String] -> [DataSource] -> IO Bool
+exec options term@Terminal{..} plotfunc plotops datasets = do
+  -- in case of DataRendered, this replaces the data with the name of its intermediate file, for later removal
+  datasources <- mapM writeDataSource $ zip datasets fileNames
+
+  let
+    plotcmds = [ asPlotCmd source ++ " " ++ popts | (source, popts) <- zip datasources plotops ]
+    plotstmt = foldl1  (\x y -> x ++ ", " ++ y) plotcmds
+    plotcmd  = foldl1  (\x y -> x ++ "; " ++ y)
+                    (preamble ++ [plotfunc ++ " " ++ plotstmt])
+
+    args = cliArgs ++ ["-e", plotcmd] ++ ["-" | Interactive `elem` options]
+
+  when (Debug `elem` options) $
+    writeFile "_plot.p" plotcmd
+
+  exitCode <- rawSystem "gnuplot" args
+
+  unless (Debug `elem` options) $
+    mapM_ removeFile [ f | DataRendered f <- datasources ]
+
+  return $ exitCode == ExitSuccess
+  where
+    preamble  = [ toString term ]
+    fileNames = [ "_plot" ++ show ix ++ ".dat" | ix <- [1 :: Int ..] ]
+    -- additional CLI options that may be terminal-specific
+    cliArgs
+      | tType == Windows                    = [ "-persist" ]
+      | otherwise                           = []
+
+-- | INTERNAL: Provides 'toString' for translating Haskell values into gnuplot commands
+--   (ordinary strings)
+class GnuplotIdiom a where
+    toString :: a -> String
+
+instance (Num x, Show x, Num y, Show y) => GnuplotIdiom (x, y) where
+    toString (x, y) = space $ shows x $ space $ show y
+
+instance (Num x, Show x, Num y, Show y, Num z, Show z) => GnuplotIdiom (x, y, z) where
+    toString (x, y, z) = space $ shows x $ space $ shows y $ space $ show z
+
+quoted, space :: String -> String
+quoted s = "\"" ++ s ++ "\""
+space x  = ' ' : x
+
+instance GnuplotIdiom Style where
+    toString x = case x of
+        Lines       -> "with lines"
+        Points      -> "with points"
+        Dots        -> "with dots"
+        Impulses    -> "with impulses"
+        Linespoints -> "with linespoints"
+        Steps       -> "with steps"
+
+
+instance GnuplotIdiom Option where
+    toString x = case x of
+        Title t -> "title \"" ++ t ++ "\""
+        Style s -> toString s
+        Color c -> "lc rgb \"" ++ toString c ++ "\""
+        Width w -> "lw " ++ show w
+
+instance GnuplotIdiom x => GnuplotIdiom [x] where
+    toString = unlines . map toString
+
+instance GnuplotIdiom Terminal where
+  toString Terminal{..} = case tType of
+    PNG{}       -> "set term png" ++ size ',' ++ output
+    PDF{}       -> "set term pdf enhanced" ++ size ',' ++ output
+    SVG{}       -> "set term svg dynamic" ++ size ',' ++ output
+    GIF{}       -> "set term gif" ++ size ',' ++ output
+    JPEG{}      -> "set term jpeg" ++ size ',' ++ output
+    Latex{}     -> "set term latex" ++ output
+    EPS{}       -> "set term postscript eps" ++ size ',' ++ output
+    PS{}        -> "set term postscript" ++ size ',' ++ output
+    Aqua        -> "set term aqua" ++ title ++ size ' '
+    Windows     -> "set term windows" ++ title ++ size ','
+    X11         -> "set term x11 persist" ++ title ++ size ','
+    Qt          -> "set term qt persist" ++ title ++ size ','
+    PNGCairo{}  -> "set term pngcairo" ++ size ',' ++ output
+    Dumb        -> "set term dumb feed" ++ size ','
+    where
+      title  = " title " ++ quoted tName |? (not . null) tName
+      output = "; set output " ++ quoted tName
+      -- different terminal types have different ways of specifying size
+      size c   = maybe "" (\(x, y) -> concat [" size ", show x, [c], show y]) tSize
+
+instance GnuplotIdiom Color where
+  toString = \case
+    Red          -> "red"
+    Blue         -> "blue"
+    Green        -> "green"
+    Yellow       -> "yellow"
+    Orange       -> "orange"
+    Magenta      -> "magenta"
+    Cyan         -> "cyan"
+    DarkRed      -> "dark-red"
+    DarkBlue     -> "dark-blue"
+    DarkGreen    -> "dark-green"
+    DarkYellow   -> "dark-yellow"
+    DarkOrange   -> "dark-orange"
+    DarkMagenta  -> "dark-magenta"
+    DarkCyan     -> "dark-cyan"
+    LightRed     -> "light-red"
+    LightBlue    -> "light-blue"
+    LightGreen   -> "light-green"
+    LightMagenta -> "light-magenta"
+    Violet       -> "violet"
+    Grey         -> "grey"
+    White        -> "white"
+    Brown        -> "brown"
+    DarkGrey     -> "dark-grey"
+    Black        -> "black"
+    RGB r g b    -> printf "#%02X%02X%02X" r g b

--- a/bench/locli/src/Cardano/Unlog/BackendDB.hs
+++ b/bench/locli/src/Cardano/Unlog/BackendDB.hs
@@ -2,6 +2,9 @@
 module Cardano.Unlog.BackendDB
        ( prepareDB
        , runLiftLogObjectsDB
+       , LoadFromDB(..)
+       , LoadLogObjects(..)
+       , LoadSummaryOnly(..)
 
        -- specific SQLite queries or statements
        , getSummary
@@ -14,7 +17,7 @@ module Cardano.Unlog.BackendDB
        ) where
 
 import           Cardano.Analysis.API.Ground (Host (..), LogObjectSource (..))
-import           Cardano.Prelude (ExceptT, Text)
+import           Cardano.Prelude (ExceptT)
 import           Cardano.Unlog.LogObject (HostLogs (..), LogObject (..), RunLogs (..), fromTextRef)
 import           Cardano.Unlog.LogObjectDB
 import           Cardano.Util (sequenceConcurrentlyChunksOf, withTimingInfo)
@@ -25,6 +28,7 @@ import           Control.Exception (SomeException (..), catch)
 import           Control.Monad
 import           Data.Aeson as Aeson (decode, eitherDecode)
 import qualified Data.ByteString.Lazy.Char8 as BSL
+import           Data.Kind (Type)
 import           Data.List (sort)
 import qualified Data.Map.Lazy as ML
 import qualified Data.Map.Strict as Map
@@ -37,22 +41,64 @@ import           System.Directory (removeFile)
 import           Database.Sqlite.Easy hiding (Text)
 
 
-runLiftLogObjectsDB :: RunLogs () -> ExceptT Text IO (RunLogs [LogObject])
-runLiftLogObjectsDB RunLogs{rlHostLogs, ..} = liftIO $ do
+class LoadFromDB l where
+  type family LoadResult l :: Type
+
+  loadQuery       :: l -> Maybe SQL
+
+  loadConvert     :: l -> SummaryDB -> [SQLData] -> LoadResult l
+
+  loadTraceFreqs  :: l -> Bool
+  loadTraceFreqs  = const False
+
+  loadTimingInfo  :: l -> Bool
+  loadTimingInfo  = const False
+
+data LoadLogObjects =
+    LoadLogObjectsAll
+  | LoadLogObjectsWith [SQLSelect6Cols]
+  | LoadTraceFreqsOnly
+  deriving (Eq, Show)
+
+data LoadSummaryOnly =
+    LoadSummaryOnly
+
+instance LoadFromDB LoadLogObjects where
+  type instance LoadResult LoadLogObjects = LogObject
+
+  loadTraceFreqs = \case {LoadLogObjectsWith{} -> False; _ -> True}
+  loadQuery = \case
+    LoadLogObjectsAll          -> Just selectAll
+    LoadLogObjectsWith selects -> Just $ sqlOrdered selects
+    LoadTraceFreqsOnly         -> Nothing
+  loadConvert    = const sqlToLogObject
+  loadTimingInfo = (== LoadLogObjectsAll)
+
+instance LoadFromDB LoadSummaryOnly where
+  type instance LoadResult LoadSummaryOnly = SummaryDB
+
+  loadQuery = const $ Just "SELECT null"
+  loadConvert _ summary _ = summary
+
+
+runLiftLogObjectsDB :: LoadFromDB l => l -> RunLogs a -> ExceptT String IO (RunLogs [LoadResult l])
+runLiftLogObjectsDB loadMode RunLogs{rlHostLogs, ..} = liftIO $ do
   hostLogs' <- Map.fromList
     <$> sequenceConcurrentlyChunksOf numCapabilities loadActions
-  pure $ RunLogs{ rlHostLogs = hostLogs', ..}
+  pure $ RunLogs{rlHostLogs = hostLogs', ..}
   where
     loadActions = map load (Map.toList rlHostLogs)
+    timingInfo h
+      | loadTimingInfo loadMode = withTimingInfo ("loadHostLogsDB/" ++ ShortText.unpack h)
+      | otherwise               = id
 
-    load (host@(Host h), hl) =
-      withTimingInfo ("loadHostLogsDB/" ++ ShortText.unpack h) $
-        (,) host <$> loadHostLogsDB hl
+    load (host@(Host h), hl) = timingInfo h $
+      (,) host <$> loadHostLogsDB loadMode hl
 
 -- If the logs have been split up into multiple files, e.g. by a log rotator,
 -- this assumes sorting log files by *name* results in chronological order
 -- of all *trace messages* contained in them.
-prepareDB :: String -> [FilePath] -> FilePath -> ExceptT Text IO ()
+prepareDB :: String -> [FilePath] -> FilePath -> ExceptT String IO ()
 prepareDB machName (sort -> logFiles) outFile = liftIO $ do
 
   removeFile outFile `catch` \SomeException{} -> pure ()
@@ -136,20 +182,25 @@ getTraceFreqs =
   ML.fromList . map fromSqlDataPair
     <$> run "SELECT * FROM tracefreq"
 
-loadHostLogsDB :: HostLogs a -> IO (HostLogs [LogObject])
-loadHostLogsDB hl =
-  case fst $ hlLogs hl of
+loadHostLogsDB :: LoadFromDB l => l -> HostLogs a -> IO (HostLogs [LoadResult l])
+loadHostLogsDB loadMode HostLogs{..} =
+  case fst hlLogs of
     log@(LogObjectSourceSQLite dbFile) ->
       withDb (fromString dbFile) $ do
         summary@SummaryDB{..} <- getSummary
-        traceFreqs            <- getTraceFreqs
-        rows                  <- run selectAll
+        traceFreqs            <- if loadTraceFreqs loadMode
+                                   then getTraceFreqs
+                                   else pure hlRawTraceFreqs
+        rows                  <- maybe (pure []) run (loadQuery loadMode)
 
-        pure $ hl
-          { hlRawTraceFreqs = traceFreqs
-          , hlRawFirstAt    = Just sdbFirstAt
-          , hlRawLastAt     = Just sdbLastAt
-          , hlRawLines      = sdbLines
-          , hlLogs          = (log, map (sqlToLogObject summary) rows)
+        let rows'             = map (loadConvert loadMode summary) rows
+
+        pure $ HostLogs
+          { hlRawTraceFreqs   = traceFreqs
+          , hlRawFirstAt      = Just sdbFirstAt
+          , hlRawLastAt       = Just sdbLastAt
+          , hlRawLines        = sdbLines
+          , hlLogs            = (log, rows')
+          , ..
           }
     other -> error $ "loadHostLogsDB: expected SQLite DB file, got " ++ show other

--- a/bench/locli/src/Cardano/Unlog/BackendFile.hs
+++ b/bench/locli/src/Cardano/Unlog/BackendFile.hs
@@ -16,8 +16,14 @@ import qualified Data.Text.Short as Text
 import           GHC.Conc (numCapabilities)
 
 
+readRunLogsBare :: JsonInputFile a -> ExceptT String IO (RunLogs ())
+readRunLogsBare rlf =
+  AE.eitherDecode
+    <$> LBS.readFile (unJsonInputFile rlf)
+        & newExceptT
+
 runLiftLogObjects :: RunLogs () -> Bool -> Maybe [LOAnyType]
-                  -> ExceptT TS.Text IO (RunLogs [LogObject])
+                  -> ExceptT String IO (RunLogs [LogObject])
 runLiftLogObjects rl@RunLogs{..} okDErr loAnyLimit = liftIO $
  go Map.empty 0 simultaneousReads
  where

--- a/bench/locli/src/Cardano/Unlog/LogObjectDB.hs
+++ b/bench/locli/src/Cardano/Unlog/LogObjectDB.hs
@@ -189,10 +189,12 @@ logObjectToSql :: LogObject -> Maybe SQLRunnable
 logObjectToSql lo@LogObject{loAt, loBody, loTid} =
   case loBody of
 
-    -- no suitable interpreter found when parsing log object stream
-    LOAny{}                       -> Nothing
     -- trace not emitted by the node
     LOGeneratorSummary{}          -> Nothing
+
+    -- no suitable interpreter found when parsing log object stream
+    LOAny{}                       -> Nothing
+
     -- not required for analysis
     LOTxsAcked{}                  -> Nothing
 

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -747,9 +747,8 @@ updateBlockForging startupTracer blockType nodeKernel nc = do
         Just Refl -> do
           -- TODO: check if runP' has changed
           blockForging <- snd (Api.protocolInfo runP')
-          let isNonProducing = ncStartAsNonProducingNode nc
           traceWith startupTracer
-                    (BlockForgingUpdate (if isNonProducing || null blockForging
+                    (BlockForgingUpdate (if null blockForging
                                           then DisabledBlockForging
                                           else EnabledBlockForging))
           setBlockForging nodeKernel blockForging

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
@@ -411,7 +411,7 @@ instance MetaTrace  (StartupTrace blk) where
   documentFor _ns = Nothing
 
   metricsDocFor (Namespace _ ["BlockForgingUpdate"]) =
-    [("forging_enabled","Can this node forge blocks? (Is it provided with block forging credentials) 0 = no, 1 = yes")]
+    [("forging_enabled","A node without forger credentials or started as non-producing has forging disabled.")]
   metricsDocFor (Namespace _ ["Common"]) =
     [("systemStartTime","The UTC time this node was started."),
      ("node.start.time","The UTC time this node was started represented in POSIX seconds.")]

--- a/cardano-tracer/configuration/metrics_help.json
+++ b/cardano-tracer/configuration/metrics_help.json
@@ -26,7 +26,7 @@
   "connectedPeers": "Number of connected peers",
   "density": "The actual number of blocks created over the maximum expected number of blocks that could be created over the span of the last @k@ blocks.",
   "epoch": "In which epoch is the tip of the current chain.",
-  "forging_enabled": "Can this node forge blocks? (Is it provided with block forging credentials) 0 = no, 1 = yes",
+  "forging_enabled": "A node without forger credentials or started as non-producing has forging disabled.",
   "forks": "counter for forks",
   "haskell_compiler_major": "Cardano compiler version information",
   "haskell_compiler_minor": "Cardano compiler version information",

--- a/nix/workbench/analyse/analyse.sh
+++ b/nix/workbench/analyse/analyse.sh
@@ -101,7 +101,7 @@ fi
 
 if test -v "WB_LOCLI_DB"
 then storage=$WB_LOCLI_DB
-else storage=0
+else storage=1
 fi
 if [[ $storage -eq 1 ]]
 then info analyse "$(red locli storage backend: database)"

--- a/nix/workbench/analyse/analyse.sh
+++ b/nix/workbench/analyse/analyse.sh
@@ -243,7 +243,7 @@ EOF
         local script=(
             hash-timeline
             logs               $(test -n "$dump_logobjects" && echo 'dump-logobjects')
-            read-context
+            read-context       $(test $storage -eq 1 && echo 'dump-tracefreqs')      # with DB storage backend, *.tracefreq.json isn't created with jq, needs to be dumped in an extra step
 
             build-mach-views   $(test -n "$dump_machviews"  && echo 'dump-mach-views')
             rebuild-chain

--- a/nix/workbench/run.sh
+++ b/nix/workbench/run.sh
@@ -698,7 +698,7 @@ EOF
            then fail "fetch-analysis:  run has not been analysed on remote: $(white $run)"
            else local analysis_files=(
                    $(ssh $env -- \
-                     sh -c "'cd $depl/$dir/$run && ls analysis/{cdf/*.cdf,*.{json,org,txt}} | fgrep -v -e flt.json -e flt.logobjs.json -e flt.perf-stats.json'" \
+                     sh -c "'cd $depl/$dir/$run && ls analysis/{cdf/*.cdf,*.{json,org,txt}} | fgrep -v -e flt.json -e logobjs.json -e perf-stats.json -e mach-views.json'" \
                      2>/dev/null)
                 )
                 local args=(
@@ -902,11 +902,11 @@ run_remote_get() {
     jq . <<<$meta > $dir/meta.json
 
     local common_run_files=(
-        genesis-alonzo.json
+        genesis.alonzo.json
         genesis-shelley.json
-        machines.json
-        network-latency-matrix.json
         profile.json
+        generator/protocol-parameters-queried.json
+        generator/plutus-budget-summary.json
     )
     local xs0=(${objects[*]})
     local xs1=(${xs0[*]/#all-hosts/        $(jq -r '.hostname | keys | .[]' <<<$meta)})

--- a/nix/workbench/shell.nix
+++ b/nix/workbench/shell.nix
@@ -40,7 +40,7 @@ in project.shellFor {
     export WB_CREATE_TESTNET_DATA=''${WB_CREATE_TESTNET_DATA:-1}
     export WB_DEPLOYMENT_NAME=''${WB_DEPLOYMENT_NAME:-$(basename $(pwd))}
     export WB_MODULAR_GENESIS=''${WB_MODULAR_GENESIS:-0}
-    export WB_LOCLI_DB=''${WB_LOCLI_DB:-0}
+    export WB_LOCLI_DB=''${WB_LOCLI_DB:-1}
     export WB_SHELL_PROFILE=${profileName}
     export WB_SHELL_PROFILE_DATA=${profileData}
 

--- a/nix/workbench/wb
+++ b/nix/workbench/wb
@@ -13,8 +13,8 @@ global_basedir=${global_basedir:-$(realpath "$(dirname "$0")")}
 # For genesis creating, create-testnet-data is the default CLI command; set to 0 to fall back to create-staked
 : "${WB_CREATE_TESTNET_DATA:=1}"
 
-# By default, do not enable the new (experimental) databse storage backend for `locli`
-: "${WB_LOCLI_DB:=0}"
+# By default, enable the new database storage backend for `locli`
+: "${WB_LOCLI_DB:=1}"
 
 . "$global_basedir"/lib.sh
 . "$global_basedir"/env.sh
@@ -195,7 +195,7 @@ start() {
         --analysis-can-fail | -af )      analysis_can_fail=t;;
         --dump-logobjects )              analyse_args+=($1);;
         --filters )                      analyse_args+=($1 $2); shift;;
-        --locli-db )                     export WB_LOCLI_DB=1;;
+        --locli-file )                   export WB_LOCLI_DB=0;;         # use the legacy file backend of `locli`
 
         ## Aux
         --verbose | -v )                 export verbose=t;;

--- a/trace-dispatcher/test/Cardano/Logging/Test/Unit/Aggregation.hs
+++ b/trace-dispatcher/test/Cardano/Logging/Test/Unit/Aggregation.hs
@@ -46,8 +46,8 @@ instance MetaTrace BaseStats where
   privacyFor  (Namespace _ ["BaseStats"]) _ = Just Public
   documentFor (Namespace _ ["BaseStats"]) = Just "Basic statistics"
   metricsDocFor (Namespace _ ["BaseStats"]) =
-    [ ("measure", "This is the value of a single measurment")
-    , ("sum", "This is the sum of all measurments")]
+    [ ("measure", "This is the value of a single measurement")
+    , ("sum", "This is the sum of all measurements")]
   allNamespaces = [Namespace [] ["BaseStats"]]
 
 emptyStats :: BaseStats

--- a/trace-forward/src/Trace/Forward/Protocol/DataPoint/Type.hs
+++ b/trace-forward/src/Trace/Forward/Protocol/DataPoint/Type.hs
@@ -49,7 +49,7 @@ data DataPointForward where
 
   -- | Both acceptor and forwarder are in idle state. The acceptor can send a
   -- request  for a list of 'DataPoint's ('MsgDataPointsRequest');
-  -- the forwarder is waiting for a request, it will replay with 'MsgDataPointsReply'.
+  -- the forwarder is waiting for a request, it will reply with 'MsgDataPointsReply'.
   StIdle :: DataPointForward
 
   -- | The acceptor has sent a next request for 'DataPoint's. The acceptor is


### PR DESCRIPTION
# Description

This PR contains various fixes and updates from P&T:
* fixes an incosistency in the node's `forging_enabled` metric (#6113)
* sets the DB storage backend for `locli` as default
* implements the groundwork for DB-backed analysis quick-queries (experimental) - thank you @fmaste for the design
* adds plotting capabalities to `locli` (experimental) by introducing a heavily modded fork of `easyplot-1.0`
* updates the `fetch-analysis` command by removing old `cardano-ops` specific files and adding protocol parameters and Plutus calibration summary by `tx-generator`.
* fixes typos -- thank you @mtullsen

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff