### PR TITLE
Network tracing fix

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -90,3 +90,11 @@ if impl (ghc >= 9.12)
     -- https://github.com/haskell-servant/servant/pull/1810
     , servant:base
     , servant-server:base
+
+source-repository-package
+  type: git
+  location: https://github.com/IntersectMBO/ouroboros-network.git
+  --sha256: sha256-F1foQA5U8vWpDpHN4EYNeoNlNn2j6bJQojeuD5V0x4Y=
+  tag: 1eafe7bc742da1709fc98c62c48c519bbce503c0
+  subdir:
+    ouroboros-network

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/P2P.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/P2P.hs
@@ -625,7 +625,7 @@ instance MetaTrace (TracePeerSelection extraDebugState extraFlags extraPeers Soc
     namespaceFor TracePromoteWarmAborted {}    =
       Namespace [] ["PromoteWarmAborted"]
     namespaceFor TracePromoteWarmBigLedgerPeers {}      =
-      Namespace [] ["PromoteWarmPBigLedgereers"]
+      Namespace [] ["PromoteWarmBigLedgerPeers"]
     namespaceFor TracePromoteWarmBigLedgerPeerFailed {}     =
       Namespace [] ["PromoteWarmBigLedgerPeerFailed"]
     namespaceFor TracePromoteWarmBigLedgerPeerDone {}       =
@@ -696,36 +696,58 @@ instance MetaTrace (TracePeerSelection extraDebugState extraFlags extraPeers Soc
     severityFor (Namespace [] ["PublicRootsRequest"]) _ = Just Info
     severityFor (Namespace [] ["PublicRootsResults"]) _ = Just Info
     severityFor (Namespace [] ["PublicRootsFailure"]) _ = Just Error
-    severityFor (Namespace [] ["GossipRequests"]) _ = Just Debug
-    severityFor (Namespace [] ["GossipResults"]) _ = Just Debug
     severityFor (Namespace [] ["ForgetColdPeers"]) _ = Just Info
+    severityFor (Namespace [] ["BigLedgerPeersRequest"]) _ = Just Info
+    severityFor (Namespace [] ["BigLedgerPeersResults"]) _ = Just Info
+    severityFor (Namespace [] ["BigLedgerPeersFailure"]) _ = Just Info
+    severityFor (Namespace [] ["ForgetBigLedgerPeers"]) _ = Just Info
+    severityFor (Namespace [] ["PeerShareRequests"]) _ = Just Debug
+    severityFor (Namespace [] ["PeerShareResults"]) _ = Just Debug
+    severityFor (Namespace [] ["PeerShareResultsFiltered"]) _ = Just Info
     severityFor (Namespace [] ["PromoteColdPeers"]) _ = Just Info
     severityFor (Namespace [] ["PromoteColdLocalPeers"]) _ = Just Info
     severityFor (Namespace [] ["PromoteColdFailed"]) _ = Just Info
     severityFor (Namespace [] ["PromoteColdDone"]) _ = Just Info
+    severityFor (Namespace [] ["PromoteColdBigLedgerPeers"]) _ = Just Info
+    severityFor (Namespace [] ["PromoteColdBigLedgerPeerFailed"]) _ = Just Info
+    severityFor (Namespace [] ["PromoteColdBigLedgerPeerDone"]) _ = Just Info
     severityFor (Namespace [] ["PromoteWarmPeers"]) _ = Just Info
     severityFor (Namespace [] ["PromoteWarmLocalPeers"]) _ = Just Info
     severityFor (Namespace [] ["PromoteWarmFailed"]) _ = Just Info
     severityFor (Namespace [] ["PromoteWarmDone"]) _ = Just Info
     severityFor (Namespace [] ["PromoteWarmAborted"]) _ = Just Info
+    severityFor (Namespace [] ["PromoteWarmBigLedgerPeers"]) _ = Just Info
+    severityFor (Namespace [] ["PromoteWarmBigLedgerPeerFailed"]) _ = Just Info
+    severityFor (Namespace [] ["PromoteWarmBigLedgerPeerDone"]) _ = Just Info
+    severityFor (Namespace [] ["PromoteWarmBigLedgerPeerAborted"]) _ = Just Info
     severityFor (Namespace [] ["DemoteWarmPeers"]) _ = Just Info
     severityFor (Namespace [] ["DemoteWarmFailed"]) _ = Just Info
     severityFor (Namespace [] ["DemoteWarmDone"]) _ = Just Info
+    severityFor (Namespace [] ["DemoteWarmBigLedgerPeers"]) _ = Just Info
+    severityFor (Namespace [] ["DemoteWarmBigLedgerPeerFailed"]) _ = Just Info
     severityFor (Namespace [] ["DemoteHotPeers"]) _ = Just Info
     severityFor (Namespace [] ["DemoteLocalHotPeers"]) _ = Just Info
     severityFor (Namespace [] ["DemoteHotFailed"]) _ = Just Info
     severityFor (Namespace [] ["DemoteHotDone"]) _ = Just Info
+    severityFor (Namespace [] ["DemoteHotBigLedgerPeers"]) _ = Just Info
+    severityFor (Namespace [] ["DemoteHotBigLedgerPeerFailed"]) _ = Just Info
+    severityFor (Namespace [] ["DemoteHotBigLedgerPeerDone"]) _ = Just Info
     severityFor (Namespace [] ["DemoteAsynchronous"]) _ = Just Info
     severityFor (Namespace [] ["DemoteLocalAsynchronous"]) _ = Just Warning
+    severityFor (Namespace [] ["DemoteBigLedgerPeersAsynchronous"]) _ = Just Info
     severityFor (Namespace [] ["GovernorWakeup"]) _ = Just Info
     severityFor (Namespace [] ["ChurnWait"]) _ = Just Info
     severityFor (Namespace [] ["ChurnMode"]) _ = Just Info
     severityFor (Namespace [] ["PickInboundPeers"]) _ = Just Info
+    severityFor (Namespace [] ["LedgerStateJudgementChanged"]) _ = Just Info
+    severityFor (Namespace [] ["OnlyBootstrapPeers"]) _ = Just Info
+    severityFor (Namespace [] ["UseBootstrapPeersChanged"]) _ = Just Notice
+    severityFor (Namespace [] ["VerifyPeerSnapshot"]) _ = Just Error
+    severityFor (Namespace [] ["BootstrapPeersFlagChangedWhilstInSensitiveState"]) _ = Just Warning
     severityFor (Namespace [] ["OutboundGovernorCriticalFailure"]) _ = Just Error
     severityFor (Namespace [] ["ChurnAction"]) _ = Just Info
     severityFor (Namespace [] ["ChurnTimeout"]) _ = Just Notice
     severityFor (Namespace [] ["DebugState"]) _ = Just Info
-    severityFor (Namespace [] ["VerifyPeerSnapshot"]) _ = Just Error
     severityFor _ _ = Nothing
 
     documentFor (Namespace [] ["LocalRootPeersChanged"]) = Just  ""
@@ -733,11 +755,11 @@ instance MetaTrace (TracePeerSelection extraDebugState extraFlags extraPeers Soc
     documentFor (Namespace [] ["PublicRootsRequest"]) = Just  ""
     documentFor (Namespace [] ["PublicRootsResults"]) = Just  ""
     documentFor (Namespace [] ["PublicRootsFailure"]) = Just  ""
-    documentFor (Namespace [] ["GossipRequests"]) = Just $ mconcat
+    documentFor (Namespace [] ["PeerShareRequests"]) = Just $ mconcat
       [ "target known peers, actual known peers, peers available for gossip,"
       , " peers selected for gossip"
       ]
-    documentFor (Namespace [] ["GossipResults"]) = Just  ""
+    documentFor (Namespace [] ["PeerShareResults"]) = Just  ""
     documentFor (Namespace [] ["ForgetColdPeers"]) = Just
       "target known peers, actual known peers, selected peers"
     documentFor (Namespace [] ["PromoteColdPeers"]) = Just
@@ -804,34 +826,59 @@ instance MetaTrace (TracePeerSelection extraDebugState extraFlags extraPeers Soc
       , Namespace [] ["PublicRootsRequest"]
       , Namespace [] ["PublicRootsResults"]
       , Namespace [] ["PublicRootsFailure"]
-      , Namespace [] ["GossipRequests"]
-      , Namespace [] ["GossipResults"]
       , Namespace [] ["ForgetColdPeers"]
+      , Namespace [] ["BigLedgerPeersRequest"]
+      , Namespace [] ["BigLedgerPeersResults"]
+      , Namespace [] ["BigLedgerPeersFailure"]
+      , Namespace [] ["ForgetBigLedgerPeers"]
+      , Namespace [] ["PeerShareRequests"]
+      , Namespace [] ["PeerShareResults"]
+      , Namespace [] ["PeerShareResultsFiltered"]
       , Namespace [] ["PromoteColdPeers"]
       , Namespace [] ["PromoteColdLocalPeers"]
       , Namespace [] ["PromoteColdFailed"]
       , Namespace [] ["PromoteColdDone"]
+      , Namespace [] ["PromoteColdBigLedgerPeers"]
+      , Namespace [] ["PromoteColdBigLedgerPeerFailed"]
+      , Namespace [] ["PromoteColdBigLedgerPeerDone"]
       , Namespace [] ["PromoteWarmPeers"]
       , Namespace [] ["PromoteWarmLocalPeers"]
       , Namespace [] ["PromoteWarmFailed"]
       , Namespace [] ["PromoteWarmDone"]
       , Namespace [] ["PromoteWarmAborted"]
+      , Namespace [] ["PromoteWarmBigLedgerPeers"]
+      , Namespace [] ["PromoteWarmBigLedgerPeerFailed"]
+      , Namespace [] ["PromoteWarmBigLedgerPeerDone"]
+      , Namespace [] ["PromoteWarmBigLedgerPeerAborted"]
       , Namespace [] ["DemoteWarmPeers"]
       , Namespace [] ["DemoteWarmFailed"]
       , Namespace [] ["DemoteWarmDone"]
+      , Namespace [] ["DemoteWarmBigLedgerPeers"]
+      , Namespace [] ["DemoteWarmBigLedgerPeerFailed"]
+      , Namespace [] ["DemoteWarmBigLedgerPeerDone"]
       , Namespace [] ["DemoteHotPeers"]
       , Namespace [] ["DemoteLocalHotPeers"]
       , Namespace [] ["DemoteHotFailed"]
       , Namespace [] ["DemoteHotDone"]
+      , Namespace [] ["DemoteHotBigLedgerPeers"]
+      , Namespace [] ["DemoteHotBigLedgerPeerFailed"]
+      , Namespace [] ["DemoteHotBigLedgerPeerDone"]
       , Namespace [] ["DemoteAsynchronous"]
       , Namespace [] ["DemoteLocalAsynchronous"]
+      , Namespace [] ["DemoteBigLedgerPeersAsynchronous"]
       , Namespace [] ["GovernorWakeup"]
       , Namespace [] ["ChurnWait"]
       , Namespace [] ["ChurnMode"]
       , Namespace [] ["PickInboundPeers"]
-      , Namespace [] ["OutboundGovernorCriticalFailure"]
-      , Namespace [] ["DebugState"]
+      , Namespace [] ["LedgerStateJudgementChanged"]
+      , Namespace [] ["OnlyBootstrapPeers"]
+      , Namespace [] ["UseBootstrapPeersChanged"]
       , Namespace [] ["VerifyPeerSnapshot"]
+      , Namespace [] ["BootstrapPeersFlagChangedWhilstInSensitiveState"]
+      , Namespace [] ["OutboundGovernorCriticalFailure"]
+      , Namespace [] ["ChurnAction"]
+      , Namespace [] ["ChurnTimeout"]
+      , Namespace [] ["DebugState"]
       ]
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
# Description

Cleanup of `MetaTrace TracePeerSelection`

See also network issue #5111

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
