### PR TITLE
cardano-testnet: remove unused enable P2P option

### DIFF
--- a/cardano-testnet/src/Parsers/Cardano.hs
+++ b/cardano-testnet/src/Parsers/Cardano.hs
@@ -35,13 +35,6 @@ pCardanoTestnetCliOptions envCli = CardanoTestnetOptions
   <$> pTestnetNodeOptions
   <*> pAnyShelleyBasedEra'
   <*> pMaxLovelaceSupply
-  <*> OA.option auto
-      (   OA.long "enable-p2p"
-      <>  OA.help "Enable P2P"
-      <>  OA.metavar "BOOL"
-      <>  OA.showDefault
-      <>  OA.value (cardanoEnableP2P def)
-      )
   <*> OA.option (OA.eitherReader readNodeLoggingFormat)
       (   OA.long "nodeLoggingFormat"
       <>  OA.help "Node logging format (json|text)"

--- a/cardano-testnet/src/Testnet/Start/Types.hs
+++ b/cardano-testnet/src/Testnet/Start/Types.hs
@@ -70,7 +70,6 @@ data CardanoTestnetOptions = CardanoTestnetOptions
   , cardanoNodeEra :: AnyShelleyBasedEra -- ^ The era to start at
   , cardanoMaxSupply :: Word64 -- ^ The amount of Lovelace you are starting your testnet with (forwarded to shelley genesis)
                                -- TODO move me to GenesisOptions when https://github.com/IntersectMBO/cardano-cli/pull/874 makes it to cardano-node
-  , cardanoEnableP2P :: Bool
   , cardanoNodeLoggingFormat :: NodeLoggingFormat
   , cardanoNumDReps :: NumDReps -- ^ The number of DReps to generate at creation
   , cardanoEnableNewEpochStateLogging :: Bool -- ^ if epoch state logging is enabled
@@ -112,7 +111,6 @@ instance Default CardanoTestnetOptions where
     { cardanoNodes = cardanoDefaultTestnetNodeOptions
     , cardanoNodeEra = AnyShelleyBasedEra ShelleyBasedEraBabbage
     , cardanoMaxSupply = 100_000_020_000_000 -- 100 000 billions Lovelace, so 100 millions ADA. This amount should be bigger than the 'byronTotalBalance' in Testnet.Start.Byron
-    , cardanoEnableP2P = False
     , cardanoNodeLoggingFormat = NodeLoggingFormatAsJson
     , cardanoNumDReps = 3
     , cardanoEnableNewEpochStateLogging = True

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
@@ -9,7 +9,6 @@ Usage: cardano-testnet cardano [--num-pool-nodes COUNT | --node-config FILEPATH]
   | --conway-era
   ]
   [--max-lovelace-supply WORD64]
-  [--enable-p2p BOOL]
   [--nodeLoggingFormat LOGGING_FORMAT]
   [--num-dreps NUMBER]
   [--enable-new-epoch-state-logging]

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/cardano.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/cardano.cli
@@ -7,7 +7,6 @@ Usage: cardano-testnet cardano [--num-pool-nodes COUNT | --node-config FILEPATH]
   | --conway-era
   ]
   [--max-lovelace-supply WORD64]
-  [--enable-p2p BOOL]
   [--nodeLoggingFormat LOGGING_FORMAT]
   [--num-dreps NUMBER]
   [--enable-new-epoch-state-logging]
@@ -42,7 +41,6 @@ Available options:
                            Max lovelace supply that your testnet starts with.
                            Ignored if a custom Shelley genesis file is passed.
                            (default: 100000020000000)
-  --enable-p2p BOOL        Enable P2P (default: False)
   --nodeLoggingFormat LOGGING_FORMAT
                            Node logging format (json|text)
                            (default: NodeLoggingFormatAsJson)


### PR DESCRIPTION
# Description

While working on other issues, I noticed that the `enable P2P` option was not implemented, so this PR removes it.

This is in line with https://github.com/IntersectMBO/cardano-node/pull/6148 and https://github.com/IntersectMBO/cardano-node/issues/6137 that move towards implementing such flags using the node's configuration file, instead of having dedicated flags.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
- [x] CI passes. See note on CI.  The following CI checks are required:
- [X] Self-reviewed the diff