### PR TITLE
Update cardano-cli. Remove redundant AsType constructors usages.

### DIFF
--- a/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
+++ b/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
@@ -82,7 +82,7 @@ library
   -- IOG dependencies
   --------------------------
   build-depends:
-    , cardano-api             ^>=10.14
+    , cardano-api             ^>=10.16
     , plutus-ledger-api       ^>=1.45
     , plutus-tx               ^>=1.45
     , plutus-tx-plugin        ^>=1.45

--- a/bench/tx-generator/src/Cardano/Benchmarking/Script/Aeson.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Script/Aeson.hs
@@ -69,7 +69,7 @@ instance ToJSON (SigningKey PaymentKey) where
 instance FromJSON (SigningKey PaymentKey) where
   parseJSON o = do
     te <- parseJSON o
-    case deserialiseFromTextEnvelope (AsSigningKey AsPaymentKey) te of
+    case deserialiseFromTextEnvelope te of
       Right k   -> pure k
       Left err  -> fail $ show err
 

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -113,9 +113,9 @@ library
                       , attoparsec-aeson
                       , base16-bytestring
                       , bytestring
-                      , cardano-api ^>= 10.14
+                      , cardano-api ^>= 10.16
                       , cardano-binary
-                      , cardano-cli ^>= 10.8
+                      , cardano-cli ^>= 10.9
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
                       , cardano-data

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2025-04-16T18:30:40Z
-  , cardano-haskell-packages 2025-04-29T14:14:35Z
+  , cardano-haskell-packages 2025-05-15T08:36:14Z
 
 packages:
   cardano-node

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -90,5 +90,5 @@ test-suite chairman-tests
   ghc-options:          -threaded -rtsopts "-with-rtsopts=-N -T"
 
   build-tool-depends:   cardano-node:cardano-node
-                      , cardano-cli:cardano-cli ^>= 10.8
+                      , cardano-cli:cardano-cli ^>= 10.9
                       , cardano-node-chairman:cardano-node-chairman

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -149,7 +149,7 @@ library
                       , async
                       , base16-bytestring
                       , bytestring
-                      , cardano-api ^>= 10.14
+                      , cardano-api ^>= 10.16
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
                       , cardano-git-rev ^>=0.2.2

--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -39,9 +39,9 @@ library
                       , aeson
                       , async
                       , bytestring
-                      , cardano-api ^>= 10.14
+                      , cardano-api ^>= 10.16
                       , cardano-binary
-                      , cardano-cli ^>= 10.8
+                      , cardano-cli ^>= 10.9
                       , cardano-crypto-class ^>= 2.2
                       , http-media
                       , iohk-monitoring

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -35,8 +35,8 @@ library
                       , aeson-pretty
                       , ansi-terminal
                       , bytestring
-                      , cardano-api ^>= 10.14
-                      , cardano-cli:{cardano-cli, cardano-cli-test-lib} ^>= 10.8
+                      , cardano-api ^>= 10.16
+                      , cardano-cli:{cardano-cli, cardano-cli-test-lib} ^>= 10.9
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
                       , cardano-git-rev ^>= 0.2.2

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Plutus/CostCalculation.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Plutus/CostCalculation.hs
@@ -40,13 +40,6 @@ import           System.Directory (makeAbsolute)
 import           System.FilePath ((</>))
 import qualified System.Info as SYS
 
-import           Hedgehog (Property)
-import qualified Hedgehog as H
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
-import qualified Hedgehog.Extras.Test.Golden as H
-import qualified Hedgehog.Extras.Test.TestWatchdog as H
-
 import           Testnet.Components.Query (findLargestUtxoForPaymentKey, getEpochStateView, getTxIx,
                    watchEpochStateUpdate)
 import           Testnet.Process.Cli.Transaction (TxOutAddress (..), mkSpendOutputsOnlyTx,
@@ -56,6 +49,13 @@ import           Testnet.Property.Util (integrationRetryWorkspace)
 import           Testnet.Start.Types (eraToString)
 import           Testnet.Types (PaymentKeyInfo (paymentKeyInfoAddr), paymentKeyInfoPair,
                    verificationKey)
+
+import           Hedgehog (Property)
+import qualified Hedgehog as H
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+import qualified Hedgehog.Extras.Test.Golden as H
+import qualified Hedgehog.Extras.Test.TestWatchdog as H
 
 -- @DISABLE_RETRIES=1 cabal run cardano-testnet-test -- -p "/Spec.hs.Spec.Ledger Events.Plutus.Cost Calc.Ref Script/"@
 hprop_ref_plutus_cost_calculation :: Property
@@ -183,7 +183,7 @@ hprop_ref_plutus_cost_calculation = integrationRetryWorkspace 2 "ref plutus scri
     execCli'
       execConfig
       [ eraName
-      , "transaction", "calculate-plutus-script-cost"
+      , "transaction", "calculate-plutus-script-cost", "online"
       , "--tx-file", unFile signedUnlockTx
       , "--out-file", unFile txCostOutput
       ]
@@ -199,7 +199,7 @@ hprop_ref_plutus_cost_calculation = integrationRetryWorkspace 2 "ref plutus scri
       execCli'
         execConfig
         [ eraName
-        , "transaction", "calculate-plutus-script-cost"
+        , "transaction", "calculate-plutus-script-cost", "online"
         , "--tx-file", unFile signedUnlockTx
         ]
 
@@ -306,7 +306,7 @@ hprop_included_plutus_cost_calculation = integrationRetryWorkspace 2 "included p
     execCli'
       execConfig
       [ eraName
-      , "transaction", "calculate-plutus-script-cost"
+      , "transaction", "calculate-plutus-script-cost", "online"
       , "--tx-file", unFile signedIncludedScript
       , "--out-file", unFile includedScriptCostOutput
       ]
@@ -421,7 +421,7 @@ hprop_included_simple_script_cost_calculation = integrationRetryWorkspace 2 "inc
       execCli'
         execConfig
         [ eraName
-        , "transaction", "calculate-plutus-script-cost"
+        , "transaction", "calculate-plutus-script-cost", "online"
         , "--tx-file", unFile signedScriptUnlock
         ]
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Query.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Query.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Cardano.Testnet.Test.Cli.Query (
     hprop_cli_queries
@@ -36,10 +37,10 @@ import qualified Data.Aeson.Encode.Pretty as Aeson
 import qualified Data.Aeson.Key as Aeson
 import qualified Data.Aeson.KeyMap as Aeson
 import qualified Data.Aeson.Lens as Aeson
-import           Data.Bifunctor (bimap)
 import qualified Data.ByteString.Lazy as LBS
 import           Data.Default.Class
 import qualified Data.Map as Map
+import           Data.Map.Strict (Map)
 import           Data.String (IsString (fromString))
 import           Data.Text (Text)
 import qualified Data.Text as T
@@ -179,10 +180,11 @@ hprop_cli_queries = integrationWorkspace "cli-queries" $ \tempAbsBasePath' -> H.
       do
         -- to stdout
         stakePoolsOut <- execCli' execConfig [ eraName, "query", "stake-pools" ]
-        H.assertWith stakePoolsOut $ \pools ->
-          NumPools (length $ lines pools) == nPools
+        stakePools <- H.noteShowM $ H.leftFail $ Aeson.eitherDecode @[String] $ fromString stakePoolsOut
+        H.assertWith stakePools $ \pools ->
+          NumPools (length pools) == nPools
         -- Light test of the query's answer, the ids should exist:
-        forM_ (lines stakePoolsOut) $ \stakePoolId -> do
+        forM_ stakePools $ \stakePoolId -> do
           execCli' execConfig [ eraName, "query", "pool-state"
                               , "--stake-pool-id", stakePoolId ]
         -- to a file
@@ -199,22 +201,15 @@ hprop_cli_queries = integrationWorkspace "cli-queries" $ \tempAbsBasePath' -> H.
       do
         -- to stdout
         stakeDistrOut <- execCli' execConfig [ eraName, "query", "stake-distribution" ]
-        -- stake addresses with stake
-        let stakeAddresses :: [(Text, Text)] =
-              map
-              ( bimap T.strip T.strip
-                . T.breakOn " " -- separate address and stake
-                . T.strip
-                . fromString )
-              . drop 2 -- drop header
-              . lines
-              $ stakeDistrOut
-        H.assertWith stakeAddresses $ \sa ->
+        stakeDistr <- H.leftFail $ Aeson.eitherDecode @(Map String Aeson.Value) $ fromString stakeDistrOut
+        H.note_ stakeDistrOut
+        let stakePools = Map.keys stakeDistr
+        H.assertWith stakePools $ \sa ->
           NumPools (length sa) == nPools
         -- Light test of the query's answer, the ids should exist:
-        forM_ stakeAddresses $ \(stakePoolId, _) -> do
+        forM_ stakePools $ \stakePoolId -> do
           execCli' execConfig [ eraName, "query", "pool-state"
-                              , "--stake-pool-id", T.unpack stakePoolId ]
+                              , "--stake-pool-id", stakePoolId ]
         -- to a file
         let stakePoolsOutFile = work </> "stake-distribution-out.json"
         H.noteM_ $ execCli' execConfig [ eraName, "query", "stake-distribution"

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction.hs
@@ -52,7 +52,6 @@ hprop_transaction = integrationRetryWorkspace 2 "simple transaction build" $ \te
 
   let
     sbe = ShelleyBasedEraConway
