### PR TITLE
cardano-testnet: allow to take node configuration file as input

### DIFF
--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -91,6 +91,7 @@ library
                       , transformers
                       , transformers-except
                       , vector
+                      , yaml
 
   hs-source-dirs:       src
   exposed-modules:      Cardano.Testnet

--- a/cardano-testnet/src/Cardano/Testnet.hs
+++ b/cardano-testnet/src/Cardano/Testnet.hs
@@ -11,6 +11,7 @@ module Cardano.Testnet (
   -- ** Testnet options
   CardanoTestnetOptions(..),
   TestnetNodeOptions(..),
+  AutomaticNodeOption(..),
   cardanoDefaultTestnetNodeOptions,
   getDefaultAlonzoGenesis,
   getDefaultShelleyGenesis,

--- a/cardano-testnet/src/Parsers/Cardano.hs
+++ b/cardano-testnet/src/Parsers/Cardano.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module Parsers.Cardano
   ( cmdCardano
   ) where
@@ -9,6 +11,7 @@ import           Cardano.CLI.EraBased.Options.Common hiding (pNetworkId)
 
 import           Prelude
 
+import           Control.Applicative
 import           Data.Default.Class
 import           Data.Functor
 import qualified Data.List as L
@@ -20,6 +23,7 @@ import           Testnet.Start.Cardano
 import           Testnet.Start.Types
 import           Testnet.Types (readNodeLoggingFormat)
 
+{- HLINT ignore "Use asum" -}
 
 optsTestnet :: EnvCli -> Parser CardanoTestnetCliOptions
 optsTestnet envCli = CardanoTestnetCliOptions
@@ -28,7 +32,7 @@ optsTestnet envCli = CardanoTestnetCliOptions
 
 pCardanoTestnetCliOptions :: EnvCli -> Parser CardanoTestnetOptions
 pCardanoTestnetCliOptions envCli = CardanoTestnetOptions
-  <$> pNumSpoNodes
+  <$> pTestnetNodeOptions
   <*> pAnyShelleyBasedEra'
   <*> pMaxLovelaceSupply
   <*> OA.option auto
@@ -47,7 +51,7 @@ pCardanoTestnetCliOptions envCli = CardanoTestnetOptions
       )
   <*> OA.option auto
       (   OA.long "num-dreps"
-      <>  OA.help "Number of delegate representatives (DReps) to generate"
+      <>  OA.help "Number of delegate representatives (DReps) to generate. Ignored if a custom Conway genesis file is passed."
       <>  OA.metavar "NUMBER"
       <>  OA.showDefault
       <>  OA.value 3
@@ -67,19 +71,27 @@ pCardanoTestnetCliOptions envCli = CardanoTestnetOptions
     pAnyShelleyBasedEra' =
       pAnyShelleyBasedEra envCli <&> (\(EraInEon x) -> AnyShelleyBasedEra x)
 
-pNumSpoNodes :: Parser [TestnetNodeOptions]
-pNumSpoNodes =
-  -- We don't support passing custom node configurations files on the CLI.
-  -- So we use a default node configuration for all nodes.
-  (`L.replicate` defaultSpoOptions) <$>
-    OA.option auto
-    (   OA.long "num-pool-nodes"
-    <>  OA.help "Number of pool nodes. Note this uses a default node configuration for all nodes."
-    <>  OA.metavar "COUNT"
-    <>  OA.showDefault
-    <>  OA.value 1)
+pTestnetNodeOptions :: Parser TestnetNodeOptions
+pTestnetNodeOptions =
+  asum' [
+      AutomaticNodeOptions . (`L.replicate` defaultSpoOptions) <$>
+        OA.option auto
+        (   OA.long "num-pool-nodes"
+        <>  OA.help "Number of pool nodes. Note this uses a default node configuration for all nodes."
+        <>  OA.metavar "COUNT"
+        <>  OA.showDefault
+        <>  OA.value 1)
+    , UserProvidedNodeOptions
+        <$> strOption ( long "node-config"
+                        <> metavar "FILEPATH"
+                        <> help "Path to the node's configuration file (which is generated otherwise). If you use this option, you should also pass all the genesis files (files pointed to by the fields \"AlonzoGenesisFile\", \"ShelleyGenesisFile\", etc.).")
+    ]
   where
     defaultSpoOptions = SpoNodeOptions []
