### PR TITLE
Bench eventlogged

### DIFF
--- a/nix/workbench/backend/nomad.nix
+++ b/nix/workbench/backend/nomad.nix
@@ -2,8 +2,6 @@
 , lib
 , stateDir
 , subBackendName
-# TODO: Fetch this from config services inside materialise-profile !
-, eventlogged ? true
 , ...
 }:
 let
@@ -147,20 +145,15 @@ let
       # the one used to enter the shell ??????????
       cardano-node = rec {
         # Local reference only used if not "cloud".
-        nix-store-path = with pkgs;
-          if eventlogged
-            then cardanoNodePackages.cardano-node.passthru.eventlogged
-            else cardanoNodePackages.cardano-node.passthru.noGitRev
-        ;
+        # Avoid rebuilding on every commit because of `set-git-rev`.
+        nix-store-path = pkgs.cardanoNodePackages.cardano-node.passthru.noGitRev;
         flake-reference = "github:intersectmbo/cardano-node";
-        flake-output =
-          if eventlogged
-            then "cardanoNodePackages.cardano-node.passthru.eventlogged"
-            else "cardanoNodePackages.cardano-node.passthru.noGitRev"
+        flake-output = "cardanoNodePackages.cardano-node.passthru.noGitRev"
         ;
       };
       cardano-cli = rec {
         # Local reference only used if not "cloud".
+        # Avoid rebuilding on every commit because of `set-git-rev`.
         nix-store-path = pkgs.cardanoNodePackages.cardano-cli.passthru.noGitRev;
         flake-reference = "github:input-output-hk/cardano-cli";
         flake-output = "cardanoNodePackages.cardano-cli.passthru.noGitRev";

--- a/nix/workbench/backend/nomad.nix
+++ b/nix/workbench/backend/nomad.nix
@@ -52,7 +52,7 @@ let
   # path of this packages while keeping the extra details as a `jq` friendly
   # reference that are used to change it later appending the desired commit
   # (interchanging commits it's still an untested feature).
-  # For cloud runs references:
+  # For "nomadcloud" runs workbench's `$WB_GITREV` is used as commit:
   # installable="${flakeReference}/${commit}#${flakeOutput}"
   installables =
     {
@@ -142,7 +142,7 @@ let
     {
       # Provided that all the "start.sh" scripts are taking it into account,
       # this packages could be configured to come from a different commit than
-      # the one used to enter the shell ??????????
+      # the one used to enter the shell.
       cardano-node = rec {
         # Local reference only used if not "cloud".
         # Avoid rebuilding on every commit because of `set-git-rev`.

--- a/nix/workbench/backend/nomad/cloud.sh
+++ b/nix/workbench/backend/nomad/cloud.sh
@@ -334,8 +334,8 @@ allocate-run-nomadcloud() {
   # outputs it needs inside the container, these are built using the packages
   # metadata in "containerPkgs" and the current commit.
   local gitrev
-  gitrev="$(git rev-parse HEAD)"
-  msg $(blue "INFO: Found GitHub commit with ID \"$gitrev\"")
+  gitrev="${WB_GITREV:?"No WB_GITREV"}"
+  msg $(blue "INFO: Found GitHub commit with ID \"$gitrev\" set on shell creation")
   # Check if the Nix package was created from a dirty git tree
   if test "$gitrev" = "0000000000000000000000000000000000000000"
   then

--- a/nix/workbench/backend/runner.nix
+++ b/nix/workbench/backend/runner.nix
@@ -38,6 +38,7 @@ let
   # build plan as computed by nix
   nixPlanJson = cardanoNodeProject.plan-nix.json;
 
+  # Optimize cache hits setting gitrev using bash once inside the shell.
   workbench-envars =
     ''
     export WB_CHAP_PATH=${chap}
@@ -50,6 +51,10 @@ let
     export WB_DEPLOYMENT_NAME=''${WB_DEPLOYMENT_NAME:-$(basename $(pwd))}
     export WB_MODULAR_GENESIS=''${WB_MODULAR_GENESIS:-0}
     export WB_LOCLI_DB=''${WB_LOCLI_DB:-1}
+    if test -z "$(git status --porcelain --untracked-files=no)"
+    then export WB_GITREV="$(git rev-parse HEAD)"
+    else export WB_GITREV="0000000000000000000000000000000000000000"
+    fi
     export CARDANO_NODE_SOCKET_PATH=${stateDir}/node-0/node.socket
     ''
     + lib.optionalString (profileBundle.profile.value.scenario == "chainsync") (
@@ -112,7 +117,7 @@ let
         gnused
         procps
         nix
-        git
+        git        # `workbench-envars` set the gitrev
         jq
       ]
     )

--- a/nix/workbench/service/healthcheck.nix
+++ b/nix/workbench/service/healthcheck.nix
@@ -2,7 +2,6 @@
 , backend
 , profile
 , nodeSpecs
-, eventlogged ? true
 }:
 
 with pkgs.lib;
@@ -14,18 +13,16 @@ let
   grep            = pkgs.gnugrep;
   jq              = pkgs.jq;
   # Avoid rebuilding the script on every commit.
-  # Both `eventlogged` and `noGitRev` do not have `set-git-rev`.
+  # `noGitRev` does not have `set-git-rev` that is set on every commit.
   cardano-node = with pkgs;
     if backend.useCabalRun
     then "cardano-node"
-    else if eventlogged
-         then cardanoNodePackages.cardano-node.passthru.eventlogged + "/bin/cardano-node"
-         else cardanoNodePackages.cardano-node.passthru.noGitRev    + "/bin/cardano-node"
+    else cardanoNodePackages.cardano-node.passthru.noGitRev + "/bin/cardano-node"
   ;
   cardano-cli  = with pkgs;
     if backend.useCabalRun
     then "cardano-cli"
-    else cardanoNodePackages.cardano-cli.passthru.noGitRev          + "/bin/cardano-cli";
+    else cardanoNodePackages.cardano-cli.passthru.noGitRev + "/bin/cardano-cli";
 in {
   start =
     # Assumptions:

--- a/nix/workbench/service/nodes.nix
+++ b/nix/workbench/service/nodes.nix
@@ -137,11 +137,11 @@ let
     } // optionalAttrs (profiling != "none") {
       inherit profiling;
     } // optionalAttrs (profiling == "none") {
-      # Switch to `cardano-node.passthru.noGitRev` if eventlog is not needed.
-      eventlog               = mkForce true;
+      # Switch to `noGitRev` to avoid rebuilding with every commit.
+      package    = pkgs.cardano-node.passthru.noGitRev;
     } // optionalAttrs backend.useCabalRun {
       # Allow the shell function to take precedence.
-      executable             = "cardano-node";
+      executable = "cardano-node";
     } // optionalAttrs isProducer {
       operationalCertificate = "../genesis/node-keys/node${toString i}.opcert";
       kesKey                 = "../genesis/node-keys/node-kes${toString i}.skey";


### PR DESCRIPTION
# Description

- As we now default to GHC9.6 for workbench we can always assume the the RTS supports eventlog (`-l`)  out of the box. Replace `passthru.eventlogged` with `passthru.noGitRev` to maximize nix cache hits.

- Make sure the commit used to enter a shell is the same one used to populate the nomad job `nix_installables` stanza. Again, use bash, already in the shell, instead of `pkgs.gitRev` to obtain the reference to maximize nix cache hits.

- Remove legacy functionality. Fixing a `jq` error found `meta.json` no longer includes a "hostname" property.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
