### PR TITLE
Add missing docstring to `hprop_shutdownOnSlotSynced`

### DIFF
--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Node/Shutdown.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Node/Shutdown.hs
@@ -187,7 +187,8 @@ hprop_shutdown = integrationRetryWorkspace 2 "shutdown" $ \tempAbsBasePath' -> H
 
       return ()
 
-
+-- Execute this test with:
+-- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/Shutdown On SlotSynced/"'@
 hprop_shutdownOnSlotSynced :: Property
 hprop_shutdownOnSlotSynced = integrationRetryWorkspace 2 "shutdown-on-slot-synced" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   -- Start a local test net


### PR DESCRIPTION
# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff