### PR TITLE
consensus: integrate `HeaderWithTime`

### DIFF
--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -192,9 +192,9 @@ library
                       , network-mux >= 0.5
                       , nothunks
                       , optparse-applicative-fork >= 0.18.1
-                      , ouroboros-consensus ^>= 0.26.0.1
+                      , ouroboros-consensus ^>= 0.27
                       , ouroboros-consensus-cardano ^>= 0.25
-                      , ouroboros-consensus-diffusion ^>= 0.22
+                      , ouroboros-consensus-diffusion ^>= 0.23
                       , ouroboros-consensus-protocol
                       , ouroboros-network-api ^>= 0.13
                       , ouroboros-network ^>= 0.20

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Peer.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Peer.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PackageImports #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.Node.Tracing.Tracers.Peer
   ( PeerT (..)
@@ -14,6 +16,7 @@ import           Cardano.Logging hiding (traceWith)
 import           Cardano.Node.Orphans ()
 import           Cardano.Node.Queries
 import           Ouroboros.Consensus.Block (Header)
+import           Ouroboros.Consensus.HeaderValidation (HeaderWithTime (..))
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client (ChainSyncClientHandle,
                    csCandidate, cschcMap, viewChainSyncState)
 import           Ouroboros.Consensus.Util.Orphans ()
@@ -49,7 +52,8 @@ import           Text.Printf (printf)
 -- The thread is linked to the parent thread for proper error propagation
 -- and labeled for easier debugging and identification.
 startPeerTracer
-  :: Tracer IO [PeerT blk]  -- ^ Tracer for the peer list
+  :: forall blk. Net.HasHeader (Header blk)
+  => Tracer IO [PeerT blk]  -- ^ Tracer for the peer list
   -> NodeKernelData blk     -- ^ Node kernel containing peer data
   -> Int                    -- ^ Delay in milliseconds between traces
   -> IO ()
@@ -103,7 +107,8 @@ ppMaxSlotNo Net.NoMaxSlotNo   = "???"
 ppMaxSlotNo (Net.MaxSlotNo x) = show (unSlotNo x)
 
 getCurrentPeers
-  :: NodeKernelData blk
+  :: forall blk. Net.HasHeader (Header blk)
+  => NodeKernelData blk
   -> IO [PeerT blk]
 getCurrentPeers nkd = mapNodeKernelDataIO extractPeers nkd
                       <&> fromSMaybe mempty
@@ -111,10 +116,22 @@ getCurrentPeers nkd = mapNodeKernelDataIO extractPeers nkd
   tuple3pop :: (a, b, c) -> (a, b)
   tuple3pop (a, b, _) = (a, b)
 
+  peerFetchStatusForgetTime :: PeerFetchStatus (HeaderWithTime blk) -> PeerFetchStatus (Header blk)
+  peerFetchStatusForgetTime = \case
+      PeerFetchStatusShutdown          -> PeerFetchStatusShutdown
+      PeerFetchStatusStarting          -> PeerFetchStatusStarting
+      PeerFetchStatusAberrant          -> PeerFetchStatusAberrant
+      PeerFetchStatusBusy              -> PeerFetchStatusBusy
+      PeerFetchStatusReady points idle -> PeerFetchStatusReady (Set.mapMonotonic Net.castPoint points) idle
+
+  peerFetchInFlightForgetTime :: PeerFetchInFlight (HeaderWithTime blk) -> PeerFetchInFlight (Header blk)
+  peerFetchInFlightForgetTime inflight =
+    inflight {peerFetchBlocksInFlight = Set.mapMonotonic Net.castPoint (peerFetchBlocksInFlight inflight)}
+
   getCandidates
     :: STM.STM IO (Map peer (ChainSyncClientHandle IO blk))
     -> STM.STM IO (Map peer (Net.AnchoredFragment (Header blk)))
-  getCandidates handle = viewChainSyncState handle csCandidate
+  getCandidates handle = viewChainSyncState handle (Net.mapAnchoredFragment hwtHeader . csCandidate)
 
   extractPeers :: NodeKernel IO RemoteAddress LocalConnectionId blk
                 -> IO [PeerT blk]
@@ -128,7 +145,7 @@ getCurrentPeers nkd = mapNodeKernelDataIO extractPeers nkd
 
     let peers = flip Map.mapMaybeWithKey candidates $ \cid af ->
                   maybe Nothing
-                        (\(status, inflight) -> Just $ PeerT cid af status inflight)
+                        (\(status, inflight) -> Just $ PeerT cid af (peerFetchStatusForgetTime status) (peerFetchInFlightForgetTime inflight))
                         $ Map.lookup cid peerStates
     pure . Map.elems $ peers
 

--- a/cardano-node/src/Cardano/Tracing/Peer.hs
+++ b/cardano-node/src/Cardano/Tracing/Peer.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.Tracing.Peer
   ( Peer (..)
@@ -17,6 +19,7 @@ import           Cardano.BM.Tracing
 import           Cardano.Node.Orphans ()
 import           Cardano.Node.Queries
 import           Ouroboros.Consensus.Block (Header)
+import           Ouroboros.Consensus.HeaderValidation (HeaderWithTime (..))
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client (ChainSyncClientHandle,
                    csCandidate, cschcMap, viewChainSyncState)
 import           Ouroboros.Consensus.Util.Orphans ()
@@ -87,7 +90,8 @@ ppStatus = \case
   PeerFetchStatusStarting -> "starting"
 
 getCurrentPeers
-  :: NodeKernelData blk
+  :: forall blk. Net.HasHeader (Header blk)
+  => NodeKernelData blk
   -> IO [Peer blk]
 getCurrentPeers nkd = mapNodeKernelDataIO extractPeers nkd
                       <&> fromSMaybe mempty
@@ -95,10 +99,22 @@ getCurrentPeers nkd = mapNodeKernelDataIO extractPeers nkd
   tuple3pop :: (a, b, c) -> (a, b)
   tuple3pop (a, b, _) = (a, b)
 
+  peerFetchStatusForgetTime :: PeerFetchStatus (HeaderWithTime blk) -> PeerFetchStatus (Header blk)
+  peerFetchStatusForgetTime = \case
+      PeerFetchStatusShutdown          -> PeerFetchStatusShutdown
+      PeerFetchStatusStarting          -> PeerFetchStatusStarting
+      PeerFetchStatusAberrant          -> PeerFetchStatusAberrant
+      PeerFetchStatusBusy              -> PeerFetchStatusBusy
+      PeerFetchStatusReady points idle -> PeerFetchStatusReady (Set.mapMonotonic Net.castPoint points) idle
+
+  peerFetchInFlightForgetTime :: PeerFetchInFlight (HeaderWithTime blk) -> PeerFetchInFlight (Header blk)
+  peerFetchInFlightForgetTime inflight =
+    inflight {peerFetchBlocksInFlight = Set.mapMonotonic Net.castPoint (peerFetchBlocksInFlight inflight)}
+
   getCandidates
     :: STM.STM IO (Map peer (ChainSyncClientHandle IO blk))
     -> STM.STM IO (Map peer (Net.AnchoredFragment (Header blk)))
-  getCandidates handle = viewChainSyncState handle csCandidate
+  getCandidates handle = viewChainSyncState handle (Net.mapAnchoredFragment hwtHeader . csCandidate)
 
   extractPeers :: NodeKernel IO RemoteAddress LocalConnectionId blk
                 -> IO [Peer blk]
@@ -112,7 +128,7 @@ getCurrentPeers nkd = mapNodeKernelDataIO extractPeers nkd
 
     let peers = flip Map.mapMaybeWithKey candidates $ \cid af ->
                   maybe Nothing
-                        (\(status, inflight) -> Just $ Peer cid af status inflight)
+                        (\(status, inflight) -> Just $ Peer cid af (peerFetchStatusForgetTime status) (peerFetchInFlightForgetTime inflight))
                         $ Map.lookup cid peerStates
     pure . Map.elems $ peers
 


### PR DESCRIPTION
# Description

The PR https://github.com/IntersectMBO/ouroboros-consensus/pull/1288 has introduced the `HeaderWithTime` datatype which annotates block headers with their slot's `RelativeTime`.

This PR ensures the tracing system is modified to effectively ignore `HeaderWithTime` by
dropping the time annotations and using the underlying `Header`, keeping the current tracing behaviour unchanged.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
