### PR TITLE
HOTFIX: old tracing - fix `utxoSize` metric post-UTxO-HD

### DIFF
--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -1082,7 +1082,7 @@ traceLeadershipChecks _ft nodeKern _tverb tr = Tracer $
         !query <- mapNodeKernelDataIO
                     (\nk ->
                        (,,)
-                         <$> nkQueryLedger (ledgerUtxoSize . ledgerState) nk
+                         <$> fmap (maybe 0 LedgerDB.ledgerTableSize) (ChainDB.getStatistics $ getChainDB nk)
                          <*> nkQueryLedger (ledgerDelegMapSize . ledgerState) nk
                          <*> nkQueryChain fragmentChainDensity nk)
                     nodeKern


### PR DESCRIPTION
# Description

The old tracing system metric `utxoSize` was missing the UTxO-HD way to query UTxO set size, which is not accessible directly via ledger state anymore. This hotfix ports the correct solution from the new tracing system to the old one.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff
