### PR TITLE
Update cardano-node changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelogs for components can be found as follows:
 - [cardano-submit-api](https://github.com/IntersectMBO/cardano-node/blob/master/cardano-submit-api/CHANGELOG.md) 
 - [trace-forward](https://github.com/IntersectMBO/cardano-node/blob/master/trace-forward/CHANGELOG.md) 
 - [cardano-tracer](https://github.com/IntersectMBO/cardano-node/blob/master/cardano-tracer/CHANGELOG.md)  
+- [cardano-node](https://github.com/IntersectMBO/cardano-node/blob/master/cardano-node/CHANGELOG.md)
 - [cardano-node-capi](https://github.com/IntersectMBO/cardano-node/blob/master/cardano-node-capi/CHANGELOG.md) 
 - [bench/tx-generator](https://github.com/IntersectMBO/cardano-node/blob/master/bench/tx-generator/CHANGELOG.md) 
 

--- a/cardano-node/CHANGELOG.md
+++ b/cardano-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next version
 
+- 
+
+## 10.3 -- April 2025
+
 - Add a new configuration field for fork-policy.
 
 - Optionally support lightweight checkpointing.
@@ -26,6 +30,21 @@
     ]
   }
   ```
+
+- Tracing
+
+  - New `PrometheusSimple` backend which runs a simple TCP server for direct exposition of metrics, without forwarding, under the URL `/metrics`.
+  - New `maxReconnectDelay` config option in `TraceOptionForwarder`: Specifies maximum delay (seconds) between (re-)connection attempts of a forwarder (default: 60s).
+  - Fix: change semantics of several `Forge.*` metrics to counters - to match semantics of legacy tracing.
+  - Fix: correct `blockdelay_cdf*` metric
+  - Fix: correct `blockReplayProgress` metric
+  - Optimizations to trace + metrics forwarding, aimed at reducing CPU usage when under low / idle load.
+
+- Configuration
+  - For details about changes to configuration for `ouroboros-genesis` please refer to the [Cardano Book](https://book.play.dev.cardano.org/)
+  - The [getting started guide](https://developers.cardano.org/docs/get-started/) may also be helpful for general queries.
+  - Networking options and related changes are listed on the [P2P section](https://staging-dev-portal.netlify.app/docs/get-started/cardano-node/p2p/)
+
 
 ## 10.2 -- January 2025
 
@@ -80,6 +99,42 @@
 - Drop NodeToClient versions 9 through 15, and add 19
 
 - Increase minor protocol version to `10.3`
+
+## 9.2.0 -- September 2024
+
+- Configuration Enhancements
+  - Database Path Customization
+    - **Separate Paths for Volatile and Immutable Databases**: Users can now specify paths for volatile and immutable databases separately.
+
+  - Command Line Options:
+    Users can specify database paths directly via command line:
+    ```
+    [ --database-path FILEPATH
+    | --immutable-database-path FILEPATH --volatile-database-path FILEPATH
+    ]
+    ```
+
+  - Configuration File:
+    Alternatively, paths can be set in the configuration YAML file under the "DatabaseFile" key:
+
+    ```yaml
+    "DatabasePath": {
+      "ImmutableDbPath": "mainnetnode/db/node-imm",
+      "VolatileDbPath": "mainnetnode/db/node-vol"
+    },
+    ```
+
+    or for a single path configuration:
+
+    ```yaml
+    "DatabasePath": "mainnetsingle/db/node",
+    ```
+
+- New tracing system
+  - Major rework of the metrics naming schema
+    - Change all metric names to match those of the current tracing system, simplifying switching back and forth for existing integrations
+    - Augment metric names with type-spefic suffixes (like e.g. `_int`)
+    - Add optional Node config value `TraceOptionMetricsPrefix` (String) to specify a namespace prefix for metric names
 
 ## 8.2.1 -- August 2023
 

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -13,7 +13,7 @@ license:                Apache-2.0
 license-files:          LICENSE
                         NOTICE
 build-type:             Simple
-extra-doc-files:        ChangeLog.md
+extra-doc-files:        CHANGELOG.md
 
 Flag unexpected_thunks
   Description:          Turn on unexpected thunks checks


### PR DESCRIPTION
# Description

@jasagredo found the inconsistency that the change-log for `cardano-node` wasn't kept completely up-to-date and its name wasn't following the convention.

As to "why" this might be: in my under-qualified opinion, I think most likely due to an undocumented technical limitation in our automated operational infrastructure, or second-most likely due to an egregious oversight. If it is indeed the former, I expect this PR to trigger the CI action in question.

In this PR, we update the `cardano-node` change-log, add a link to it from the top-level change-log, and also update its reference in the respective `cardano-node.cabal` file.

> NOTE: The markdown link checker is expected to fail, since the link will only be valid once we merge this PR

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