-    txEra = AsConwayEra
     era = toCardanoEra sbe
     cEra = AnyCardanoEra era
     tempBaseAbsPath = makeTmpBaseAbsPath $ TmpAbsolutePath tempAbsPath'
@@ -93,8 +92,8 @@ hprop_transaction = integrationRetryWorkspace 2 "simple transaction build" $ \te
     , "--out-file", txbodyFp
     ]
   cddlUnwitnessedTx <- H.readJsonFileOk txbodyFp
-  apiTx <- H.evalEither $ deserialiseFromTextEnvelope (AsTx txEra) cddlUnwitnessedTx
-  let txFee = L.unCoin $ extractTxFee apiTx
+  apiTx <- H.evalEither $ deserialiseFromTextEnvelope cddlUnwitnessedTx
+  let txFee = L.unCoin $ extractTxFee sbe apiTx
 
   -- This is the current calculated fee.
   -- It's a sanity check to see if anything has
@@ -133,6 +132,6 @@ hprop_transaction = integrationRetryWorkspace 2 "simple transaction build" $ \te
 txOutValue :: TxOut ctx era -> TxOutValue era
 txOutValue (TxOut _ v _ _) = v
 
-extractTxFee :: Tx era -> L.Coin
-extractTxFee (ShelleyTx sbe ledgerTx) =
+extractTxFee :: ShelleyBasedEra era -> Tx era -> L.Coin
+extractTxFee _ (ShelleyTx sbe ledgerTx) =
   shelleyBasedEraConstraints sbe $ ledgerTx ^. (L.bodyTxL . L.feeTxBodyL)

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/CommitteeAddNew.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/CommitteeAddNew.hs
@@ -44,7 +44,7 @@ import qualified Testnet.Process.Cli.DRep as DRep
 import           Testnet.Process.Cli.Keys
 import qualified Testnet.Process.Cli.SPO as SPO
 import           Testnet.Process.Cli.SPO (createStakeKeyRegistrationCertificate)
