### PR TITLE
Fix exit code for SIGTERM

### DIFF
--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -9,6 +9,8 @@
 
 - Lower the log severity from Error to Info for TracePromoteWarmBigLedgerPeerAborted and ResponderStartFailure
 
+- Change to exit with 0 rather than 1 when a SIGTERM is caught.
+
 - Add a new configuration field for fork-policy.
 
 - Optionally support lightweight checkpointing.

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -58,7 +58,7 @@ import           Cardano.Node.Tracing.StateRep (NodeState (NodeKernelOnline))
 import           Cardano.Node.Tracing.Tracers.NodeVersion (getNodeVersion)
 import           Cardano.Node.Tracing.Tracers.Startup (getStartupInfo)
 import           Cardano.Node.Types
-import           Cardano.Prelude (FatalError (..), bool, (:~:) (..))
+import           Cardano.Prelude (ExitCode (..), FatalError (..), bool, (:~:) (..))
 import           Cardano.Tracing.Config (TraceOptions (..), TraceSelection (..))
 import           Cardano.Tracing.Tracers
 
@@ -226,7 +226,7 @@ installSigTermHandler = do
     Signals.sigTERM
     (Signals.CatchOnce $ do
       runThreadIdMay <- deRefWeak runThreadIdWk
-      forM_ runThreadIdMay $ \runThreadId -> killThread runThreadId
+      forM_ runThreadIdMay $ \runThreadId -> Exception.throwTo runThreadId ExitSuccess
     )
     Nothing
 #endif


### PR DESCRIPTION
# Description

When catching SIGTERM the node does a clean exit, but its exit status is 1. This makes it impossible to differentiate between a clean shutdown triggered by SIGTERM and a crash.

This changes it so that cardano-node exits with 0 when exiting due to catching SIGTERM.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
