### PR TITLE
Fix inconsistency in log line

### DIFF
--- a/cardano-testnet/src/Testnet/Components/Configuration.hs
+++ b/cardano-testnet/src/Testnet/Components/Configuration.hs
@@ -192,7 +192,7 @@ createSPOGenesisAndFiles
   -- Alonzo and Conway genesis that are optional and if not
   -- supplised the users get a default
   H.note_ $ "Number of pools: " <> show nPoolNodes
-  H.note_ $ "Number of stake delegators: " <> show nPoolNodes
+  H.note_ $ "Number of stake delegators: " <> show numStakeDelegators
   H.note_ $ "Number of seeded UTxO keys: " <> show numSeededUTxOKeys
 
   let era = toCardanoEra sbe


### PR DESCRIPTION
# Description

The log line `"Number of stake delegators: "` used to display the wrong value.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
