### PR TITLE
cardano-testnet: show in types the two scenarios that are supported

### DIFF
--- a/cardano-testnet/src/Parsers/Cardano.hs
+++ b/cardano-testnet/src/Parsers/Cardano.hs
@@ -71,7 +71,7 @@ pCardanoTestnetCliOptions envCli = CardanoTestnetOptions
     pAnyShelleyBasedEra' =
       pAnyShelleyBasedEra envCli <&> (\(EraInEon x) -> AnyShelleyBasedEra x)
 
-pTestnetNodeOptions :: Parser TestnetNodeOptions
+pTestnetNodeOptions :: Parser [TestnetNodeOptions]
 pTestnetNodeOptions =
   asum' [
       AutomaticNodeOptions . (`L.replicate` defaultSpoOptions) <$>

--- a/cardano-testnet/src/Testnet/Components/Configuration.hs
+++ b/cardano-testnet/src/Testnet/Components/Configuration.hs
@@ -152,16 +152,11 @@ numSeededUTxOKeys = 3
 
 createSPOGenesisAndFiles
   :: (MonadTest m, MonadCatch m, MonadIO m, HasCallStack)
-  => CardanoTestnetOptions -- ^ The options to use
-  -> GenesisOptions
-  -> UserProvidedData (ShelleyGenesis StandardCrypto)
-  -> UserProvidedData AlonzoGenesis
-  -> UserProvidedData (ConwayGenesis StandardCrypto)
+  => Either AutomaticNodeOptions [InputNodeConfigFile]
   -> TmpAbsolutePath
   -> m FilePath -- ^ Shelley genesis directory
 createSPOGenesisAndFiles
-  testnetOptions genesisOptions@GenesisOptions{genesisTestnetMagic}
-  mShelleyGenesis mAlonzoGenesis mConwayGenesis
+  testnetOptions
   (TmpAbsolutePath tempAbsPath) = GHC.withFrozenCallStack $ do
   AnyShelleyBasedEra sbe <- pure cardanoNodeEra
 

--- a/cardano-testnet/src/Testnet/Start/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Start/Cardano.hs
@@ -162,17 +162,7 @@ cardanoTestnetDefault testnetOptions genesisOptions conf = do
 -- > └── module
 cardanoTestnet :: ()
   => HasCallStack
-  => CardanoTestnetOptions -- ^ The options to use
-  -> GenesisOptions
-  -> UserProvidedData (ShelleyGenesis StandardCrypto)
-  -- ^ The shelley genesis to use, One possible way to provide this value is to use 'getDefaultShelleyGenesis'
-  -- and customize it. Generated if omitted.
-  -> UserProvidedData AlonzoGenesis
-  -- ^ The alonzo genesis to use. One possible way to provide this value is to use 'getDefaultAlonzoGenesis'
-  -- and customize it. Generated if omitted.
-  -> UserProvidedData (ConwayGenesis StandardCrypto)
-  -- ^ The conway genesis to use. One possible way to provide this value is to use 'defaultConwayGenesis'
-  -- and customize it. Generated if omitted.
+  => CardanoTestnetCliOptions -- ^ The options to use
   -> Conf
   -> H.Integration TestnetRuntime
 cardanoTestnet

--- a/cardano-testnet/src/Testnet/Start/Types.hs
+++ b/cardano-testnet/src/Testnet/Start/Types.hs
@@ -66,7 +66,7 @@ instance Default CardanoTestnetCliOptions where
 data CardanoTestnetOptions = CardanoTestnetOptions
   { -- | Options controlling how many nodes to create and whether to use user-provided
     -- configuration files, or to generate them automatically.
-    cardanoNodes :: TestnetNodeOptions
+    cardanoNodes :: [TestnetNodeOptions]
   , cardanoNodeEra :: AnyShelleyBasedEra -- ^ The era to start at
   , cardanoMaxSupply :: Word64 -- ^ The amount of Lovelace you are starting your testnet with (forwarded to shelley genesis)
                                -- TODO move me to GenesisOptions when https://github.com/IntersectMBO/cardano-cli/pull/874 makes it to cardano-node
@@ -138,17 +138,10 @@ instance Default GenesisOptions where
 data TestnetNodeOptions =
   UserProvidedNodeOptions FilePath
   -- ^ Value used when the user specifies the node configuration file. We start one single SPO node.
-  | AutomaticNodeOptions [AutomaticNodeOption]
-  -- ^ Value used when @cardano-testnet@ controls the node configuration files.
-  -- We start a custom number of nodes.
-  deriving (Eq, Show)
-
--- | Type used when the user doesn't specify the node configuration file. We start
--- a custom number of nodes. The '@String' arguments will be appended to the default
--- options when starting the node.
-data AutomaticNodeOption =
-    SpoNodeOptions [String]
+  | SpoNodeOptions [String]
+    -- ^ Value used to start a SPO node and let @cardano-testnet@ create its configuration
   | RelayNodeOptions [String]
+    -- ^ Value used to start a relay node and let @cardano-testnet@ create its configuration
   deriving (Eq, Show)
 
 -- | Type used to track whether the user is providing its data (node configuration file path, genesis file, etc.)

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
@@ -1,23 +1,26 @@
 Usage: cardano-testnet (cardano | version | help)
 
-Usage: cardano-testnet cardano [--num-pool-nodes COUNT | --node-config FILEPATH]
-  [ --shelley-era
-  | --allegra-era
-  | --mary-era
-  | --alonzo-era
-  | --babbage-era
-  | --conway-era
-  ]
-  [--max-lovelace-supply WORD64]
-  [--enable-p2p BOOL]
+Usage: cardano-testnet cardano
+  [[[--num-spo-nodes COUNT]
+    [--num-relay-nodes COUNT]
+    [--max-lovelace-supply WORD64]
+    [--num-dreps NUMBER]
+    [--epoch-length SLOTS]
+    [--slot-length SECONDS]
+    [--active-slots-coeff DOUBLE]
+    [ --shelley-era
+    | --allegra-era
+    | --mary-era
+    | --alonzo-era
+    | --babbage-era
+    | --conway-era
+    ]
+   ]
+   | --node-config FILEPATH]
   [--nodeLoggingFormat LOGGING_FORMAT]
-  [--num-dreps NUMBER]
   [--enable-new-epoch-state-logging]
   [--output-dir DIRECTORY]
   --testnet-magic INT
-  [--epoch-length SLOTS]
-  [--slot-length SECONDS]
-  [--active-slots-coeff DOUBLE]
 
   Start a testnet in any era
 


### PR DESCRIPTION
This PR is meant to show possible follow-ups of https://github.com/IntersectMBO/cardano-node/pull/6148, i.e. how we would implement these remarks of mine:

> Have pTestnetNodeOptions return a list of TestnetNodeOption and TestnetNodeOption be UserProvidedNodeOptions Filepath | SpoNodeOptions [Srting] | RelayNodeOptions [ String]. In other words merge the types TestnetNodeOptions and AutomaticNodeOption. This will generalize the behavior so that the user can create multiple nodes, no matter whether they are using custom options or using default behavior (Spo or Relay). This will require a bit of generalization in [Cardano.hs](https://github.com/IntersectMBO/cardano-node/pull/cardano-testnet/src/Testnet/Start/Cardano.hs) but not much.

This is shown in the first commit of this PR.

> Reflect in the types the tying behavior between the node configuration file being passed by the user and the genesis files being passed by the user too.

This is shown in commits 2 and 3 of this PR