### PR TITLE
Lower severity for some network tracers.

### DIFF
--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -7,6 +7,8 @@
   (from `cardano-node:Cardano.Node.Tracing.Peers` to `trace-dispatcher:Cardano.Logging.Types.NodePeers`), and
   `NodeStartupInfo` (from `cardano-tracer:Cardano.Node.Startup` to `cardano-node:Cardano.Node.Tracing.NodeStartupInfo.hs`).
 
+- Lower the log severity from Error to Info for TracePromoteWarmBigLedgerPeerAborted and ResponderStartFailure
+
 - Add a new configuration field for fork-policy.
 
 - Optionally support lightweight checkpointing.

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/P2P.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/P2P.hs
@@ -708,6 +708,7 @@ instance MetaTrace (TracePeerSelection extraDebugState extraFlags extraPeers Soc
     severityFor (Namespace [] ["PromoteWarmFailed"]) _ = Just Info
     severityFor (Namespace [] ["PromoteWarmDone"]) _ = Just Info
     severityFor (Namespace [] ["PromoteWarmAborted"]) _ = Just Info
+    severityFor (Namespace [] ["PromoteWarmBigLedgerPeerAborted"]) _ = Just Info
     severityFor (Namespace [] ["DemoteWarmPeers"]) _ = Just Info
     severityFor (Namespace [] ["DemoteWarmFailed"]) _ = Just Info
     severityFor (Namespace [] ["DemoteWarmDone"]) _ = Just Info

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/P2P.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/P2P.hs
@@ -1760,7 +1760,7 @@ instance MetaTrace (InboundGovernor.Trace addr) where
 
     severityFor (Namespace _ ["NewConnection"]) _ = Just Debug
     severityFor (Namespace _ ["ResponderRestarted"]) _ = Just Debug
-    severityFor (Namespace _ ["ResponderStartFailure"]) _ = Just Error
+    severityFor (Namespace _ ["ResponderStartFailure"]) _ = Just Info
     severityFor (Namespace _ ["ResponderErrored"]) _ = Just Info
     severityFor (Namespace _ ["ResponderStarted"]) _ = Just Debug
     severityFor (Namespace _ ["ResponderTerminated"]) _ = Just Debug

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -586,7 +586,7 @@ instance HasSeverityAnnotation (InboundGovernor.Trace addr) where
     case ev of
       InboundGovernor.TrNewConnection {}           -> Debug
       InboundGovernor.TrResponderRestarted {}      -> Debug
-      InboundGovernor.TrResponderStartFailure {}   -> Error
+      InboundGovernor.TrResponderStartFailure {}   -> Info
       InboundGovernor.TrResponderErrored {}        -> Info
       InboundGovernor.TrResponderStarted {}        -> Debug
       InboundGovernor.TrResponderTerminated {}     -> Debug

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -485,7 +485,7 @@ instance HasSeverityAnnotation (TracePeerSelection extraDebugState extraFlags (C
       TracePromoteWarmBigLedgerPeers {}       -> Info
       TracePromoteWarmBigLedgerPeerFailed {}  -> Error
       TracePromoteWarmBigLedgerPeerDone {}    -> Info
-      TracePromoteWarmBigLedgerPeerAborted {} -> Error
+      TracePromoteWarmBigLedgerPeerAborted {} -> Info
 
       TraceDemoteWarmBigLedgerPeers {}      -> Info
       TraceDemoteWarmBigLedgerPeerFailed {} -> Info


### PR DESCRIPTION
# Description

Lower the severity of some network tracers.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
