### PR TITLE
nixosNodeSvc: rm eventlogged pkg as ghc >= 9.4 includes RTS support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -133,7 +133,7 @@
         inherit (ouroboros-consensus-cardano.components.exes) db-analyser db-synthesizer db-truncater snapshot-converter;
         # Add cardano-node and cardano-cli with their git revision stamp.
         # Keep available an alternative without the git revision, like the other
-        # passthru (profiled, asserted and eventlogged in nix/haskell.nix) that
+        # passthru (profiled and asserted in nix/haskell.nix) that
         # have no git revision but for the same compilation alternative.
         cardano-node =
           let node = project.exes.cardano-node;

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -415,16 +415,6 @@ project.appendOverlays (with haskellLib.projectOverlays; [
             (name: { flags.asserts = true; });
         }];
       };
-      eventlogged = final.appendModule
-        {
-          # From 9.2+
-          # on the commandline: error: [-Wdeprecated-flags, Werror=deprecated-flags]
-          #     -eventlog is deprecated: the eventlog is now enabled in all runtime system ways
-          modules = [({ lib, pkgs, config, ... }: lib.mkIf (builtins.compareVersions config.compiler.version "9.2" < 0) {
-            packages = final.pkgs.lib.genAttrs [ "cardano-node" ]
-              (name: { configureFlags = [ "--ghc-option=-eventlog" ]; });
-          })];
-        };
       # add passthru to hsPkgs:
       hsPkgs = lib.mapAttrsRecursiveCond (v: !(lib.isDerivation v))
         (path: value:
@@ -436,7 +426,6 @@ project.appendOverlays (with haskellLib.projectOverlays; [
                 passthru = {
                   profiled = lib.getAttrFromPath path final.profiled.hsPkgs;
                   asserted = lib.getAttrFromPath path final.asserted.hsPkgs;
-                  eventlogged = lib.getAttrFromPath path final.eventlogged.hsPkgs;
                 };
               }
           else value)

--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -226,7 +226,6 @@ in {
         type = types.package;
         default = if (cfg.profiling != "none")
           then cfg.cardanoNodePackages.cardano-node.passthru.profiled
-          else if cfg.eventlog then cfg.cardanoNodePackages.cardano-node.passthru.eventlogged
           else if cfg.asserts then cfg.cardanoNodePackages.cardano-node.passthru.asserted
           else cfg.cardanoNodePackages.cardano-node;
         defaultText = "cardano-node";


### PR DESCRIPTION
# Description

Removes the `eventlogged` package as ghc >= `9.4` includes unconditional `-eventlog` support in `RTS`.

Refs:
* [GHC deprecated -eventlog note](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/phases.html#ghc-flag-eventlog)
* [PR comment](https://github.com/IntersectMBO/cardano-node/pull/6206#pullrequestreview-2814000802)

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] CI passes. See note on CI.  The following CI checks are required:
- [X] Self-reviewed the diff