### PR TITLE
Node 10.5 QueryBatchSize LedgerDB tuning

### DIFF
--- a/configuration/cardano/mainnet-config-bp.json
+++ b/configuration/cardano/mainnet-config-bp.json
@@ -15,7 +15,7 @@
   "LedgerDB": {
     "Backend": "V2InMemory",
     "NumOfDiskSnapshots": 2,
-    "QueryBatchSize": 100,
+    "QueryBatchSize": 100000,
     "SnapshotInterval": 4320
   },
   "MaxKnownMajorProtocolVersion": 2,

--- a/configuration/cardano/mainnet-config.json
+++ b/configuration/cardano/mainnet-config.json
@@ -15,7 +15,7 @@
   "LedgerDB": {
     "Backend": "V2InMemory",
     "NumOfDiskSnapshots": 2,
-    "QueryBatchSize": 100,
+    "QueryBatchSize": 100000,
     "SnapshotInterval": 4320
   },
   "MaxKnownMajorProtocolVersion": 2,

--- a/configuration/cardano/mainnet-config.yaml
+++ b/configuration/cardano/mainnet-config.yaml
@@ -64,7 +64,7 @@ LedgerDB:
 
   # When querying the store for a big range of UTxOs (such as with
   # QueryUTxOByAddress), the store will be read in batches of this size.
-  QueryBatchSize: 100
+  QueryBatchSize: 100000
 
   # The backend can either be in memory with `V2InMemory` or on disk with
   # `V1LMDB`.

--- a/configuration/cardano/testnet-template-config.json
+++ b/configuration/cardano/testnet-template-config.json
@@ -11,7 +11,7 @@
   "LedgerDB": {
     "Backend": "V2InMemory",
     "NumOfDiskSnapshots": 2,
-    "QueryBatchSize": 100,
+    "QueryBatchSize": 100000,
     "SnapshotInterval": 216
   },
   "MaxConcurrencyDeadline": 4,

--- a/flake.lock
+++ b/flake.lock
@@ -582,11 +582,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1747798193,
-        "narHash": "sha256-nb+fPI8ZcIGIVVFuPmjzseDu+81dDlxI7iux1NpJA5Y=",
+        "lastModified": 1748449255,
+        "narHash": "sha256-JdLwzKcmWjDocyl4aGUpXWua85WiFyz9/kTFBkwfrLk=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "46a0a7b586b3a358b5e96ea3050f8aeca1a34c2d",
+        "rev": "72a50c13ae70080794b9f661cea9bd2014cb462b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Description

* Bumps iohkNix flake pin to adjust `QueryBatchSize` declared default from 100 to 100000 to match the [Consensus UTXO HD Migration Guide](https://ouroboros-consensus.cardano.intersectmbo.org/docs/for-developers/utxo-hd/migrating/#populate-the-new-configuration-options)
*  Adjusts corresponding config files to match iohkNix update and for related CI jobs to pass

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] CI passes. See note on CI.  The following CI checks are required:
- [X] Self-reviewed the diff