### PR TITLE
Make peer snapshot path relative to topology file

### DIFF
--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -501,7 +501,6 @@ handleSimpleNode blockType runP p2pMode tracers nc onKernel = do
         ledgerPeerSnapshotPathVar <- newTVarIO ntPeerSnapshotPath
         ledgerPeerSnapshotVar <- newTVarIO =<< updateLedgerPeerSnapshot
                                                 (startupTracer tracers)
-                                                (ncTopologyFile nc)
                                                 (readTVar ledgerPeerSnapshotPathVar)
                                                 (const . pure $ ())
 
@@ -542,7 +541,6 @@ handleSimpleNode blockType runP p2pMode tracers nc onKernel = do
                   ledgerPeerSnapshotPathVar
                 void $ updateLedgerPeerSnapshot
                   (startupTracer tracers)
-                  (ncTopologyFile nc)
                   (readTVar ledgerPeerSnapshotPathVar)
                   (writeTVar ledgerPeerSnapshotVar)
                 traceWith (startupTracer tracers) (BlockForgingUpdate NotEffective)
@@ -771,7 +769,6 @@ installP2PSigHUPHandler startupTracer blockType nc nodeKernel localRootsVar publ
                                   useLedgerVar useBootstrapPeersVar ledgerPeerSnapshotPathVar
       void $ updateLedgerPeerSnapshot
                startupTracer
-               (ncTopologyFile nc)
                (readTVar ledgerPeerSnapshotPathVar)
                (writeTVar ledgerPeerSnapshotVar)
     )
@@ -884,14 +881,13 @@ updateTopologyConfiguration startupTracer nc localRootsVar publicRootsVar useLed
 #endif
 
 updateLedgerPeerSnapshot :: Tracer IO (StartupTrace blk)
-                         -> TopologyFile
                          -> STM IO (Maybe PeerSnapshotFile)
                          -> (Maybe LedgerPeerSnapshot -> STM IO ())
                          -> IO (Maybe LedgerPeerSnapshot)
-updateLedgerPeerSnapshot startupTracer topoFile readLedgerPeerPath writeVar = do
+updateLedgerPeerSnapshot startupTracer readLedgerPeerPath writeVar = do
   mPeerSnapshotFile <- atomically readLedgerPeerPath
   mLedgerPeerSnapshot <- forM mPeerSnapshotFile $ \f -> do
-    lps@(LedgerPeerSnapshot (wOrigin, _)) <- readPeerSnapshotFile topoFile f
+    lps@(LedgerPeerSnapshot (wOrigin, _)) <- readPeerSnapshotFile f
     lps <$ traceWith startupTracer (LedgerPeerSnapshotLoaded wOrigin)
   atomically . writeVar $ mLedgerPeerSnapshot
   pure mLedgerPeerSnapshot


### PR DESCRIPTION
# Description

Make peer snapshot path relative to topology file

Fixes https://github.com/IntersectMBO/cardano-node/issues/6179

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
