### PR TITLE
Flake cleanup

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -33,21 +33,6 @@
         "type": "github"
       }
     },
-    "blank": {
-      "locked": {
-        "lastModified": 1625557891,
-        "narHash": "sha256-O8/MWsPBGhhyPoPLHZAuoZiiHo9q6FLlEeIDEXuj6T4=",
-        "owner": "divnix",
-        "repo": "blank",
-        "rev": "5a5d2684073d9f563072ed07c871d577a6c614a8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "divnix",
-        "repo": "blank",
-        "type": "github"
-      }
-    },
     "blst": {
       "flake": false,
       "locked": {
@@ -124,15 +109,14 @@
         ],
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "tullia": "tullia"
+        ]
       },
       "locked": {
-        "lastModified": 1679408951,
-        "narHash": "sha256-xM78upkrXjRu/739V/IxFrA9m+6rvgOiolt4ReKLAog=",
+        "lastModified": 1741965132,
+        "narHash": "sha256-SjNEfsLa+2FKS4GlszaH0fO/QGJbooNFMYU1GVdJToo=",
         "owner": "input-output-hk",
         "repo": "cardano-automation",
-        "rev": "628f135d243d4a9e388c187e4c6179246038ee72",
+        "rev": "78d16a837d74a72822041ee1b970daa73ac83b9e",
         "type": "github"
       },
       "original": {
@@ -143,7 +127,7 @@
     },
     "cardano-mainnet-mirror": {
       "inputs": {
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -191,64 +175,6 @@
         "type": "github"
       }
     },
-    "devshell": {
-      "inputs": {
-        "flake-utils": [
-          "cardano-automation",
-          "tullia",
-          "std",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "cardano-automation",
-          "tullia",
-          "std",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1663445644,
-        "narHash": "sha256-+xVlcK60x7VY1vRJbNUEAHi17ZuoQxAIH4S4iUFUGBA=",
-        "owner": "numtide",
-        "repo": "devshell",
-        "rev": "e3dc3e21594fe07bdb24bdf1c8657acaa4cb8f66",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "devshell",
-        "type": "github"
-      }
-    },
-    "dmerge": {
-      "inputs": {
-        "nixlib": [
-          "cardano-automation",
-          "tullia",
-          "std",
-          "nixpkgs"
-        ],
-        "yants": [
-          "cardano-automation",
-          "tullia",
-          "std",
-          "yants"
-        ]
-      },
-      "locked": {
-        "lastModified": 1659548052,
-        "narHash": "sha256-fzI2gp1skGA8mQo/FBFrUAtY0GQkAIAaV/V127TJPyY=",
-        "owner": "divnix",
-        "repo": "data-merge",
-        "rev": "d160d18ce7b1a45b88344aa3f13ed1163954b497",
-        "type": "github"
-      },
-      "original": {
-        "owner": "divnix",
-        "repo": "data-merge",
-        "type": "github"
-      }
-    },
     "em": {
       "flake": false,
       "locked": {
@@ -283,22 +209,6 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_2": {
-      "flake": false,
-      "locked": {
         "lastModified": 1647532380,
         "narHash": "sha256-wswAxyO8AJTH7d5oU8VK82yBCpqwA+p6kLgpb1f1PAY=",
         "owner": "input-output-hk",
@@ -313,7 +223,7 @@
         "type": "github"
       }
     },
-    "flake-compat_3": {
+    "flake-compat_2": {
       "flake": false,
       "locked": {
         "lastModified": 1672831974,
@@ -337,51 +247,6 @@
         "owner": "numtide",
         "repo": "flake-utils",
         "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_3": {
-      "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_4": {
-      "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
         "type": "github"
       },
       "original": {
@@ -444,25 +309,6 @@
         "url": "https://gitlab.haskell.org/ghc/ghc"
       }
     },
-    "gomod2nix": {
-      "inputs": {
-        "nixpkgs": "nixpkgs",
-        "utils": "utils"
-      },
-      "locked": {
-        "lastModified": 1655245309,
-        "narHash": "sha256-d/YPoQ/vFn1+GTmSdvbSBSTOai61FONxB4+Lt6w/IVI=",
-        "owner": "tweag",
-        "repo": "gomod2nix",
-        "rev": "40d32f82fc60d66402eb0972e6e368aeab3faf58",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tweag",
-        "repo": "gomod2nix",
-        "type": "github"
-      }
-    },
     "hackageNix": {
       "flake": false,
       "locked": {
@@ -486,7 +332,7 @@
         "cabal-34": "cabal-34",
         "cabal-36": "cabal-36",
         "cardano-shell": "cardano-shell",
-        "flake-compat": "flake-compat_3",
+        "flake-compat": "flake-compat_2",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
         "ghc910X": "ghc910X",
         "ghc911": "ghc911",
@@ -800,50 +646,10 @@
         "type": "github"
       }
     },
-    "mdbook-kroki-preprocessor": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1661755005,
-        "narHash": "sha256-1TJuUzfyMycWlOQH67LR63/ll2GDZz25I3JfScy/Jnw=",
-        "owner": "JoelCourtney",
-        "repo": "mdbook-kroki-preprocessor",
-        "rev": "93adb5716d035829efed27f65f2f0833a7d3e76f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "JoelCourtney",
-        "repo": "mdbook-kroki-preprocessor",
-        "type": "github"
-      }
-    },
-    "n2c": {
-      "inputs": {
-        "flake-utils": "flake-utils_4",
-        "nixpkgs": [
-          "cardano-automation",
-          "tullia",
-          "std",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1665039323,
-        "narHash": "sha256-SAh3ZjFGsaCI8FRzXQyp56qcGdAqgKEfJWPCQ0Sr7tQ=",
-        "owner": "nlewo",
-        "repo": "nix2container",
-        "rev": "b008fe329ffb59b67bf9e7b08ede6ee792f2741a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nlewo",
-        "repo": "nix2container",
-        "type": "github"
-      }
-    },
     "nix": {
       "inputs": {
         "lowdown-src": "lowdown-src",
-        "nixpkgs": "nixpkgs_5",
+        "nixpkgs": "nixpkgs_2",
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
@@ -858,95 +664,6 @@
         "owner": "NixOS",
         "ref": "2.11.0",
         "repo": "nix",
-        "type": "github"
-      }
-    },
-    "nix-nomad": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "flake-utils": [
-          "cardano-automation",
-          "tullia",
-          "nix2container",
-          "flake-utils"
-        ],
-        "gomod2nix": "gomod2nix",
-        "nixpkgs": [
-          "cardano-automation",
-          "tullia",
-          "nixpkgs"
-        ],
-        "nixpkgs-lib": [
-          "cardano-automation",
-          "tullia",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1658277770,
-        "narHash": "sha256-T/PgG3wUn8Z2rnzfxf2VqlR1CBjInPE0l1yVzXxPnt0=",
-        "owner": "tristanpemble",
-        "repo": "nix-nomad",
-        "rev": "054adcbdd0a836ae1c20951b67ed549131fd2d70",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tristanpemble",
-        "repo": "nix-nomad",
-        "type": "github"
-      }
-    },
-    "nix2container": {
-      "inputs": {
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1658567952,
-        "narHash": "sha256-XZ4ETYAMU7XcpEeAFP3NOl9yDXNuZAen/aIJ84G+VgA=",
-        "owner": "nlewo",
-        "repo": "nix2container",
-        "rev": "60bb43d405991c1378baf15a40b5811a53e32ffa",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nlewo",
-        "repo": "nix2container",
-        "type": "github"
-      }
-    },
-    "nixago": {
-      "inputs": {
-        "flake-utils": [
-          "cardano-automation",
-          "tullia",
-          "std",
-          "flake-utils"
-        ],
-        "nixago-exts": [
-          "cardano-automation",
-          "tullia",
-          "std",
-          "blank"
-        ],
-        "nixpkgs": [
-          "cardano-automation",
-          "tullia",
-          "std",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1661824785,
-        "narHash": "sha256-/PnwdWoO/JugJZHtDUioQp3uRiWeXHUdgvoyNbXesz8=",
-        "owner": "nix-community",
-        "repo": "nixago",
-        "rev": "8c1f9e5f1578d4b2ea989f618588d62a335083c3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixago",
         "type": "github"
       }
     },
@@ -967,18 +684,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1653581809,
-        "narHash": "sha256-Uvka0V5MTGbeOfWte25+tfRL3moECDh1VwokWSZUdoY=",
+        "lastModified": 1642336556,
+        "narHash": "sha256-QSPPbFEwy0T0DrIuSzAACkaANPQaR1lZR/nHZGz9z04=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "83658b28fe638a170a19b8933aa008b30640fbd1",
+        "rev": "f3d9d4bd898cca7d04af2ae4f6ef01f2219df3d6",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "id": "nixpkgs",
+        "type": "indirect"
       }
     },
     "nixpkgs-2003": {
@@ -1127,51 +842,6 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1654807842,
-        "narHash": "sha256-ADymZpr6LuTEBXcy6RtFHcUZdjKTBRTMYwu19WOx17E=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "fc909087cc3386955f21b4665731dbdaceefb1d8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1665087388,
-        "narHash": "sha256-FZFPuW9NWHJteATOf79rZfwfRn5fE0wi9kRzvGfDHPA=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "95fda953f6db2e9496d2682c4fc7b82f959878f7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1642336556,
-        "narHash": "sha256-QSPPbFEwy0T0DrIuSzAACkaANPQaR1lZR/nHZGz9z04=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "f3d9d4bd898cca7d04af2ae4f6ef01f2219df3d6",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_5": {
-      "locked": {
         "lastModified": 1657693803,
         "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
         "owner": "NixOS",
@@ -1211,7 +881,7 @@
         "customConfig": "customConfig",
         "em": "em",
         "empty-flake": "empty-flake",
-        "flake-compat": "flake-compat_2",
+        "flake-compat": "flake-compat",
         "hackageNix": "hackageNix",
         "haskellNix": "haskellNix",
         "incl": "incl",
@@ -1220,7 +890,7 @@
           "haskellNix",
           "nixpkgs-unstable"
         ],
-        "utils": "utils_2"
+        "utils": "utils"
       }
     },
     "secp256k1": {
@@ -1273,44 +943,6 @@
         "type": "github"
       }
     },
-    "std": {
-      "inputs": {
-        "blank": "blank",
-        "devshell": "devshell",
-        "dmerge": "dmerge",
-        "flake-utils": "flake-utils_3",
-        "makes": [
-          "cardano-automation",
-          "tullia",
-          "std",
-          "blank"
-        ],
-        "mdbook-kroki-preprocessor": "mdbook-kroki-preprocessor",
-        "microvm": [
-          "cardano-automation",
-          "tullia",
-          "std",
-          "blank"
-        ],
-        "n2c": "n2c",
-        "nixago": "nixago",
-        "nixpkgs": "nixpkgs_3",
-        "yants": "yants"
-      },
-      "locked": {
-        "lastModified": 1665513321,
-        "narHash": "sha256-D6Pacw9yf/HMs84KYuCxHXnNDL7v43gtcka5URagFqE=",
-        "owner": "divnix",
-        "repo": "std",
-        "rev": "94a90eedb9cfc115b12ae8f6622d9904788559e4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "divnix",
-        "repo": "std",
-        "type": "github"
-      }
-    },
     "systems": {
       "locked": {
         "lastModified": 1681028828,
@@ -1326,46 +958,7 @@
         "type": "github"
       }
     },
-    "tullia": {
-      "inputs": {
-        "nix-nomad": "nix-nomad",
-        "nix2container": "nix2container",
-        "nixpkgs": [
-          "cardano-automation",
-          "nixpkgs"
-        ],
-        "std": "std"
-      },
-      "locked": {
-        "lastModified": 1668711738,
-        "narHash": "sha256-CBjky16o9pqsGE1bWu6nRlRajgSXMEk+yaFQLibqXcE=",
-        "owner": "input-output-hk",
-        "repo": "tullia",
-        "rev": "ead1f515c251f0e060060ef0e2356a51d3dfe4b0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "tullia",
-        "type": "github"
-      }
-    },
     "utils": {
-      "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "utils_2": {
       "inputs": {
         "systems": "systems"
       },
@@ -1380,29 +973,6 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "yants": {
-      "inputs": {
-        "nixpkgs": [
-          "cardano-automation",
-          "tullia",
-          "std",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1660507851,
-        "narHash": "sha256-BKjq7JnVuUR/xDtcv6Vm9GYGKAblisXrAgybor9hT/s=",
-        "owner": "divnix",
-        "repo": "yants",
-        "rev": "0b895ca02a8fa72bad50b454cb3e7d8a66407c96",
-        "type": "github"
-      },
-      "original": {
-        "owner": "divnix",
-        "repo": "yants",
         "type": "github"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -1203,22 +1203,6 @@
         "type": "github"
       }
     },
-    "ops-lib": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1713366514,
-        "narHash": "sha256-0hNlv+grFTE+TeXIbxSY97QoEEaUupOKMusZ4PesdrQ=",
-        "owner": "input-output-hk",
-        "repo": "ops-lib",
-        "rev": "19d83fa8eab1c0b7765f736eb4e8569d84d3e39d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "ops-lib",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "CHaP": "CHaP",
@@ -1230,16 +1214,12 @@
         "flake-compat": "flake-compat_2",
         "hackageNix": "hackageNix",
         "haskellNix": "haskellNix",
-        "hostNixpkgs": [
-          "nixpkgs"
-        ],
         "incl": "incl",
         "iohkNix": "iohkNix",
         "nixpkgs": [
           "haskellNix",
           "nixpkgs-unstable"
         ],
-        "ops-lib": "ops-lib",
         "utils": "utils_2"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -48,21 +48,6 @@
         "type": "github"
       }
     },
-    "blank_2": {
-      "locked": {
-        "lastModified": 1625557891,
-        "narHash": "sha256-O8/MWsPBGhhyPoPLHZAuoZiiHo9q6FLlEeIDEXuj6T4=",
-        "owner": "divnix",
-        "repo": "blank",
-        "rev": "5a5d2684073d9f563072ed07c871d577a6c614a8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "divnix",
-        "repo": "blank",
-        "type": "github"
-      }
-    },
     "blst": {
       "flake": false,
       "locked": {
@@ -128,21 +113,6 @@
         "owner": "haskell",
         "ref": "3.6",
         "repo": "cabal",
-        "type": "github"
-      }
-    },
-    "call-flake": {
-      "locked": {
-        "lastModified": 1687380775,
-        "narHash": "sha256-bmhE1TmrJG4ba93l9WQTLuYM53kwGQAjYHRvHOeuxWU=",
-        "owner": "divnix",
-        "repo": "call-flake",
-        "rev": "74061f6c241227cd05e79b702db9a300a2e4131a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "divnix",
-        "repo": "call-flake",
         "type": "github"
       }
     },
@@ -276,36 +246,6 @@
       "original": {
         "owner": "divnix",
         "repo": "data-merge",
-        "type": "github"
-      }
-    },
-    "dmerge_2": {
-      "inputs": {
-        "haumea": [
-          "std",
-          "haumea"
-        ],
-        "nixlib": [
-          "std",
-          "lib"
-        ],
-        "yants": [
-          "std",
-          "yants"
-        ]
-      },
-      "locked": {
-        "lastModified": 1686862774,
-        "narHash": "sha256-ojGtRQ9pIOUrxsQEuEPerUkqIJEuod9hIflfNkY+9CE=",
-        "owner": "divnix",
-        "repo": "dmerge",
-        "rev": "9f7f7a8349d33d7bd02e0f2b484b1f076e503a96",
-        "type": "github"
-      },
-      "original": {
-        "owner": "divnix",
-        "ref": "0.2.1",
-        "repo": "dmerge",
         "type": "github"
       }
     },
@@ -594,28 +534,6 @@
         "type": "github"
       }
     },
-    "haumea": {
-      "inputs": {
-        "nixpkgs": [
-          "std",
-          "lib"
-        ]
-      },
-      "locked": {
-        "lastModified": 1685133229,
-        "narHash": "sha256-FePm/Gi9PBSNwiDFq3N+DWdfxFq0UKsVVTJS3cQPn94=",
-        "owner": "nix-community",
-        "repo": "haumea",
-        "rev": "34dd58385092a23018748b50f9b23de6266dffc2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "ref": "v0.2.2",
-        "repo": "haumea",
-        "type": "github"
-      }
-    },
     "hls-1.10": {
       "flake": false,
       "locked": {
@@ -810,17 +728,14 @@
     },
     "incl": {
       "inputs": {
-        "nixlib": [
-          "std",
-          "lib"
-        ]
+        "nixlib": "nixlib"
       },
       "locked": {
-        "lastModified": 1669263024,
-        "narHash": "sha256-E/+23NKtxAqYG/0ydYgxlgarKnxmDbg6rCMWnOBqn9Q=",
+        "lastModified": 1693483555,
+        "narHash": "sha256-Beq4WhSeH3jRTZgC1XopTSU10yLpK1nmMcnGoXO0XYo=",
         "owner": "divnix",
         "repo": "incl",
-        "rev": "ce7bebaee048e4cd7ebdb4cee7885e00c4e2abca",
+        "rev": "526751ad3d1e23b07944b14e3f6b7a5948d3007b",
         "type": "github"
       },
       "original": {
@@ -866,21 +781,6 @@
         "owner": "stable-haskell",
         "ref": "iserv-syms",
         "repo": "iserv-proxy",
-        "type": "github"
-      }
-    },
-    "lib": {
-      "locked": {
-        "lastModified": 1694306727,
-        "narHash": "sha256-26fkTOJOI65NOTNKFvtcJF9mzzf/kK9swHzfYt1Dl6Q=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "c30b6a84c0b84ec7aecbe74466033facc9ed103f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
         "type": "github"
       }
     },
@@ -1047,6 +947,21 @@
       "original": {
         "owner": "nix-community",
         "repo": "nixago",
+        "type": "github"
+      }
+    },
+    "nixlib": {
+      "locked": {
+        "lastModified": 1667696192,
+        "narHash": "sha256-hOdbIhnpWvtmVynKcsj10nxz9WROjZja+1wRAJ/C9+s=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "babd9cd2ca6e413372ed59fbb1ecc3c3a5fd3e5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
         "type": "github"
       }
     },
@@ -1271,37 +1186,6 @@
         "type": "github"
       }
     },
-    "nixpkgs_6": {
-      "locked": {
-        "lastModified": 1708343346,
-        "narHash": "sha256-qlzHvterVRzS8fS0ophQpkh0rqw0abijHEOAKm0HmV0=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "9312b935a538684049cb668885e60f15547d4c5f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "release-23.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nosys": {
-      "locked": {
-        "lastModified": 1668010795,
-        "narHash": "sha256-JBDVBnos8g0toU7EhIIqQ1If5m/nyBqtHhL3sicdPwI=",
-        "owner": "divnix",
-        "repo": "nosys",
-        "rev": "feade0141487801c71ff55623b421ed535dbdefa",
-        "type": "github"
-      },
-      "original": {
-        "owner": "divnix",
-        "repo": "nosys",
-        "type": "github"
-      }
-    },
     "old-ghc-nix": {
       "flake": false,
       "locked": {
@@ -1335,51 +1219,6 @@
         "type": "github"
       }
     },
-    "paisano": {
-      "inputs": {
-        "call-flake": "call-flake",
-        "nixpkgs": [
-          "std",
-          "nixpkgs"
-        ],
-        "nosys": "nosys",
-        "yants": [
-          "std",
-          "yants"
-        ]
-      },
-      "locked": {
-        "lastModified": 1708640854,
-        "narHash": "sha256-EpcAmvIS4ErqhXtVEfd2GPpU/E/s8CCRSfYzk6FZ/fY=",
-        "owner": "paisano-nix",
-        "repo": "core",
-        "rev": "adcf742bc9463c08764ca9e6955bd5e7dcf3a3fe",
-        "type": "github"
-      },
-      "original": {
-        "owner": "paisano-nix",
-        "ref": "0.2.0",
-        "repo": "core",
-        "type": "github"
-      }
-    },
-    "paisano-tui": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1708637035,
-        "narHash": "sha256-R19YURSK+MY/Rw6FZnojQS9zuDh+OoTAyngQAjjoubc=",
-        "owner": "paisano-nix",
-        "repo": "tui",
-        "rev": "231761b260587a64817e4ffae3afc15defaa15db",
-        "type": "github"
-      },
-      "original": {
-        "owner": "paisano-nix",
-        "ref": "v0.5.0",
-        "repo": "tui",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "CHaP": "CHaP",
@@ -1394,13 +1233,13 @@
         "hostNixpkgs": [
           "nixpkgs"
         ],
+        "incl": "incl",
         "iohkNix": "iohkNix",
         "nixpkgs": [
           "haskellNix",
           "nixpkgs-unstable"
         ],
         "ops-lib": "ops-lib",
-        "std": "std_2",
         "utils": "utils_2"
       }
     },
@@ -1484,60 +1323,6 @@
         "owner": "divnix",
         "repo": "std",
         "rev": "94a90eedb9cfc115b12ae8f6622d9904788559e4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "divnix",
-        "repo": "std",
-        "type": "github"
-      }
-    },
-    "std_2": {
-      "inputs": {
-        "arion": [
-          "std",
-          "blank"
-        ],
-        "blank": "blank_2",
-        "devshell": [
-          "std",
-          "blank"
-        ],
-        "dmerge": "dmerge_2",
-        "haumea": "haumea",
-        "incl": "incl",
-        "lib": "lib",
-        "makes": [
-          "std",
-          "blank"
-        ],
-        "microvm": [
-          "std",
-          "blank"
-        ],
-        "n2c": [
-          "std",
-          "blank"
-        ],
-        "nixago": [
-          "std",
-          "blank"
-        ],
-        "nixpkgs": "nixpkgs_6",
-        "paisano": "paisano",
-        "paisano-tui": "paisano-tui",
-        "terranix": [
-          "std",
-          "blank"
-        ],
-        "yants": "yants_2"
-      },
-      "locked": {
-        "lastModified": 1715201063,
-        "narHash": "sha256-LcLYV5CDhIiJs3MfxGZFKsXPR4PtfnY4toZ75GM+2Pw=",
-        "owner": "divnix",
-        "repo": "std",
-        "rev": "b6924a7d37a46fc1dda8efe405040e27ecf1bbd6",
         "type": "github"
       },
       "original": {
@@ -1633,27 +1418,6 @@
         "owner": "divnix",
         "repo": "yants",
         "rev": "0b895ca02a8fa72bad50b454cb3e7d8a66407c96",
-        "type": "github"
-      },
-      "original": {
-        "owner": "divnix",
-        "repo": "yants",
-        "type": "github"
-      }
-    },
-    "yants_2": {
-      "inputs": {
-        "nixpkgs": [
-          "std",
-          "lib"
-        ]
-      },
-      "locked": {
-        "lastModified": 1686863218,
-        "narHash": "sha256-kooxYm3/3ornWtVBNHM3Zh020gACUyFX2G0VQXnB+mk=",
-        "owner": "divnix",
-        "repo": "yants",
-        "rev": "8f0da0dba57149676aa4817ec0c880fbde7a648d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,8 @@
   description = "Cardano Node";
 
   nixConfig = {
-    extra-substituters = [ "https://cache.iog.io" ];
-    extra-trusted-public-keys = [ "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=" ];
+    extra-substituters = ["https://cache.iog.io"];
+    extra-trusted-public-keys = ["hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="];
   };
 
   inputs = {
@@ -66,359 +66,417 @@
     utils.url = "github:numtide/flake-utils";
   };
 
-  outputs =
-    { cardano-automation
-    , cardano-mainnet-mirror
-    , CHaP
-    , em
-    , haskellNix
-    , incl
-    , iohkNix
-    , nixpkgs
-    , self
-    , utils
-    , ...
-    }@input:
-    let
-      inherit (nixpkgs) lib;
-      inherit (lib) head mapAttrs recursiveUpdate optionalAttrs;
-      inherit (utils.lib) eachSystem flattenTree;
-      inherit (iohkNix.lib) prefixNamesWith;
-      removeRecurse = lib.filterAttrsRecursive (n: _: n != "recurseForDerivations");
+  outputs = {
+    cardano-automation,
+    cardano-mainnet-mirror,
+    CHaP,
+    em,
+    haskellNix,
+    incl,
+    iohkNix,
+    nixpkgs,
+    self,
+    utils,
+    ...
+  } @ input: let
+    inherit (nixpkgs) lib;
+    inherit (lib) head mapAttrs recursiveUpdate optionalAttrs;
+    inherit (utils.lib) eachSystem flattenTree;
+    inherit (iohkNix.lib) prefixNamesWith;
+    removeRecurse = lib.filterAttrsRecursive (n: _: n != "recurseForDerivations");
 
-      macOS-security = pkgs:
-        # make `/usr/bin/security` available in `PATH`, which is needed for stack
-        # on darwin which calls this binary to find certificates
-        pkgs.writeScriptBin "security" ''exec /usr/bin/security "$@"'';
+    macOS-security = pkgs:
+    # make `/usr/bin/security` available in `PATH`, which is needed for stack
+    # on darwin which calls this binary to find certificates
+      pkgs.writeScriptBin "security" ''exec /usr/bin/security "$@"'';
 
-      supportedSystems = import ./nix/supported-systems.nix;
-      defaultSystem = head supportedSystems;
-      customConfig = recursiveUpdate
-        (import ./nix/custom-config.nix customConfig)
-        input.customConfig;
+    supportedSystems = import ./nix/supported-systems.nix;
+    defaultSystem = head supportedSystems;
+    customConfig =
+      recursiveUpdate
+      (import ./nix/custom-config.nix customConfig)
+      input.customConfig;
 
-      overlays = [
-        # crypto needs to come before haskell.nix.
-        # FIXME: _THIS_IS_BAD_
-        iohkNix.overlays.crypto
-        haskellNix.overlay
-        iohkNix.overlays.haskell-nix-extra
-        iohkNix.overlays.haskell-nix-crypto
-        iohkNix.overlays.cardano-lib
-        iohkNix.overlays.utils
-        (final: prev: {
-          inherit customConfig;
-          bench-data-publish = cardano-automation.outputs.packages.${final.system}."bench-data-publish:exe:bench-data-publish";
-          em = import em { inherit (final) system;
-                           nixpkgsSrcs = nixpkgs.outPath;
-                           nixpkgsRev = nixpkgs.rev; };
-          gitrev = final.customConfig.gitrev or self.rev or "0000000000000000000000000000000000000000";
-          commonLib = lib
-            // iohkNix.lib
-            // final.cardanoLib
-            // import ./nix/svclib.nix { inherit (final) pkgs; };
-        })
-        (import ./nix/pkgs.nix)
-        self.overlay
-      ];
+    overlays = [
+      # crypto needs to come before haskell.nix.
+      # FIXME: _THIS_IS_BAD_
+      iohkNix.overlays.crypto
+      haskellNix.overlay
+      iohkNix.overlays.haskell-nix-extra
+      iohkNix.overlays.haskell-nix-crypto
+      iohkNix.overlays.cardano-lib
+      iohkNix.overlays.utils
+      (final: prev: {
+        inherit customConfig;
+        bench-data-publish = cardano-automation.outputs.packages.${final.system}."bench-data-publish:exe:bench-data-publish";
+        em = import em {
+          inherit (final) system;
+          nixpkgsSrcs = nixpkgs.outPath;
+          nixpkgsRev = nixpkgs.rev;
+        };
+        gitrev = final.customConfig.gitrev or self.rev or "0000000000000000000000000000000000000000";
+        commonLib =
+          lib
+          // iohkNix.lib
+          // final.cardanoLib
+          // import ./nix/svclib.nix {inherit (final) pkgs;};
+      })
+      (import ./nix/pkgs.nix)
+      self.overlay
+    ];
 
-      collectExes = project:
-        let set-git-rev = import ./nix/set-git-rev.nix { inherit (project) pkgs; };
-        in
-        # take all executables from the project local packages
-        project.exes // (with project.hsPkgs; {
-          # add some executables from other relevant packages
-          inherit (bech32.components.exes) bech32;
-          inherit (ouroboros-consensus-cardano.components.exes) db-analyser db-synthesizer db-truncater;
-          # add cardano-node and cardano-cli with their git revision stamp
-          cardano-node = set-git-rev project.exes.cardano-node;
-          cardano-cli = set-git-rev cardano-cli.components.exes.cardano-cli;
-        });
+    collectExes = project: let
+      set-git-rev = import ./nix/set-git-rev.nix {inherit (project) pkgs;};
+    in
+      # take all executables from the project local packages
+      project.exes
+      // (with project.hsPkgs; {
+        # add some executables from other relevant packages
+        inherit (bech32.components.exes) bech32;
+        inherit (ouroboros-consensus-cardano.components.exes) db-analyser db-synthesizer db-truncater;
+        # add cardano-node and cardano-cli with their git revision stamp
+        cardano-node = set-git-rev project.exes.cardano-node;
+        cardano-cli = set-git-rev cardano-cli.components.exes.cardano-cli;
+      });
 
-      mkCardanoNodePackages = project: (collectExes project) // {
+    mkCardanoNodePackages = project:
+      (collectExes project)
+      // {
         inherit (project.pkgs) cardanoLib;
       };
 
-      mkFlakeAttrs = pkgs: rec {
-        inherit (pkgs) system;
-        inherit (pkgs.haskell-nix) haskellLib;
-        inherit (haskellLib) collectChecks' collectComponents';
-        inherit (pkgs.commonLib) eachEnv environments mkSupervisordCluster;
-        inherit (pkgs.stdenv) hostPlatform;
-        project = pkgs.cardanoNodeProject;
+    mkFlakeAttrs = pkgs: rec {
+      inherit (pkgs) system;
+      inherit (pkgs.haskell-nix) haskellLib;
+      inherit (haskellLib) collectChecks' collectComponents';
+      inherit (pkgs.commonLib) eachEnv environments mkSupervisordCluster;
+      inherit (pkgs.stdenv) hostPlatform;
+      project = pkgs.cardanoNodeProject;
 
-        macOS-security =
-          utils.writeScriptBin "security" ''exec /usr/bin/security "$@"'';
+      macOS-security =
+        utils.writeScriptBin "security" ''exec /usr/bin/security "$@"'';
 
-        # This is used by `nix develop .` to open a devShell
-        devShells =
-        let
-          shell = import ./shell.nix { inherit pkgs customConfig cardano-mainnet-mirror; };
-        in {
-          inherit (shell) devops workbench-shell;
-          default = shell.dev;
-          cluster = shell;
-          profiled = project.profiled.shell;
-        };
+      # This is used by `nix develop .` to open a devShell
+      devShells = let
+        shell = import ./shell.nix {inherit pkgs customConfig cardano-mainnet-mirror;};
+      in {
+        inherit (shell) devops workbench-shell;
+        default = shell.dev;
+        cluster = shell;
+        profiled = project.profiled.shell;
+      };
 
-        # NixOS tests run a node and submit-api and validate it listens
-        nixosTests = import ./nix/nixos/tests {
-          inherit pkgs;
-        };
+      # NixOS tests run a node and submit-api and validate it listens
+      nixosTests = import ./nix/nixos/tests {
+        inherit pkgs;
+      };
 
-        checks = flattenTree project.checks //
-          # Linux only checks:
-          (optionalAttrs hostPlatform.isLinux (
-            prefixNamesWith "nixosTests/" (mapAttrs (_: v: v.${system} or v) nixosTests)
-          ))
-          # checks run on default system only;
-          // (optionalAttrs (system == defaultSystem) {
+      checks =
+        flattenTree project.checks
+        //
+        # Linux only checks:
+        (optionalAttrs hostPlatform.isLinux (
+          prefixNamesWith "nixosTests/" (mapAttrs (_: v: v.${system} or v) nixosTests)
+        ))
+        # checks run on default system only;
+        // (optionalAttrs (system == defaultSystem) {
           hlint = pkgs.callPackage pkgs.hlintCheck {
             inherit (project.args) src;
           };
         });
 
-        exes = (collectExes project) // {
+      exes =
+        (collectExes project)
+        // {
           inherit (pkgs) checkCabalProject;
-        } // flattenTree (pkgs.scripts // {
-          # `tests` are the test suites which have been built.
-          inherit (project) tests;
-          # `benchmarks` (only built, not run).
-          inherit (project) benchmarks;
-        });
+        }
+        // flattenTree (pkgs.scripts
+          // {
+            # `tests` are the test suites which have been built.
+            inherit (project) tests;
+            # `benchmarks` (only built, not run).
+            inherit (project) benchmarks;
+          });
 
-        # The parametrisable workbench.
-        inherit (pkgs) workbench;
+      # The parametrisable workbench.
+      inherit (pkgs) workbench;
 
-        packages =
-          exes
-          # Linux only packages:
-          // optionalAttrs (system == "x86_64-linux")
-          (let workbenchTest =
-                { profileName, workbenchStartArgs ? [] }:
-                (pkgs.workbench-runner
-                  {
-                    inherit profileName workbenchStartArgs;
-                    backendName = "supervisor";
-                    useCabalRun = false;
-                    cardano-node-rev = pkgs.gitrev;
-                  }).workbench-profile-run;
-          in
-          {
-            "dockerImage/node" = pkgs.dockerImage;
-            "dockerImage/submit-api" = pkgs.submitApiDockerImage;
+      packages =
+        exes
+        # Linux only packages:
+        // optionalAttrs (system == "x86_64-linux")
+        (let
+          workbenchTest = {
+            profileName,
+            workbenchStartArgs ? [],
+          }:
+            (pkgs.workbench-runner
+              {
+                inherit profileName workbenchStartArgs;
+                backendName = "supervisor";
+                useCabalRun = false;
+                cardano-node-rev = pkgs.gitrev;
+              })
+            .workbench-profile-run;
+        in {
+          "dockerImage/node" = pkgs.dockerImage;
+          "dockerImage/submit-api" = pkgs.submitApiDockerImage;
 
-            ## This is a very light profile, no caching&pinning needed.
-            workbench-ci-test =
-              workbenchTest { profileName        = "ci-test-hydra-coay";
-                              workbenchStartArgs = [ "--create-testnet-data" ];
-                            };
-            workbench-ci-test-trace =
-              workbenchTest { profileName        = "ci-test-hydra-coay";
-                              workbenchStartArgs = [ "--create-testnet-data" "--trace" ];
-                            };
+          ## This is a very light profile, no caching&pinning needed.
+          workbench-ci-test = workbenchTest {
+            profileName = "ci-test-hydra-coay";
+            workbenchStartArgs = ["--create-testnet-data"];
+          };
+          workbench-ci-test-trace = workbenchTest {
+            profileName = "ci-test-hydra-coay";
+            workbenchStartArgs = ["--create-testnet-data" "--trace"];
+          };
 
-            inherit (pkgs) all-profiles-json profile-data-nomadperf;
+          inherit (pkgs) all-profiles-json profile-data-nomadperf;
 
-            system-tests = pkgs.writeShellApplication {
-              name = "system-tests";
-              runtimeInputs = with pkgs; [ git gnused ];
-              text = ''
-                  NODE_REV="${self.rev or ""}"
-                  if [[ -z $NODE_REV ]]; then
-                    echo "Sorry, need clean/pushed git revision to run system tests"
-                    exit 1;
-                  fi
-                  MAKE_TARGET=testpr
-                  mkdir -p tmp && cd tmp
-                  rm -rf cardano-node-tests
-                  git clone https://github.com/intersectmbo/cardano-node-tests.git
-                  cd cardano-node-tests
-                  sed -i '1 s/^.*$/#! \/usr\/bin\/env bash/' ./.github/regression.sh
-                  export NODE_REV
-                  export MAKE_TARGET
-                  nix develop --accept-flake-config .#base -c ./.github/regression.sh 2>&1
-              '';
-            };
-          })
-          # Add checks to be able to build them individually
-          // (prefixNamesWith "checks/" checks);
+          system-tests = pkgs.writeShellApplication {
+            name = "system-tests";
+            runtimeInputs = with pkgs; [git gnused];
+            text = ''
+              NODE_REV="${self.rev or ""}"
+              if [[ -z $NODE_REV ]]; then
+                echo "Sorry, need clean/pushed git revision to run system tests"
+                exit 1;
+              fi
+              MAKE_TARGET=testpr
+              mkdir -p tmp && cd tmp
+              rm -rf cardano-node-tests
+              git clone https://github.com/intersectmbo/cardano-node-tests.git
+              cd cardano-node-tests
+              sed -i '1 s/^.*$/#! \/usr\/bin\/env bash/' ./.github/regression.sh
+              export NODE_REV
+              export MAKE_TARGET
+              nix develop --accept-flake-config .#base -c ./.github/regression.sh 2>&1
+            '';
+          };
+        })
+        # Add checks to be able to build them individually
+        // (prefixNamesWith "checks/" checks);
 
-        apps = lib.mapAttrs (n: p: { type = "app"; program = p.exePath or (if (p.executable or false) then "${p}" else "${p}/bin/${p.name or n}"); }) exes;
+      apps =
+        lib.mapAttrs (n: p: {
+          type = "app";
+          program =
+            p.exePath
+            or (
+              if (p.executable or false)
+              then "${p}"
+              else "${p}/bin/${p.name or n}"
+            );
+        })
+        exes;
 
+      ciJobs = let
+        ciJobsVariants =
+          mapAttrs (
+            _: p:
+              (mkFlakeAttrs (pkgs.extend (prev: final: {cardanoNodeProject = p;}))).ciJobs
+          )
+          project.projectVariants;
         ciJobs =
-          let
-            ciJobsVariants = mapAttrs (_: p:
-              (mkFlakeAttrs (pkgs.extend (prev: final: { cardanoNodeProject = p; }))).ciJobs
-            ) project.projectVariants;
-            ciJobs = {
-              cardano-deployment = pkgs.cardanoLib.mkConfigHtml { inherit (pkgs.cardanoLib.environments) mainnet preview preprod; };
-            } // optionalAttrs (system == "x86_64-linux") {
-              native = packages // {
+          {
+            cardano-deployment = pkgs.cardanoLib.mkConfigHtml {inherit (pkgs.cardanoLib.environments) mainnet preview preprod;};
+          }
+          // optionalAttrs (system == "x86_64-linux") {
+            native =
+              packages
+              // {
                 shells = devShells;
                 internal = {
                   roots.project = project.roots;
                   plan-nix.project = project.plan-nix;
                 };
-                profiled = lib.genAttrs [ "cardano-node" "tx-generator" "locli" ] (n:
-                  packages.${n}.passthru.profiled
+                profiled = lib.genAttrs ["cardano-node" "tx-generator" "locli"] (
+                  n:
+                    packages.${n}.passthru.profiled
                 );
-                asserted = lib.genAttrs [ "cardano-node" ] (n:
-                  packages.${n}.passthru.asserted
+                asserted = lib.genAttrs ["cardano-node"] (
+                  n:
+                    packages.${n}.passthru.asserted
                 );
                 variants = mapAttrs (_: v: removeAttrs v.native ["variants"]) ciJobsVariants;
               };
-              musl =
-                let
-                  muslProject = project.projectCross.musl64;
-                  projectExes = collectExes muslProject;
-                in
-                projectExes // {
-                  cardano-node-linux = import ./nix/binary-release.nix {
-                    inherit pkgs;
-                    inherit (exes.cardano-node.identifier) version;
-                    platform = "linux";
-                    exes = lib.collect lib.isDerivation (
-                      # FIXME: restore tx-generator and gen-plutus once
-                      #        plutus-scripts-bench is fixed for musl
-                      #
-                      # It stands to question though, whether or not we want those to be
-                      # in the cardano-node-linux as executables anyway?
-                      removeAttrs projectExes [ "tx-generator" "gen-plutus" ]
-                    );
-                  };
-                  internal.roots.project = muslProject.roots;
-                  variants = mapAttrs (_: v: removeAttrs v.musl ["variants"]) ciJobsVariants;
+            musl = let
+              muslProject = project.projectCross.musl64;
+              projectExes = collectExes muslProject;
+            in
+              projectExes
+              // {
+                cardano-node-linux = import ./nix/binary-release.nix {
+                  inherit pkgs;
+                  inherit (exes.cardano-node.identifier) version;
+                  platform = "linux";
+                  exes = lib.collect lib.isDerivation (
+                    # FIXME: restore tx-generator and gen-plutus once
+                    #        plutus-scripts-bench is fixed for musl
+                    #
+                    # It stands to question though, whether or not we want those to be
+                    # in the cardano-node-linux as executables anyway?
+                    removeAttrs projectExes ["tx-generator" "gen-plutus"]
+                  );
                 };
-              windows =
-                let
-                  windowsProject = project.projectCross.mingwW64;
-                  projectExes = collectExes windowsProject;
-                in
-                projectExes
-                  // (removeRecurse {
-                  inherit (windowsProject) checks tests benchmarks;
-                  cardano-node-win64 = import ./nix/binary-release.nix {
-                    inherit pkgs;
-                    inherit (exes.cardano-node.identifier) version;
-                    platform = "win64";
-                    exes = lib.collect lib.isDerivation (
-                      # FIXME: restore tx-generator once plutus-scripts-bench is fixed for windows:
-                      removeAttrs projectExes [ "tx-generator" ]
-                    );
-                  };
-                  internal.roots.project = windowsProject.roots;
-                  variants = mapAttrs (_: v: removeAttrs v.windows ["variants"]) ciJobsVariants;
-                });
-            } // optionalAttrs (system == "x86_64-darwin") {
-              native = lib.filterAttrs
-                (n: _:
-                  # only build docker images once on linux:
+                internal.roots.project = muslProject.roots;
+                variants = mapAttrs (_: v: removeAttrs v.musl ["variants"]) ciJobsVariants;
+              };
+            windows = let
+              windowsProject = project.projectCross.mingwW64;
+              projectExes = collectExes windowsProject;
+            in
+              projectExes
+              // (removeRecurse {
+                inherit (windowsProject) checks tests benchmarks;
+                cardano-node-win64 = import ./nix/binary-release.nix {
+                  inherit pkgs;
+                  inherit (exes.cardano-node.identifier) version;
+                  platform = "win64";
+                  exes = lib.collect lib.isDerivation (
+                    # FIXME: restore tx-generator once plutus-scripts-bench is fixed for windows:
+                    removeAttrs projectExes ["tx-generator"]
+                  );
+                };
+                internal.roots.project = windowsProject.roots;
+                variants = mapAttrs (_: v: removeAttrs v.windows ["variants"]) ciJobsVariants;
+              });
+          }
+          // optionalAttrs (system == "x86_64-darwin") {
+            native =
+              lib.filterAttrs
+              (n: _:
+                # only build docker images once on linux:
                   !(lib.hasPrefix "dockerImage" n))
-                packages // {
+              packages
+              // {
                 cardano-node-macos = import ./nix/binary-release.nix {
                   inherit pkgs;
                   inherit (exes.cardano-node.identifier) version;
                   platform = "macos";
                   exes = lib.collect lib.isDerivation (collectExes project);
                 };
-                shells = removeAttrs devShells [ "profiled" ];
+                shells = removeAttrs devShells ["profiled"];
                 internal = {
                   roots.project = project.roots;
                   plan-nix.project = project.plan-nix;
                 };
                 variants = mapAttrs (_: v: removeAttrs v.native ["variants"]) ciJobsVariants;
               };
-            };
-            nonRequiredPaths = [
-              #FIXME: cardano-tracer-test for windows should probably be disabled in haskell.nix config:
-              "windows\\.(.*\\.)?checks\\.cardano-tracer\\.cardano-tracer-test"
-              #FIXME: plutus-scripts-bench (dep of tx-generator) does not compile for windows:
-              "windows\\.(.*\\.)?tx-generator.*"
-              #FIXME: plutus-scripts-bench's gen-plutus does not compile for musl
-              "musl\\.(.*\\.)?tx-generator.*"
-              "musl\\.(.*\\.)?gen-plutus.*"
-              # hlint required status is controled via the github action:
-              "native\\.(.*\\.)?checks/hlint"
-              #system-tests are build and run separately:
-              "native\\.(.*\\.)?system-tests"
-            ] ++
-            lib.optionals (system == "x86_64-darwin") [
-              #FIXME: make variants nonrequired for macos until CI has more capacity for macos builds
-              "native\\.variants\\..*"
-              "native\\.checks/cardano-testnet/cardano-testnet-test"
-            ];
-          in
-          pkgs.callPackages iohkNix.utils.ciJobsAggregates
-            {
-              inherit ciJobs;
-              nonRequiredPaths = map (r: p: builtins.match r p != null) nonRequiredPaths;
-            } // ciJobs;
-      };
-
-      flake = eachSystem supportedSystems (system:
-        let
-          inherit (haskellNix) config;
-          pkgs = import nixpkgs {
-            inherit config system overlays;
           };
-          inherit (mkFlakeAttrs pkgs) environments packages checks apps project ciJobs devShells workbench;
-        in
+        nonRequiredPaths =
+          [
+            #FIXME: cardano-tracer-test for windows should probably be disabled in haskell.nix config:
+            "windows\\.(.*\\.)?checks\\.cardano-tracer\\.cardano-tracer-test"
+            #FIXME: plutus-scripts-bench (dep of tx-generator) does not compile for windows:
+            "windows\\.(.*\\.)?tx-generator.*"
+            #FIXME: plutus-scripts-bench's gen-plutus does not compile for musl
+            "musl\\.(.*\\.)?tx-generator.*"
+            "musl\\.(.*\\.)?gen-plutus.*"
+            # hlint required status is controled via the github action:
+            "native\\.(.*\\.)?checks/hlint"
+            #system-tests are build and run separately:
+            "native\\.(.*\\.)?system-tests"
+          ]
+          ++ lib.optionals (system == "x86_64-darwin") [
+            #FIXME: make variants nonrequired for macos until CI has more capacity for macos builds
+            "native\\.variants\\..*"
+            "native\\.checks/cardano-testnet/cardano-testnet-test"
+          ];
+      in
+        pkgs.callPackages iohkNix.utils.ciJobsAggregates
         {
+          inherit ciJobs;
+          nonRequiredPaths = map (r: p: builtins.match r p != null) nonRequiredPaths;
+        }
+        // ciJobs;
+    };
 
-          inherit environments checks project ciJobs devShells workbench;
+    flake = eachSystem supportedSystems (
+      system: let
+        inherit (haskellNix) config;
+        pkgs = import nixpkgs {
+          inherit config system overlays;
+        };
+        inherit (mkFlakeAttrs pkgs) environments packages checks apps project ciJobs devShells workbench;
+      in {
+        inherit environments checks project ciJobs devShells workbench;
 
-          legacyPackages = pkgs // {
+        legacyPackages =
+          pkgs
+          // {
             # allows access to hydraJobs without specifying <arch>:
             hydraJobs = ciJobs;
           };
 
-          packages = packages // {
+        packages =
+          packages
+          // {
             # Built by `nix build .`
             default = packages.cardano-node;
           };
 
-          # Run by `nix run .`
-          apps = apps // {
+        # Run by `nix run .`
+        apps =
+          apps
+          // {
             default = apps.cardano-node;
           };
-
-        }
-      );
-
-    in
-    removeAttrs flake [ "ciJobs" ] // {
-
-      hydraJobs = flake.ciJobs // (let pkgs = self.legacyPackages.${defaultSystem}; in {
-        inherit (pkgs.callPackages iohkNix.utils.ciJobsAggregates {
-          ciJobs = lib.mapAttrs (_: lib.getAttr "required") flake.ciJobs // {
-            # ensure hydra notify:
-            gitrev = pkgs.writeText "gitrev" pkgs.gitrev;
-          };
-        }) required;
-      });
+      }
+    );
+  in
+    removeAttrs flake ["ciJobs"]
+    // {
+      hydraJobs =
+        flake.ciJobs
+        // (let
+          pkgs = self.legacyPackages.${defaultSystem};
+        in {
+          inherit
+            (pkgs.callPackages iohkNix.utils.ciJobsAggregates {
+              ciJobs =
+                lib.mapAttrs (_: lib.getAttr "required") flake.ciJobs
+                // {
+                  # ensure hydra notify:
+                  gitrev = pkgs.writeText "gitrev" pkgs.gitrev;
+                };
+            })
+            required
+            ;
+        });
 
       # allows precise paths (avoid fallbacks) with nix build/eval:
       outputs = self;
 
       overlay = final: prev: {
-        cardanoNodeProject = (import ./nix/haskell.nix {
-          inherit (final) haskell-nix;
-          inherit CHaP incl;
-          macOS-security = macOS-security (final.pkgs);
-        }).appendModule [
-          customConfig.haskellNix
-        ];
+        cardanoNodeProject =
+          (import ./nix/haskell.nix {
+            inherit (final) haskell-nix;
+            inherit CHaP incl;
+            macOS-security = macOS-security (final.pkgs);
+          })
+          .appendModule [
+            customConfig.haskellNix
+          ];
         cardanoNodePackages = mkCardanoNodePackages final.cardanoNodeProject;
         inherit (final.cardanoNodePackages) cardano-node cardano-cli cardano-submit-api cardano-tracer bech32 locli db-analyser;
       };
       nixosModules = {
-        cardano-node = { pkgs, lib, ... }: {
-          imports = [ ./nix/nixos/cardano-node-service.nix ];
+        cardano-node = {
+          pkgs,
+          lib,
+          ...
+        }: {
+          imports = [./nix/nixos/cardano-node-service.nix];
           services.cardano-node.cardanoNodePackages = lib.mkDefault (mkCardanoNodePackages flake.project.${pkgs.system});
         };
-        cardano-submit-api = { pkgs, lib, ... }: {
-          imports = [ ./nix/nixos/cardano-submit-api-service.nix ];
+        cardano-submit-api = {
+          pkgs,
+          lib,
+          ...
+        }: {
+          imports = [./nix/nixos/cardano-submit-api-service.nix];
           services.cardano-submit-api.cardanoNodePackages = lib.mkDefault (mkCardanoNodePackages flake.project.${pkgs.system});
         };
       };

--- a/flake.nix
+++ b/flake.nix
@@ -56,7 +56,7 @@
 
     cardano-mainnet-mirror.url = "github:input-output-hk/cardano-mainnet-mirror/nix";
 
-    std.url = "github:divnix/std";
+    incl.url = "github:divnix/incl";
 
     cardano-automation = {
       url = "github:input-output-hk/cardano-automation";
@@ -77,7 +77,7 @@
     , iohkNix
     , ops-lib
     , cardano-mainnet-mirror
-    , std
+    , incl
     , cardano-automation
     , em
     , ...
@@ -407,8 +407,7 @@
       overlay = final: prev: {
         cardanoNodeProject = (import ./nix/haskell.nix {
           inherit (final) haskell-nix;
-          inherit (std) incl;
-          inherit CHaP;
+          inherit CHaP incl;
           macOS-security = macOS-security (final.pkgs);
         }).appendModule [
           customConfig.haskellNix

--- a/flake.nix
+++ b/flake.nix
@@ -7,52 +7,6 @@
   };
 
   inputs = {
-    # IMPORTANT: report any change to nixpkgs channel in nix/default.nix:
-    nixpkgs.follows = "haskellNix/nixpkgs-unstable";
-    hackageNix = {
-      url = "github:input-output-hk/hackage.nix";
-      flake = false;
-    };
-    haskellNix = {
-      # GHC 8.10.7 cross compilation for windows is broken in newer versions of haskell.nix.
-      # Unpin this once we no longer need GHC 8.10.7.
-      url = "github:input-output-hk/haskell.nix/cb139fa956158397aa398186bb32dd26f7318784";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.hackage.follows = "hackageNix";
-    };
-    CHaP = {
-      url = "github:intersectmbo/cardano-haskell-packages?ref=repo";
-      flake = false;
-    };
-    utils.url = "github:numtide/flake-utils";
-    iohkNix = {
-      url = "github:input-output-hk/iohk-nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-    flake-compat = {
-      url = "github:input-output-hk/flake-compat/fixes";
-      flake = false;
-    };
-    em = {
-      url = "github:deepfire/em";
-      flake = false;
-    };
-
-    # Custom user config (default: empty), eg.:
-    # { outputs = {...}: {
-    #   # Cutomize listeming port of node scripts:
-    #   nixosModules.cardano-node = {
-    #     services.cardano-node.port = 3002;
-    #   };
-    # };
-    customConfig.url = "github:input-output-hk/empty-flake";
-
-    empty-flake.url = "github:input-output-hk/empty-flake";
-
-    cardano-mainnet-mirror.url = "github:input-output-hk/cardano-mainnet-mirror/nix";
-
-    incl.url = "github:divnix/incl";
-
     cardano-automation = {
       url = "github:input-output-hk/cardano-automation";
       inputs = {
@@ -60,19 +14,69 @@
         nixpkgs.follows = "nixpkgs";
       };
     };
+
+    cardano-mainnet-mirror.url = "github:input-output-hk/cardano-mainnet-mirror/nix";
+
+    # Custom user config (default: empty), eg:
+    # { outputs = {...}: {
+    #   # Customize listening port of node scripts:
+    #   nixosModules.cardano-node.services.cardano-node.port = 3002;
+    # };
+    customConfig.url = "github:input-output-hk/empty-flake";
+
+    CHaP = {
+      url = "github:intersectmbo/cardano-haskell-packages?ref=repo";
+      flake = false;
+    };
+
+    em = {
+      url = "github:deepfire/em";
+      flake = false;
+    };
+
+    empty-flake.url = "github:input-output-hk/empty-flake";
+
+    flake-compat = {
+      url = "github:input-output-hk/flake-compat/fixes";
+      flake = false;
+    };
+
+    hackageNix = {
+      url = "github:input-output-hk/hackage.nix";
+      flake = false;
+    };
+
+    haskellNix = {
+      # GHC 8.10.7 cross compilation for windows is broken in newer versions of haskell.nix.
+      # Unpin this once we no longer need GHC 8.10.7.
+      url = "github:input-output-hk/haskell.nix/cb139fa956158397aa398186bb32dd26f7318784";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.hackage.follows = "hackageNix";
+    };
+
+    incl.url = "github:divnix/incl";
+
+    iohkNix = {
+      url = "github:input-output-hk/iohk-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    nixpkgs.follows = "haskellNix/nixpkgs-unstable";
+
+    utils.url = "github:numtide/flake-utils";
   };
 
   outputs =
-    { self
-    , nixpkgs
-    , utils
-    , haskellNix
-    , CHaP
-    , iohkNix
+    { cardano-automation
     , cardano-mainnet-mirror
-    , incl
-    , cardano-automation
+    , CHaP
     , em
+    , haskellNix
+    , incl
+    , iohkNix
+    , nixpkgs
+    , self
+    , utils
     , ...
     }@input:
     let

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,6 @@
   inputs = {
     # IMPORTANT: report any change to nixpkgs channel in nix/default.nix:
     nixpkgs.follows = "haskellNix/nixpkgs-unstable";
-    hostNixpkgs.follows = "nixpkgs";
     hackageNix = {
       url = "github:input-output-hk/hackage.nix";
       flake = false;
@@ -29,10 +28,6 @@
     iohkNix = {
       url = "github:input-output-hk/iohk-nix";
       inputs.nixpkgs.follows = "nixpkgs";
-    };
-    ops-lib = {
-      url = "github:input-output-hk/ops-lib";
-      flake = false;
     };
     flake-compat = {
       url = "github:input-output-hk/flake-compat/fixes";
@@ -70,12 +65,10 @@
   outputs =
     { self
     , nixpkgs
-    , hostNixpkgs
     , utils
     , haskellNix
     , CHaP
     , iohkNix
-    , ops-lib
     , cardano-mainnet-mirror
     , incl
     , cardano-automation
@@ -123,7 +116,7 @@
         })
         (import ./nix/pkgs.nix)
         self.overlay
-      ] ++ (import ops-lib.outPath {}).overlays;
+      ];
 
       collectExes = project:
         let set-git-rev = import ./nix/set-git-rev.nix { inherit (project) pkgs; };

--- a/flake.nix
+++ b/flake.nix
@@ -86,7 +86,7 @@
     removeRecurse = lib.filterAttrsRecursive (n: _: n != "recurseForDerivations");
 
     macOS-security = pkgs:
-    # make `/usr/bin/security` available in `PATH`, which is needed for stack
+    # Make `/usr/bin/security` available in `PATH`, which is needed for stack
     # on darwin which calls this binary to find certificates
       pkgs.writeScriptBin "security" ''exec /usr/bin/security "$@"'';
 
@@ -98,7 +98,7 @@
       input.customConfig;
 
     overlays = [
-      # crypto needs to come before haskell.nix.
+      # Crypto needs to come before haskell.nix.
       # FIXME: _THIS_IS_BAD_
       iohkNix.overlays.crypto
       haskellNix.overlay
@@ -128,13 +128,13 @@
     collectExes = project: let
       set-git-rev = import ./nix/set-git-rev.nix {inherit (project) pkgs;};
     in
-      # take all executables from the project local packages
+      # Take all executables from the project local packages
       project.exes
       // (with project.hsPkgs; {
-        # add some executables from other relevant packages
+        # Add some executables from other relevant packages
         inherit (bech32.components.exes) bech32;
         inherit (ouroboros-consensus-cardano.components.exes) db-analyser db-synthesizer db-truncater;
-        # add cardano-node and cardano-cli with their git revision stamp
+        # Add cardano-node and cardano-cli with their git revision stamp
         cardano-node = set-git-rev project.exes.cardano-node;
         cardano-cli = set-git-rev cardano-cli.components.exes.cardano-cli;
       });
@@ -178,7 +178,7 @@
         (optionalAttrs hostPlatform.isLinux (
           prefixNamesWith "nixosTests/" (mapAttrs (_: v: v.${system} or v) nixosTests)
         ))
-        # checks run on default system only;
+        # Checks run on default system only:
         // (optionalAttrs (system == defaultSystem) {
           hlint = pkgs.callPackage pkgs.hlintCheck {
             inherit (project.args) src;
@@ -198,7 +198,7 @@
             inherit (project) benchmarks;
           });
 
-      # The parametrisable workbench.
+      # The parameterisable workbench.
       inherit (pkgs) workbench;
 
       packages =
@@ -222,7 +222,7 @@
           "dockerImage/node" = pkgs.dockerImage;
           "dockerImage/submit-api" = pkgs.submitApiDockerImage;
 
-          ## This is a very light profile, no caching&pinning needed.
+          # This is a very light profile, no caching and pinning needed.
           workbench-ci-test = workbenchTest {
             profileName = "ci-test-hydra-coay";
             workbenchStartArgs = ["--create-testnet-data"];
@@ -347,7 +347,7 @@
             native =
               lib.filterAttrs
               (n: _:
-                # only build docker images once on linux:
+                # Only build docker images once on linux:
                   !(lib.hasPrefix "dockerImage" n))
               packages
               // {
@@ -367,20 +367,20 @@
           };
         nonRequiredPaths =
           [
-            #FIXME: cardano-tracer-test for windows should probably be disabled in haskell.nix config:
+            # FIXME: cardano-tracer-test for windows should probably be disabled in haskell.nix config:
             "windows\\.(.*\\.)?checks\\.cardano-tracer\\.cardano-tracer-test"
-            #FIXME: plutus-scripts-bench (dep of tx-generator) does not compile for windows:
+            # FIXME: plutus-scripts-bench (dep of tx-generator) does not compile for windows:
             "windows\\.(.*\\.)?tx-generator.*"
-            #FIXME: plutus-scripts-bench's gen-plutus does not compile for musl
+            # FIXME: plutus-scripts-bench's gen-plutus does not compile for musl
             "musl\\.(.*\\.)?tx-generator.*"
             "musl\\.(.*\\.)?gen-plutus.*"
             # hlint required status is controled via the github action:
             "native\\.(.*\\.)?checks/hlint"
-            #system-tests are build and run separately:
+            # system-tests are build and run separately:
             "native\\.(.*\\.)?system-tests"
           ]
           ++ lib.optionals (system == "x86_64-darwin") [
-            #FIXME: make variants nonrequired for macos until CI has more capacity for macos builds
+            # FIXME: make variants nonrequired for macos until CI has more capacity for macos builds
             "native\\.variants\\..*"
             "native\\.checks/cardano-testnet/cardano-testnet-test"
           ];
@@ -406,7 +406,7 @@
         legacyPackages =
           pkgs
           // {
-            # allows access to hydraJobs without specifying <arch>:
+            # Allows access to hydraJobs without specifying <arch>:
             hydraJobs = ciJobs;
           };
 
@@ -438,7 +438,7 @@
               ciJobs =
                 lib.mapAttrs (_: lib.getAttr "required") flake.ciJobs
                 // {
-                  # ensure hydra notify:
+                  # Ensure hydra notify:
                   gitrev = pkgs.writeText "gitrev" pkgs.gitrev;
                 };
             })
@@ -446,7 +446,7 @@
             ;
         });
 
-      # allows precise paths (avoid fallbacks) with nix build/eval:
+      # Allows precise paths (avoid fallbacks) with nix build/eval:
       outputs = self;
 
       overlay = final: prev: {

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -43,6 +43,7 @@ let
 
         # These programs will be available inside the nix-shell.
         nativeBuildInputs = with pkgs.pkgsBuildBuild; [
+          alejandra
           nix-prefetch-git
           pkg-config
           hlint

--- a/shell.nix
+++ b/shell.nix
@@ -106,6 +106,7 @@ let
     packages = _: [];
 
     nativeBuildInputs = with cardanoNodePackages; [
+      alejandra
       nix
       cardano-cli
       bech32


### PR DESCRIPTION
# Description

A small flake cleanup PR which:
* Removes unneeded/unused inputs of std, hostNixpkgs, ops-lib
* Removes ops-lib overlays as they are no longer used
* Replaces the std `incl` source filter with a lightweight direct input which uses the same source
* Cleans up comments, sorts inputs and output attr args alphabetically
* Formats flake.nix with alejandra
* Adds alejandra to the default (dev) and devops shells
* Bumps cardano-automation for a flake inputs optimized commit

Using flake [inputs-check](https://github.com/input-output-hk/inputs-check), we can see some overall flake closure size improvements which should improve initial devShell loads a bit, depending on bandwidth:

|                               |   Before PR   |  After PR  |
| ----------------------------: | :-----------: | :--------: |
| Top Level Inputs              |       15      |     13     |
| Total Inputs                  |      165      |     99     |
| Unique Input Closures         |       81      |     53     |
| Total Input Closure size (B)  |  4754634272   | 4199170824 |
| Total Input Closure size (GB) |     4.75      |    4.19    |

These PR changes reduce total flake closure size by about 18%, most of which is coming from removing nested `std` and `tullia` inputs.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] CI passes. See note on CI.  The following CI checks are required:
- [X] Self-reviewed the diff