### PR TITLE
cabal.project: Update index-states and make it build

### DIFF
--- a/bench/locli/locli.cabal
+++ b/bench/locli/locli.cabal
@@ -212,7 +212,7 @@ test-suite test-locli
   build-depends:        cardano-prelude
                       , containers
                       , hedgehog
-                      , hedgehog-extras ^>= 0.7
+                      , hedgehog-extras < 0.7.1
                       , locli
                       , text
 

--- a/cabal.project
+++ b/cabal.project
@@ -13,8 +13,8 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state:
-  , hackage.haskell.org 2025-06-03T08:07:10Z
-  , cardano-haskell-packages 2025-06-03T08:30:50Z
+  , hackage.haskell.org 2025-06-24T21:06:59Z
+  , cardano-haskell-packages 2025-06-24T21:42:18Z
 
 packages:
   cardano-node
@@ -59,42 +59,15 @@ package plutus-scripts-bench
 
 allow-newer:
   , katip:Win32
-  , ekg-forward:ouroboros-network-framework
-  , ekg-wai:time
-
--- IMPORTANT
--- Do NOT add more source-repository-package stanzas here unless they are strictly
--- temporary! Please read the section in CONTRIBUTING about updating dependencies.
 
 if impl (ghc >= 9.12)
   allow-newer:
-    -- https://github.com/phadej/vec/issues/118
-    , bin:base
-    , fin:base
-    , ral:base
-
-    -- https://github.com/haskellari/tree-diff/issues/97
-    , tree-diff:base
-
     -- https://github.com/kapralVV/Unique/issues/11
     , Unique:hashable
-
-    -- https://github.com/fizruk/http-api-data/pull/146
-    , http-api-data:base
-
-    -- https://github.com/ocharles/libsystemd-journal/pull/32
-    , libsystemd-journal:base
 
     -- https://github.com/Gabriella439/Haskell-Pipes-Safe-Library/pull/70
     , pipes-safe:base
 
-    -- https://github.com/haskell-servant/servant/pull/1810
-    , servant:base
-    , servant-server:base
-
-    , cardano-ping:base
-    , network-mux:base
-    , ouroboros-network:base
-    , ouroboros-network-api:base
-    , ouroboros-network-framework:base
-    , ouroboros-network-protocols:base
+-- IMPORTANT
+-- Do NOT add more source-repository-package stanzas here unless they are strictly
+-- temporary! Please read the section in CONTRIBUTING about updating dependencies.

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -75,7 +75,7 @@ test-suite chairman-tests
                       , data-default-class
                       , filepath
                       , hedgehog
-                      , hedgehog-extras ^>= 0.7
+                      , hedgehog-extras < 0.7.1
                       , network
                       , process
                       , random

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -264,7 +264,7 @@ test-suite cardano-node-test
                       , filepath
                       , hedgehog
                       , hedgehog-corpus
-                      , hedgehog-extras
+                      , hedgehog-extras ^>= 0.7.0
                       , iproute
                       , mtl
                       , ouroboros-consensus

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -68,7 +68,7 @@ library
                       , extra
                       , filepath
                       , hedgehog
-                      , hedgehog-extras ^>= 0.7
+                      , hedgehog-extras < 0.7.1
                       , lens-aeson
                       , microlens
                       , monad-control

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1748961716,
-        "narHash": "sha256-t4wX4FOTmylk+mRjpJQllF15ntSXBwyXZfU8qLBIS9s=",
+        "lastModified": 1750802472,
+        "narHash": "sha256-yu5Y1Fqmyw0bKlunaydk/ZuBaw2apff7Lb1RZ7EUU2s=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "14dfcdcbc66bbb07e00c048210c4002a4dbbfe90",
+        "rev": "5f235deec2d482f3cde3adc2adf622627460a00d",
         "type": "github"
       },
       "original": {
@@ -293,11 +293,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1745281520,
-        "narHash": "sha256-dk/70Cmjx8fGSURcAHQnowETeAOElzDxn0wH/P4DUWA=",
+        "lastModified": 1750811208,
+        "narHash": "sha256-4ZehGGDhdY48ZlTXnFPEeKSJ3Zv+CqGuGu3Q/lEJz88=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "4c98778277c642e326b3cb7c2c9cbb9163b9ffbd",
+        "rev": "bfedf19d6cde9fa11c6f9dedab998a2463cbfa8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Description

* Remove some old SRPS.
* Restrict version of hedgehog-extras (had to use `< 0.7.1` because `^>= 0.7.0` was still picking version `0.7.2` which is not compatible.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [ ] Self-reviewed the diff
