### PR TITLE
Adds checkpoint and peer snap files to binary artifacts

### DIFF
--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-node
-version:                10.3.0
+version:                10.3.1
 synopsis:               The cardano full node
 description:            The cardano full node.
 category:               Cardano,

--- a/nix/binary-release.nix
+++ b/nix/binary-release.nix
@@ -32,6 +32,8 @@ let
         AlonzoGenesisFile = "alonzo-genesis.json";
       } // lib.optionalAttrs (env.nodeConfig ? ConwayGenesisFile) {
         ConwayGenesisFile = "conway-genesis.json";
+      } // lib.optionalAttrs (env.nodeConfig ? CheckpointsFile) {
+        CheckpointsFile = "checkpoints.json";
       };
       nodeConfig = pkgs.writeText
         "config.json"
@@ -42,6 +44,10 @@ let
         "config-bp.json"
         (builtins.toJSON
           (env.nodeConfigBp // genesisAttrs));
+
+      peerSnapshot = pkgs.writeText
+        "peer-snapshot.json"
+        (builtins.toJSON env.peerSnapshot);
 
       topologyConfig = pkgs.cardanoLib.mkTopology env;
 
@@ -54,6 +60,7 @@ let
         mkdir -p "share/${name}"
         jq . < "${nodeConfig}" > share/${name}/config.json
         jq . < "${nodeConfigBp}" > share/${name}/config-bp.json
+        jq . < "${peerSnapshot}" > share/${name}/peer-snapshot.json
         jq . < "${topologyConfig}" > share/${name}/topology.json
         cp -n --remove-destination -v \
           "${ByronGenesisFile}" \
@@ -68,6 +75,11 @@ let
         cp -n --remove-destination -v \
           "${env.nodeConfig.ConwayGenesisFile}" \
            share/${name}/conway-genesis.json
+        ''}
+        ${lib.optionalString (env.nodeConfig ? CheckpointsFile) ''
+        cp -n --remove-destination -v \
+          "${env.nodeConfig.CheckpointsFile}" \
+           share/${name}/checkpoints.json
         ''}
       '';
 


### PR DESCRIPTION
# Description

* Adds checkpoint and peer snapshot files to the binary artifact context.
* Bumps node version to `10.3.1`.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] The version bounds in `.cabal` files are updated
- [X] CI passes
- [X] Self-reviewed the diff