+    -- \| Because asum is not available GHC 8.10.7's base (4.14.3.0). This can be removed
+    -- when oldest version of GHC we use is >= 9.0 (base >= 4.15)
+    asum' :: (Foldable t, Alternative f) => t (f a) -> f a
+    asum' = foldr (<|>) empty
 
 pGenesisOptions :: Parser GenesisOptions
 pGenesisOptions =
@@ -92,7 +104,8 @@ pGenesisOptions =
     pEpochLength =
       OA.option auto
         (   OA.long "epoch-length"
-        <>  OA.help "Epoch length, in number of slots"
+        -- TODO Check that this flag is not used when a custom Shelley genesis file is passed
+        <>  OA.help "Epoch length, in number of slots. Ignored if a custom Shelley genesis file is passed."
         <>  OA.metavar "SLOTS"
         <>  OA.showDefault
         <>  OA.value (genesisEpochLength def)
@@ -100,7 +113,8 @@ pGenesisOptions =
     pSlotLength =
       OA.option auto
         (   OA.long "slot-length"
-        <>  OA.help "Slot length"
+        -- TODO Check that this flag is not used when a custom Shelley genesis file is passed
+        <>  OA.help "Slot length. Ignored if a custom Shelley genesis file is passed."
         <>  OA.metavar "SECONDS"
         <>  OA.showDefault
         <>  OA.value (genesisSlotLength def)
@@ -108,7 +122,8 @@ pGenesisOptions =
     pActiveSlotCoeffs =
       OA.option auto
         (   OA.long "active-slots-coeff"
-        <>  OA.help "Active slots co-efficient"
+        -- TODO Check that this flag is not used when a custom Shelley genesis file is passed
+        <>  OA.help "Active slots coefficient. Ignored if a custom Shelley genesis file is passed."
         <>  OA.metavar "DOUBLE"
         <>  OA.showDefault
         <>  OA.value (genesisActiveSlotsCoeff def)
@@ -129,7 +144,8 @@ pMaxLovelaceSupply :: Parser Word64
 pMaxLovelaceSupply =
   option auto
       (   long "max-lovelace-supply"
-      <>  help "Max lovelace supply that your testnet starts with."
+      -- TODO Check that this flag is not used when a custom Shelley genesis file is passed
+      <>  help "Max lovelace supply that your testnet starts with. Ignored if a custom Shelley genesis file is passed."
       <>  metavar "WORD64"
       <>  showDefault
       <>  value (cardanoMaxSupply def)

--- a/cardano-testnet/src/Parsers/Run.hs
+++ b/cardano-testnet/src/Parsers/Run.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Parsers.Run
   ( commands
@@ -8,14 +9,27 @@ module Parsers.Run
   , opts
   ) where
 
-import           Cardano.CLI.Environment
+import           Cardano.Api.Ledger (StandardCrypto)
+import           Cardano.Api.Shelley (ShelleyGenesis)
 
+import           Cardano.CLI.Environment
+import           Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis)
+import           Cardano.Ledger.Conway.Genesis (ConwayGenesis)
+import           Cardano.Node.Configuration.POM
+import           Cardano.Node.Types
+
+import qualified Data.Aeson as Aeson
 import           Data.Foldable
+import           Data.Monoid
+import           Data.Yaml (decodeFileThrow)
 import           Options.Applicative
 import qualified Options.Applicative as Opt
+import qualified System.Directory as System
+import           System.FilePath (takeDirectory, (</>))
 
 import           Testnet.Property.Run
 import           Testnet.Start.Cardano
+import           Testnet.Start.Types
 
 import           Parsers.Cardano
 import           Parsers.Help
@@ -52,5 +66,49 @@ runTestnetCmd = \case
 
 
 runCardanoOptions :: CardanoTestnetCliOptions -> IO ()
-runCardanoOptions (CardanoTestnetCliOptions testnetOptions shelleyOptions) =
-  runTestnet testnetOptions $ cardanoTestnetDefault testnetOptions shelleyOptions
+runCardanoOptions (CardanoTestnetCliOptions testnetOptions genesisOptions) =
+    case cardanoNodes testnetOptions of
+      AutomaticNodeOptions _ -> runTestnet testnetOptions $ cardanoTestnetDefault testnetOptions genesisOptions
+      UserProvidedNodeOptions nodeInputConfigFile -> do
+        nodeConfigFile <- readNodeConfigurationFile nodeInputConfigFile
+        let protocolConfig :: NodeProtocolConfiguration =
+              case getLast $ pncProtocolConfig nodeConfigFile of
+                Nothing -> error $ "Genesis files not specified in node configuration file: " <> nodeInputConfigFile
+                Just x -> x
+            adjustedProtocolConfig =
+              -- Make all the files be relative to the location of the config file.
+              adjustFilePaths (takeDirectory nodeInputConfigFile </>) protocolConfig
+            (shelley, alonzo, conway) = getShelleyGenesises adjustedProtocolConfig
+        shelleyGenesis :: UserProvidedData (ShelleyGenesis StandardCrypto) <-
+          genesisFilepathToData $ npcShelleyGenesisFile shelley
+        alonzoGenesis :: UserProvidedData AlonzoGenesis <-
+          genesisFilepathToData $ npcAlonzoGenesisFile alonzo
+        conwayGenesis :: UserProvidedData (ConwayGenesis StandardCrypto) <-
+          genesisFilepathToData $ npcConwayGenesisFile conway
+        runTestnet testnetOptions $ cardanoTestnet
+          testnetOptions
+          genesisOptions
+          shelleyGenesis
+          alonzoGenesis
+          conwayGenesis
+  where
+    getShelleyGenesises (NodeProtocolConfigurationCardano _byron shelley alonzo conway _hardForkConfig _checkPointConfig) =
+      (shelley, alonzo, conway)
+    readNodeConfigurationFile :: FilePath -> IO PartialNodeConfiguration
+    readNodeConfigurationFile file = do
+      errOrNodeConfig <- Aeson.eitherDecodeFileStrict' file
+      case errOrNodeConfig of
+        Left err -> error $ "Error reading node configuration file: " <> err
+        Right nodeConfig -> pure nodeConfig
+    genesisFilepathToData :: Aeson.FromJSON a => GenesisFile -> IO (UserProvidedData a)
+    genesisFilepathToData (GenesisFile filepath) = do
+      exists <- System.doesFileExist filepath
+      if exists
+        then UserProvidedData <$> decodeFileThrow filepath
+        else
+          -- Here we forbid mixing defaulting of genesis files with providing a user node configuration file:
+          --
+          -- Because of this check, either the user passes a node configuration file AND he passes all the genesis files.
+          -- Or the user doesn't pass a node configuration file AND cardano-testnet generates all the genesis files.
+          -- See the discussion here: https://github.com/IntersectMBO/cardano-node/pull/6103#discussion_r1995431437
+          error $ "Genesis file specified in node configuration file does not exist: " <> filepath

--- a/cardano-testnet/src/Testnet/Runtime.hs
+++ b/cardano-testnet/src/Testnet/Runtime.hs
@@ -142,16 +142,13 @@ startNode tp node ipv4 port _testnetMagic nodeCmd = GHC.withFrozenCallStack $ do
        left MaxSprocketLengthExceededError
 
     let socketAbsPath = H.sprocketSystemName sprocket
+        completeNodeCmd =  nodeCmd ++
+                             [ "--socket-path", H.sprocketArgumentName sprocket
+                             , "--port", show port
+                             , "--host-addr", showIpv4Address ipv4
+                             ]
 
-    nodeProcess
-      <- newExceptT . fmap (first ExecutableRelatedFailure) . try
-           $ procNode $ mconcat
-                         [ nodeCmd
-                         , [ "--socket-path", H.sprocketArgumentName sprocket
-                           , "--port", show port
-                           , "--host-addr", showIpv4Address ipv4
-                           ]
-                         ]
+    nodeProcess <- newExceptT . fmap (first ExecutableRelatedFailure) . try $ procNode completeNodeCmd
 
     -- The port number if it is obtained using 'H.randomPort', it is firstly bound to and then closed. The closing
     -- and release in the operating system is done asynchronously and can be slow. Here we wait until the port

--- a/cardano-testnet/src/Testnet/Start/Types.hs
+++ b/cardano-testnet/src/Testnet/Start/Types.hs
@@ -7,6 +7,7 @@
 module Testnet.Start.Types
   ( CardanoTestnetCliOptions(..)
   , CardanoTestnetOptions(..)
+  , InputNodeConfigFile(..)
   , NumDReps(..)
   , NumPools(..)
   , NumRelays(..)
@@ -18,8 +19,7 @@ module Testnet.Start.Types
   , eraToString
 
   , TestnetNodeOptions(..)
-  , testnetNodeExtraCliArgs
-  , isSpoNodeOptions
+  , AutomaticNodeOption(..)
   , isRelayNodeOptions
   , cardanoDefaultTestnetNodeOptions
   , GenesisOptions(..)
@@ -64,9 +64,9 @@ instance Default CardanoTestnetCliOptions where
 -- | Options which, contrary to 'GenesisOptions' are not implemented
 -- by tuning the genesis files.
 data CardanoTestnetOptions = CardanoTestnetOptions
-  { -- | List of node options. Each option will result in a single node being
-    -- created.
-    cardanoNodes :: [TestnetNodeOptions]
+  { -- | Options controlling how many nodes to create and whether to use user-provided
+    -- configuration files, or to generate them automatically.
+    cardanoNodes :: TestnetNodeOptions
   , cardanoNodeEra :: AnyShelleyBasedEra -- ^ The era to start at
   , cardanoMaxSupply :: Word64 -- ^ The amount of Lovelace you are starting your testnet with (forwarded to shelley genesis)
                                -- TODO move me to GenesisOptions when https://github.com/IntersectMBO/cardano-cli/pull/874 makes it to cardano-node
@@ -77,13 +77,23 @@ data CardanoTestnetOptions = CardanoTestnetOptions
   , cardanoOutputDir :: Maybe FilePath -- ^ The output directory where to store files, sockets, and so on. If unset, a temporary directory is used.
   } deriving (Eq, Show)
 
+-- | Path to the configuration file of the node, specified by the user
+newtype InputNodeConfigFile = InputNodeConfigFile FilePath
+  deriving (Eq, Show)
+
 cardanoNumPools :: CardanoTestnetOptions -> NumPools
 cardanoNumPools CardanoTestnetOptions{cardanoNodes} =
-  NumPools . length $ filter isSpoNodeOptions cardanoNodes
+  NumPools $
+    case cardanoNodes of
+      UserProvidedNodeOptions _ -> 1
+      AutomaticNodeOptions opts -> length $ filter isSpoNodeOptions opts
 
 cardanoNumRelays :: CardanoTestnetOptions -> NumRelays
 cardanoNumRelays CardanoTestnetOptions{cardanoNodes} =
-  NumRelays . length $ filter isRelayNodeOptions cardanoNodes
+  NumRelays $
+    case cardanoNodes of
+      UserProvidedNodeOptions _ -> 1
+      AutomaticNodeOptions opts -> length $ filter isRelayNodeOptions opts
 
 -- | Number of stake pool nodes
 newtype NumPools = NumPools Int
@@ -125,12 +135,20 @@ instance Default GenesisOptions where
     , genesisActiveSlotsCoeff = 0.05
     }
 
--- | Specify a SPO (Shelley era onwards only) or a Relay node
-data TestnetNodeOptions
-  = SpoNodeOptions [String]
+data TestnetNodeOptions =
+  UserProvidedNodeOptions FilePath
+  -- ^ Value used when the user specifies the node configuration file. We start one single SPO node.
+  | AutomaticNodeOptions [AutomaticNodeOption]
+  -- ^ Value used when @cardano-testnet@ controls the node configuration files.
+  -- We start a custom number of nodes.
+  deriving (Eq, Show)
+
+-- | Type used when the user doesn't specify the node configuration file. We start
+-- a custom number of nodes. The '@String' arguments will be appended to the default
+-- options when starting the node.
+data AutomaticNodeOption =
+    SpoNodeOptions [String]
   | RelayNodeOptions [String]
-    -- ^ These arguments will be appended to the default set of CLI options when
-    -- starting the node.
   deriving (Eq, Show)
 
 -- | Type used to track whether the user is providing its data (node configuration file path, genesis file, etc.)
@@ -139,25 +157,20 @@ data UserProvidedData a =
     UserProvidedData a
   | NoUserProvidedData
 
--- | Get extra CLI arguments passed to the node executable
-testnetNodeExtraCliArgs :: TestnetNodeOptions -> [String]
-testnetNodeExtraCliArgs (SpoNodeOptions args) = args
-testnetNodeExtraCliArgs (RelayNodeOptions args) = args
-
-isSpoNodeOptions :: TestnetNodeOptions -> Bool
+isSpoNodeOptions :: AutomaticNodeOption -> Bool
 isSpoNodeOptions SpoNodeOptions{} = True
 isSpoNodeOptions RelayNodeOptions{} = False
 
-isRelayNodeOptions :: TestnetNodeOptions -> Bool
+isRelayNodeOptions :: AutomaticNodeOption -> Bool
 isRelayNodeOptions SpoNodeOptions{} = False
 isRelayNodeOptions RelayNodeOptions{} = True
 
-cardanoDefaultTestnetNodeOptions :: [TestnetNodeOptions]
+cardanoDefaultTestnetNodeOptions :: TestnetNodeOptions
 cardanoDefaultTestnetNodeOptions =
-  [ SpoNodeOptions []
-  , RelayNodeOptions []
-  , RelayNodeOptions []
-  ]
+  AutomaticNodeOptions [ SpoNodeOptions []
+                       , RelayNodeOptions []
+                       , RelayNodeOptions []
+                       ]
 
 data NodeLoggingFormat = NodeLoggingFormatAsJson | NodeLoggingFormatAsText deriving (Eq, Show)
 

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
@@ -1,6 +1,6 @@
 Usage: cardano-testnet (cardano | version | help)
 
-Usage: cardano-testnet cardano [--num-pool-nodes COUNT]
+Usage: cardano-testnet cardano [--num-pool-nodes COUNT | --node-config FILEPATH]
   [ --shelley-era
   | --allegra-era
   | --mary-era

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/cardano.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/cardano.cli
@@ -1,4 +1,4 @@
-Usage: cardano-testnet cardano [--num-pool-nodes COUNT]
+Usage: cardano-testnet cardano [--num-pool-nodes COUNT | --node-config FILEPATH]
   [ --shelley-era
   | --allegra-era
   | --mary-era
@@ -22,6 +22,11 @@ Usage: cardano-testnet cardano [--num-pool-nodes COUNT]
 Available options:
   --num-pool-nodes COUNT   Number of pool nodes. Note this uses a default node
                            configuration for all nodes. (default: 1)
+  --node-config FILEPATH   Path to the node's configuration file (which is
+                           generated otherwise). If you use this option, you
+                           should also pass all the genesis files (files pointed
+                           to by the fields "AlonzoGenesisFile",
+                           "ShelleyGenesisFile", etc.).
   --shelley-era            Specify the Shelley era - DEPRECATED - will be
                            removed in the future
   --allegra-era            Specify the Allegra era - DEPRECATED - will be
@@ -35,13 +40,15 @@ Available options:
   --conway-era             Specify the Conway era
   --max-lovelace-supply WORD64
                            Max lovelace supply that your testnet starts with.
+                           Ignored if a custom Shelley genesis file is passed.
                            (default: 100000020000000)
   --enable-p2p BOOL        Enable P2P (default: False)
   --nodeLoggingFormat LOGGING_FORMAT
                            Node logging format (json|text)
                            (default: NodeLoggingFormatAsJson)
   --num-dreps NUMBER       Number of delegate representatives (DReps) to
-                           generate (default: 3)
+                           generate. Ignored if a custom Conway genesis file is
+                           passed. (default: 3)
   --enable-new-epoch-state-logging
                            Enable new epoch state logging to
                            logs/ledger-epoch-state.log
@@ -49,8 +56,11 @@ Available options:
                            It is created if it doesn't exist. If unset, a
                            temporary directory is used.
   --testnet-magic INT      Specify a testnet magic id.
-  --epoch-length SLOTS     Epoch length, in number of slots (default: 500)
-  --slot-length SECONDS    Slot length (default: 0.1)
+  --epoch-length SLOTS     Epoch length, in number of slots. Ignored if a custom
+                           Shelley genesis file is passed. (default: 500)
+  --slot-length SECONDS    Slot length. Ignored if a custom Shelley genesis file
+                           is passed. (default: 0.1)
   --active-slots-coeff DOUBLE
-                           Active slots co-efficient (default: 5.0e-2)
+                           Active slots coefficient. Ignored if a custom Shelley
+                           genesis file is passed. (default: 5.0e-2)
   -h,--help                Show this help text

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/LeadershipSchedule.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/LeadershipSchedule.hs
@@ -67,10 +67,10 @@ hprop_leadershipSchedule = integrationRetryWorkspace 2 "leadership-schedule" $ \
       cTestnetOptions = def
         { cardanoNodeEra = asbe
         , cardanoNodes =
-          [ SpoNodeOptions []
-          , SpoNodeOptions []
-          , SpoNodeOptions []
-          ]
+          AutomaticNodeOptions [ SpoNodeOptions []
+                               , SpoNodeOptions []
+                               , SpoNodeOptions []
+                               ]
         }
       eraString = eraToString sbe
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs
@@ -114,9 +114,9 @@ hprop_gov_no_confidence = integrationWorkspace "no-confidence" $ \tempAbsBasePat
     } <- cardanoTestnet
            fastTestnetOptions
            genesisOptions
-           conf
-           NoUserProvidedData NoUserProvidedData NoUserProvidedData
+           NoUserProvidedData NoUserProvidedData
            (UserProvidedData conwayGenesisWithCommittee)
+           conf
 
   poolNode1 <- H.headM testnetNodes
   poolSprocket1 <- H.noteShow $ nodeSprocket poolNode1

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitutionSPO.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitutionSPO.hs
@@ -58,10 +58,10 @@ hprop_ledger_events_propose_new_constitution_spo = integrationWorkspace "propose
       fastTestnetOptions = def
         { cardanoNodeEra = AnyShelleyBasedEra sbe
         , cardanoNodes =
-          [ SpoNodeOptions []
-          , SpoNodeOptions []
-          , SpoNodeOptions []
-          ]
+          AutomaticNodeOptions [ SpoNodeOptions []
+                               , SpoNodeOptions []
+                               , SpoNodeOptions []
+                               ]
         }
       shelleyOptions = def { genesisEpochLength = 100 }
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Node/Shutdown.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Node/Shutdown.hs
@@ -198,8 +198,9 @@ hprop_shutdownOnSlotSynced = integrationRetryWorkspace 2 "shutdown-on-slot-synce
       slotLen = 0.01
   let fastTestnetOptions = def
         { cardanoNodes =
-          [ SpoNodeOptions ["--shutdown-on-slot-synced", show maxSlot]
-          ]
+          AutomaticNodeOptions
+            [ SpoNodeOptions ["--shutdown-on-slot-synced", show maxSlot]
+            ]
         }
       shelleyOptions = def
         { genesisEpochLength = 300


### PR DESCRIPTION
> [!WARNING]
>
> If this design is chosen (over https://github.com/IntersectMBO/cardano-node/pull/6103), then https://github.com/cardano-foundation/developer-portal/pull/1426 needs to be amended correspondingly

# Description

Fixes https://github.com/IntersectMBO/cardano-node/issues/6069

Fixes https://github.com/IntersectMBO/cardano-node/issues/6137

Variant of https://github.com/IntersectMBO/cardano-node/pull/6103 where passing the node configuration file and the genesis files are tied:

* Either you pass the node configuration file and all 3 genesis files,
* or you pass none of these; and `cardano-testnet` generates everything for you

# Follow-up issues to create

@Jimbo4350> please tick them if you agree :slightly_smiling_face:  I'll create them

* [ ] Have `pTestnetNodeOptions` return a list of `TestnetNodeOption` and `TestnetNodeOption` be `UserProvidedNodeOptions Filepath | SpoNodeOptions [Srting] | RelayNodeOptions [ String]`. In other words merge the types `TestnetNodeOptions` and `AutomaticNodeOption`. This will generalize the behavior so that the user can create multiple nodes, no matter whether they are using custom options or using default behavior (`Spo` or `Relay`). This will require a bit of generalization in [Cardano.hs](cardano-testnet/src/Testnet/Start/Cardano.hs) but not much. :left_right_arrow: shown here: https://github.com/IntersectMBO/cardano-node/pull/6155
* [ ] ~~Change `cardanoTestnet` to take `Filepath` for genesis files instead of Haskell values, maybe?~~ Decided against
* [ ] Check that the CLI flags changing genesis values are not used when passing a custom genesis file (TODOs are added in the code already about this).
* [ ] Reflect in the types the tying behavior between the node configuration file being passed by the user and the genesis files being passed by the user too. :left_right_arrow: shown here: https://github.com/IntersectMBO/cardano-node/pull/6155
* [X] Created already: https://github.com/IntersectMBO/cardano-node/issues/6122

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [ ] CI passes. See note on CI.  The following CI checks are required:
- [X] Self-reviewed the diff