### PR TITLE
nix: change default GC for cardano-node

### DIFF
--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -696,7 +696,7 @@ in {
 
       rtsArgs = mkOption {
         type = types.listOf types.str;
-        default = [ "-N2" "-I0" "-A16m" "-qg" "-qb" "--disable-delayed-os-memory-return" ];
+        default = [ "-N2" "-I0" "-A16m" "-qg1" "-qb1" "--disable-delayed-os-memory-return" ];
         apply = args: if (args != [] || cfg.profilingArgs != [] || cfg.rts_flags_override != []) then
           ["+RTS"] ++ cfg.profilingArgs ++ args ++ cfg.rts_flags_override ++ ["-RTS"]
           else [];


### PR DESCRIPTION
# Description

This PR changes the default garbage collector (GC) settings for the `cardano-node` nix service config (SVC).
Sequential GC is replaced by parallel, load-balanced GC for all but the youngest generation.

Changing the default compiler to GHC9.6 prompted scrutinizing GC settings, as the ones most beneficial on GHC8.10 can't be assumed to automatically be the best pick for GHC9.6. The change in this PR showed slight improvement in network performance, and solid reduction of GC pauses in our benchmarks (see below).

Please note that these settings are not imposed to operate a `cardano-node` - however, they're recommended for efficiency of block producers.
* The Haskell package itself leaves GC unspecified (besides `-I0`, which is strongly advised to minimize GC pauses).
* The nix SVC offers attrs `rtsArgs` to _replace_ all default RTS arguments with custom settings, and `rts_flags_override` to _override_ individual arguments from `rtsArgs`.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff