### PR TITLE
ghc: drop haskellNix ghc 8.10 variant support

### DIFF
--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -22,8 +22,8 @@ let
       src = ../.;
       name = "cardano-node";
       compiler-nix-name = lib.mkDefault "ghc96";
-      # extra-compilers
-      flake.variants = lib.genAttrs ["ghc8107"] (x: {compiler-nix-name = x;});
+      # Extra-compilers
+      # flake.variants = lib.genAttrs ["ghc$VERSION"] (x: {compiler-nix-name = x;});
       cabalProjectLocal = ''
         repository cardano-haskell-packages-local
           url: file:${CHaP}


### PR DESCRIPTION
# Description

Drops support for haskellNix ghc 8.10

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [X] CI passes. See note on CI.  The following CI checks are required:
- [X] Self-reviewed the diff