### PR TITLE
cardano-testnet: store node PIDs as files

### DIFF
--- a/cardano-testnet/src/Testnet/Runtime.hs
+++ b/cardano-testnet/src/Testnet/Runtime.hs
@@ -127,6 +127,7 @@ startNode tp node ipv4 port _testnetMagic nodeCmd = GHC.withFrozenCallStack $ do
 
   let nodeStdoutFile = logDir </> node </> "stdout.log"
       nodeStderrFile = logDir </> node </> "stderr.log"
+      nodePidFile = logDir </> node </> "node.pid"
       socketRelPath = socketDir </> node </> "sock"
       sprocket = Sprocket tempBaseAbsPath socketRelPath
 
@@ -167,8 +168,11 @@ startNode tp node ipv4 port _testnetMagic nodeCmd = GHC.withFrozenCallStack $ do
     -- We force the evaluation of initiateProcess so we can be sure that
     -- the process has started. This allows us to read stderr in order
     -- to fail early on errors generated from the cardano-node binary.
-    _ <- liftIO (IO.getPid hProcess)
+    pid <- liftIO (IO.getPid hProcess)
       >>= hoistMaybe (NodeExecutableError $ "startNode:" <+> pretty node <+> "'s process did not start.")
+
+    -- We then log the pid in the temp dir structure.
+    liftIO $ IO.writeFile nodePidFile $ show pid
 
     -- Wait for socket to be created
     eSprocketError <-

--- a/cardano-testnet/src/Testnet/Start/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Start/Cardano.hs
@@ -124,7 +124,8 @@ cardanoTestnetDefault testnetOptions genesisOptions conf = do
 -- > │   └── README.md
 -- > ├── logs
 -- > │   ├── node{1,2,3}
--- > │   │   └── {stderr,stdout}.log
+-- > │   │   ├── node.pid
+-- > |   |   └── {stderr,stdout}.log
 -- > │   ├── ledger-epoch-state-diffs.log
 -- > │   ├── ledger-epoch-state.log
 -- > │   ├── node-20241010121635.log
@@ -305,7 +306,6 @@ cardanoTestnet
         <> spoNodeCliArgs
         <> maybe [] extraCliArgs nodeOptions
     pure $ eRuntime <&> \rt -> rt{poolKeys=mKeys}
-    -- TODO log the node's pid in a file. This is useful for killing the node later.
 
   let (failedNodes, testnetNodes') = partitionEithers eTestnetNodes
   unless (null failedNodes) $ do


### PR DESCRIPTION
# Description

This PR causes the PIDs of node processes to be stored in `logs/nodeN/node-PID.pid`.
The file name is prefixed by `node-` because pids may be signed depending on platforms:
we don't want file names starting with `-` lying around.

This will be useful for killing node processes later.

Closes #6149

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff

