### PR TITLE
KeepAlive tracing improvements

### DIFF
--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -27,6 +27,9 @@
   }
   ```
 
+- KeepAlive client tracing: dropped `KeepAliveClient` from `kind` of
+  `AddSample` messages in the legacy tracing system.
+
 ## 10.2 -- January 2025
 
 - Use p2p network stack by default, warn when using the legacy network stack.

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
@@ -68,14 +68,11 @@ import qualified Ouroboros.Network.BlockFetch.ClientState as BlockFetch
 import           Ouroboros.Network.BlockFetch.Decision
 import           Ouroboros.Network.BlockFetch.Decision.Trace (TraceDecisionEvent (..))
 import           Ouroboros.Network.ConnectionId (ConnectionId (..))
-import           Ouroboros.Network.DeltaQ (GSV (..), PeerGSV (..))
-import           Ouroboros.Network.KeepAlive (TraceKeepAliveClient (..))
 import           Ouroboros.Network.SizeInBytes (SizeInBytes (..))
 import           Ouroboros.Network.TxSubmission.Inbound hiding (txId)
 import           Ouroboros.Network.TxSubmission.Outbound
 
 import           Control.Monad (guard)
-import           Control.Monad.Class.MonadTime.SI (Time (..))
 import           Data.Aeson (ToJSON, Value (Number, String), toJSON, (.=))
 import qualified Data.Aeson as Aeson
 import           Data.Foldable (Foldable (toList))
@@ -84,7 +81,7 @@ import           Data.IntPSQ (IntPSQ)
 import qualified Data.IntPSQ as Pq
 import qualified Data.List as List
 import qualified Data.Text as Text
-import           Data.Time (DiffTime, NominalDiffTime)
+import           Data.Time (NominalDiffTime)
 import           Data.Word (Word32, Word64)
 import           Network.TypedProtocol.Core
 
@@ -2113,41 +2110,6 @@ instance MetaTrace (TraceBlockchainTimeEvent t) where
     , Namespace [] ["CurrentSlotUnknown"]
     , Namespace [] ["SystemClockMovedBack"]
     ]
-
---------------------------------------------------------------------------------
--- KeepAliveClient Tracer
---------------------------------------------------------------------------------
-
-instance Show remotePeer => LogFormatting (TraceKeepAliveClient remotePeer) where
-    forMachine _dtal (AddSample peer rtt pgsv) =
-        mconcat
-          [ "kind" .= String "AddSample"
-          , "address" .= show peer
-          , "rtt" .= rtt
-          , "sampleTime" .= show (dTime $ sampleTime pgsv)
-          , "outboundG" .= (realToFrac $ gGSV (outboundGSV pgsv) :: Double)
-          , "inboundG" .= (realToFrac $ gGSV (inboundGSV pgsv) :: Double)
-          ]
-        where
-          gGSV :: GSV -> DiffTime
-          gGSV (GSV g _ _) = g
-
-          dTime :: Time -> Double
-          dTime (Time d) = realToFrac d
-
-    forHuman = showT
-
-instance MetaTrace (TraceKeepAliveClient remotePeer) where
-  namespaceFor AddSample {} = Namespace [] ["KeepAliveClient"]
-
-  severityFor (Namespace _ ["KeepAliveClient"]) Nothing = Just Info
-  severityFor _ _ = Nothing
-
-  documentFor (Namespace _ ["KeepAliveClient"]) = Just
-    "A server read has occurred, either for an add block or a rollback"
-  documentFor _ = Just ""
-
-  allNamespaces = [Namespace [] ["KeepAliveClient"]]
 
 --------------------------------------------------------------------------------
 -- Gsm Tracer

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -1526,7 +1526,7 @@ instance (Show txid, Show tx)
 instance Show remotePeer => ToObject (TraceKeepAliveClient remotePeer) where
   toObject _verb (AddSample peer rtt pgsv) =
     mconcat
-      [ "kind" .= String "KeepAliveClient AddSample"
+      [ "kind" .= String "AddSample"
       , "address" .= show peer
       , "rtt" .= rtt
       , "sampleTime" .= show (dTime $ sampleTime pgsv)


### PR DESCRIPTION

# Description

* new tracing system: moved instances to NodeToNode module, where other
  mini-protocol tracers are defined.
* make the output of the legacy tracing system for keep alive
  measurements, the same as the new one.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
