### PR TITLE
Align tracing severities among tracing systems

### DIFF
--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
@@ -1813,7 +1813,7 @@ instance MetaTrace (TraceForgeEvent blk) where
   severityFor (Namespace _ ["LedgerState"]) _ = Just Debug
   severityFor (Namespace _ ["NoLedgerView"]) _ = Just Error
   severityFor (Namespace _ ["LedgerView"]) _ = Just Debug
-  severityFor (Namespace _ ["ForgeStateUpdateError"]) _ = Just Error
+  severityFor (Namespace _ ["ForgeStateUpdateError"]) _ = Just Critical
   severityFor (Namespace _ ["NodeCannotForge"]) _ = Just Error
   severityFor (Namespace _ ["NodeNotLeader"]) _ = Just Info
   severityFor (Namespace _ ["NodeIsLeader"]) _ = Just Info
@@ -1825,6 +1825,9 @@ instance MetaTrace (TraceForgeEvent blk) where
   severityFor (Namespace _ ["AdoptedBlock"]) _ = Just Info
   severityFor (Namespace _ ["AdoptionThreadDied"]) _ = Just Error
   severityFor _ _ = Nothing
+
+  privacyFor (Namespace _ ["ForgeStateUpdateError"]) _ = Just Confidential
+  privacyFor _ _ = Nothing
 
   metricsDocFor (Namespace _ ["StartLeadershipCheck"]) =
     [("Forge.about-to-lead", "")]

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -842,22 +842,24 @@ mkConsensusTracers mbEKGDirect trSel verb tr nodeKern fStats = do
    mkForgeTracers :: IO ForgeTracers
    mkForgeTracers = do
      -- We probably don't want to pay the extra IO cost per-counter-increment. -- sk
-     staticMeta <- mkLOMeta Critical Confidential
+     metaCritical <- mkLOMeta Critical Confidential
+     metaInfo <- mkLOMeta Info Public
+     metaError <- mkLOMeta Error Public
      let name :: LoggerName = "metrics.Forge"
      ForgeTracers
-       <$> counting (liftCounting staticMeta name "forged" tr)
-       <*> counting (liftCounting staticMeta name "forge-about-to-lead" tr)
-       <*> counting (liftCounting staticMeta name "could-not-forge" tr)
-       <*> counting (liftCounting staticMeta name "adopted" tr)
-       <*> counting (liftCounting staticMeta name "didnt-adopt" tr)
-       <*> counting (liftCounting staticMeta name "forged-invalid" tr)
-       <*> counting (liftCounting staticMeta name "node-not-leader" tr)
-       <*> counting (liftCounting staticMeta name "cannot-forge" tr)
-       <*> counting (liftCounting staticMeta name "forge-state-update-error" tr)
-       <*> counting (liftCounting staticMeta name "block-from-future" tr)
-       <*> counting (liftCounting staticMeta name "slot-is-immutable" tr)
-       <*> counting (liftCounting staticMeta name "node-is-leader" tr)
-       <*> counting (liftCounting staticMeta name "adoption-thread-died" tr)
+       <$> counting (liftCounting metaInfo     name "forged"                   tr)
+       <*> counting (liftCounting metaInfo     name "forge-about-to-lead"      tr)
+       <*> counting (liftCounting metaError    name "could-not-forge"          tr)
+       <*> counting (liftCounting metaInfo     name "adopted"                  tr)
+       <*> counting (liftCounting metaError    name "didnt-adopt"              tr)
+       <*> counting (liftCounting metaError    name "forged-invalid"           tr)
+       <*> counting (liftCounting metaInfo     name "node-not-leader"          tr)
+       <*> counting (liftCounting metaError    name "cannot-forge"             tr)
+       <*> counting (liftCounting metaCritical name "forge-state-update-error" tr)
+       <*> counting (liftCounting metaError    name "block-from-future"        tr)
+       <*> counting (liftCounting metaError    name "slot-is-immutable"        tr)
+       <*> counting (liftCounting metaInfo     name "node-is-leader"           tr)
+       <*> counting (liftCounting metaError    name "adoption-thread-died"     tr)
 
    traceServedCount :: Maybe EKGDirect -> TraceChainSyncServerEvent blk -> IO ()
    traceServedCount Nothing _ = pure ()

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -1369,21 +1369,25 @@ forgeStateInfoMetricsTraceTransformer p tr = Tracer $
                   $ fromIntegral kesPeriodsUntilExpiry
               ]
 
-        meta <- mkLOMeta Critical Confidential
-        mapM_ (traceNamedObject metricsTr . (meta,)) logValues
+        metaInfo <- mkLOMeta Info Public
+        mapM_ (traceNamedObject metricsTr . (metaInfo,)) logValues
 
         -- Trace warning messages on the last 7 KES periods and, in the
         -- final and subsequent KES periods, trace alert messages.
         metaWarning <- mkLOMeta Warning Public
         metaAlert <- mkLOMeta Alert Public
-        when (kesPeriodsUntilExpiry <= 7) $
-          traceWith tr
-            ( mempty
-            , LogObject
-                mempty
-                (if kesPeriodsUntilExpiry <= 1 then metaAlert else metaWarning)
-                (LogStructuredText mempty (expiryLogMessage kesPeriodsUntilExpiry))
-            )
+        traceWith tr
+          ( mempty
+          , LogObject
+              mempty
+              (if kesPeriodsUntilExpiry > 7
+               then metaInfo
+                else if kesPeriodsUntilExpiry > 1
+                     then metaWarning
+                     else metaAlert
+              )
+              (LogStructuredText mempty (expiryLogMessage kesPeriodsUntilExpiry))
+          )
   where
     expiryLogMessage :: Word -> Text
     expiryLogMessage kesPeriodsUntilExpiry =


### PR DESCRIPTION
# Description

- old-tracing: KES regular traces are now Info
- old-tracing: Forge counters are traced the same way as new-tracing
- new-tracing: ForgetStateUpdateError is now Critical Confidential (was Error Public)

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff