### PR TITLE
cardano-node service: `builtins.isFunction` -> `lib.isFunction`

### DIFF
--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -323,7 +323,7 @@ in {
       ipv6HostAddr = mkOption {
         type = funcToOr nullOrStr;
         default = _: null;
-        apply = ip: if (builtins.isFunction ip) then ip else _: ip;
+        apply = ip: if (lib.isFunction ip) then ip else _: ip;
         description = ''
           The ipv6 host address to bind to. Set to null to disable.
         '';
@@ -348,7 +348,7 @@ in {
       stateDir = mkOption {
         type = funcToOr types.str;
         default = "${cfg.stateDirBase}cardano-node";
-        apply = x : if (builtins.isFunction x) then x else i: x;
+        apply = x : if (lib.isFunction x) then x else i: x;
         description = ''
           Directory to store blockchain data, for each instance.
         '';
@@ -365,7 +365,7 @@ in {
       runtimeDir = mkOption {
         type = funcToOr nullOrStr;
         default = i: ''${cfg.runDirBase}${suffixDir "cardano-node" i}'';
-        apply = x : if builtins.isFunction x then x else if x == null then _: null else "${cfg.runDirBase}${suffixDir "cardano-node" x}";
+        apply = x : if lib.isFunction x then x else if x == null then _: null else "${cfg.runDirBase}${suffixDir "cardano-node" x}";
         description = ''
           Runtime directory relative to ${cfg.runDirBase}, for each instance
         '';
@@ -374,14 +374,14 @@ in {
       databasePath = mkOption {
         type = funcToOr types.str;
         default = i : "${cfg.stateDir i}/${cfg.dbPrefix i}";
-        apply = x : if builtins.isFunction x then x else _ : x;
+        apply = x : if lib.isFunction x then x else _ : x;
         description = ''Node database path, for each instance.'';
       };
 
       lmdbDatabasePath = mkOption {
         type = funcToOr nullOrStr;
         default = null;
-        apply = x : if builtins.isFunction x then x else if x == null then _: null else _: x;
+        apply = x : if lib.isFunction x then x else if x == null then _: null else _: x;
         description = ''
           Node UTxO-HD LMDB path for performant disk I/O, for each instance.
           This could point to a direct-access SSD, with a specifically created journal-less file system and optimized mount options.
@@ -391,14 +391,14 @@ in {
       socketPath = mkOption {
         type = funcToOr types.str;
         default = i : "${runtimeDir i}/node.socket";
-        apply = x : if builtins.isFunction x then x else _ : x;
+        apply = x : if lib.isFunction x then x else _ : x;
         description = ''Local communication socket path, for each instance.'';
       };
 
       tracerSocketPathAccept = mkOption {
         type = funcToOr nullOrStr;
         default = null;
-        apply = x : if builtins.isFunction x then x else _ : x;
+        apply = x : if lib.isFunction x then x else _ : x;
         description = ''
           Listen for incoming cardano-tracer connection on a local socket,
           for each instance.
@@ -408,7 +408,7 @@ in {
       tracerSocketPathConnect = mkOption {
         type = funcToOr nullOrStr;
         default = null;
-        apply = x : if builtins.isFunction x then x else _ : x;
+        apply = x : if lib.isFunction x then x else _ : x;
         description = ''
           Connect to cardano-tracer listening on a local socket,
           for each instance.
@@ -456,7 +456,7 @@ in {
       dbPrefix = mkOption {
         type = types.either types.str (types.functionTo types.str);
         default = suffixDir "db-${cfg.environment}";
-        apply = x : if builtins.isFunction x then x else suffixDir x;
+        apply = x : if lib.isFunction x then x else suffixDir x;
         description = ''
           Prefix of database directories inside `stateDir`.
           (eg. for "db", there will be db-0, etc.).
@@ -679,7 +679,7 @@ in {
       withUtxoHdLmdb = mkOption {
         type = funcToOr types.bool;
         default = false;
-        apply = x: if builtins.isFunction x then x else _: x;
+        apply = x: if lib.isFunction x then x else _: x;
         description = ''On an UTxO-HD enabled node, the in-memory backend is the default. This activates the on-disk backend (LMDB) instead.'';
       };
 
@@ -726,7 +726,7 @@ in {
         type = funcToOr nullOrStr;
         default = null;
         example = i: "/etc/cardano-node/peer-snapshot-${toString i}.json";
-        apply = x: if builtins.isFunction x then x else _: x;
+        apply = x: if lib.isFunction x then x else _: x;
         description = ''
           If set, cardano-node will load a peer snapshot file from the declared absolute path.
 


### PR DESCRIPTION
# Description

This fixes

```
    145|       "--config ${nodeConfigFile}"
    146|       "--database-path ${instanceDbPath}"
       |                        ^
    147|       "--topology ${topology i}"

 error: cannot coerce a set to a string: { __functionArgs = «thunk»; __functor =
 «thunk»; }
```

when using a nixpkgs that includes https://github.com/NixOS/nixpkgs/pull/386208

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
