### PR TITLE
fix `wait-for-hydra` for when there are too many check runs

### DIFF
--- a/.github/workflows/release-ghcr.yaml
+++ b/.github/workflows/release-ghcr.yaml
@@ -1,4 +1,4 @@
-name: Upload to ghci.io
+name: Upload to ghcr.io
 
 on:
   push:

--- a/.github/workflows/release-ghcr.yaml
+++ b/.github/workflows/release-ghcr.yaml
@@ -33,12 +33,12 @@ jobs:
             success)
               echo "ci/hydra-build:required succeeded"
               exit 0;;
-            failure)
-              echo "ci/hydra-build:required failed"
-              exit 1;;
-            *)
+            '')
               echo "ci/hydra-build:required pending. Waiting 30s..."
               sleep 30;;
+            *)
+              echo "ci/hydra-build:required terminated unsuccessfully"
+              exit 1;;
           esac
         done
 

--- a/.github/workflows/release-ghcr.yaml
+++ b/.github/workflows/release-ghcr.yaml
@@ -28,7 +28,7 @@ jobs:
     - name: Waiting for ci/hydra-build:required to complete
       run: |
         while [[ true ]]; do
-          conclusion=$(gh api repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/check-runs --jq '.check_runs[] | select(.name == "ci/hydra-build:required") | .conclusion')
+          conclusion=$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/check-runs?check_name=ci/hydra-build:required" --jq '.check_runs[].conclusion')
           case "$conclusion" in
             success)
               echo "ci/hydra-build:required succeeded"

--- a/.github/workflows/release-ghcr.yaml
+++ b/.github/workflows/release-ghcr.yaml
@@ -28,16 +28,17 @@ jobs:
     - name: Waiting for ci/hydra-build:required to complete
       run: |
         while [[ true ]]; do
-          conclusion=$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/check-runs?check_name=ci/hydra-build:required" --jq '.check_runs[].conclusion')
+          check_name='ci/hydra-build:required'
+          conclusion=$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/check-runs?check_name=$check_name" --jq '.check_runs[].conclusion')
           case "$conclusion" in
             success)
-              echo "ci/hydra-build:required succeeded"
+              echo "$check_name succeeded"
               exit 0;;
             '')
-              echo "ci/hydra-build:required pending. Waiting 30s..."
+              echo "$check_name pending. Waiting 30s..."
               sleep 30;;
             *)
-              echo "ci/hydra-build:required terminated unsuccessfully"
+              echo "$check_name terminated unsuccessfully"
               exit 1;;
           esac
         done

--- a/.github/workflows/release-upload.yaml
+++ b/.github/workflows/release-upload.yaml
@@ -33,12 +33,12 @@ jobs:
             success)
               echo "ci/hydra-build:required succeeded"
               exit 0;;
-            failure)
-              echo "ci/hydra-build:required failed"
-              exit 1;;
-            *)
+            '')
               echo "ci/hydra-build:required pending. Waiting 30s..."
               sleep 30;;
+            *)
+              echo "ci/hydra-build:required terminated unsuccessfully"
+              exit 1;;
           esac
         done
     

--- a/.github/workflows/release-upload.yaml
+++ b/.github/workflows/release-upload.yaml
@@ -28,16 +28,17 @@ jobs:
     - name: Get specific check run status
       run: |
         while [[ true ]]; do
-          conclusion=$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/check-runs?check_name=ci/hydra-build:required" --jq '.check_runs[].conclusion')
+          check_name='ci/hydra-build:required'
+          conclusion=$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/check-runs?check_name=$check_name" --jq '.check_runs[].conclusion')
           case "$conclusion" in
             success)
-              echo "ci/hydra-build:required succeeded"
+              echo "$check_name succeeded"
               exit 0;;
             '')
-              echo "ci/hydra-build:required pending. Waiting 30s..."
+              echo "$check_name pending. Waiting 30s..."
               sleep 30;;
             *)
-              echo "ci/hydra-build:required terminated unsuccessfully"
+              echo "$check_name terminated unsuccessfully"
               exit 1;;
           esac
         done

--- a/.github/workflows/release-upload.yaml
+++ b/.github/workflows/release-upload.yaml
@@ -25,7 +25,7 @@ jobs:
     name: "Wait for hydra check-runs"
     runs-on: ubuntu-latest
     steps:
-    - name: Get specific check run status
+    - name: Waiting for ci/hydra-build:required to complete
       run: |
         while [[ true ]]; do
           check_name='ci/hydra-build:required'

--- a/.github/workflows/release-upload.yaml
+++ b/.github/workflows/release-upload.yaml
@@ -28,7 +28,7 @@ jobs:
     - name: Get specific check run status
       run: |
         while [[ true ]]; do
-          conclusion=$(gh api repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/check-runs --jq '.check_runs[] | select(.name == "ci/hydra-build:required") | .conclusion')
+          conclusion=$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/check-runs?check_name=ci/hydra-build:required" --jq '.check_runs[].conclusion')
           case "$conclusion" in
             success)
               echo "ci/hydra-build:required succeeded"


### PR DESCRIPTION
# Description

When there are more than 30 (the default pagination page size) check runs, the Hydra statuses are sometimes not found, blocking progress.

We can query only the status we need instead of searching though all statuses.

Also includes #6126, as requested, so we only have to merge one PR.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- ~~New tests are added if needed and existing tests are updated.~~
- ~~Any changes are noted in the `CHANGELOG.md` for affected package~~
- ~~The version bounds in `.cabal` files are updated~~
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - ~~Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version~~
  - ~~Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version~~
  - ~~Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`~~
- [x] Self-reviewed the diff