### PR TITLE
cardano-testnet: Use user-specified genesis files (if any) instead of the one generated by create-testnet-data

### DIFF
--- a/cardano-testnet/src/Cardano/Testnet.hs
+++ b/cardano-testnet/src/Cardano/Testnet.hs
@@ -13,7 +13,7 @@ module Cardano.Testnet (
   TestnetNodeOptions(..),
   cardanoDefaultTestnetNodeOptions,
   getDefaultAlonzoGenesis,
-  getDefaultShelleyGenesis,
+  getDefaultGenesisBatch,
 
   -- * Configuration
   Conf(..),

--- a/cardano-testnet/src/Testnet/Start/Types.hs
+++ b/cardano-testnet/src/Testnet/Start/Types.hs
@@ -23,7 +23,9 @@ module Testnet.Start.Types
   , isSpoNodeOptions
   , isRelayNodeOptions
   , cardanoDefaultTestnetNodeOptions
+  , GenesisBatch(..)
   , GenesisOptions(..)
+  , GenesisOrigin(..)
 
   , NodeLoggingFormat(..)
   , Conf(..)
@@ -33,6 +35,11 @@ module Testnet.Start.Types
   ) where
 
 import           Cardano.Api hiding (cardanoEra)
+import           Cardano.Api.Ledger (StandardCrypto)
+
+import           Cardano.Ledger.Alonzo.Genesis
+import           Cardano.Ledger.Conway.Genesis
+import           Cardano.Ledger.Shelley.Genesis
 
 import           Prelude
 
@@ -138,6 +145,14 @@ data TestnetNodeOptions
 data UserNodeConfig =
   UserNodeConfigNotSubmitted
   | UserNodeConfig FilePath
+
+-- | Type to track if a genesis file was provided by the user or defaulted by @cardano-testnet@.
+data GenesisOrigin =
+  UserProvidedOrigin -- ^ Caller of @cardano-tesnet@ provided the genesis files
+  | DefaultedOrigin -- ^ Genesis file provided by @cardano-testnet@ itself
+
+-- | Type to bundle all genesis files, whether provided by the user or defaulted by @cardano-testnet@.
+newtype GenesisBatch = GenesisBatch (ShelleyGenesis StandardCrypto, AlonzoGenesis, ConwayGenesis StandardCrypto, GenesisOrigin)
 
 -- | Get extra CLI arguments passed to the node executable
 testnetNodeExtraCliArgs :: TestnetNodeOptions -> [String]

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs
@@ -104,14 +104,8 @@ hprop_gov_no_confidence = integrationWorkspace "no-confidence" $ \tempAbsBasePat
       committeeThreshold = unsafeBoundedRational 0.5
       committee = L.Committee (Map.fromList [(comKeyCred1, EpochNo 100)]) committeeThreshold
 
