### PR TITLE
Eliminate `cardano-node` dependency from `cardano-tracer`

### DIFF
--- a/bench/tx-generator/src/Cardano/Benchmarking/Tracer.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Tracer.hs
@@ -33,6 +33,7 @@ import           Cardano.Benchmarking.Types
 import           Cardano.Benchmarking.Version as Version
 import           Cardano.Logging
 import           Cardano.Node.Startup
+import           Cardano.Node.Tracing.NodeInfo () -- MetaTrace NodeInfo
 import           Ouroboros.Network.IOManager (IOManager)
 
 import           Control.Monad (forM, guard)

--- a/cabal.project
+++ b/cabal.project
@@ -60,6 +60,7 @@ package plutus-scripts-bench
 allow-newer:
   , katip:Win32
   , ekg-wai:time
+  , data-default
 
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly

--- a/cabal.project
+++ b/cabal.project
@@ -60,7 +60,6 @@ package plutus-scripts-bench
 allow-newer:
   , katip:Win32
   , ekg-wai:time
-  , data-default
 
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly

--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -2,6 +2,10 @@
 
 ## Next version
 
+- Removed `cardano-node' as a dependency from `cardano-tracer'. This necessitated moving `NodeInfo` from
+  `cardano-tracer:Cardano.Node.Startup`to `trace-dispatcher:Cardano.Logging.Types.NodeInfo`, and `NodePeers` from
+  `cardano-node:Cardano.Node.Tracing.Peers` to `trace-dispatcher:Cardano.Logging.Types.NodePeers`.
+
 - Add a new configuration field for fork-policy.
 
 - Optionally support lightweight checkpointing.

--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -2,9 +2,10 @@
 
 ## Next version
 
-- Removed `cardano-node' as a dependency from `cardano-tracer'. This necessitated moving `NodeInfo` from
-  `cardano-tracer:Cardano.Node.Startup`to `trace-dispatcher:Cardano.Logging.Types.NodeInfo`, and `NodePeers` from
-  `cardano-node:Cardano.Node.Tracing.Peers` to `trace-dispatcher:Cardano.Logging.Types.NodePeers`.
+* Removed `cardano-node' as a dependency from `cardano-tracer'. This necessitated moving `NodeInfo`
+  (from `cardano-tracer:Cardano.Node.Startup` to `trace-dispatcher:Cardano.Logging.Types.NodeInfo`), `NodePeers`
+  (from `cardano-node:Cardano.Node.Tracing.Peers` to `trace-dispatcher:Cardano.Logging.Types.NodePeers`), and
+  `NodeStartupInfo` (from `cardano-tracer:Cardano.Node.Startup` to `cardano-node:Cardano.Node.Tracing.NodeStartupInfo.hs`).
 
 - Add a new configuration field for fork-policy.
 

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -94,14 +94,16 @@ library
                         Cardano.Node.TraceConstraints
                         Cardano.Node.Tracing
                         Cardano.Node.Tracing.API
-                        Cardano.Node.Tracing.Consistency
                         Cardano.Node.Tracing.Compat
+                        Cardano.Node.Tracing.Consistency
                         Cardano.Node.Tracing.DefaultTraceConfig
                         Cardano.Node.Tracing.Documentation
                         Cardano.Node.Tracing.Era.Byron
                         Cardano.Node.Tracing.Era.HardFork
                         Cardano.Node.Tracing.Era.Shelley
                         Cardano.Node.Tracing.Formatting
+                        Cardano.Node.Tracing.NodeInfo
+                        Cardano.Node.Tracing.NodeStartupInfo
                         Cardano.Node.Tracing.Peers
                         Cardano.Node.Tracing.Render
                         Cardano.Node.Tracing.StateRep

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -217,7 +217,7 @@ library
                       , sop-extras
                       , text >= 2.0
                       , time
-                      , trace-dispatcher ^>= 2.9
+                      , trace-dispatcher ^>= 2.9.1
                       , trace-forward ^>= 2.2.11
                       , trace-resources ^>= 0.2.3
                       , tracer-transformers

--- a/cardano-node/src/Cardano/Node/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Startup.hs
@@ -136,14 +136,14 @@ data StartupTrace blk =
   | LedgerPeerSnapshotLoaded (WithOrigin SlotNo)
   | MovedTopLevelOption String
 
-data EnabledBlockForging 
+data EnabledBlockForging
   = EnabledBlockForging
   | DisabledBlockForging
   | NotEffective
     -- ^ one needs to send `SIGHUP` after consensus
     -- initialised itself (especially after replying all
     -- blocks).
-  deriving stock 
+  deriving stock
     (Eq, Show)
 
 data BasicInfoCommon = BasicInfoCommon {

--- a/cardano-node/src/Cardano/Node/Tracing/Documentation.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Documentation.hs
@@ -18,7 +18,7 @@ module Cardano.Node.Tracing.Documentation
   , docTracersFirstPhase
   ) where
 
-
+import           Cardano.Node.Tracing.NodeStartupInfo () -- MetaTrace NodeVersionTrace
 import           Cardano.Logging as Logging
 import           Cardano.Logging.Resources
 import           Cardano.Logging.Resources.Types ()
@@ -28,6 +28,7 @@ import           Cardano.Node.Startup
 import           Cardano.Node.TraceConstraints
 import           Cardano.Node.Tracing.DefaultTraceConfig (defaultCardanoConfig)
 import           Cardano.Node.Tracing.Formatting ()
+import           Cardano.Node.Tracing.NodeInfo ()
 import qualified Cardano.Node.Tracing.StateRep as SR
 import           Cardano.Node.Tracing.Tracers.BlockReplayProgress
 import           Cardano.Node.Tracing.Tracers.ChainDB

--- a/cardano-node/src/Cardano/Node/Tracing/NodeInfo.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/NodeInfo.hs
@@ -1,0 +1,27 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Cardano.Node.Tracing.NodeInfo
+  ( NodeInfo (..)
+  ) where
+
+import           Cardano.Logging.Types.NodeInfo (NodeInfo (..))
+import           Cardano.Logging.Types (MetaTrace(..), Namespace (..), SeverityS (..))
+
+instance MetaTrace NodeInfo where
+  namespaceFor NodeInfo {}  =
+    Namespace [] ["NodeInfo"]
+  severityFor  (Namespace _ ["NodeInfo"]) _ =
+    Just Info
+  severityFor _ns _ =
+    Nothing
+  documentFor  (Namespace _ ["NodeInfo"]) = Just
+    "Basic information about this node collected at startup\
+        \\n\
+        \\n _niName_: Name of the node. \
+        \\n _niProtocol_: Protocol which this nodes uses. \
+        \\n _niVersion_: Software version which this node is using. \
+        \\n _niStartTime_: Start time of this node. \
+        \\n _niSystemStartTime_: How long did the start of the node took."
+  documentFor _ns =
+     Nothing
+  allNamespaces = [ Namespace [] ["NodeInfo"]]

--- a/cardano-node/src/Cardano/Node/Tracing/NodeStartupInfo.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/NodeStartupInfo.hs
@@ -1,0 +1,26 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Cardano.Node.Tracing.NodeStartupInfo
+  ( NodeStartupInfo (..)
+  ) where
+
+import           Cardano.Logging.Types.NodeStartupInfo (NodeStartupInfo (..))
+import           Cardano.Logging.Types (MetaTrace(..), Namespace (..), SeverityS (..))
+
+instance MetaTrace NodeStartupInfo where
+  namespaceFor NodeStartupInfo {}  =
+    Namespace [] ["NodeStartupInfo"]
+  severityFor  (Namespace _ ["NodeStartupInfo"]) _ =
+    Just Info
+  severityFor _ns _ =
+    Nothing
+  documentFor  (Namespace _ ["NodeStartupInfo"]) = Just
+    "Startup information about this node, required for RTView\
+        \\n\
+        \\n _suiEra_: Name of the current era. \
+        \\n _suiSlotLength_: Slot length, in seconds. \
+        \\n _suiEpochLength_: Epoch length, in slots. \
+        \\n _suiSlotsPerKESPeriod_: KES period length, in slots."
+  documentFor _ns =
+     Nothing
+  allNamespaces = [ Namespace [] ["NodeStartupInfo"]]

--- a/cardano-node/src/Cardano/Node/Tracing/Peers.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Peers.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE StandaloneDeriving #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Cardano.Node.Tracing.Peers
   ( NodePeers (..)
@@ -9,24 +7,7 @@ module Cardano.Node.Tracing.Peers
 
 import           Cardano.Logging
 import           Cardano.Node.Tracing.Tracers.Peer (PeerT, ppPeer)
-
-import           Control.DeepSeq (NFData)
-import           Data.Aeson (FromJSON, ToJSON)
-import           Data.Text (Text)
-import           GHC.Generics (Generic)
-
-type PeerInfoPP = Text -- The result of 'ppPeer' function.
-
--- | This type contains an information about current peers of the node.
---   It will be asked by external applications as a DataPoint.
-newtype NodePeers = NodePeers [PeerInfoPP]
-
-deriving instance Generic NodePeers
-deriving instance NFData NodePeers
-
-instance ToJSON NodePeers
-instance FromJSON NodePeers
-
+import           Cardano.Logging.Types.NodePeers (NodePeers(..))
 
 instance MetaTrace NodePeers where
   namespaceFor NodePeers {}  =

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
@@ -24,7 +24,7 @@ import           Cardano.Node.TraceConstraints
 import           Cardano.Node.Tracing
 import           Cardano.Node.Tracing.Consistency (checkNodeTraceConfiguration')
 import           Cardano.Node.Tracing.Formatting ()
-import           Cardano.Node.Tracing.Peers
+import           Cardano.Node.Tracing.Peers (traceNodePeers)
 import qualified Cardano.Node.Tracing.StateRep as SR
 import           Cardano.Node.Tracing.Tracers.BlockReplayProgress
 import           Cardano.Node.Tracing.Tracers.ChainDB
@@ -37,7 +37,6 @@ import           Cardano.Node.Tracing.Tracers.NodeToNode ()
 import           Cardano.Node.Tracing.Tracers.NodeVersion (getNodeVersion)
 import           Cardano.Node.Tracing.Tracers.NonP2P ()
 import           Cardano.Node.Tracing.Tracers.P2P ()
-import           Cardano.Node.Tracing.Tracers.Peer ()
 import           Cardano.Node.Tracing.Tracers.Shutdown ()
 import           Cardano.Node.Tracing.Tracers.Startup ()
 import qualified Ouroboros.Cardano.Network.PeerSelection.Governor.PeerSelectionState as Cardano

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Peer.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Peer.hs
@@ -68,32 +68,27 @@ startPeerTracer tracer nodeKernel delayMilliseconds = do
         traceWith tracer peers
         threadDelay (delayMilliseconds * 1000)
 
-
 data PeerT blk = PeerT
     RemoteConnectionId
     (Net.AnchoredFragment (Header blk))
     (PeerFetchStatus (Header blk))
     (PeerFetchInFlight (Header blk))
 
-
 ppPeer :: PeerT blk -> Text
 ppPeer (PeerT cid _af status inflight) =
   Text.pack $ printf "%-15s %-8s %s" (ppCid cid) (ppStatus status) (ppInFlight inflight)
 
-ppCid :: RemoteConnectionId -> String
-ppCid = takeWhile (/= ':') . show . remoteAddress
+  where
+  ppCid :: RemoteConnectionId -> String
+  ppCid = takeWhile (/= ':') . show . remoteAddress
 
-ppInFlight :: PeerFetchInFlight header -> String
-ppInFlight f = printf
- "%5s  %3d  %5d  %6d"
- (ppMaxSlotNo $ peerFetchMaxSlotNo f)
- (peerFetchReqsInFlight f)
- (Set.size $ peerFetchBlocksInFlight f)
- (peerFetchBytesInFlight f)
-
-ppMaxSlotNo :: Net.MaxSlotNo -> String
-ppMaxSlotNo Net.NoMaxSlotNo   = "???"
-ppMaxSlotNo (Net.MaxSlotNo x) = show (unSlotNo x)
+  ppInFlight :: PeerFetchInFlight header -> String
+  ppInFlight f = printf
+    "%5s  %3d  %5d  %6d"
+    (ppMaxSlotNo $ peerFetchMaxSlotNo f)
+    (peerFetchReqsInFlight f)
+    (Set.size $ peerFetchBlocksInFlight f)
+    (peerFetchBytesInFlight f)
 
 ppStatus :: PeerFetchStatus header -> String
 ppStatus = \case
@@ -102,6 +97,10 @@ ppStatus = \case
   PeerFetchStatusAberrant -> "aberrant"
   PeerFetchStatusBusy     -> "fetching"
   PeerFetchStatusReady {} -> "ready"
+
+ppMaxSlotNo :: Net.MaxSlotNo -> String
+ppMaxSlotNo Net.NoMaxSlotNo   = "???"
+ppMaxSlotNo (Net.MaxSlotNo x) = show (unSlotNo x)
 
 getCurrentPeers
   :: NodeKernelData blk

--- a/cardano-tracer/CHANGELOG.md
+++ b/cardano-tracer/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## 0.3.3 (April, 2025)
+* Removed `cardano-node' as a dependency from `cardano-tracer'. This necessitated moving `NodeInfo` from
+  `cardano-tracer:Cardano.Node.Startup`to `trace-dispatcher:Cardano.Logging.Types.NodeInfo`, and `NodePeers` from
+  `cardano-node:Cardano.Node.Tracing.Peers` to `trace-dispatcher:Cardano.Logging.Types.NodePeers`.
+
 ## 0.3.2 (March 2025)
 
 * When requesting forwarded metrics, ask for delta to previous request only. New config option `ekgRequestFull` defaults to `false`; set to `true` to revert this behavior.

--- a/cardano-tracer/CHANGELOG.md
+++ b/cardano-tracer/CHANGELOG.md
@@ -1,9 +1,11 @@
 # ChangeLog
 
 ## 0.3.3 (April, 2025)
-* Removed `cardano-node' as a dependency from `cardano-tracer'. This necessitated moving `NodeInfo` from
-  `cardano-tracer:Cardano.Node.Startup`to `trace-dispatcher:Cardano.Logging.Types.NodeInfo`, and `NodePeers` from
-  `cardano-node:Cardano.Node.Tracing.Peers` to `trace-dispatcher:Cardano.Logging.Types.NodePeers`.
+* Redesigned `Cardano.Tracer.Handlers.Notifications.Timer` interface with IO-actions instead of TVars.
+* Removed `cardano-node' as a dependency from `cardano-tracer'. This necessitated moving `NodeInfo`
+  (from `cardano-tracer:Cardano.Node.Startup` to `trace-dispatcher:Cardano.Logging.Types.NodeInfo`), `NodePeers`
+  (from `cardano-node:Cardano.Node.Tracing.Peers` to `trace-dispatcher:Cardano.Logging.Types.NodePeers`), and
+  `NodeStartupInfo` (from `cardano-tracer:Cardano.Node.Startup` to `cardano-node:Cardano.Node.Tracing.NodeStartupInfo.hs`).
 
 ## 0.3.2 (March 2025)
 

--- a/cardano-tracer/cardano-tracer.cabal
+++ b/cardano-tracer/cardano-tracer.cabal
@@ -164,14 +164,13 @@ library
   if (flag(systemd) && os(linux)) || flag(rtview)
     build-depends:      unordered-containers
 
-  build-depends:        aeson
+  build-depends:        aeson >= 2.1.0.0
                       , async
                       , auto-update
                       , bimap
                       , blaze-html
                       , bytestring
-                      , cardano-node
-                      , cborg
+                      , cborg ^>= 0.2.4
                       , containers
                       , contra-tracer
                       , directory
@@ -182,21 +181,22 @@ library
                       , filepath
                       , http-types
                       , mime-mail
-                      , network-mux
+                      , network-mux >= 0.5
                       , optparse-applicative
                       , ouroboros-network ^>= 0.20
-                      , ouroboros-network-api
+                      , ouroboros-network-api ^>= 0.13
                       , ouroboros-network-framework
                       , signal
                       , slugify
                       , smtp-mail ^>= 0.5
-                      , stm
+                      , stm <2.5.2 || >=2.5.3
                       , string-qq
                       , text
                       , time
-                      , trace-dispatcher
-                      , trace-forward
-                      , trace-resources
+                      , trace-dispatcher ^>= 2.8.1
+                      , trace-forward ^>= 2.2.10
+                      , trace-resources ^>= 0.2.3
+                      , unordered-containers
                       , wai ^>= 3.2
                       , warp ^>= 3.4
                       , yaml
@@ -250,13 +250,13 @@ library demo-forwarder-lib
                       , filepath
                       , generic-data
                       , network-mux
-                      , optparse-applicative-fork
-                      , ouroboros-network-api
+                      , optparse-applicative-fork >= 0.18.1
+                      , ouroboros-network-api ^>= 0.12
                       , ouroboros-network-framework
                       , tasty-quickcheck
                       , time
-                      , trace-dispatcher
-                      , trace-forward
+                      , trace-dispatcher ^>= 2.8.1
+                      , trace-forward ^>= 2.2.10
                       , vector
                       , vector-algorithms
                       , QuickCheck
@@ -293,12 +293,12 @@ library demo-acceptor-lib
                       , extra
                       , filepath
                       , generic-data
-                      , optparse-applicative-fork
-                      , ouroboros-network-api
-                      , stm
+                      , optparse-applicative-fork >= 0.18.1
+                      , ouroboros-network-api ^>= 0.12
+                      , stm <2.5.2 || >=2.5.3
                       , text
                       , tasty-quickcheck
-                      , trace-forward
+                      , trace-forward ^>= 2.2.10
                       , vector
                       , vector-algorithms
                       , QuickCheck
@@ -352,16 +352,16 @@ test-suite cardano-tracer-test
                       , filepath
                       , generic-data
                       , network-mux
-                      , optparse-applicative-fork
-                      , ouroboros-network-api
+                      , optparse-applicative-fork >= 0.18.1
+                      , ouroboros-network-api ^>= 0.12
                       , ouroboros-network-framework
-                      , stm
+                      , stm <2.5.2 || >=2.5.3
                       , tasty
                       , tasty-quickcheck
                       , text
                       , time
-                      , trace-dispatcher
-                      , trace-forward
+                      , trace-dispatcher ^>= 2.8.1
+                      , trace-forward ^>= 2.2.10
                       , unix-compat
                       , vector
                       , vector-algorithms
@@ -411,9 +411,9 @@ test-suite cardano-tracer-test-ext
                       , generic-data
                       , Glob
                       , network-mux
-                      , optparse-applicative-fork
-                      , ouroboros-network
-                      , ouroboros-network-api
+                      , optparse-applicative-fork >= 0.18.1
+                      , ouroboros-network ^>= 0.19.0.3
+                      , ouroboros-network-api ^>= 0.12
                       , ouroboros-network-framework
                       , process
                       , QuickCheck
@@ -421,8 +421,8 @@ test-suite cardano-tracer-test-ext
                       , tasty-quickcheck
                       , text
                       , time
-                      , trace-dispatcher
-                      , trace-forward
+                      , trace-dispatcher ^>= 2.8.1
+                      , trace-forward ^>= 2.2.10
                       , unix-compat
                       , vector
                       , vector-algorithms
@@ -440,7 +440,7 @@ benchmark cardano-tracer-bench
   main-is:              cardano-tracer-bench.hs
 
   if flag(rtview)
-    build-depends:      stm
+    build-depends:      stm <2.5.2 || >=2.5.3
   build-depends:        cardano-tracer
                       , criterion
                       , directory
@@ -448,7 +448,7 @@ benchmark cardano-tracer-bench
                       , extra
                       , filepath
                       , time
-                      , trace-dispatcher
+                      , trace-dispatcher ^>= 2.8.1
 
   ghc-options:          -threaded
                         -rtsopts

--- a/cardano-tracer/cardano-tracer.cabal
+++ b/cardano-tracer/cardano-tracer.cabal
@@ -129,7 +129,6 @@ library
                         Cardano.Tracer.Handlers.Notifications.Email
                         Cardano.Tracer.Handlers.Notifications.Send
                         Cardano.Tracer.Handlers.Notifications.Settings
-                        Cardano.Tracer.Handlers.Notifications.Timer
                         Cardano.Tracer.Handlers.Notifications.Types
                         Cardano.Tracer.Handlers.Notifications.Utils
 
@@ -147,7 +146,8 @@ library
                         Cardano.Tracer.Types
                         Cardano.Tracer.Utils
 
-  other-modules:        Paths_cardano_tracer
+  other-modules:        Cardano.Tracer.Handlers.Notifications.Timer
+                        Paths_cardano_tracer
   autogen-modules:      Paths_cardano_tracer
 
   if flag(rtview)

--- a/cardano-tracer/cardano-tracer.cabal
+++ b/cardano-tracer/cardano-tracer.cabal
@@ -193,10 +193,9 @@ library
                       , string-qq
                       , text
                       , time
-                      , trace-dispatcher ^>= 2.8.1
+                      , trace-dispatcher ^>= 2.9
                       , trace-forward ^>= 2.2.10
                       , trace-resources ^>= 0.2.3
-                      , unordered-containers
                       , wai ^>= 3.2
                       , warp ^>= 3.4
                       , yaml
@@ -251,11 +250,11 @@ library demo-forwarder-lib
                       , generic-data
                       , network-mux
                       , optparse-applicative-fork >= 0.18.1
-                      , ouroboros-network-api ^>= 0.12
+                      , ouroboros-network-api ^>= 0.13
                       , ouroboros-network-framework
                       , tasty-quickcheck
                       , time
-                      , trace-dispatcher ^>= 2.8.1
+                      , trace-dispatcher ^>= 2.9
                       , trace-forward ^>= 2.2.10
                       , vector
                       , vector-algorithms
@@ -294,7 +293,7 @@ library demo-acceptor-lib
                       , filepath
                       , generic-data
                       , optparse-applicative-fork >= 0.18.1
-                      , ouroboros-network-api ^>= 0.12
+                      , ouroboros-network-api ^>= 0.13
                       , stm <2.5.2 || >=2.5.3
                       , text
                       , tasty-quickcheck
@@ -353,14 +352,14 @@ test-suite cardano-tracer-test
                       , generic-data
                       , network-mux
                       , optparse-applicative-fork >= 0.18.1
-                      , ouroboros-network-api ^>= 0.12
+                      , ouroboros-network-api ^>= 0.13
                       , ouroboros-network-framework
                       , stm <2.5.2 || >=2.5.3
                       , tasty
                       , tasty-quickcheck
                       , text
                       , time
-                      , trace-dispatcher ^>= 2.8.1
+                      , trace-dispatcher ^>= 2.9
                       , trace-forward ^>= 2.2.10
                       , unix-compat
                       , vector
@@ -412,8 +411,8 @@ test-suite cardano-tracer-test-ext
                       , Glob
                       , network-mux
                       , optparse-applicative-fork >= 0.18.1
-                      , ouroboros-network ^>= 0.19.0.3
-                      , ouroboros-network-api ^>= 0.12
+                      , ouroboros-network ^>= 0.20
+                      , ouroboros-network-api ^>= 0.13
                       , ouroboros-network-framework
                       , process
                       , QuickCheck
@@ -421,7 +420,7 @@ test-suite cardano-tracer-test-ext
                       , tasty-quickcheck
                       , text
                       , time
-                      , trace-dispatcher ^>= 2.8.1
+                      , trace-dispatcher ^>= 2.9
                       , trace-forward ^>= 2.2.10
                       , unix-compat
                       , vector
@@ -448,7 +447,7 @@ benchmark cardano-tracer-bench
                       , extra
                       , filepath
                       , time
-                      , trace-dispatcher ^>= 2.8.1
+                      , trace-dispatcher ^>= 2.9
 
   ghc-options:          -threaded
                         -rtsopts

--- a/cardano-tracer/cardano-tracer.cabal
+++ b/cardano-tracer/cardano-tracer.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-tracer
-version:                0.3.2
+version:                0.3.3
 synopsis:               A service for logging and monitoring over Cardano nodes
 description:            A service for logging and monitoring over Cardano nodes.
 category:               Cardano,
@@ -193,7 +193,7 @@ library
                       , string-qq
                       , text
                       , time
-                      , trace-dispatcher ^>= 2.9
+                      , trace-dispatcher ^>= 2.9.1
                       , trace-forward ^>= 2.2.10
                       , trace-resources ^>= 0.2.3
                       , wai ^>= 3.2

--- a/cardano-tracer/src/Cardano/Tracer/Configuration.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Configuration.hs
@@ -72,12 +72,19 @@ data RotationParams = RotationParams
   deriving stock (Eq, Generic, Show)
   deriving anyclass ToJSON
 
+-- | Some fields are defaulted: 
+-- 
+-- `rpFrequencySecs` defaults to 1 minute. 
+-- 
+-- Max age for `RotationParams` can be specified in `rpMaxAgeMinutes`
+-- or `rpMaxAgeHours`: otherwise defaulting to 24 hours.
 instance FromJSON RotationParams where
   parseJSON = withObject "RotationParams" \o -> do
     rpFrequencySecs <- o .: "rpFrequencySecs"
+                   <|> pure 60
     rpLogLimitBytes <- o .: "rpLogLimitBytes"
     rpMaxAgeMinutes <- o .: "rpMaxAgeMinutes"
-                   <|> (o .: "rpMaxAgeHours" <&> (* 60))
+                   <|> o .: "rpMaxAgeHours" <&> (* 60)
                    <|> pure (24 * 60)
     rpKeepFilesNum  <- o .: "rpKeepFilesNum"
     pure RotationParams{..}

--- a/cardano-tracer/src/Cardano/Tracer/Configuration.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Configuration.hs
@@ -77,7 +77,8 @@ instance FromJSON RotationParams where
     rpFrequencySecs <- o .: "rpFrequencySecs"
     rpLogLimitBytes <- o .: "rpLogLimitBytes"
     rpMaxAgeMinutes <- o .: "rpMaxAgeMinutes"
-                   <|> o .: "rpMaxAgeHours" <&> (* 60)
+                   <|> (o .: "rpMaxAgeHours" <&> (* 60))
+                   <|> pure (24 * 60)
     rpKeepFilesNum  <- o .: "rpKeepFilesNum"
     pure RotationParams{..}
 

--- a/cardano-tracer/src/Cardano/Tracer/Configuration.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Configuration.hs
@@ -72,10 +72,10 @@ data RotationParams = RotationParams
   deriving stock (Eq, Generic, Show)
   deriving anyclass ToJSON
 
--- | Some fields are defaulted: 
--- 
--- `rpFrequencySecs` defaults to 1 minute. 
--- 
+-- | Some fields are defaulted:
+--
+-- `rpFrequencySecs` defaults to 1 minute.
+--
 -- Max age for `RotationParams` can be specified in `rpMaxAgeMinutes`
 -- or `rpMaxAgeHours`: otherwise defaulting to 24 hours.
 instance FromJSON RotationParams where
@@ -84,7 +84,7 @@ instance FromJSON RotationParams where
                    <|> pure 60
     rpLogLimitBytes <- o .: "rpLogLimitBytes"
     rpMaxAgeMinutes <- o .: "rpMaxAgeMinutes"
-                   <|> o .: "rpMaxAgeHours" <&> (* 60)
+                   <|> (o .: "rpMaxAgeHours" <&> (* 60))
                    <|> pure (24 * 60)
     rpKeepFilesNum  <- o .: "rpKeepFilesNum"
     pure RotationParams{..}

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/Notifications/Timer.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/Notifications/Timer.hs
@@ -30,7 +30,7 @@ checkPeriod :: PeriodInSec
 checkPeriod = 1
 
 traceOnly :: Trace IO TracerTrace -> String -> IO ()
-traceOnly tracer = 
+traceOnly tracer =
   traceWith tracer . TracerError . Text.pack
 
 type Timer :: Type
@@ -48,7 +48,7 @@ mkTimer
   -> Bool
   -> PeriodInSec
   -> IO Timer
-mkTimer = mkTimerOnFailure (pure ()) 
+mkTimer = mkTimerOnFailure (pure ())
 
 mkTimerStderr
   :: IO ()
@@ -89,7 +89,7 @@ mkTimerOnFailure onFailure tracer io state callPeriod_sec = do
   let tryIO :: IO () = try @SomeException io >>= \case
         Left exception -> do
           traceOnly tracer (displayException exception)
-          onFailure 
+          onFailure
         _ -> reset
 
   let run ::  IO ()
@@ -110,4 +110,3 @@ mkTimerOnFailure onFailure tracer io state callPeriod_sec = do
     , startTimer    = modifyIORef' isRunning (const True)
     , stopTimer     = modifyIORef' isRunning (const False)
     }
-

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/Notifications/Utils.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/Notifications/Utils.hs
@@ -41,7 +41,7 @@ initEventsQueues tracer rtvSD nodesNames dpReqs curDPLock = do
       lastTime <- newTVarIO nullTime
       let mkEventQueue ident (evsS, evsP) = do
             evsQ <- newTBQueueIO 2000
-            evsT <- mkTimer
+            evsT <- mkTimer tracer
               (makeAndSendNotification tracer emailSettings nodesNames dpReqs curDPLock lastTime evsQ) evsS evsP
             pure (ident, (evsQ, evsT))
 

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/EraSettings.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/EraSettings.hs
@@ -6,7 +6,7 @@ module Cardano.Tracer.Handlers.RTView.Update.EraSettings
   ( runEraSettingsUpdater
   ) where
 
-import           Cardano.Node.Startup (NodeStartupInfo (..))
+import           Cardano.Logging.Types.NodeStartupInfo (NodeStartupInfo (..))
 import           Cardano.Tracer.Environment
 import           Cardano.Tracer.Handlers.RTView.State.EraSettings
 import           Cardano.Tracer.Handlers.Utils

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/NodeInfo.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/NodeInfo.hs
@@ -5,7 +5,7 @@ module Cardano.Tracer.Handlers.RTView.Update.NodeInfo
   ( askNSetNodeInfo
   ) where
 
-import           Cardano.Node.Startup (NodeInfo (..))
+import           Cardano.Logging.Types.NodeInfo (NodeInfo (..))
 import           Cardano.Tracer.Environment
 import           Cardano.Tracer.Handlers.RTView.State.Displayed
 import           Cardano.Tracer.Handlers.RTView.UI.Utils

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/NodeState.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/NodeState.hs
@@ -3,10 +3,13 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.Tracer.Handlers.RTView.Update.NodeState
-  ( askNSetNodeState
+  ( NodeStateWrapper (..)
+  , askNSetNodeState
   ) where
 
-import           Cardano.Node.Tracing.StateRep
+-- import           Cardano.Node.Tracing.StateRep
+import           Data.Aeson
+import           Data.Aeson.Types (Parser)
 import           Cardano.Tracer.Environment
 import           Cardano.Tracer.Handlers.RTView.State.Displayed
 import           Cardano.Tracer.Handlers.RTView.UI.Utils
@@ -15,7 +18,7 @@ import           Cardano.Tracer.Handlers.RTView.Utils
 import           Cardano.Tracer.Types
 
 import           Control.Monad.Extra (whenJustM)
-import           Data.Text (pack)
+import           Data.Text (Text, pack)
 import           Text.Printf (printf)
 
 import           Graphics.UI.Threepenny.Core (UI, liftIO)
@@ -28,16 +31,43 @@ askNSetNodeState
   -> UI ()
 askNSetNodeState tracerEnv displayed =
   forConnectedUI_ tracerEnv $ \nodeId ->
-    whenJustM (liftIO $ askDataPoint teDPRequestors teCurrentDPLock nodeId "NodeState") $ \(ns :: NodeState) ->
-      case ns of
-        NodeAddBlock (AddedToCurrentChain _ _ syncPct) -> setSyncProgress nodeId syncPct
-        _ -> return ()
+    whenJustM (liftIO $ askDataPoint teDPRequestors teCurrentDPLock nodeId "NodeState") \(NodeStateWrapper syncPct) ->
+      setSyncProgress nodeId syncPct
  where
   TracerEnv{teDPRequestors, teCurrentDPLock} = tracerEnv
 
+  setSyncProgress :: NodeId -> Double -> UI ()
   setSyncProgress nodeId@(NodeId anId) syncPct = do
     let nodeSyncProgressElId = anId <> "__node-sync-progress"
     if syncPct < 100.0
       then setDisplayedValue nodeId displayed nodeSyncProgressElId $
              pack (printf "%.2f" syncPct) <> "&nbsp;%"
       else setTextAndClasses nodeSyncProgressElId "100&nbsp;%" "rt-view-percent-done"
+
+-- | This is to avoid creating a dependency on `cardano-node's `NodeState'.
+--
+-- Before: Pattern matching on `NodeState' to access a single Double:
+--
+-- @
+--   NodeAddBlock (AddedToCurrentChain _ _ syncPct) -> setSyncProgress nodeId syncPct
+--   _ -> return ()
+-- @
+--
+-- Now: We pattern match on a newtype wrapper for a `Double' and parse
+-- it from a JSON object if it matches the serialization of
+-- `NodeAddBlock (AddedToCurrentChain _ _ syncPct)'.
+--
+-- @
+--   \(NodeStateWrapper syncPct) -> setSyncProgress nodeId syncPct
+-- @
+newtype NodeStateWrapper = NodeStateWrapper
+  { getNodeStateWrapper :: Double }
+
+instance FromJSON NodeStateWrapper where
+  parseJSON :: Value -> Parser NodeStateWrapper
+  parseJSON = withObject "NodeState" \obj -> do
+    -- Check if this is a NodeAddBlock constructor, verify that it's
+    -- AddedToCurrentChain and extract the Double.
+    "NodeAddBlock" :: Text <- obj .: "tag"
+    [_, _, double] <- obj .: "contents"
+    pure (NodeStateWrapper double)

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/Peers.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/RTView/Update/Peers.hs
@@ -12,7 +12,7 @@ module Cardano.Tracer.Handlers.RTView.Update.Peers
   ) where
 
 import           Cardano.Logging (showT)
-import           Cardano.Node.Tracing.Peers
+import           Cardano.Logging.Types.NodePeers (NodePeers(..))
 import           Cardano.Tracer.Environment
 import           Cardano.Tracer.Handlers.RTView.State.Peers
 import           Cardano.Tracer.Handlers.RTView.UI.HTML.Node.Peers

--- a/cardano-tracer/src/Cardano/Tracer/Run.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Run.hs
@@ -111,8 +111,7 @@ doRunCardanoTracer config rtViewStateDir tr protocolsBrake dpRequestors = do
 
   traceWith tr TracerInitEventQueues
 #if RTVIEW
-  eventsQueues   <- initEventsQueues rtViewStateDir connectedNodesNames dpRequestors currentDPLock
-
+  eventsQueues   <- initEventsQueues tr rtViewStateDir connectedNodesNames dpRequestors currentDPLock
   rtViewPageOpened <- newTVarIO False
 #endif
 

--- a/cardano-tracer/src/Cardano/Tracer/Utils.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Utils.hs
@@ -39,7 +39,7 @@ module Cardano.Tracer.Utils
   , sequenceConcurrently_
   ) where
 
-import           Cardano.Node.Startup (NodeInfo (..))
+import           Cardano.Logging.Types.NodeInfo (NodeInfo(..))
 import           Cardano.Tracer.Configuration
 import           Cardano.Tracer.Environment
 import           Cardano.Tracer.Handlers.Utils

--- a/trace-dispatcher/CHANGELOG.md
+++ b/trace-dispatcher/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Revision history for trace-dispatcher
 
+## 2.9.1 (April, 2025)
+* Removed `cardano-node' as a dependency from `cardano-tracer'. This necessitated moving `NodeInfo` from
+  `cardano-tracer:Cardano.Node.Startup`to `trace-dispatcher:Cardano.Logging.Types.NodeInfo`, and `NodePeers` from
+  `cardano-node:Cardano.Node.Tracing.Peers` to `trace-dispatcher:Cardano.Logging.Types.NodePeers`.
+
 ## 2.9 -- Mar 2025
 
 * New `PrometheusSimple` backend which runs a simple TCP server for direct exposition of metrics, without forwarding.

--- a/trace-dispatcher/CHANGELOG.md
+++ b/trace-dispatcher/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Revision history for trace-dispatcher
 
 ## 2.9.1 (April, 2025)
-* Removed `cardano-node' as a dependency from `cardano-tracer'. This necessitated moving `NodeInfo` from
-  `cardano-tracer:Cardano.Node.Startup`to `trace-dispatcher:Cardano.Logging.Types.NodeInfo`, and `NodePeers` from
-  `cardano-node:Cardano.Node.Tracing.Peers` to `trace-dispatcher:Cardano.Logging.Types.NodePeers`.
+* Removed `cardano-node' as a dependency from `cardano-tracer'. This necessitated moving `NodeInfo`
+  (from `cardano-tracer:Cardano.Node.Startup` to `trace-dispatcher:Cardano.Logging.Types.NodeInfo`), `NodePeers`
+  (from `cardano-node:Cardano.Node.Tracing.Peers` to `trace-dispatcher:Cardano.Logging.Types.NodePeers`), and
+  `NodeStartupInfo` (from `cardano-tracer:Cardano.Node.Startup` to `cardano-node:Cardano.Node.Tracing.NodeStartupInfo.hs`).
 
 ## 2.9 -- Mar 2025
 

--- a/trace-dispatcher/src/Cardano/Logging/Types.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Types.hs
@@ -82,7 +82,7 @@ import           Network.Socket (PortNumber)
 -- | The Trace carries the underlying tracer Tracer from the contra-tracer package.
 --   It adds a 'LoggingContext' and maybe a 'TraceControl' to every message.
 newtype Trace m a = Trace
-  {unpackTrace :: T.Tracer m (LoggingContext, Either TraceControl a)}
+                            {unpackTrace :: T.Tracer m (LoggingContext, Either TraceControl a)}
 
 -- | Contramap lifted to Trace
 instance Monad m => T.Contravariant (Trace m) where

--- a/trace-dispatcher/src/Cardano/Logging/Types.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Types.hs
@@ -2,9 +2,9 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 {-# OPTIONS_GHC -Wno-partial-fields  #-}
 
@@ -252,7 +252,7 @@ data LoggingContext = LoggingContext {
   , lcPrivacy   :: Maybe Privacy
   , lcDetails   :: Maybe DetailLevel
   }
-  deriving stock 
+  deriving stock
     (Show, Generic)
   deriving anyclass
     Serialise
@@ -377,7 +377,7 @@ data TraceObject = TraceObject {
   , toTimestamp :: !UTCTime
   , toHostname  :: !Text
   , toThreadId  :: !Text
-} deriving stock 
+} deriving stock
     (Eq, Show, Generic)
   -- ^ Instances for 'TraceObject' to forward it using 'trace-forward' library.
   deriving anyclass

--- a/trace-dispatcher/src/Cardano/Logging/Types/NodeInfo.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Types/NodeInfo.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# Language DerivingStrategies #-}
+{-# Language DeriveAnyClass #-}
+
+module Cardano.Logging.Types.NodeInfo
+  ( NodeInfo (..)
+  )
+  where
+
+import           Control.DeepSeq (NFData)
+import           Data.Aeson (FromJSON, ToJSON)
+import           Data.Text (Text)
+import           Data.Time (UTCTime)
+import           GHC.Generics (Generic)
+
+-- | NodeInfo
+
+data NodeInfo = NodeInfo
+  { niName            :: Text
+  , niProtocol        :: Text
+  , niVersion         :: Text
+  , niCommit          :: Text
+  , niStartTime       :: UTCTime
+  , niSystemStartTime :: UTCTime
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (NFData, ToJSON, FromJSON)

--- a/trace-dispatcher/src/Cardano/Logging/Types/NodePeers.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Types/NodePeers.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+
+module Cardano.Logging.Types.NodePeers
+  ( NodePeers (..)
+  , PeerInfoPP
+  )
+  where
+
+import           Control.DeepSeq (NFData)
+import           Data.Aeson (FromJSON, ToJSON)
+import           Data.Text (Text)
+import           GHC.Generics (Generic)
+
+type PeerInfoPP = Text -- The result of 'ppPeer' function.
+
+-- | This type contains an information about current peers of the node.
+--   It will be asked by external applications as a DataPoint.
+newtype NodePeers = NodePeers [PeerInfoPP]
+  deriving stock    Generic
+  deriving anyclass (NFData, ToJSON, FromJSON)

--- a/trace-dispatcher/src/Cardano/Logging/Types/NodeStartupInfo.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Types/NodeStartupInfo.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# Language DerivingStrategies #-}
+{-# Language DeriveAnyClass #-}
+
+module Cardano.Logging.Types.NodeStartupInfo
+  ( NodeStartupInfo (..)
+  )
+  where
+
+import           Control.DeepSeq (NFData)
+import           Data.Aeson (FromJSON, ToJSON)
+import           Data.Text (Text)
+import           Data.Time (NominalDiffTime)
+import           Data.Word (Word64)
+import           GHC.Generics (Generic)
+
+-- | NodeStartupInfo
+
+-- | This information is taken from 'BasicInfoShelleyBased'. It is required for
+--   'cardano-tracer' service (particularly, for RTView).
+data NodeStartupInfo = NodeStartupInfo
+  { suiEra               :: Text
+  , suiSlotLength        :: NominalDiffTime
+  , suiEpochLength       :: Word64
+  , suiSlotsPerKESPeriod :: Word64
+  } 
+  deriving stock 
+    (Eq, Show, Generic)
+  deriving anyclass
+    (NFData, ToJSON, FromJSON)

--- a/trace-dispatcher/src/Cardano/Logging/Types/NodeStartupInfo.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Types/NodeStartupInfo.hs
@@ -23,8 +23,8 @@ data NodeStartupInfo = NodeStartupInfo
   , suiSlotLength        :: NominalDiffTime
   , suiEpochLength       :: Word64
   , suiSlotsPerKESPeriod :: Word64
-  } 
-  deriving stock 
+  }
+  deriving stock
     (Eq, Show, Generic)
   deriving anyclass
     (NFData, ToJSON, FromJSON)

--- a/trace-dispatcher/trace-dispatcher.cabal
+++ b/trace-dispatcher/trace-dispatcher.cabal
@@ -42,6 +42,9 @@ library
                       Cardano.Logging.Tracer.Forward
                       Cardano.Logging.Tracer.Composed
                       Cardano.Logging.Types
+                      Cardano.Logging.Types.NodeInfo
+                      Cardano.Logging.Types.NodePeers
+                      Cardano.Logging.Types.NodeStartupInfo
                       Cardano.Logging.Utils
                       Cardano.Logging.Version
                       Control.Tracer.Arrow

--- a/trace-dispatcher/trace-dispatcher.cabal
+++ b/trace-dispatcher/trace-dispatcher.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   trace-dispatcher
-version:                2.9
+version:                2.9.1
 synopsis:               Tracers for Cardano
 description:            Package for development of simple and efficient tracers
                         based on the arrow based contra-tracer package


### PR DESCRIPTION
# Description

This includes 3 separate commits:

- [X] [*a022921*](https://github.com/IntersectMBO/cardano-node/pull/6125/commits/a02292193d244cb7a1b261eb5747213154e3f416): `cardano-tracer`: Eliminate `cardano-node` dependency.
- [X] [*77de57e*](https://github.com/IntersectMBO/cardano-node/pull/6125/commits/77de57e3c4769d07c2e55379b3e2209495ac86b0): `cardano-tracer`: Hide *mkTimer* module, change *STM* to *IORef* (fixes issue "[Leaky thread in *mkTimer*](https://github.com/IntersectMBO/cardano-node/issues/6083)").
- [x] [*78297ba*](https://github.com/IntersectMBO/cardano-node/pull/6125/commits/78297ba471cd528e8f45d15755b56f0603ebd8c9): `cardano-node:` Make *rpMaxAgeMinutes* optional.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Rebase on master
- [X] Add error reporting to `instance FromJSON NodeStateWrapper`
- [X] New tests are added if needed and existing tests are updated. 
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] (This is on hold:) The version bounds in `.cabal` files are updated
- [X] CI passes. See note on CI.  The following CI checks are required:
  - [X] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [X] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
