### PR TITLE
TSLCP: Chain density

### DIFF
--- a/bench/cardano-profile/data/all-profiles-coay.json
+++ b/bench/cardano-profile/data/all-profiles-coay.json
@@ -66,39 +66,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -484,39 +452,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -902,39 +838,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -1324,39 +1228,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -1748,39 +1620,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -2616,39 +2456,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -3484,39 +3292,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -4355,39 +4131,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -5223,39 +4967,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -6094,39 +5806,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -6964,39 +6644,7 @@
         "000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -7386,39 +7034,7 @@
         "000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -7808,39 +7424,7 @@
         "000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -8230,39 +7814,7 @@
         "000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -8654,39 +8206,7 @@
         "000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -9076,39 +8596,7 @@
         "000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -9498,39 +8986,7 @@
         "000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -9918,39 +9374,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -10336,39 +9760,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -10754,39 +10146,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": "/tmp"
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -11091,6 +10451,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 15,
       "shutdown_on_slot_synced": null,
+      "ssd_directory": "/tmp",
       "tracer": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": true,
@@ -11204,8 +10565,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -11626,8 +10986,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -12016,39 +11375,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -12464,8 +11791,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -12856,39 +12182,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -13278,39 +12572,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -13890,39 +13152,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -14516,39 +13746,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -15142,39 +14340,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -15754,39 +14920,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -16639,39 +15773,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -17559,39 +16661,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -18478,39 +17548,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -18896,39 +17934,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -19318,39 +18324,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 10,
       "locations": [
@@ -19738,39 +18712,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -20381,8 +19323,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -20803,8 +19744,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -21193,39 +20133,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -21641,8 +20549,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -22031,39 +20938,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -22453,39 +21328,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -22874,39 +21717,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -23294,39 +22105,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -23743,8 +22522,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -24166,8 +22944,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -24557,39 +23334,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -24978,39 +23723,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -25398,39 +24111,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -25817,39 +24498,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -26236,39 +24885,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -26658,39 +25275,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -27078,39 +25663,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -27496,39 +26049,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -27944,8 +26465,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -28555,8 +27075,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -29172,8 +27691,7 @@
             "memory_max": 124000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -29753,39 +28271,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -30171,39 +28657,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -30589,39 +29043,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -31011,39 +29433,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -31432,39 +29822,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -31850,39 +30208,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -32270,39 +30596,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -32689,39 +30983,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -33551,39 +31813,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -33970,39 +32200,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -34394,39 +32592,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -34816,39 +32982,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -35427,39 +33561,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -35846,39 +33948,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -36708,39 +34778,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -37572,39 +35610,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -38436,39 +36442,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -39301,39 +37275,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -40167,39 +38109,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -40586,39 +38496,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -41008,39 +38886,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -41429,39 +39275,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -41851,39 +39665,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -42272,39 +40054,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -42694,39 +40444,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -43115,39 +40833,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -43536,39 +41222,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -44144,39 +41798,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -44752,39 +42374,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -45360,39 +42950,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -45968,39 +43526,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -46576,39 +44102,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -46996,39 +44490,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -47415,39 +44877,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -47834,39 +45264,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -48281,8 +45679,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -48910,8 +46307,7 @@
             "memory_max": 124000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -49504,39 +46900,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -50431,39 +47795,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -51359,39 +48691,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -52269,39 +49569,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -53178,39 +50446,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -53627,8 +50863,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -54050,8 +51285,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -54441,39 +51675,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -55083,8 +52285,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -55700,8 +52901,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -56317,8 +53517,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -56934,8 +54133,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -57551,8 +54749,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -58135,39 +55332,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -58791,8 +55956,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -59391,39 +56555,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -60047,8 +57179,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -60678,8 +57809,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -61563,8 +58693,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -62448,8 +59577,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -63317,8 +60445,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -64189,8 +61316,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -65144,8 +62270,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -66098,8 +63223,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -67053,8 +64177,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -67640,39 +64763,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -68553,39 +65644,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -69481,39 +66540,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -70408,39 +67435,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -71336,39 +68331,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -72263,39 +69226,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -73190,39 +70121,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -74123,39 +71022,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -75035,39 +71902,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -75986,8 +72821,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -76924,8 +73758,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -77863,8 +74696,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -78802,8 +75634,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -79727,8 +76558,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -80653,8 +77483,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -81546,39 +78375,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -81964,39 +78761,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -82382,39 +79147,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -82800,39 +79533,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -83218,39 +79919,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -83636,39 +80305,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -84056,39 +80693,7 @@
         "1000000000000000"
       ]
     },
-    "cluster": {
-      "aws": {
-        "instance_type": {
-          "explorer": "m5.4xlarge",
-          "producer": "c5.2xlarge"
-        },
-        "use_public_routing": false
-      },
-      "keep_running": false,
-      "minimun_storage": {
-        "explorer": 14155776,
-        "producer": 12582912
-      },
-      "nomad": {
-        "class": "",
-        "fetch_logs_ssh": false,
-        "host_volumes": null,
-        "namespace": "default",
-        "resources": {
-          "explorer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          },
-          "producer": {
-            "cores": 2,
-            "memory": 15000,
-            "memory_max": 16000
-          }
-        }
-      },
-      "ssd_directory": null
-    },
+    "cluster": null,
     "composition": {
       "dense_pool_density": 1,
       "locations": [
@@ -84515,8 +81120,7 @@
             "memory_max": 124000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -85136,8 +81740,7 @@
             "memory_max": 124000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -85755,8 +82358,7 @@
             "memory_max": 124000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -86366,8 +82968,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -86980,8 +83581,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -87594,8 +84194,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -88208,8 +84807,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -88822,8 +85420,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -89442,8 +86039,7 @@
             "memory_max": 124000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -90055,8 +86651,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -90669,8 +87264,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -91281,8 +87875,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -92147,8 +88740,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -93016,8 +89608,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -93968,8 +90559,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,
@@ -94919,8 +91509,7 @@
             "memory_max": 16000
           }
         }
-      },
-      "ssd_directory": null
+      }
     },
     "composition": {
       "dense_pool_density": 1,

--- a/bench/cardano-profile/data/all-profiles-coay.json
+++ b/bench/cardano-profile/data/all-profiles-coay.json
@@ -371,7 +371,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 15,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -757,7 +757,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 15,
       "shutdown_on_slot_synced": null,
-      "tracer": false,
+      "trace_forwarding": false,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -1143,7 +1143,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 15,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -1536,7 +1536,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 15,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -2370,7 +2370,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 1800,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -3206,7 +3206,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 3600,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -4045,7 +4045,7 @@
       ],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 3600,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -4881,7 +4881,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 14400,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -5720,7 +5720,7 @@
       ],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 14400,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -6559,7 +6559,7 @@
       ],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 1800,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -6950,7 +6950,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 38901589,
-      "tracer": false,
+      "trace_forwarding": false,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -7340,7 +7340,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 38901589,
-      "tracer": false,
+      "trace_forwarding": false,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -7730,7 +7730,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 38901589,
-      "tracer": false,
+      "trace_forwarding": false,
       "tracing_backend": "iohk-monitoring",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -8120,7 +8120,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 38901589,
-      "tracer": false,
+      "trace_forwarding": false,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -8512,7 +8512,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 237599,
-      "tracer": false,
+      "trace_forwarding": false,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -8902,7 +8902,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 237599,
-      "tracer": false,
+      "trace_forwarding": false,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -9292,7 +9292,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 237599,
-      "tracer": false,
+      "trace_forwarding": false,
       "tracing_backend": "iohk-monitoring",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -9679,7 +9679,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 15,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -10065,7 +10065,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 15,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -10452,7 +10452,7 @@
       "shutdown_on_block_synced": 15,
       "shutdown_on_slot_synced": null,
       "ssd_directory": "/tmp",
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": true,
       "verbatim": {
@@ -10873,7 +10873,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 15,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -11294,7 +11294,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 15,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -11680,7 +11680,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 15,
       "shutdown_on_slot_synced": null,
-      "tracer": false,
+      "trace_forwarding": false,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -12099,7 +12099,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 15,
       "shutdown_on_slot_synced": null,
-      "tracer": false,
+      "trace_forwarding": false,
       "tracing_backend": "iohk-monitoring",
       "utxo_lmdb": false,
       "verbatim": {
@@ -12487,7 +12487,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 15,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -13069,7 +13069,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 15,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -13663,7 +13663,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 15,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -14257,7 +14257,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 15,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -14837,7 +14837,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 15,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -15690,7 +15690,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 15,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -16578,7 +16578,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 15,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -17467,7 +17467,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 15,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -17853,7 +17853,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 15,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -18239,7 +18239,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 8,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -18629,7 +18629,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 8,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -19210,7 +19210,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 8,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -19631,7 +19631,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 8,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -20052,7 +20052,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 8,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -20438,7 +20438,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 8,
       "shutdown_on_slot_synced": null,
-      "tracer": false,
+      "trace_forwarding": false,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -20857,7 +20857,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 8,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "iohk-monitoring",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -21243,7 +21243,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 8,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -21636,7 +21636,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 8,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -22022,7 +22022,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 8,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -22409,7 +22409,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -22829,7 +22829,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -23251,7 +23251,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -23638,7 +23638,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -24028,7 +24028,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -24415,7 +24415,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 2400,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -24802,7 +24802,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 2400,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -25192,7 +25192,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 2400,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -25582,7 +25582,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 2400,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -25968,7 +25968,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 900,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -26354,7 +26354,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 1,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -26962,7 +26962,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 1,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -27572,7 +27572,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 1,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -28188,7 +28188,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 1,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -28576,7 +28576,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 1,
       "shutdown_on_slot_synced": null,
-      "tracer": false,
+      "trace_forwarding": false,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -28962,7 +28962,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 1,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "iohk-monitoring",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -29348,7 +29348,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 1,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -29741,7 +29741,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 1,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -30127,7 +30127,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 1,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -30513,7 +30513,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 1,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -30900,7 +30900,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 2400,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -31730,7 +31730,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 4800,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -32117,7 +32117,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 2400,
-      "tracer": false,
+      "trace_forwarding": false,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -32507,7 +32507,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 2400,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -32899,7 +32899,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 2400,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -33478,7 +33478,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 2400,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -33865,7 +33865,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 2400,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -34695,7 +34695,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 4800,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -35527,7 +35527,7 @@
       ],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 4800,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -36359,7 +36359,7 @@
       ],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 4800,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -37192,7 +37192,7 @@
       ],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 4800,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -38026,7 +38026,7 @@
       ],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 4800,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -38413,7 +38413,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 2400,
-      "tracer": false,
+      "trace_forwarding": false,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -38803,7 +38803,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 2400,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -39192,7 +39192,7 @@
       ],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 2400,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -39582,7 +39582,7 @@
       ],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 2400,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -39971,7 +39971,7 @@
       ],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 2400,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -40361,7 +40361,7 @@
       ],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 2400,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -40750,7 +40750,7 @@
       ],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 2400,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -41139,7 +41139,7 @@
       ],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 2400,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -41715,7 +41715,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 2400,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -42291,7 +42291,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 4800,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -42867,7 +42867,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 1200,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -43443,7 +43443,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 2400,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -44019,7 +44019,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 1200,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -44407,7 +44407,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -44794,7 +44794,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -45181,7 +45181,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -45568,7 +45568,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -46176,7 +46176,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -46804,7 +46804,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -47711,7 +47711,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 56000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -48607,7 +48607,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 56000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -49485,7 +49485,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 56000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -50363,7 +50363,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 56000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -50750,7 +50750,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "iohk-monitoring",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -51170,7 +51170,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "iohk-monitoring",
       "utxo_lmdb": false,
       "verbatim": {
@@ -51592,7 +51592,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "iohk-monitoring",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -52171,7 +52171,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -52785,7 +52785,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 72000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -53401,7 +53401,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 72000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -54017,7 +54017,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 72000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -54633,7 +54633,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 72000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -55249,7 +55249,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 72000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -55842,7 +55842,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -56470,7 +56470,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 72000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -57065,7 +57065,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -57693,7 +57693,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 72000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -58563,7 +58563,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 72000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -59447,7 +59447,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 72000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -60329,7 +60329,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 72000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -61200,7 +61200,7 @@
       ],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 72000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -62140,7 +62140,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 72000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -63094,7 +63094,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 72000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -64047,7 +64047,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 72000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -64677,7 +64677,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 72000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -65560,7 +65560,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 9000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -66442,7 +66442,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 9000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -67351,7 +67351,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 9000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -68247,7 +68247,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 9000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -69142,7 +69142,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 9000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -70038,7 +70038,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 9000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -70939,7 +70939,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 9000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -71819,7 +71819,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 9000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -72707,7 +72707,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 9000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -73642,7 +73642,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 72000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -74580,7 +74580,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 72000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -75518,7 +75518,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 72000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -76442,7 +76442,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 72000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -77367,7 +77367,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 72000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -78292,7 +78292,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 72000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -78680,7 +78680,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 15,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -79066,7 +79066,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 15,
       "shutdown_on_slot_synced": null,
-      "tracer": false,
+      "trace_forwarding": false,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -79452,7 +79452,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 15,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "iohk-monitoring",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -79838,7 +79838,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": 15,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -80224,7 +80224,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 1200,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -80610,7 +80610,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 1200,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -80998,7 +80998,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": null,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -81616,7 +81616,7 @@
       ],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 7200,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -82234,7 +82234,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 7200,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -82852,7 +82852,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 7200,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -83465,7 +83465,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 64000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -84078,7 +84078,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 64000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -84691,7 +84691,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 64000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -85304,7 +85304,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 64000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -85917,7 +85917,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 64000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -86535,7 +86535,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 64000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -87148,7 +87148,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 64000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "iohk-monitoring",
       "utxo_lmdb": false,
       "verbatim": {
@@ -87761,7 +87761,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 64000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "iohk-monitoring",
       "utxo_lmdb": false,
       "verbatim": {}
@@ -88624,7 +88624,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 64000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -89492,7 +89492,7 @@
       ],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 64000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -90429,7 +90429,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 64000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -91380,7 +91380,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 64000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {
@@ -92330,7 +92330,7 @@
       "rts_flags_override": [],
       "shutdown_on_block_synced": null,
       "shutdown_on_slot_synced": 64000,
-      "tracer": true,
+      "trace_forwarding": true,
       "tracing_backend": "trace-dispatcher",
       "utxo_lmdb": false,
       "verbatim": {

--- a/bench/cardano-profile/data/test/chainsync-early-alonzo-coay/profile.json
+++ b/bench/cardano-profile/data/test/chainsync-early-alonzo-coay/profile.json
@@ -283,6 +283,7 @@
     "heap_limit": null,
     "shutdown_on_slot_synced": 38901589,
     "shutdown_on_block_synced": null,
+    "ssd_directory": null,
     "tracing_backend": "trace-dispatcher",
     "tracer": false,
     "utxo_lmdb": false,
@@ -306,39 +307,7 @@
     "ekg": false,
     "withresources": false
   },
-  "cluster": {
-    "nomad": {
-      "namespace": "default",
-      "class": "",
-      "resources": {
-        "producer": {
-          "cores": 2,
-          "memory": 15000,
-          "memory_max": 16000
-        },
-        "explorer": {
-          "cores": 2,
-          "memory": 15000,
-          "memory_max": 16000
-        }
-      },
-      "host_volumes": null,
-      "fetch_logs_ssh": false
-    },
-    "aws": {
-      "instance_type": {
-        "producer": "c5.2xlarge",
-        "explorer": "m5.4xlarge"
-      },
-      "use_public_routing": false
-    },
-    "minimun_storage": {
-      "producer": 12582912,
-      "explorer": 14155776
-    },
-    "keep_running": false,
-    "ssd_directory": null
-  },
+  "cluster": null,
   "extra_desc": "without cardano-tracer",
   "suffix": "notrc",
   "desc": "Mainnet chain syncing benchmark",

--- a/bench/cardano-profile/data/test/chainsync-early-alonzo-coay/profile.json
+++ b/bench/cardano-profile/data/test/chainsync-early-alonzo-coay/profile.json
@@ -284,8 +284,8 @@
     "shutdown_on_slot_synced": 38901589,
     "shutdown_on_block_synced": null,
     "ssd_directory": null,
+    "trace_forwarding": false,
     "tracing_backend": "trace-dispatcher",
-    "tracer": false,
     "utxo_lmdb": false,
     "verbatim": {}
   },

--- a/bench/cardano-profile/data/test/chainsync-early-byron-coay/profile.json
+++ b/bench/cardano-profile/data/test/chainsync-early-byron-coay/profile.json
@@ -284,8 +284,8 @@
     "shutdown_on_slot_synced": 237599,
     "shutdown_on_block_synced": null,
     "ssd_directory": null,
+    "trace_forwarding": false,
     "tracing_backend": "trace-dispatcher",
-    "tracer": false,
     "utxo_lmdb": false,
     "verbatim": {}
   },

--- a/bench/cardano-profile/data/test/chainsync-early-byron-coay/profile.json
+++ b/bench/cardano-profile/data/test/chainsync-early-byron-coay/profile.json
@@ -283,6 +283,7 @@
     "heap_limit": null,
     "shutdown_on_slot_synced": 237599,
     "shutdown_on_block_synced": null,
+    "ssd_directory": null,
     "tracing_backend": "trace-dispatcher",
     "tracer": false,
     "utxo_lmdb": false,
@@ -336,8 +337,7 @@
       "producer": 12582912,
       "explorer": 14155776
     },
-    "keep_running": false,
-    "ssd_directory": null
+    "keep_running": false
   },
   "extra_desc": "without cardano-tracer",
   "suffix": "notrc",

--- a/bench/cardano-profile/data/test/ci-test-bage.json
+++ b/bench/cardano-profile/data/test/ci-test-bage.json
@@ -282,8 +282,8 @@
     "heap_limit": null,
     "shutdown_on_slot_synced": null,
     "shutdown_on_block_synced": 3,
+    "trace_forwarding": true,
     "tracing_backend": "trace-dispatcher",
-    "tracer": true,
     "utxo_lmdb": false,
     "verbatim": {}
   },

--- a/bench/cardano-profile/data/test/ci-test-bage.json
+++ b/bench/cardano-profile/data/test/ci-test-bage.json
@@ -313,39 +313,7 @@
     "ekg": false,
     "withresources": false
   },
-  "cluster": {
-    "nomad": {
-      "namespace": "default",
-      "class": "",
-      "resources": {
-        "producer": {
-          "cores": 2,
-          "memory": 15000,
-          "memory_max": 16000
-        },
-        "explorer": {
-          "cores": 2,
-          "memory": 15000,
-          "memory_max": 16000
-        }
-      },
-      "host_volumes": null,
-      "fetch_logs_ssh": false
-    },
-    "aws": {
-      "instance_type": {
-        "producer": "c5.2xlarge",
-        "explorer": "m5.4xlarge"
-      },
-      "use_public_routing": false
-    },
-    "minimun_storage": {
-      "producer": 12582912,
-      "explorer": 14155776
-    },
-    "keep_running": false,
-    "ssd_directory": null
-  },
+  "cluster": null,
   "desc": "Miniature dataset, CI-friendly duration, test scale",
   "name": "ci-test-bage",
   "overlay": {},

--- a/bench/cardano-profile/data/test/ci-test-coay/profile.json
+++ b/bench/cardano-profile/data/test/ci-test-coay/profile.json
@@ -283,8 +283,8 @@
     "shutdown_on_slot_synced": null,
     "shutdown_on_block_synced": 3,
     "ssd_directory": null,
+    "trace_forwarding": true,
     "tracing_backend": "trace-dispatcher",
-    "tracer": true,
     "utxo_lmdb": false,
     "verbatim": {}
   },

--- a/bench/cardano-profile/data/test/ci-test-coay/profile.json
+++ b/bench/cardano-profile/data/test/ci-test-coay/profile.json
@@ -282,6 +282,7 @@
     "heap_limit": null,
     "shutdown_on_slot_synced": null,
     "shutdown_on_block_synced": 3,
+    "ssd_directory": null,
     "tracing_backend": "trace-dispatcher",
     "tracer": true,
     "utxo_lmdb": false,
@@ -313,39 +314,7 @@
     "ekg": false,
     "withresources": false
   },
-  "cluster": {
-    "nomad": {
-      "namespace": "default",
-      "class": "",
-      "resources": {
-        "producer": {
-          "cores": 2,
-          "memory": 15000,
-          "memory_max": 16000
-        },
-        "explorer": {
-          "cores": 2,
-          "memory": 15000,
-          "memory_max": 16000
-        }
-      },
-      "host_volumes": null,
-      "fetch_logs_ssh": false
-    },
-    "aws": {
-      "instance_type": {
-        "producer": "c5.2xlarge",
-        "explorer": "m5.4xlarge"
-      },
-      "use_public_routing": false
-    },
-    "minimun_storage": {
-      "producer": 12582912,
-      "explorer": 14155776
-    },
-    "keep_running": false,
-    "ssd_directory": null
-  },
+  "cluster": null,
   "desc": "Miniature dataset, CI-friendly duration, test scale",
   "name": "ci-test-coay",
   "overlay": {},

--- a/bench/cardano-profile/data/test/ci-test-dense10-coay/profile.json
+++ b/bench/cardano-profile/data/test/ci-test-dense10-coay/profile.json
@@ -283,8 +283,8 @@
     "shutdown_on_slot_synced": null,
     "shutdown_on_block_synced": 3,
     "ssd_directory": null,
+    "trace_forwarding": true,
     "tracing_backend": "trace-dispatcher",
-    "tracer": true,
     "utxo_lmdb": false,
     "verbatim": {}
   },

--- a/bench/cardano-profile/data/test/ci-test-dense10-coay/profile.json
+++ b/bench/cardano-profile/data/test/ci-test-dense10-coay/profile.json
@@ -282,6 +282,7 @@
     "heap_limit": null,
     "shutdown_on_slot_synced": null,
     "shutdown_on_block_synced": 3,
+    "ssd_directory": null,
     "tracing_backend": "trace-dispatcher",
     "tracer": true,
     "utxo_lmdb": false,
@@ -313,39 +314,7 @@
     "ekg": false,
     "withresources": false
   },
-  "cluster": {
-    "nomad": {
-      "namespace": "default",
-      "class": "",
-      "resources": {
-        "producer": {
-          "cores": 2,
-          "memory": 15000,
-          "memory_max": 16000
-        },
-        "explorer": {
-          "cores": 2,
-          "memory": 15000,
-          "memory_max": 16000
-        }
-      },
-      "host_volumes": null,
-      "fetch_logs_ssh": false
-    },
-    "aws": {
-      "instance_type": {
-        "producer": "c5.2xlarge",
-        "explorer": "m5.4xlarge"
-      },
-      "use_public_routing": false
-    },
-    "minimun_storage": {
-      "producer": 12582912,
-      "explorer": 14155776
-    },
-    "keep_running": false,
-    "ssd_directory": null
-  },
+  "cluster": null,
   "desc": "Miniature dataset, CI-friendly duration, test scale",
   "name": "ci-test-dense10-coay",
   "overlay": {},

--- a/bench/cardano-profile/data/test/default-coay/profile.json
+++ b/bench/cardano-profile/data/test/default-coay/profile.json
@@ -283,8 +283,8 @@
     "shutdown_on_slot_synced": null,
     "shutdown_on_block_synced": null,
     "ssd_directory": null,
+    "trace_forwarding": true,
     "tracing_backend": "trace-dispatcher",
-    "tracer": true,
     "utxo_lmdb": false,
     "verbatim": {}
   },

--- a/bench/cardano-profile/data/test/default-coay/profile.json
+++ b/bench/cardano-profile/data/test/default-coay/profile.json
@@ -282,6 +282,7 @@
     "heap_limit": null,
     "shutdown_on_slot_synced": null,
     "shutdown_on_block_synced": null,
+    "ssd_directory": null,
     "tracing_backend": "trace-dispatcher",
     "tracer": true,
     "utxo_lmdb": false,
@@ -315,39 +316,7 @@
     "ekg": false,
     "withresources": false
   },
-  "cluster": {
-    "nomad": {
-      "namespace": "default",
-      "class": "",
-      "resources": {
-        "producer": {
-          "cores": 2,
-          "memory": 15000,
-          "memory_max": 16000
-        },
-        "explorer": {
-          "cores": 2,
-          "memory": 15000,
-          "memory_max": 16000
-        }
-      },
-      "host_volumes": null,
-      "fetch_logs_ssh": false
-    },
-    "aws": {
-      "instance_type": {
-        "producer": "c5.2xlarge",
-        "explorer": "m5.4xlarge"
-      },
-      "use_public_routing": false
-    },
-    "minimun_storage": {
-      "producer": 12582912,
-      "explorer": 14155776
-    },
-    "keep_running": false,
-    "ssd_directory": null
-  },
+  "cluster": null,
   "name": "default-coay",
   "desc": "Default, as per nix/workbench/profile/prof0-defaults.jq",
   "overlay": {},

--- a/bench/cardano-profile/data/test/fast-nomadperf-coay/profile.json
+++ b/bench/cardano-profile/data/test/fast-nomadperf-coay/profile.json
@@ -478,8 +478,8 @@
     "shutdown_on_slot_synced": null,
     "shutdown_on_block_synced": 1,
     "ssd_directory": null,
+    "trace_forwarding": true,
     "tracing_backend": "trace-dispatcher",
-    "tracer": true,
     "utxo_lmdb": false,
     "verbatim": {
       "EnableP2P": true

--- a/bench/cardano-profile/data/test/fast-nomadperf-coay/profile.json
+++ b/bench/cardano-profile/data/test/fast-nomadperf-coay/profile.json
@@ -477,6 +477,7 @@
     "heap_limit": null,
     "shutdown_on_slot_synced": null,
     "shutdown_on_block_synced": 1,
+    "ssd_directory": null,
     "tracing_backend": "trace-dispatcher",
     "tracer": true,
     "utxo_lmdb": false,
@@ -540,8 +541,7 @@
       "producer": 12582912,
       "explorer": 14155776
     },
-    "keep_running": true,
-    "ssd_directory": null
+    "keep_running": true
   },
   "desc": "Stop as soon as we've seen a single block",
   "extra_desc": "with P2P networking",

--- a/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Builtin/Empty.hs
+++ b/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Builtin/Empty.hs
@@ -114,7 +114,6 @@ profilesNoEraEmpty = map baseNoDataset
   let fast =
           P.empty & V.datasetEmpty . genesis . fastDuration
         . P.uniCircle . P.loopback
-        . V.clusterDefault -- TODO: "cluster" should be "null" here.
       fast1 = fast & V.hosts 1
       fast2 = fast & V.hosts 2
   in [
@@ -134,7 +133,6 @@ profilesNoEraEmpty = map baseNoDataset
   let ciTest =
           P.empty & V.datasetEmpty . genesis . ciTestDuration
         . P.uniCircle . V.hosts 2 . P.loopback
-        . V.clusterDefault -- TODO: "cluster" should be "null" here.
   in [
   -- Local
     ciTest & P.name "ci-test"          . V.valueLocal . P.traceForwardingOn  . P.newTracing . P.p2pOff
@@ -152,7 +150,6 @@ profilesNoEraEmpty = map baseNoDataset
           P.empty & V.datasetEmpty . V.genesisVariantPreVoltaire . ciTestDuration
         . P.uniCircle . V.hosts 2 . P.loopback
         . P.analysisSizeSmall
-        . V.clusterDefault -- TODO: "cluster" should be "null" here.
   in [
      -- intricacies of fee calculation..., default fee works for ci-test-plutus and ci-bench-plutus
     ciTestHydra & P.name "ci-test-hydra" . P.txFeeOverwrite 1380000 . V.plutusLoop . P.traceForwardingOn  . P.newTracing . P.p2pOn . P.blocksize64k
@@ -166,7 +163,6 @@ profilesNoEraEmpty = map baseNoDataset
         -- TODO: "default-*" uses 6 nodes and `uniCircle`.
         . P.torus . V.hosts 6 . P.loopback
         . P.tracerWithresources
-        . V.clusterDefault -- TODO: "cluster" should be "null" here.
       bench = trace & traceBenchDuration
       full  = trace & traceFullDuration
   in [
@@ -190,7 +186,6 @@ profilesNoEraEmpty = map baseNoDataset
         -- TODO: The only one without 0 delegators.
         --       Fix and remove `baseNoDataset` (Same `base` for all).
         . P.utxo 0 . P.delegators 6 . P.dreps 0
-        . V.clusterDefault -- TODO: "cluster" should be "null" here.
       value  = noCliStop & V.genesisVariant300
       -- TODO: "fast-plutus" and "ci-test-plutus" are using `genesisVariant300`.
       plutus = noCliStop & V.genesisVariantPreVoltaire
@@ -214,7 +209,6 @@ profilesNoEraEmpty = map baseNoDataset
   let ep =
           P.empty & V.datasetEmpty . genesis . epochTransitionDuration
         . P.uniCircle . V.hosts 2 . P.loopback
-        . V.clusterDefault -- TODO: "cluster" should be "null" here.
   in [
     ep & P.name "epoch-transition" . V.valueLocal . P.traceForwardingOn . P.newTracing . P.p2pOff
   ]

--- a/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Builtin/ForgeStress.hs
+++ b/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Builtin/ForgeStress.hs
@@ -29,7 +29,6 @@ base =
   . P.p2pOff . P.newTracing
   . P.initCooldown 5
   . P.analysisStandard
-  . V.clusterDefault -- TODO: "cluster" should be "null" here.
 
 -- Helpers by timescale:
 

--- a/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Builtin/K3.hs
+++ b/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Builtin/K3.hs
@@ -35,7 +35,6 @@ profilesNoEraK3 =
         . P.p2pOff
         . P.traceForwardingOn . P.newTracing
         . P.analysisStandard . P.analysisUnitary
-        . V.clusterDefault -- TODO: "cluster" should be "null" here.
   in [
     k3 & P.name "k3-3ep-5kTx-10000kU-1300kD-64kbs-fixed-loaded"        . V.valueBase . P.slotDuration 0.2 . P.tps 12
   , k3 & P.name "k3-3ep-9kTx-10000kU-1300kD-64kbs-5tps-fixed-loaded"   . V.valueBase . P.slotDuration 1   . P.tps  5

--- a/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Builtin/Legacy/Dense.hs
+++ b/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Builtin/Legacy/Dense.hs
@@ -29,7 +29,6 @@ profilesNoEraDense =
         . V.genesisVariant300
         . E.ciTestDuration
         . P.cBlockMinimumAdoptions 9
-        . V.clusterDefault -- TODO: "cluster" should be "null" here.
   in [
     ciTestDense & P.name "ci-test-dense10" . V.valueLocal . P.traceForwardingOn . P.newTracing . P.p2pOff
   ]

--- a/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Builtin/Miniature.hs
+++ b/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Builtin/Miniature.hs
@@ -64,7 +64,6 @@ profilesNoEraMiniature =
         . P.desc "Miniature dataset, CI-friendly duration, bench scale"
         . P.uniCircle . P.loopback
         . benchDuration
-        . V.clusterDefault -- TODO: "cluster" should be "null" here.
       -- Helpers by size:
       ciBench02  = ciBench & V.hosts  2
       ciBench10  = ciBench & V.hosts 10
@@ -114,7 +113,6 @@ profilesNoEraMiniature =
         . P.dreps 0
         . P.p2pOn
         . P.analysisSizeFull . P.analysisUnitary
-        . V.clusterDefault -- TODO: "cluster" should be "null" here.
   in [
     dense & P.name "6-dense"            . V.valueCloud . duration30  . P.traceForwardingOn . P.newTracing
   , dense & P.name "6-dense-rtsprof"    . V.valueCloud . duration30  . P.traceForwardingOn . P.newTracing . P.rtsHeapProf . P.rtsEventlogged

--- a/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Builtin/Model.hs
+++ b/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Builtin/Model.hs
@@ -40,7 +40,6 @@ profilesNoEraModel =
         . V.fundsDouble
         . P.traceForwardingOn . P.newTracing
         . P.analysisStandard . P.analysisEpoch3Plus
-        . V.clusterDefault -- TODO: "cluster" should be "null" here.
         . P.desc "Status-quo dataset, 7 epochs"
       secp       = V.plutusDoubleSaturation . V.plutusTypeECDSA . P.analysisSizeModerate
       value      = V.valueBase . P.tps 9 -- "value" with the Plutus `txFee`.

--- a/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Builtin/Plutuscall.hs
+++ b/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Builtin/Plutuscall.hs
@@ -43,7 +43,6 @@ profilesNoEraPlutuscall =
         . P.p2pOff
         . P.traceForwardingOn . P.newTracing
         . P.analysisStandard
-        . V.clusterDefault -- TODO: "cluster" should be "null" here.
         . P.desc "Small dataset, honest 15 epochs duration"
 
       loop            = plutusCall & V.plutusTypeLoop    . V.plutusDoubleSaturation     . P.analysisSizeModerate . P.analysisEpoch3Plus

--- a/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Builtin/Scenario/Chainsync.hs
+++ b/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Builtin/Scenario/Chainsync.hs
@@ -34,7 +34,6 @@ profilesNoEraChainsync =
          --       Remove and use `V.datasetEmpty` in module "Scenario.Base".
         . P.delegators 0
         . P.analysisPerformance
-        . V.clusterDefault -- TODO: "cluster" should be "null" here.
         . P.preset "mainnet"
         . P.desc "Mainnet chain syncing benchmark"
       {--

--- a/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Builtin/Scenario/Idle.hs
+++ b/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Builtin/Scenario/Idle.hs
@@ -34,7 +34,6 @@ profilesNoEraIdle =
          --       Remove and use `V.datasetEmpty` in module "Scenario.Base".
         . P.delegators 6
         . P.analysisUnitary
-        . V.clusterDefault -- TODO: "cluster" should be "null" here.
       updateQuorum = P.shelley (KeyMap.insert "updateQuorum" (Aeson.Number 1))
   in [
     idle & P.name "devops" . V.timescaleDevops     . P.extraFutureOffset 10 . updateQuorum . P.traceForwardingOn . P.newTracing . P.p2pOff . P.analysisOff

--- a/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Builtin/Scenario/TracerOnly.hs
+++ b/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Builtin/Scenario/TracerOnly.hs
@@ -32,7 +32,6 @@ profilesNoEraTracerOnly =
          --       Remove and use `V.datasetEmpty` in module "Scenario.Base".
         . P.delegators 6
         . P.analysisStandard . P.analysisUnitary
-        . V.clusterDefault -- TODO: "cluster" should be "null" here.
   in [
     tracerOnly & P.name "tracer-only"
                . P.desc "Idle scenario:  start only the tracer & detach from tty;  no termination"

--- a/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Extra/Scaling.hs
+++ b/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Extra/Scaling.hs
@@ -40,7 +40,6 @@ profilesNoEraScalingLocal =
         . P.loopback
         . V.valueLocal
         . E.fastDuration
-        . V.clusterDefault -- TODO: "cluster" should be "null" here.
   in [
     fastStartup & P.name "faststartup-24M"                    . P.utxo 24000000 . V.fundsDefault . V.genesisVariant300
   ]

--- a/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Playground.hs
+++ b/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Playground.hs
@@ -82,7 +82,6 @@ profilesNoEraPlayground =
         . M.benchDuration
         . P.traceForwardingOn . P.newTracing
         . P.p2pOn
-        . V.clusterDefault -- TODO: "cluster" should be "null" here.
         . V.genesisVariantVoltaire
         -- Cloud Plutus workload
         . V.plutusTypeLoop . V.plutusBase . P.tps 0.85
@@ -99,7 +98,6 @@ profilesNoEraPlayground =
         . compressedFor3Epochs
         . V.plutusDoublePlusSaturation . P.txFee 1000000
         . P.analysisStandard
-        . V.clusterDefault -- TODO: "cluster" should be "null" here.
   in [
   -- Budget profiles.
     ciBenchLike & P.name "calibrate-volt"

--- a/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Types.hs
+++ b/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Types.hs
@@ -397,8 +397,7 @@ data Node = Node
   -- TODO: Move up "EnableP2P". A new level only for this?
   , verbatim :: NodeVerbatim
 
-  -- TODO: "tracing_backend" is null or has a backend name!
-  , trace_forwarding :: Bool -- TODO: Rename in workbench/bash from "tracer"
+  , trace_forwarding :: Bool
   , tracing_backend :: String
 
   -- TODO: Create an RTS property.
@@ -411,35 +410,11 @@ data Node = Node
   }
   deriving (Eq, Show, Generic)
 
-instance Aeson.ToJSON Node where
-  toJSON n =
-    Aeson.object
-      [ "utxo_lmdb"                Aeson..= utxo_lmdb n
-      , "ssd_directory"            Aeson..= ssd_directory n
-      , "verbatim"                 Aeson..= verbatim n
-      -- TODO: Rename in workbench/bash to "trace_forwarding".
-      , "tracer"                   Aeson..= trace_forwarding n
-      , "tracing_backend"          Aeson..= tracing_backend n
-      , "rts_flags_override"       Aeson..= rts_flags_override n
-      , "heap_limit"               Aeson..= heap_limit n
-      , "shutdown_on_slot_synced"  Aeson..= shutdown_on_slot_synced n
-      , "shutdown_on_block_synced" Aeson..= shutdown_on_block_synced n
-      ]
+instance Aeson.ToJSON Node
 
 instance Aeson.FromJSON Node where
-  parseJSON =
-    Aeson.withObject "Node" $ \o -> do
-      Node
-        <$> o Aeson..:  "utxo_lmdb"
-        <*> o Aeson..:? "ssd_directory"
-        <*> o Aeson..:  "verbatim"
-        -- TODO: Rename in workbench/bash to "trace_forwarding".
-        <*> o Aeson..:  "tracer"
-        <*> o Aeson..:  "tracing_backend"
-        <*> o Aeson..:  "rts_flags_override"
-        <*> o Aeson..:  "heap_limit"
-        <*> o Aeson..:  "shutdown_on_slot_synced"
-        <*> o Aeson..:  "shutdown_on_block_synced"
+  parseJSON = Aeson.genericParseJSON
+    (Aeson.defaultOptions {Aeson.rejectUnknownFields = True})
 
 -- Properties passed directly to the node(s) "config.json" file.
 newtype NodeVerbatim = NodeVerbatim

--- a/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Types.hs
+++ b/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Types.hs
@@ -93,7 +93,7 @@ data Profile = Profile
   , workloads :: [Workload]
 
   , tracer :: Tracer
-  , cluster :: Cluster
+  , cluster :: Maybe Cluster
   , analysis :: Analysis
   , derived :: Derived
   , cli_args :: CliArgs
@@ -392,6 +392,7 @@ instance Aeson.FromJSON Chunks where
 data Node = Node
   { 
     utxo_lmdb :: Bool
+  , ssd_directory :: Maybe String
 
   -- TODO: Move up "EnableP2P". A new level only for this?
   , verbatim :: NodeVerbatim
@@ -414,6 +415,7 @@ instance Aeson.ToJSON Node where
   toJSON n =
     Aeson.object
       [ "utxo_lmdb"                Aeson..= utxo_lmdb n
+      , "ssd_directory"            Aeson..= ssd_directory n
       , "verbatim"                 Aeson..= verbatim n
       -- TODO: Rename in workbench/bash to "trace_forwarding".
       , "tracer"                   Aeson..= trace_forwarding n
@@ -428,15 +430,16 @@ instance Aeson.FromJSON Node where
   parseJSON =
     Aeson.withObject "Node" $ \o -> do
       Node
-        <$> o Aeson..: "utxo_lmdb"
-        <*> o Aeson..: "verbatim"
+        <$> o Aeson..:  "utxo_lmdb"
+        <*> o Aeson..:? "ssd_directory"
+        <*> o Aeson..:  "verbatim"
         -- TODO: Rename in workbench/bash to "trace_forwarding".
-        <*> o Aeson..: "tracer"
-        <*> o Aeson..: "tracing_backend"
-        <*> o Aeson..: "rts_flags_override"
-        <*> o Aeson..: "heap_limit"
-        <*> o Aeson..: "shutdown_on_slot_synced"
-        <*> o Aeson..: "shutdown_on_block_synced"
+        <*> o Aeson..:  "tracer"
+        <*> o Aeson..:  "tracing_backend"
+        <*> o Aeson..:  "rts_flags_override"
+        <*> o Aeson..:  "heap_limit"
+        <*> o Aeson..:  "shutdown_on_slot_synced"
+        <*> o Aeson..:  "shutdown_on_block_synced"
 
 -- Properties passed directly to the node(s) "config.json" file.
 newtype NodeVerbatim = NodeVerbatim
@@ -610,7 +613,6 @@ data Cluster = Cluster
   { nomad :: ClusterNomad
   , aws :: ClusterAWS
   , minimun_storage :: Maybe (ByNodeType Int)
-  , ssd_directory :: Maybe String
   , keep_running :: Bool
   }
   deriving (Eq, Show, Generic)

--- a/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Vocabulary.hs
+++ b/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Vocabulary.hs
@@ -21,8 +21,6 @@ module Cardano.Benchmarking.Profile.Vocabulary (
 
 , plutusTypeLoop, plutusTypeLoop2024, plutusTypeECDSA, plutusTypeSchnorr
 , plutusTypeBLST, plutusTypeRIPEMD
-
-, clusterDefault
 ) where
 
 --------------------------------------------------------------------------------
@@ -250,37 +248,3 @@ plutusTypeRIPEMD =
     , KeyMap.fromList [("bytes", Aeson.String "5a56da88e6fd8419181dec4d3dd6997bab953d2f")]
     ]
   . P.txFee 940000
-
--- Definition vocabulary: cluster.
-----------------------------------
-
--- TODO: Should not exists, should be null instead!
-clusterDefault :: Types.Profile -> Types.Profile
-clusterDefault p =
-  p {Types.cluster =
-    Types.Cluster {
-      Types.nomad = Types.ClusterNomad {
-        Types.namespace = "default"
-      , Types.nomad_class = ""
-      , Types.resources = Types.ByNodeType {
-          Types.producer = Types.Resources 2 15000 16000
-        , Types.explorer = Just $ Types.Resources 2 15000 16000
-        }
-      , Types.host_volumes = Nothing
-      , Types.fetch_logs_ssh = False
-      }
-    , Types.aws = Types.ClusterAWS {
-        Types.instance_type = Types.ByNodeType {
-          Types.producer = "c5.2xlarge"
-        , Types.explorer = Just "m5.4xlarge"
-        }
-      , Types.use_public_routing = False
-      }
-    , Types.minimun_storage = Just $ Types.ByNodeType {
-        Types.producer = 12582912
-      , Types.explorer = Just 14155776
-      }
-    , Types.ssd_directory = Nothing
-    , Types.keep_running = False
-    }
-  }

--- a/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Vocabulary.hs
+++ b/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Vocabulary.hs
@@ -70,8 +70,8 @@ timescaleCompressed =
 
 timescaleSmall :: Types.Profile -> Types.Profile
 timescaleSmall =
-    P.epochLength 1200 . P.parameterK 6
-  . P.slotDuration 1 . P.activeSlotsCoeff 0.05
+    P.slotDuration 1 . P.activeSlotsCoeff 0.05
+  . P.epochLength 1200 . P.parameterK 6
 
 -- Used by "model", "value", and "plutus".
 timescaleModel :: Types.Profile -> Types.Profile

--- a/bench/cardano-profile/test/Main.hs
+++ b/bench/cardano-profile/test/Main.hs
@@ -345,6 +345,7 @@ ciTestBage = Types.Profile {
   , Types.scenario = Types.FixedLoaded
   , Types.node = Types.Node {
       Types.utxo_lmdb = False
+    , Types.ssd_directory = Nothing
     , Types.verbatim = Types.NodeVerbatim Nothing
     , Types.trace_forwarding = True
     , Types.tracing_backend = "trace-dispatcher"
@@ -374,31 +375,7 @@ ciTestBage = Types.Profile {
     , Types.ekg = False
     , Types.withresources = False
   }
-  , Types.cluster = Types.Cluster {
-      Types.nomad = Types.ClusterNomad {
-        Types.namespace = "default"
-      , Types.nomad_class = ""
-      , Types.resources = Types.ByNodeType {
-          Types.producer = Types.Resources 2 15000 16000
-        , Types.explorer = Just $ Types.Resources 2 15000 16000
-        }
-      , Types.host_volumes = Nothing
-      , Types.fetch_logs_ssh = False
-      }
-    , Types.aws = Types.ClusterAWS {
-        Types.instance_type = Types.ByNodeType {
-          Types.producer = "c5.2xlarge"
-        , Types.explorer = Just "m5.4xlarge"
-        }
-      , Types.use_public_routing = False
-      }
-    , Types.minimun_storage = Just $ Types.ByNodeType {
-        Types.producer = 12582912
-      , Types.explorer = Just 14155776
-      }
-    , Types.ssd_directory = Nothing
-    , Types.keep_running = False
-  }
+  , Types.cluster = Nothing
   , Types.analysis = Types.Analysis {
       Types.analysisType = Just "standard"
     , Types.cluster_base_startup_overhead_s = 40

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
@@ -1516,7 +1516,7 @@ instance LogFormatting TraceStartLeadershipCheckPlus where
                 , "slot" .= toJSON (unSlotNo tsSlotNo)
                 , "utxoSize" .= Number (fromIntegral tsUtxoSize)
                 , "delegMapSize" .= Number (fromIntegral tsDelegMapSize)
-                , "chainDensity" .= Number (fromRational (toRational tsChainDensity))
+                , "chainDensity" .= toJSON tsChainDensity
                 ]
   forHuman TraceStartLeadershipCheckPlus {..} =
       "Checking for leadership in slot " <> showT (unSlotNo tsSlotNo)

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/StartLeadershipCheck.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/StartLeadershipCheck.hs
@@ -19,7 +19,8 @@ import           Data.IORef (readIORef)
 import           Data.Word (Word64)
 
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block (BlockNo (..), blockNo, unBlockNo)
+import qualified Ouroboros.Network.AnchoredSeq as AS
+import           Ouroboros.Network.Block (BlockNo (..), blockNo, unBlockNo, blockSlot)
 import           Ouroboros.Network.NodeToClient (LocalConnectionId)
 import           Ouroboros.Network.NodeToNode (RemoteAddress)
 
@@ -34,7 +35,6 @@ import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import qualified Ouroboros.Consensus.Storage.LedgerDB.Forker as LedgerDB
 
 import           Cardano.Node.Queries (LedgerQueries (..), NodeKernelData (..))
-import           Cardano.Slotting.Slot (fromWithOrigin)
 
 import           Cardano.Ledger.BaseTypes (StrictMaybe (..))
 
@@ -112,21 +112,20 @@ fragmentChainDensity frag = calcDensity blockD slotD
     calcDensity bl sl
       | sl > 0 = fromIntegral bl / fromIntegral sl
       | otherwise = 0
-    slotN  = unSlotNo $ fromWithOrigin 0 (AF.headSlot frag)
-    -- Slot of the tip - slot @k@ blocks back. Use 0 as the slot for genesis
-    -- includes EBBs
-    slotD   = slotN
-            - unSlotNo (fromWithOrigin 0 (AF.lastSlot frag))
-    -- Block numbers start at 1. We ignore the genesis EBB, which has block number 0.
-    blockD = blockN - firstBlock
-    blockN = unBlockNo $ fromWithOrigin (BlockNo 1) (AF.headBlockNo frag)
-    firstBlock = case unBlockNo . blockNo <$> AF.last frag of
-      -- Empty fragment, no blocks. We have that @blocks = 1 - 1 = 0@
-      Left _  -> 1
-      -- The oldest block is the genesis EBB with block number 0,
-      -- don't let it contribute to the number of blocks
-      Right 0 -> 1
-      Right b -> b
+    -- NOTE: this ignores the Byron era with its EBB complication:
+    -- the length would be underestimated by 1, if the AF is anchored at the
+    -- epoch boundary.
+    -- https://github.com/cardano-foundation/CIPs/pull/974
+    (blockD, slotD) =
+      case (frag, frag) of
+        (AS.Empty{}, AS.Empty{}) -> (0,0)
+        (firstFrag AS.:< _, _ AS.:> lastFrag) ->
+          -- For a validly constructed AnchoredFragment (Header blk) that does
+          -- not involve EBBs this value is always equal to AF.length.
+          ( unBlockNo $ blockNo   lastFrag - blockNo   firstFrag - 1
+          -- This value is zero for the genesis block and block 1.
+          , unSlotNo  $ blockSlot lastFrag - blockSlot firstFrag
+          )
 
 nkQueryChain ::
      (AF.AnchoredFragment (Header blk) -> a)

--- a/nix/workbench/backend/nomad-job.nix
+++ b/nix/workbench/backend/nomad-job.nix
@@ -465,7 +465,7 @@ let
       //
       # If it needs host volumes add the constraints (can't be "null" or "[]".)
       ### - https://developer.hashicorp.com/nomad/tutorials/stateful-workloads/stateful-workloads-host-volumes
-      (lib.optionalAttrs (profile.cluster.nomad.host_volumes != null) {
+      (lib.optionalAttrs ((profile.cluster or null) != null && profile.cluster.nomad.host_volumes != null) {
         volume = lib.listToAttrs (lib.lists.imap0
           (i: v: {
             # Internal name, reference to mount in this group's tasks below.
@@ -559,7 +559,7 @@ let
               # When using dedicated Nomad clusters on AWS we want to use public
               # IPs/routing, all the other cloud runs will run behind a
               # VPC/firewall.
-              if profile.cluster.aws.use_public_routing
+              if (profile.cluster or null) != null && profile.cluster.aws.use_public_routing
               then "\${attr.unique.platform.aws.public-ipv4}"
               else "" # Local runs just use 127.0.0.1.
             ;
@@ -591,7 +591,7 @@ let
           };
 
           # If it needs host volumes mount them (defined above if any).
-          volume_mount = if profile.cluster.nomad.host_volumes != null
+          volume_mount = if (profile.cluster or null) != null && profile.cluster.nomad.host_volumes != null
             then lib.lists.imap0
               (i: v: {
                 # Internal name, defined above in the group's specification.
@@ -1306,7 +1306,7 @@ let
       [
         # Address string to
         (
-          if profile.cluster.aws.use_public_routing
+          if (profile.cluster or null) != null && profile.cluster.aws.use_public_routing
           then ''--host-addr {{ env "attr.unique.platform.aws.local-ipv4" }}''
           else ''--host-addr 0.0.0.0''
         )

--- a/nix/workbench/backend/nomad-job.nix
+++ b/nix/workbench/backend/nomad-job.nix
@@ -742,7 +742,7 @@ let
           ## If using oneTracerPerNode no "tracer volumes" need to be mounted
           ## (because of no socket sharing between tasks), and tracer files are
           ## created using templates.
-          (lib.optionals (profile.node.tracer && oneTracerPerNode) [
+          (lib.optionals (profile.node.trace_forwarding && oneTracerPerNode) [
             ## Tracer start.sh script.
             {
               env = false;
@@ -1016,7 +1016,7 @@ let
       in lib.listToAttrs (
         # If not oneTracerPerNode, an individual tracer task is needed (instead
         # of running a tracer alongside a node with supervisor)
-        lib.optionals (profile.node.tracer && !oneTracerPerNode) [
+        lib.optionals (profile.node.trace_forwarding && !oneTracerPerNode) [
           {
             name = "tracer";
             value = valueF

--- a/nix/workbench/backend/supervisor.nix
+++ b/nix/workbench/backend/supervisor.nix
@@ -24,7 +24,7 @@ let
           profile = profileBundle.profile.value;
           nodeSpecs = profileBundle.node-specs.value;
           withGenerator = true;
-          withTracer = profileBundle.profile.value.node.tracer;
+          withTracer = profileBundle.profile.value.node.trace_forwarding;
           withSsh = false;
           inetHttpServerPort = "127.0.0.1:9001";
         };

--- a/nix/workbench/service/generator.nix
+++ b/nix/workbench/service/generator.nix
@@ -55,7 +55,7 @@ let
                               then "plutus-datum.json"
                               else null
         ;
-      } // optionalAttrs profile.node.tracer {
+      } // optionalAttrs profile.node.trace_forwarding {
         tracerSocketPath = "../tracer/tracer.socket";
       } // optionalAttrs backend.useCabalRun {
         executable     = "tx-generator";

--- a/nix/workbench/service/nodes.nix
+++ b/nix/workbench/service/nodes.nix
@@ -88,7 +88,7 @@ let
           {
             inherit (pkgs) lib;
             inherit nodeSpec;
-            inherit (profile.node) tracing_backend tracer;
+            inherit (profile.node) tracing_backend trace_forwarding;
           }
           (recursiveUpdate
             (recursiveUpdate
@@ -154,7 +154,7 @@ let
       operationalCertificate = "../genesis/node-keys/node${toString i}.opcert";
       kesKey                 = "../genesis/node-keys/node-kes${toString i}.skey";
       vrfKey                 = "../genesis/node-keys/node-vrf${toString i}.skey";
-    } // optionalAttrs profile.node.tracer {
+    } // optionalAttrs profile.node.trace_forwarding {
       tracerSocketPathConnect = mkDefault "../tracer/tracer.socket";
     };
 

--- a/nix/workbench/service/nodes.nix
+++ b/nix/workbench/service/nodes.nix
@@ -54,8 +54,8 @@ let
        else throw "configHardforksIntoEra:  unknown era '${era}'";
 
   liveTablesPath = i: 
-    if (profile.cluster ? "ssd_directory" && profile.cluster.ssd_directory != null)
-    then "${profile.cluster.ssd_directory}/lmdb-node-${toString i}"
+    if (profile.node ? "ssd_directory" && profile.node.ssd_directory != null)
+    then "${profile.node.ssd_directory}/lmdb-node-${toString i}"
     else null;
 
   ##

--- a/nix/workbench/service/tracing.nix
+++ b/nix/workbench/service/tracing.nix
@@ -1,7 +1,7 @@
 { lib
 , nodeSpec
-, tracer
 , tracing_backend
+, trace_forwarding
 }:
 cfg:
 
@@ -25,7 +25,7 @@ let
           backends = [
             "Stdout MachineFormat"
             "EKGBackend"
-            ] ++ optional tracer
+            ] ++ optional trace_forwarding
                  "Forwarder";
         };
 


### PR DESCRIPTION
# Description

| TraceBlockContext (block,slot) |   sl |      %   | anchor length |
|--------------------------------|------|----------|---------------|
|                       (0,   0) |    - |  0 %   0 |             0 |
|                       (1,   2) |    2 |  X %   0 |             1 |
|                       (2,   8) |    6 |  0 %   6 |             2 |
|                       (3,  56) |   48 |  1 %  54 |             3 |
|                       (4,  93) |   37 |  2 %  91 |             4 |
|                       (5, 156) |   63 |  3 % 154 |             5 |
|                       (6, 186) |   30 |  4 % 184 |             6 |
|                       (7, 199) |   13 |  5 % 197 |             7 |
|                       (8, 238) |   39 |  6 % 236 |             8 |
|                       (9, 245) |    7 |  7 % 243 |             9 |

x = 18446744073709551615
(maxBound :: Word64)

# Timeline obtained from the legacy tracing system:
https://github.com/IntersectMBO/cardano-node/blame/5264a7cd77a428ed04e25a11f22aba920ec399a6/cardano-node/src/Cardano/Tracing/Tracers.hs#L1773

- 2019-10: Chain density design
- - [tracing chain quality #250](https://github.com/IntersectMBO/cardano-node/issues/250)
- 2019-11: Implementation
- - [[#250] tracing chain density and display in LiveView#261](https://github.com/IntersectMBO/cardano-node/pull/261)
- - [Commit e992b94](https://github.com/IntersectMBO/cardano-node/commit/e992b944704e2d56aeb06597fa812c09a070488d)
- 2020-01: Only whitespace
- - [[CAD-402] Add tracers for the block forge microbenchmarking. #464](https://github.com/IntersectMBO/cardano-node/pull/464)
- - [Commit a7a0a45](https://github.com/IntersectMBO/cardano-node/commit/a7a0a453c445f0907e00dc285e7e5feb7971ea50)
- 2020-02:
- - [Update to latest version of ouroboros-network and other deps #569](https://github.com/IntersectMBO/cardano-node/pull/569)
- - [Commit 75025b9](https://github.com/IntersectMBO/cardano-node/commit/75025b941712a9e565412b6d840f62221b930056)
- - `blockN = unBlockNo $ fromMaybe 1 (AF.headBlockNo frag)` -> `blockN = unBlockNo $ fromWithOrigin (BlockNo 1) (AF.headBlockNo frag)`
- 2020-12: Extract function
- - [CAD-2069: Tracing changes supporting K=1000](https://github.com/IntersectMBO/cardano-node/pull/2156)
- - [Commit df847ed](https://github.com/IntersectMBO/cardano-node/commit/df847ed3b45d141ba12b918f392067ac4d4a60ec)

# Related
- [CAD-2907 Tracing: SendFetchRequest](https://github.com/IntersectMBO/cardano-node/pull/2756)
- - [CAD-2907 tracing: a more precise AF length calculation](https://github.com/IntersectMBO/cardano-node/pull/2756/commits/e8d66b08048b27f5d942a1ae5562293154b5809a)

# As used now in monitoring
https://github.com/input-output-hk/cardano-playground/blob/main/flake/opentofu/grafana/dashboards/cardano-node.json#L326

Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
