### PR TITLE
Change default era parser value from Babbage to Conway

### DIFF
--- a/cardano-testnet/src/Parsers/Run.hs
+++ b/cardano-testnet/src/Parsers/Run.hs
@@ -11,6 +11,7 @@ module Parsers.Run
 
 import           Cardano.Api.Shelley (ShelleyGenesis)
 
+import           Cardano.Api (AnyCardanoEra(..), CardanoEra(..))
 import           Cardano.CLI.Environment
 import           Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis)
 import           Cardano.Ledger.Conway.Genesis (ConwayGenesis)
@@ -51,11 +52,13 @@ data CardanoTestnetCommands
 commands :: EnvCli -> Parser CardanoTestnetCommands
 commands envCli =
   asum
-    [ fmap StartCardanoTestnet (subparser (cmdCardano envCli))
+    [ fmap StartCardanoTestnet (subparser (cmdCardano envCli'))
     , fmap GetVersion (subparser cmdVersion)
-    , fmap (Help pref (opts envCli)) (subparser cmdHelp)
+    , fmap (Help pref (opts envCli')) (subparser cmdHelp)
     ]
-
+  where
+    -- Override default era to Conway instead of Babbage in parsers
+    envCli' = envCli{envCliAnyCardanoEra = Just $ AnyCardanoEra ConwayEra}
 
 runTestnetCmd :: CardanoTestnetCommands -> IO ()
 runTestnetCmd = \case


### PR DESCRIPTION
# Description

This PR fixes an issue that happened when `cardano-testnet` was called without any explicit era argument. It used to default to `babbage` when calling `cardano-cli`, which is no longer supported.

This PR changes the default value of the era parser for `cardano-testnet` to `conway`, which is supported.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