-  alonzoGenesis <- getDefaultAlonzoGenesis sbe
-  shelleyGenesis' <-
-    getDefaultShelleyGenesis
-      asbe
-      (cardanoMaxSupply fastTestnetOptions)
-      shelleyOptions
-  let conwayGenesisWithCommittee =
-        defaultConwayGenesis { L.cgCommittee = committee }
+  GenesisBatch(shelleyGenesis', alonzoGenesis, conwayGenesis, _) <- getDefaultGenesisBatch fastTestnetOptions shelleyOptions
+  let conwayGenesisWithCommittee = conwayGenesis { L.cgCommittee = committee }
 
   TestnetRuntime
     { testnetMagic
@@ -120,8 +114,8 @@ hprop_gov_no_confidence = integrationWorkspace "no-confidence" $ \tempAbsBasePat
     , configurationFile
     } <- cardanoTestnet
            fastTestnetOptions
-           conf UserNodeConfigNotSubmitted shelleyGenesis'
-           alonzoGenesis conwayGenesisWithCommittee
+           conf UserNodeConfigNotSubmitted
+           (GenesisBatch (shelleyGenesis', alonzoGenesis, conwayGenesisWithCommittee, UserProvidedOrigin))
 
   poolNode1 <- H.headM testnetNodes
   poolSprocket1 <- H.noteShow $ nodeSprocket poolNode1


### PR DESCRIPTION
# Description

Fixes https://github.com/IntersectMBO/cardano-node/issues/6130

As per @Jimbo4350's advice, we don't try to fiddle the genesis file generated by `create-testnet-data` when the user provided one. We simply take the one provided by the user as it is (and the user has hence full control but is on its own).

# How to trust this PR

First of all, it fixes the usecase of the person reporting the bug: https://github.com/IntersectMBO/cardano-node/issues/6130#issuecomment-2687007627 (see `[edit]`)

And then, mesdames, messieurs; strap your belt, because it's a bit complex. We do have a test that would have caught this bug, but it's unplugged. Let's plug it by applying this patch:

```diff
diff --git a/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs b/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
index 0afabc462..a67cfd311 100644
--- a/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
+++ b/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
@@ -18,6 +18,7 @@ import qualified Cardano.Testnet.Test.Gov.DRepDeposit as Gov
 import qualified Cardano.Testnet.Test.Gov.DRepRetirement as Gov
 import qualified Cardano.Testnet.Test.Gov.GovActionTimeout as Gov
 import qualified Cardano.Testnet.Test.Gov.InfoAction as LedgerEvents
+import qualified Cardano.Testnet.Test.Gov.NoConfidence as Gov
 import qualified Cardano.Testnet.Test.Gov.PParamChangeFailsSPO as Gov
 import qualified Cardano.Testnet.Test.Gov.ProposeNewConstitution as Gov
 import qualified Cardano.Testnet.Test.Gov.Transaction.HashMismatch as WrongHash
@@ -36,9 +37,6 @@ import           Testnet.Property.Run (ignoreOnMacAndWindows, ignoreOnWindows)
 
 import qualified Test.Tasty as T
 import           Test.Tasty (TestTree)
-
--- import qualified Cardano.Testnet.Test.Cli.LeadershipSchedule
--- import qualified Cardano.Testnet.Test.Gov.NoConfidence as Gov
 -- import qualified Cardano.Testnet.Test.Gov.ProposeNewConstitutionSPO as Gov
 -- import qualified Cardano.Testnet.Test.Cli.LeadershipSchedule
 -- import qualified Cardano.Testnet.Test.Gov.TreasuryGrowth as Gov
@@ -55,7 +53,7 @@ tests = do
             , T.testGroup "Governance"
                [ ignoreOnMacAndWindows "Committee Add New" Gov.hprop_constitutional_committee_add_new
                -- FIXME No Confidence has SPO voting, requires multiple SPOs
-               -- , ignoreOnMacAndWindows "Committee Motion Of No Confidence"  Gov.hprop_gov_no_confidence
+               , ignoreOnMacAndWindows "Committee Motion Of No Confidence"  Gov.hprop_gov_no_confidence
                -- TODO: Disabled because proposals for parameter changes are not working
                -- , ignoreOnWindows "DRep Activity" Gov.hprop_check_drep_activity
                -- , ignoreOnWindows "Predefined Abstain DRep" Gov.hprop_check_predefined_abstain_drep
```

Then run this test as follows:

```shell
> DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/Committee Motion Of No Confidence/"'
```

This test is going to fail (that is why it's unplugged it's the first place, if it doesn't fail put an `H.assert False` in it). Then grab the sandbox's directory in the log, i.e. look for something like:

```shell
H.writeFile proposalAnchorFile $
                  ┃   │ Writing file: /tmp/nix-shell.QBFwBF/no-confidence-test-95bbd910c96cb7a1/work/sample-proposal-anchor
```

This gives you the sandbox's location: `/tmp/nix-shell.QBFwBF/no-confidence-test-95bbd910c96cb7a1`

Then inspect the `/tmp/nix-shell.QBFwBF/no-confidence-test-95bbd910c96cb7a1/conway-genesis.json` file. Before this PR, it was containing:

```json
"committee": {
        "members": {},
        "threshold": 0
    },
```

After this PR, this file contains:

```json
  "committee": {
    "members": {
      "keyHash-ce9cf4886e6db0831d490e13c3161778e057e171bf9e4f4a259ffbbf": 100
    },
    "threshold": 0.5
  },
```

which is to be expected, because the `No Confidence` test does pass a custom Conway genesis file with 1 committee member: 

* https://github.com/IntersectMBO/cardano-node/blob/17b20815064f2a018be3b33614d927705fdba5d1/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs#L105
* https://github.com/IntersectMBO/cardano-node/blob/17b20815064f2a018be3b33614d927705fdba5d1/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs#L114

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [x] CI passes. See note on CI.  The following CI checks are required:
- [X] Self-reviewed the diff