-import           Testnet.Process.Cli.Transaction
+import           Testnet.Process.Cli.Transaction (retrieveTransactionId, signTx, submitTx)
 import           Testnet.Process.Run (addEnvVarsToConfig, execCli', mkExecConfig)
 import           Testnet.Property.Util (integrationWorkspace)
 import           Testnet.Start.Types (GenesisOptions (..), cardanoNumPools)

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs
@@ -97,7 +97,7 @@ hprop_gov_no_confidence = integrationWorkspace "no-confidence" $ \tempAbsBasePat
 
   CommitteeColdKeyHash comKeyHash1 <-
     H.evalEither
-      $ deserialiseFromRawBytesHex (AsHash AsCommitteeColdKey)
+      $ deserialiseFromRawBytesHex
       $ BSC.pack comKeyHash1Str
 
   let comKeyCred1 = L.KeyHashObj comKeyHash1

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitutionSPO.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitutionSPO.hs
@@ -33,7 +33,7 @@ import           Testnet.Process.Cli.Keys
 import qualified Testnet.Process.Cli.SPO as SPO
 import           Testnet.Process.Cli.Transaction
 import           Testnet.Process.Run (execCli', mkExecConfig)
-import           Testnet.Property.Util (integrationWorkspace)
+import           Testnet.Property.Util (integrationRetryWorkspace)
 import           Testnet.Start.Types
 import           Testnet.Types
 
@@ -45,7 +45,7 @@ import qualified Hedgehog.Extras as H
 -- Execute me with:
 -- @cabal test cardano-testnet-test --test-options '-p "/Propose New Constitution SPO/"'@
 hprop_ledger_events_propose_new_constitution_spo :: Property
-hprop_ledger_events_propose_new_constitution_spo = integrationWorkspace "propose-new-constitution-spo" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
+hprop_ledger_events_propose_new_constitution_spo = integrationRetryWorkspace 2 "propose-new-constitution-spo" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   conf@Conf { tempAbsPath=tempAbsPath@(TmpAbsolutePath work) }
     <- mkConf tempAbsBasePath'
   let tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryWithdrawal.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryWithdrawal.hs
@@ -42,6 +42,7 @@ import           Testnet.Components.Query
 import           Testnet.Defaults
 import           Testnet.Process.Cli.Keys (cliStakeAddressKeyGen)
 import           Testnet.Process.Cli.SPO (createStakeKeyRegistrationCertificate)
+import           Testnet.Process.Cli.Transaction (retrieveTransactionId)
 import           Testnet.Process.Run (addEnvVarsToConfig, execCli', mkExecConfig)
 import           Testnet.Property.Util (integrationRetryWorkspace)
 import           Testnet.Start.Types
@@ -195,10 +196,7 @@ hprop_ledger_events_treasury_withdrawal = integrationRetryWorkspace 2  "treasury
     ]
 -- }}}
 
-  txidString <- mconcat . lines <$> execCli' execConfig
-    [ "latest", "transaction", "txid"
-    , "--tx-file", txbodySignedFp
-    ]
+  txIdString <- H.noteShowM $ retrieveTransactionId execConfig (File txbodySignedFp)
 
   currentEpoch <- getCurrentEpochNo epochStateView
   let terminationEpoch = succ . succ $ currentEpoch
@@ -213,7 +211,7 @@ hprop_ledger_events_treasury_withdrawal = integrationRetryWorkspace 2  "treasury
     execCli' execConfig
       [ eraName, "governance", "vote", "create"
       , "--yes"
-      , "--governance-action-tx-id", txidString
+      , "--governance-action-tx-id", txIdString
       , "--governance-action-index", show governanceActionIndex
       , "--drep-verification-key-file", verificationKeyFp $ defaultDRepKeyPair n
       , "--out-file", voteFp n

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SubmitApi/Transaction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SubmitApi/Transaction.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NumericUnderscores #-}

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1745944473,
-        "narHash": "sha256-zKJE6viU6JKUGlesde00In7VrALXv+lC6r/1QiQBB4s=",
+        "lastModified": 1747299417,
+        "narHash": "sha256-VRwq8JRAMnIgoxfgR60ppz37Wo6NixL9BbzwVhBveik=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "60bade9ab7b16121307e12a0fb9aefb2e245faef",
+        "rev": "10ebc8624f5440c245112f2e3dbf0e123e7e99e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Description

Update cardano-cli-10.9.0.0 & cardano-api-10.16.0.0. Remove redundant AsType constructors usages.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
