### PR TITLE
CI github api pagination handling

### DIFF
--- a/.github/workflows/release-ghcr.yaml
+++ b/.github/workflows/release-ghcr.yaml
@@ -29,7 +29,7 @@ jobs:
       run: |
         while [[ true ]]; do
           check_name='ci/hydra-build:required'
-          conclusion=$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/check-runs?check_name=$check_name" --jq '.check_runs[].conclusion')
+          conclusion=$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/check-runs?check_name=$check_name" --paginate --jq '.check_runs[].conclusion')
           case "$conclusion" in
             success)
               echo "$check_name succeeded"
@@ -88,7 +88,7 @@ jobs:
     - name: Obtaining latest release tag
       id: latest-tag
       run: |
-        LATEST_TAG=$(gh api repos/$GITHUB_REPOSITORY/releases/latest --jq '.tag_name')
+        LATEST_TAG=$(gh api repos/$GITHUB_REPOSITORY/releases/latest --paginate --jq '.tag_name')
         echo "LATEST_TAG=$LATEST_TAG" >> "$GITHUB_OUTPUT"
         echo "Latest release tag is: $LATEST_TAG"
 

--- a/.github/workflows/release-upload.yaml
+++ b/.github/workflows/release-upload.yaml
@@ -29,7 +29,7 @@ jobs:
       run: |
         while [[ true ]]; do
           check_name='ci/hydra-build:required'
-          conclusion=$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/check-runs?check_name=$check_name" --jq '.check_runs[].conclusion')
+          conclusion=$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/check-runs?check_name=$check_name" --paginate --jq '.check_runs[].conclusion')
           case "$conclusion" in
             success)
               echo "$check_name succeeded"
@@ -42,7 +42,7 @@ jobs:
               exit 1;;
           esac
         done
-    
+
   pull:
     needs: [wait-for-hydra]
     strategy:
@@ -77,11 +77,11 @@ jobs:
             win64)
               nix build --builders "" --max-jobs 0 ${{ steps.flake-metadata.outputs.LOCKED_URL }}#hydraJobs.x86_64-linux.windows.cardano-node-win64
               cp result/cardano-node-*-*.zip .
-              ;;              
+              ;;
           esac
       - uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.sha }}-${{ matrix.arch }}       
+          name: ${{ github.sha }}-${{ matrix.arch }}
           path: cardano-node-*-*.*
           retention-days: 1
 


### PR DESCRIPTION
# Description

* Adds auto-pagination handling for github gh api calls where unexpected breakage might otherwise occur when the desired results aren't on the first returned page
* Removes extra whitespace
* Tested with the following where the selected `GITHUB_SHA` had 68 status checks and default page length is 30:
```
❯ gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/check-runs" \
  --paginate \
  --jq '.check_runs[] | select(.name == "ci/hydra-build:required") | .conclusion'
success
```
Without the `--paginate` option present to parse all status checks present across multiple pages, the query return is empty with RC of 0 in this example.  The built in gh jq filtering is a post processing step after the pagination options scope the initial response size.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] CI passes. See note on CI.  The following CI checks are required:
- [X] Self-reviewed the diff
