### PR TITLE
WIP: Integrate KES agent 

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -62,6 +62,8 @@ allow-newer:
   , ekg-forward:ouroboros-network-framework
   , ekg-wai:time
 
+  , cardano-api
+
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
@@ -98,3 +100,79 @@ if impl (ghc >= 9.12)
     , ouroboros-network-api:base
     , ouroboros-network-framework:base
     , ouroboros-network-protocols:base
+
+allow-newer:
+  cardano-ledger-core,
+  cardano-ledger-byron,
+  serdoc-core:tasty-quickcheck,
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/kes-agent
+  tag: 07437ed49022b13759c87c4e314f08fcff64b81a
+  --sha256: sha256-oTsxaFAs1c/H0oYLhiivO5mr48oHNsPi5k2XyXxwCJg=
+  subdir:
+      kes-agent
+
+source-repository-package
+   type: git
+   location: https://github.com/IntersectMBO/ouroboros-network
+   tag: 3e8d3b4b8c87ead794876c62d7fe25f32efb5142
+   --sha256: 08fpkx3iagj83nn413h9a865zjcj3lrf7017a756qd2wg2jg3amq
+   subdir:
+     ouroboros-network-api
+
+source-repository-package
+   type: git
+   location: https://github.com/IntersectMBO/cardano-ledger
+   tag: b44ce911475794a15f908ad27a6f497d6a27e8ba
+   --sha256: sha256-MXaVKKH9siUsmOnJmYyL6if48dx11zugux7AWGPABfA=
+   subdir:
+      eras/allegra/impl
+      eras/alonzo/impl
+      eras/alonzo/test-suite
+      eras/babbage/impl
+      eras/babbage/test-suite
+      eras/byron/chain/executable-spec
+      eras/byron/crypto
+      eras/byron/ledger/executable-spec
+      eras/byron/ledger/impl
+      eras/conway/impl
+      eras/conway/test-suite
+      eras/mary/impl
+      eras/shelley/impl
+      eras/shelley-ma/test-suite
+      eras/shelley/test-suite
+      libs/cardano-data
+      libs/cardano-ledger-api
+      libs/cardano-ledger-binary
+      libs/cardano-ledger-core
+      libs/cardano-ledger-test
+      libs/cardano-protocol-tpraos
+      libs/constrained-generators
+      libs/non-integral
+      libs/set-algebra
+      libs/small-steps
+      libs/vector-map
+
+source-repository-package
+  type: git
+  location: https://github.com/IntersectMBO/ouroboros-consensus
+  tag: 9fdeacc0ba74009bd3078f08cd6b443a3f296515
+  --sha256: sha256-oTsxaFAs1c/H0oYLhiivO5mr48oHNsPi5k2XyXxwCJg=
+  subdir:
+      ouroboros-consensus
+      ouroboros-consensus-cardano
+      ouroboros-consensus-diffusion
+      ouroboros-consensus-protocol
+      sop-extras
+      strict-sop-core
+
+source-repository-package
+  type: git
+  location: https://github.com/IntersectMBO/cardano-api
+  tag: 5e32849f753e40b9db852a3999ccf506da776a44
+  --sha256: sha256-oTsxaFAs1c/H0oYLhiivO5mr48oHNsPi5k2XyXxwCJg=
+  subdir:
+      cardano-api
+

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -181,6 +181,7 @@ library
                       , hostname
                       , io-classes >= 1.5
                       , iohk-monitoring ^>= 0.2
+                      , kes-agent
                       , microlens
                       , network-mux
                       , iproute

--- a/cardano-node/src/Cardano/Node/Configuration/NodeAddress.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/NodeAddress.hs
@@ -34,7 +34,7 @@ import           Cardano.Api
 
 import           Ouroboros.Network.PeerSelection.RelayAccessPoint (DomainAccessPoint (..))
 
-import           Data.Aeson (FromJSON (..), ToJSON (..), Value (..), object, withObject, (.:), (.=))
+import           Data.Aeson (Value (..), object, withObject, (.:), (.=))
 import           Data.IP (IP (..), IPv4, IPv6)
 import qualified Data.IP as IP
 import           Data.Text (Text)

--- a/cardano-node/src/Cardano/Node/Parsers.hs
+++ b/cardano-node/src/Cardano/Node/Parsers.hs
@@ -56,7 +56,7 @@ nodeRunParser = do
   -- Protocol files
   byronCertFile   <- optional parseByronDelegationCert
   byronKeyFile    <- optional parseByronSigningKey
-  shelleyKESFile  <- optional parseKesKeyFilePath
+  shelleyKESSource  <- optional parseKesSourceFilePath
   shelleyVRFFile  <- optional parseVrfKeyFilePath
   shelleyCertFile <- optional parseOperationalCertFilePath
   shelleyBulkCredsFile <- optional parseBulkCredsFilePath
@@ -89,7 +89,7 @@ nodeRunParser = do
            , pncProtocolFiles = Last $ Just ProtocolFilepaths
              { byronCertFile
              , byronKeyFile
-             , shelleyKESFile
+             , shelleyKESSource
              , shelleyVRFFile
              , shelleyCertFile
              , shelleyBulkCredsFile
@@ -334,15 +334,33 @@ parseBulkCredsFilePath =
         <> completer (bashCompleter "file")
     )
 
---TODO: pass the current KES evolution, not the KES_0
-parseKesKeyFilePath :: Parser FilePath
-parseKesKeyFilePath =
-  strOption
-    ( long "shelley-kes-key"
-        <> metavar "FILEPATH"
-        <> help "Path to the KES signing key."
-        <> completer (bashCompleter "file")
-    )
+-- --TODO: pass the current KES evolution, not the KES_0
+-- parseKesKeyFilePath :: Parser FilePath
+-- parseKesKeyFilePath =
+--   strOption
+--     ( long "shelley-kes-key"
+--         <> metavar "FILEPATH"
+--         <> help "Path to the KES signing key."
+--         <> completer (bashCompleter "file")
+--     )
+
+parseKesSourceFilePath :: Parser KESSource
+parseKesSourceFilePath = asum
+  [ KESKeyFilePath <$>
+      strOption
+        ( long "shelley-kes-key"
+            <> metavar "FILEPATH"
+            <> help "Path to the KES signing key."
+            <> completer (bashCompleter "file")
+        )
+  , KESAgentSocketPath <$>
+      strOption
+        ( long "shelley-kes-agent-socket"
+            <> metavar "SOCKET_FILEPATH"
+            <> help "Path to the KES Agent socket"
+            <> completer (bashCompleter "file")
+        )
+  ]
 
 parseVrfKeyFilePath :: Parser FilePath
 parseVrfKeyFilePath =

--- a/cardano-node/src/Cardano/Node/Protocol/Alonzo.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Alonzo.hs
@@ -9,7 +9,6 @@ module Cardano.Node.Protocol.Alonzo
   ) where
 
 import           Cardano.Api
-import           Cardano.Api.Shelley
 
 import qualified Cardano.Ledger.Alonzo.Genesis as Alonzo
 import           Cardano.Node.Orphans ()

--- a/cardano-node/src/Cardano/Node/Protocol/Byron.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Byron.hs
@@ -13,6 +13,7 @@ module Cardano.Node.Protocol.Byron
   ) where
 
 import           Cardano.Api.Byron
+import           Cardano.Api
 
 import qualified Cardano.Chain.Genesis as Genesis
 import qualified Cardano.Chain.Update as Update

--- a/cardano-node/src/Cardano/Node/Protocol/Shelley.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Shelley.hs
@@ -23,7 +23,7 @@ module Cardano.Node.Protocol.Shelley
   ) where
 
 import qualified Cardano.Api as Api
-import           Cardano.Api.Shelley hiding (FileError)
+import           Cardano.Api hiding (FileError)
 
 import qualified Cardano.Crypto.Hash.Class as Crypto
 import           Cardano.Ledger.BaseTypes (ProtVer (..), natVersion)

--- a/cardano-node/src/Cardano/Node/Protocol/Shelley.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Shelley.hs
@@ -39,7 +39,7 @@ import           Cardano.Protocol.Crypto (StandardCrypto)
 import           Cardano.Tracing.OrphanInstances.HardFork ()
 import           Cardano.Tracing.OrphanInstances.Shelley ()
 import qualified Ouroboros.Consensus.Cardano as Consensus
-import           Ouroboros.Consensus.Protocol.Praos.Common (PraosCanBeLeader (..))
+import           Ouroboros.Consensus.Protocol.Praos.Common (PraosCanBeLeader (..), PraosCredentialsSource(..))
 import           Ouroboros.Consensus.Shelley.Node (Nonce (..), ProtocolParamsShelleyBased (..),
                    ShelleyLeaderCredentials (..))
 
@@ -224,6 +224,7 @@ readLeaderCredentialsBulk ProtocolFilepaths { shelleyBulkCredsFile = mfp } =
                              (teVrf,  loc "vrf")
                              (teKes,  loc "kes")
 
+-- TODO: enable KES agent
 mkPraosLeaderCredentials ::
      OperationalCertificate
   -> SigningKey VrfKey
@@ -236,11 +237,11 @@ mkPraosLeaderCredentials
     ShelleyLeaderCredentials
     { shelleyLeaderCredentialsCanBeLeader =
         PraosCanBeLeader {
-        praosCanBeLeaderOpCert     = opcert,
+          praosCanBeLeaderCredentialsSource =
+            PraosCredentialsUnsound opcert kesKey,
           praosCanBeLeaderColdVerKey = coerceKeyRole vkey,
           praosCanBeLeaderSignKeyVRF = vrfKey
         },
-      shelleyLeaderCredentialsInitSignKey = kesKey,
       shelleyLeaderCredentialsLabel = "Shelley"
     }
 

--- a/cardano-node/src/Cardano/Node/Protocol/Shelley.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Shelley.hs
@@ -141,27 +141,38 @@ readLeaderCredentialsSingleton
    ProtocolFilepaths
      { shelleyCertFile      = Nothing,
        shelleyVRFFile       = Nothing,
-       shelleyKESFile       = Nothing
+       shelleyKESSource     = Nothing
      } = pure []
 -- Or to supply all of the files
 readLeaderCredentialsSingleton
   ProtocolFilepaths { shelleyCertFile = Just opCertFile,
                       shelleyVRFFile = Just vrfFile,
-                      shelleyKESFile = Just kesFile
+                      shelleyKESSource = Just kesSource
                     } = do
     vrfSKey <-
       firstExceptT FileError (newExceptT $ readFileTextEnvelope (File vrfFile))
 
-    (opCert, kesSKey) <- opCertKesKeyCheck (File kesFile) (File opCertFile)
+    (credentialsSource, vkey) <- case kesSource of
+      KESKeyFilePath kesFile -> do
+        (OperationalCertificate opCert vkey, KesSigningKey kesKey) <-
+          opCertKesKeyCheck (File kesFile) (File opCertFile)
+        pure (PraosCredentialsUnsound opCert kesKey, vkey)
 
-    return [mkPraosLeaderCredentials opCert vrfSKey kesSKey]
+      -- TODO: minor yikes: when we're using an agent, we don't check that the
+      -- opcert and the key provided by the KES agent match, like we do when
+      -- the key is provided in a file on the command line
+      KESAgentSocketPath socketFile -> do
+        OperationalCertificate _ vkey <- firstExceptT FileError $ newExceptT $ readFileTextEnvelope $ File opCertFile
+        pure (PraosCredentialsAgent socketFile, vkey)
+
+    return [mkPraosLeaderCredentials credentialsSource vkey vrfSKey]
 
 -- But not OK to supply some of the files without the others.
 readLeaderCredentialsSingleton ProtocolFilepaths {shelleyCertFile = Nothing} =
      left OCertNotSpecified
 readLeaderCredentialsSingleton ProtocolFilepaths {shelleyVRFFile = Nothing} =
      left VRFKeyNotSpecified
-readLeaderCredentialsSingleton ProtocolFilepaths {shelleyKESFile = Nothing} =
+readLeaderCredentialsSingleton ProtocolFilepaths {shelleyKESSource = Nothing} =
      left KESKeyNotSpecified
 
 opCertKesKeyCheck
@@ -201,9 +212,9 @@ readLeaderCredentialsBulk ProtocolFilepaths { shelleyBulkCredsFile = mfp } =
      -> ExceptT PraosLeaderCredentialsError IO (ShelleyLeaderCredentials StandardCrypto)
    parseShelleyCredentials ShelleyCredentials { scCert, scVrf, scKes } = do
      mkPraosLeaderCredentials
-       <$> parseEnvelope scCert
-       <*> parseEnvelope scVrf
-       <*> parseEnvelope scKes
+       <$> undefined scCert -- parseEnvelope scCert
+       <*> undefined scVrf -- parseEnvelope scVrf
+       <*> undefined scKes -- parseEnvelope scKes
 
    readBulkFile
      :: Maybe FilePath
@@ -224,32 +235,30 @@ readLeaderCredentialsBulk ProtocolFilepaths { shelleyBulkCredsFile = mfp } =
                              (teVrf,  loc "vrf")
                              (teKes,  loc "kes")
 
--- TODO: enable KES agent
 mkPraosLeaderCredentials ::
-     OperationalCertificate
+     PraosCredentialsSource StandardCrypto
+  -> VerificationKey StakePoolKey
   -> SigningKey VrfKey
-  -> SigningKey KesKey
   -> ShelleyLeaderCredentials StandardCrypto
 mkPraosLeaderCredentials
-    (OperationalCertificate opcert (StakePoolVerificationKey vkey))
-    (VrfSigningKey vrfKey)
-    (KesSigningKey kesKey) =
+    credentialsSource
+    (StakePoolVerificationKey vkey)
+    (VrfSigningKey vrfKey) =
     ShelleyLeaderCredentials
     { shelleyLeaderCredentialsCanBeLeader =
         PraosCanBeLeader {
-          praosCanBeLeaderCredentialsSource =
-            PraosCredentialsUnsound opcert kesKey,
+          praosCanBeLeaderCredentialsSource = credentialsSource,
           praosCanBeLeaderColdVerKey = coerceKeyRole vkey,
           praosCanBeLeaderSignKeyVRF = vrfKey
         },
       shelleyLeaderCredentialsLabel = "Shelley"
     }
 
-parseEnvelope ::
+_parseEnvelope ::
      HasTextEnvelope a
   => (TextEnvelope, String)
   -> ExceptT PraosLeaderCredentialsError IO a
-parseEnvelope (te, loc) =
+_parseEnvelope (te, loc) =
   firstExceptT (FileError . Api.FileError loc) . hoistEither $
     deserialiseFromTextEnvelope te
 

--- a/cardano-node/src/Cardano/Node/Queries.hs
+++ b/cardano-node/src/Cardano/Node/Queries.hs
@@ -260,8 +260,10 @@ instance Shelley.EraCertState era => LedgerQueries (Shelley.ShelleyBlock protoco
     . Shelley.shelleyLedgerState
   ledgerDRepCount =
       Map.size
-    . Shelley.vsDReps
-    . (^. Shelley.certVStateL)
+    . undefined
+    -- . State.vsDReps
+    -- . (^. vsDRepsL)
+    -- . (^. Shelley.certVStateL)
     . Shelley.lsCertState
     . Shelley.esLState
     . Shelley.nesEs

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -22,8 +22,7 @@ module Cardano.Node.Run
   , checkVRFFilePermissions
   ) where
 
-import           Cardano.Api (File (..), FileDirection (..))
-import           Cardano.Api.Internal.Error (displayError)
+import           Cardano.Api (File (..), FileDirection (..), displayError)
 import qualified Cardano.Api as Api
 import           System.Random (randomIO)
 
@@ -249,7 +248,7 @@ handleNodeWithTracers cmdPc nc0 p@(SomeConsensusProtocol blockType runP) = do
             EnabledP2PMode -> nc0
       case ncTraceConfig nc of
         TraceDispatcher{} -> do
-          blockForging <- snd (Api.protocolInfo runP)
+          blockForging <- snd (Api.protocolInfo runP) nullTracer -- FIXME: this should be a real tracer
           tracers <-
             initTraceDispatcher
               nc
@@ -308,7 +307,7 @@ handleNodeWithTracers cmdPc nc0 p@(SomeConsensusProtocol blockType runP) = do
 
           traceWith (nodeVersionTracer tracers) getNodeVersion
           let isNonProducing = ncStartAsNonProducingNode nc
-          blockForging <- snd (Api.protocolInfo runP)
+          blockForging <- snd (Api.protocolInfo runP) nullTracer -- FIXME: this should be a real tracer
           traceWith (startupTracer tracers)
                     (BlockForgingUpdate (if isNonProducing || null blockForging
                                           then DisabledBlockForging
@@ -506,7 +505,7 @@ handleSimpleNode blockType runP p2pMode tracers nc onKernel = do
               , rnProtocolInfo   = pInfo
               , rnNodeKernelHook = \registry nodeKernel -> do
                   -- set the initial block forging
-                  blockForging <- snd (Api.protocolInfo runP)
+                  blockForging <- snd (Api.protocolInfo runP) nullTracer -- FIXME: this should be a real tracer
 
                   unless (ncStartAsNonProducingNode nc) $
                     setBlockForging nodeKernel blockForging
@@ -604,7 +603,7 @@ handleSimpleNode blockType runP p2pMode tracers nc onKernel = do
                 , rnProtocolInfo   = pInfo
                 , rnNodeKernelHook = \registry nodeKernel -> do
                     -- set the initial block forging
-                    blockForging <- snd (Api.protocolInfo runP)
+                    blockForging <- snd (Api.protocolInfo runP)nullTracer -- FIXME: this should be a real tracer
 
                     unless (ncStartAsNonProducingNode nc) $
                       setBlockForging nodeKernel blockForging
@@ -813,7 +812,7 @@ updateBlockForging startupTracer blockType nodeKernel nc = do
       case Api.reflBlockType blockType blockType' of
         Just Refl -> do
           -- TODO: check if runP' has changed
-          blockForging <- snd (Api.protocolInfo runP')
+          blockForging <- snd (Api.protocolInfo runP') nullTracer -- FIXME: this should be a real tracer
           traceWith startupTracer
                     (BlockForgingUpdate (if null blockForging
                                           then DisabledBlockForging

--- a/cardano-node/src/Cardano/Node/Tracing/Era/Shelley.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Era/Shelley.hs
@@ -19,7 +19,7 @@ module Cardano.Node.Tracing.Era.Shelley () where
 
 import           Cardano.Api (textShow)
 import           Cardano.Api.Ledger (fromVRFVerKeyHash)
-import qualified Cardano.Api.Shelley as Api
+import qualified Cardano.Api as Api
 
 import qualified Cardano.Crypto.Hash.Class as Crypto
 import qualified Cardano.Crypto.VRF.Class as Crypto
@@ -740,9 +740,6 @@ instance
   ) => LogFormatting (ShelleyNewEpochPredFailure era) where
   forMachine dtal (EpochFailure f) = forMachine dtal f
   forMachine dtal (MirFailure f) = forMachine dtal f
-  forMachine _dtal (CorruptRewardUpdate update) =
-    mconcat [ "kind" .= String "CorruptRewardUpdate"
-             , "update" .= String (textShow update) ]
 
 
 instance

--- a/cardano-node/src/Cardano/Node/Tracing/Render.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Render.hs
@@ -30,7 +30,6 @@ module Cardano.Node.Tracing.Render
   , renderMissingRedeemers
   ) where
 
--- import qualified Cardano.Api.Shelley as Api
 import qualified Cardano.Api as Api
 
 import qualified Cardano.Crypto.Hash.Class as Crypto

--- a/cardano-node/src/Cardano/Node/Tracing/Render.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Render.hs
@@ -30,7 +30,8 @@ module Cardano.Node.Tracing.Render
   , renderMissingRedeemers
   ) where
 
-import qualified Cardano.Api.Shelley as Api
+-- import qualified Cardano.Api.Shelley as Api
+import qualified Cardano.Api as Api
 
 import qualified Cardano.Crypto.Hash.Class as Crypto
 import           Cardano.Ledger.Alonzo.Scripts (AlonzoPlutusPurpose (..), AsItem (..),

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
@@ -342,6 +342,10 @@ mkConsensusTracers configReflection trBase trForward mbTrEKG _trDataPoint trConf
                 ["Consensus", "Startup"]
     configureTracers configReflection trConfig [consensusStartupErrorTr]
 
+    !consensusKESAgentTr <- mkCardanoTracer
+                trBase trForward mbTrEKG
+                ["Consensus", "KESAgent"]
+
     !consensusGddTr <- mkCardanoTracer
                  trBase trForward mbTrEKG
                  ["Consensus", "GDD"]
@@ -402,6 +406,8 @@ mkConsensusTracers configReflection trBase trForward mbTrEKG _trDataPoint trConf
           traceWith keepAliveClientTr
       , Consensus.consensusErrorTracer = Tracer $
           traceWith consensusStartupErrorTr . ConsensusStartupException
+      , Consensus.kesAgentTracer = Tracer $
+          traceWith consensusKESAgentTr
       , Consensus.gsmTracer = Tracer $
           traceWith consensusGsmTr
       , Consensus.csjTracer = Tracer $

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
@@ -2223,21 +2223,24 @@ instance MetaTrace V1.BackingStoreValueHandleTrace where
     ]
 
 instance LogFormatting V2.FlavorImplSpecificTrace where
-  forMachine _dtal V2.FlavorImplSpecificTraceInMemory =
-    mconcat [ "kind" .= String "InMemory" ]
-  forMachine _dtal V2.FlavorImplSpecificTraceOnDisk =
-    mconcat [ "kind" .= String "OnDisk" ]
+  forMachine _dtal _ = undefined
+  -- forMachine _dtal V2.FlavorImplSpecificTraceInMemory =
+  --   mconcat [ "kind" .= String "InMemory" ]
+  -- forMachine _dtal V2.FlavorImplSpecificTraceOnDisk =
+  --   mconcat [ "kind" .= String "OnDisk" ]
 
-  forHuman V2.FlavorImplSpecificTraceInMemory =
-    "An in-memory backing store event was traced"
-  forHuman V2.FlavorImplSpecificTraceOnDisk =
-    "An on-disk backing store event was traced"
+  forHuman _ = undefined
+  -- forHuman V2.FlavorImplSpecificTraceInMemory =
+  --   "An in-memory backing store event was traced"
+  -- forHuman V2.FlavorImplSpecificTraceOnDisk =
+  --   "An on-disk backing store event was traced"
 
 instance MetaTrace V2.FlavorImplSpecificTrace where
-  namespaceFor V2.FlavorImplSpecificTraceInMemory =
-    Namespace [] ["InMemory"]
-  namespaceFor V2.FlavorImplSpecificTraceOnDisk =
-    Namespace [] ["OnDisk"]
+  namespaceFor _ = undefined
+  -- namespaceFor V2.FlavorImplSpecificTraceInMemory =
+  --   Namespace [] ["InMemory"]
+  -- namespaceFor V2.FlavorImplSpecificTraceOnDisk =
+  --   Namespace [] ["OnDisk"]
 
   severityFor (Namespace _ ["InMemory"]) _ = Just Info
   severityFor (Namespace _ ["OnDisk"])   _ = Just Info

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
@@ -80,6 +80,7 @@ import qualified Data.Text as Text
 import           Data.Time (NominalDiffTime)
 import           Data.Word (Word32, Word64)
 import           Network.TypedProtocol.Core
+import Ouroboros.Consensus.Protocol.Praos.AgentClient
 
 
 instance (LogFormatting adr, Show adr) => LogFormatting (ConnectionId adr) where
@@ -2267,3 +2268,31 @@ instance ( StandardHash blk
             ]
 
   forHuman = showT
+
+--------------------------------------------------------------------------------
+-- KES Agent tracer
+--------------------------------------------------------------------------------
+
+instance LogFormatting KESAgentClientTrace where
+  forMachine _dtal = \case
+    KESAgentClientException _ ->
+      mconcat [ "kind" .= String "KESAgentClientException" ]
+    KESAgentClientTrace _ ->
+      mconcat [ "kind" .= String "KESAgentClientTrace" ]
+
+  forHuman = showT
+
+
+instance MetaTrace KESAgentClientTrace where
+  namespaceFor = \case
+    KESAgentClientException _ ->
+      Namespace [] ["KESAgentClientException"]
+    KESAgentClientTrace _ ->
+      Namespace [] ["KESAgentClientTrace"]
+
+  severityFor = undefined
+  documentFor = undefined
+  allNamespaces =
+    [ Namespace [] ["KESAgentClientException"]
+    , Namespace [] ["KESAgentClientTrace"]
+    ]

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
@@ -81,6 +81,7 @@ import           Data.Time (NominalDiffTime)
 import           Data.Word (Word32, Word64)
 import           Network.TypedProtocol.Core
 import Ouroboros.Consensus.Protocol.Praos.AgentClient
+import qualified Cardano.KESAgent.Processes.ServiceClient as Agent
 
 
 instance (LogFormatting adr, Show adr) => LogFormatting (ConnectionId adr) where
@@ -2273,12 +2274,115 @@ instance ( StandardHash blk
 -- KES Agent tracer
 --------------------------------------------------------------------------------
 
-instance LogFormatting KESAgentClientTrace where
+instance LogFormatting Agent.ServiceClientTrace where
   forMachine _dtal = \case
-    KESAgentClientException _ ->
-      mconcat [ "kind" .= String "KESAgentClientException" ]
-    KESAgentClientTrace _ ->
-      mconcat [ "kind" .= String "KESAgentClientTrace" ]
+    Agent.ServiceClientVersionHandshakeTrace _vhdt ->
+      mconcat [ "kind" .= String "ServiceClientVersionHandshakeTrace" ]
+    Agent.ServiceClientVersionHandshakeFailed ->
+      mconcat [ "kind" .= String "ServiceClientVersionHandshakeFailed" ]
+    Agent.ServiceClientDriverTrace _sdt ->
+      mconcat [ "kind" .= String "ServiceClientDriverTrace" ]
+    Agent.ServiceClientSocketClosed ->
+      mconcat [ "kind" .= String "ServiceClientSocketClosed" ]
+    Agent.ServiceClientConnected _s ->
+      mconcat [ "kind" .= String "ServiceClientConnected" ]
+    Agent.ServiceClientAttemptReconnect _ _ _ _ ->
+      mconcat [ "kind" .= String "ServiceClientAttemptReconnect" ]
+    Agent.ServiceClientReceivedKey _tbt ->
+      mconcat [ "kind" .= String "ServiceClientReceivedKey" ]
+    Agent.ServiceClientDeclinedKey _tbt ->
+      mconcat [ "kind" .= String "ServiceClientDeclinedKey" ]
+    Agent.ServiceClientDroppedKey ->
+      mconcat [ "kind" .= String "ServiceClientDroppedKey" ]
+    Agent.ServiceClientOpCertNumberCheck _ _ ->
+      mconcat [ "kind" .= String "ServiceClientOpCertNumberCheck" ]
+    Agent.ServiceClientAbnormalTermination _s ->
+      mconcat [ "kind" .= String "ServiceClientAbnormalTermination" ]
+    Agent.ServiceClientStopped ->
+      mconcat [ "kind" .= String "ServiceClientStopped" ]
+
+  forHuman = showT
+
+instance MetaTrace Agent.ServiceClientTrace where
+  namespaceFor = \case
+    Agent.ServiceClientVersionHandshakeTrace _vhdt ->
+      Namespace [] ["ServiceClientVersionHandshakeTrace"]
+    Agent.ServiceClientVersionHandshakeFailed ->
+      Namespace [] ["ServiceClientVersionHandshakeFailed"]
+    Agent.ServiceClientDriverTrace _sdt ->
+      Namespace [] ["ServiceClientDriverTrace"]
+    Agent.ServiceClientSocketClosed ->
+      Namespace [] ["ServiceClientSocketClosed"]
+    Agent.ServiceClientConnected _s ->
+      Namespace [] ["ServiceClientConnected"]
+    Agent.ServiceClientAttemptReconnect _ _ _ _ ->
+      Namespace [] ["ServiceClientAttemptReconnect"]
+    Agent.ServiceClientReceivedKey _tbt ->
+      Namespace [] ["ServiceClientReceivedKey"]
+    Agent.ServiceClientDeclinedKey _tbt ->
+      Namespace [] ["ServiceClientDeclinedKey"]
+    Agent.ServiceClientDroppedKey ->
+      Namespace [] ["ServiceClientDroppedKey"]
+    Agent.ServiceClientOpCertNumberCheck _ _ ->
+      Namespace [] ["ServiceClientOpCertNumberCheck"]
+    Agent.ServiceClientAbnormalTermination _s ->
+      Namespace [] ["ServiceClientAbnormalTermination"]
+    Agent.ServiceClientStopped ->
+      Namespace [] ["ServiceClientStopped"]
+
+  severityFor ns _ = case ns of
+    Namespace [] ["ServiceClientVersionHandshakeTrace"] ->
+      Just Debug
+    Namespace [] ["ServiceClientVersionHandshakeFailed"] ->
+      Just Error
+    Namespace [] ["ServiceClientDriverTrace"] ->
+      Just Debug
+    Namespace [] ["ServiceClientSocketClosed"] ->
+      Just Info
+    Namespace [] ["ServiceClientConnected"] ->
+      Just Info
+    Namespace [] ["ServiceClientAttemptReconnect"] ->
+      Just Info
+    Namespace [] ["ServiceClientReceivedKey"] ->
+      Just Info
+    Namespace [] ["ServiceClientDeclinedKey"] ->
+      Just Info
+    Namespace [] ["ServiceClientDroppedKey"] ->
+      Just Info
+    Namespace [] ["ServiceClientOpCertNumberCheck"] ->
+      Just Debug
+    Namespace [] ["ServiceClientAbnormalTermination"] ->
+      Just Error
+    Namespace [] ["ServiceClientStopped"] ->
+      Just Info
+    Namespace _ _ -> Nothing
+
+  documentFor _ = Nothing
+  allNamespaces =
+    [ Namespace [] ["ServiceClientVersionHandshakeTrace"]
+    , Namespace [] ["ServiceClientVersionHandshakeFailed"]
+    , Namespace [] ["ServiceClientDriverTrace"]
+    , Namespace [] ["ServiceClientSocketClosed"]
+    , Namespace [] ["ServiceClientConnected"]
+    , Namespace [] ["ServiceClientAttemptReconnect"]
+    , Namespace [] ["ServiceClientReceivedKey"]
+    , Namespace [] ["ServiceClientDeclinedKey"]
+    , Namespace [] ["ServiceClientDroppedKey"]
+    , Namespace [] ["ServiceClientOpCertNumberCheck"]
+    , Namespace [] ["ServiceClientAbnormalTermination"]
+    , Namespace [] ["ServiceClientStopped"]
+    ]
+
+instance LogFormatting KESAgentClientTrace where
+  forMachine dtal = \case
+    KESAgentClientException ex -> mconcat
+      [ "kind" .= String "KESAgentClientException"
+      , "exception" .= String (Text.pack $ show ex)
+      ]
+    KESAgentClientTrace t -> mconcat
+      [ "kind" .= String "KESAgentClientTrace"
+      , "trace" .= forMachine dtal t
+      ]
 
   forHuman = showT
 
@@ -2287,12 +2391,15 @@ instance MetaTrace KESAgentClientTrace where
   namespaceFor = \case
     KESAgentClientException _ ->
       Namespace [] ["KESAgentClientException"]
-    KESAgentClientTrace _ ->
-      Namespace [] ["KESAgentClientTrace"]
+    KESAgentClientTrace t -> nsCast $ namespaceFor t
 
-  severityFor = undefined
-  documentFor = undefined
+  severityFor (Namespace [] ["KESAgentClientException"]) _ = Just Error
+  severityFor (Namespace [] ["KESAgentClientTrace"]) _ = Just Info
+  severityFor _ _ = Nothing
+
+  documentFor _ = Nothing
+
   allNamespaces =
-    [ Namespace [] ["KESAgentClientException"]
-    , Namespace [] ["KESAgentClientTrace"]
-    ]
+    Namespace [] ["KESAgentClientException"] :
+    fmap nsCast (allNamespaces :: [Namespace Agent.ServiceClientTrace])
+

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
@@ -471,6 +471,7 @@ nodeToClientVersionToInt = \case
   NodeToClientV_18 -> 18
   NodeToClientV_19 -> 19
   NodeToClientV_20 -> 20
+  NodeToClientV_21 -> 21
 
 nodeToNodeVersionToInt :: NodeToNodeVersion -> Int
 nodeToNodeVersionToInt = \case

--- a/cardano-node/src/Cardano/Node/Types.hs
+++ b/cardano-node/src/Cardano/Node/Types.hs
@@ -16,6 +16,7 @@ module Cardano.Node.Types
   , GenesisFile(..)
   , PeerSnapshotFile (..)
   , CheckpointsFile(..)
+  , KESSource(..)
   , ProtocolFilepaths (..)
   , GenesisHash(..)
   , CheckpointsHash(..)
@@ -164,11 +165,16 @@ class AdjustFilePaths a where
   adjustFilePaths :: (FilePath -> FilePath) -> a -> a
 
 
+data KESSource
+  = KESKeyFilePath FilePath
+  | KESAgentSocketPath FilePath
+  deriving (Eq, Show)
+
 data ProtocolFilepaths =
      ProtocolFilepaths {
        byronCertFile        :: !(Maybe FilePath)
      , byronKeyFile         :: !(Maybe FilePath)
-     , shelleyKESFile       :: !(Maybe FilePath)
+     , shelleyKESSource     :: !(Maybe KESSource)
      , shelleyVRFFile       :: !(Maybe FilePath)
      , shelleyCertFile      :: !(Maybe FilePath)
      , shelleyBulkCredsFile :: !(Maybe FilePath)

--- a/cardano-node/src/Cardano/Tracing/Config.hs
+++ b/cardano-node/src/Cardano/Tracing/Config.hs
@@ -162,6 +162,7 @@ type TraceLocalTxMonitorProtocol = ("TraceLocalTxMonitorProtocol" :: Symbol)
 type TraceLocalTxSubmissionProtocol = ("TraceLocalTxSubmissionProtocol" :: Symbol)
 type TraceLocalTxSubmissionServer = ("TraceLocalTxSubmissionServer" :: Symbol)
 type TraceMempool = ("TraceMempool" :: Symbol)
+type TraceKESAgent = ("TraceKESAgent" :: Symbol)
 type TraceBackingStore = ("TraceBackingStore" :: Symbol)
 type TraceMux = ("TraceMux" :: Symbol)
 type TraceLocalMux = ("TraceLocalMux" :: Symbol)
@@ -242,6 +243,7 @@ data TraceSelection
   , traceLocalTxSubmissionProtocol :: OnOff TraceLocalTxSubmissionProtocol
   , traceLocalTxSubmissionServer :: OnOff TraceLocalTxSubmissionServer
   , traceMempool :: OnOff TraceMempool
+  , traceKESAgent :: OnOff TraceKESAgent
   , traceBackingStore :: OnOff TraceBackingStore
   , traceMux :: OnOff TraceMux
   , tracePeerSelection :: OnOff TracePeerSelection
@@ -312,6 +314,7 @@ data PartialTraceSelection
       , pTraceLocalTxSubmissionProtocol :: Last (OnOff TraceLocalTxSubmissionProtocol)
       , pTraceLocalTxSubmissionServer :: Last (OnOff TraceLocalTxSubmissionServer)
       , pTraceMempool :: Last (OnOff TraceMempool)
+      , pTraceKESAgent :: Last (OnOff TraceKESAgent)
       , pTraceBackingStore :: Last (OnOff TraceBackingStore)
       , pTraceMux :: Last (OnOff TraceMux)
       , pTracePeerSelection :: Last (OnOff TracePeerSelection)
@@ -383,6 +386,7 @@ instance FromJSON PartialTraceSelection where
       <*> parseTracer (Proxy @TraceLocalTxSubmissionProtocol) v
       <*> parseTracer (Proxy @TraceLocalTxSubmissionServer) v
       <*> parseTracer (Proxy @TraceMempool) v
+      <*> parseTracer (Proxy @TraceKESAgent) v
       <*> parseTracer (Proxy @TraceBackingStore) v
       <*> parseTracer (Proxy @TraceMux) v
       <*> parseTracer (Proxy @TracePeerSelection) v
@@ -451,6 +455,7 @@ defaultPartialTraceConfiguration =
     , pTraceLocalTxSubmissionProtocol = pure $ OnOff False
     , pTraceLocalTxSubmissionServer = pure $ OnOff False
     , pTraceMempool = pure $ OnOff True
+    , pTraceKESAgent = pure $ OnOff True
     , pTraceBackingStore = pure $ OnOff False
     , pTraceMux = pure $ OnOff True
     , pTracePeerSelection = pure $ OnOff True
@@ -521,6 +526,7 @@ partialTraceSelectionToEither (Last (Just (PartialTraceDispatcher pTraceSelectio
    traceLocalTxSubmissionProtocol <- proxyLastToEither (Proxy @TraceLocalTxSubmissionProtocol) pTraceLocalTxSubmissionProtocol
    traceLocalTxSubmissionServer <- proxyLastToEither (Proxy @TraceLocalTxSubmissionServer) pTraceLocalTxSubmissionServer
    traceMempool <- proxyLastToEither (Proxy @TraceMempool) pTraceMempool
+   traceKESAgent <- proxyLastToEither (Proxy @TraceKESAgent) pTraceKESAgent
    traceBackingStore <- proxyLastToEither (Proxy @TraceBackingStore) pTraceBackingStore
    traceMux <- proxyLastToEither (Proxy @TraceMux) pTraceMux
    tracePeerSelection <- proxyLastToEither (Proxy @TracePeerSelection) pTracePeerSelection
@@ -584,6 +590,7 @@ partialTraceSelectionToEither (Last (Just (PartialTraceDispatcher pTraceSelectio
              , traceLocalTxSubmissionProtocol = traceLocalTxSubmissionProtocol
              , traceLocalTxSubmissionServer = traceLocalTxSubmissionServer
              , traceMempool = traceMempool
+             , traceKESAgent = traceKESAgent
              , traceBackingStore = traceBackingStore
              , traceMux = traceMux
              , tracePeerSelection = tracePeerSelection
@@ -651,6 +658,7 @@ partialTraceSelectionToEither (Last (Just (PartialTracingOnLegacy pTraceSelectio
   traceLocalTxSubmissionProtocol <- proxyLastToEither (Proxy @TraceLocalTxSubmissionProtocol) pTraceLocalTxSubmissionProtocol
   traceLocalTxSubmissionServer <- proxyLastToEither (Proxy @TraceLocalTxSubmissionServer) pTraceLocalTxSubmissionServer
   traceMempool <- proxyLastToEither (Proxy @TraceMempool) pTraceMempool
+  traceKESAgent <- proxyLastToEither (Proxy @TraceKESAgent) pTraceKESAgent
   traceBackingStore <- proxyLastToEither (Proxy @TraceBackingStore) pTraceBackingStore
   traceMux <- proxyLastToEither (Proxy @TraceMux) pTraceMux
   tracePeerSelection <- proxyLastToEither (Proxy @TracePeerSelection) pTracePeerSelection
@@ -714,6 +722,7 @@ partialTraceSelectionToEither (Last (Just (PartialTracingOnLegacy pTraceSelectio
             , traceLocalTxSubmissionProtocol = traceLocalTxSubmissionProtocol
             , traceLocalTxSubmissionServer = traceLocalTxSubmissionServer
             , traceMempool = traceMempool
+            , traceKESAgent = traceKESAgent
             , traceBackingStore = traceBackingStore
             , traceMux = traceMux
             , tracePeerSelection = tracePeerSelection

--- a/cardano-node/src/Cardano/Tracing/HasIssuer.hs
+++ b/cardano-node/src/Cardano/Tracing/HasIssuer.hs
@@ -11,9 +11,8 @@ module Cardano.Tracing.HasIssuer
   , HasIssuer (..)
   ) where
 
-import           Cardano.Api (serialiseToRawBytes, verificationKeyHash)
+import           Cardano.Api (serialiseToRawBytes, VerificationKey( StakePoolVerificationKey), verificationKeyHash)
 import           Cardano.Api.Byron (VerificationKey (ByronVerificationKey))
-import           Cardano.Api.Shelley (VerificationKey (StakePoolVerificationKey))
 
 import qualified Cardano.Chain.Block as Byron
 import qualified Cardano.Ledger.Shelley.API as Shelley

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -2388,6 +2388,7 @@ instance ToJSON NodeToClientVersion where
   toJSON NodeToClientV_18 = Number 18
   toJSON NodeToClientV_19 = Number 19
   toJSON NodeToClientV_20 = Number 20
+  toJSON NodeToClientV_21 = Number 21
   -- NB: When adding a new version here, update FromJSON below as well!
 
 instance FromJSON NodeToClientVersion where
@@ -2395,6 +2396,8 @@ instance FromJSON NodeToClientVersion where
   parseJSON (Number 17) = return NodeToClientV_17
   parseJSON (Number 18) = return NodeToClientV_18
   parseJSON (Number 19) = return NodeToClientV_19
+  parseJSON (Number 20) = return NodeToClientV_20
+  parseJSON (Number 21) = return NodeToClientV_21
   parseJSON (Number x) = fail ("FromJSON.NodeToClientVersion: unsupported node-to-client protocol version " ++ show x)
   parseJSON x          = fail ("FromJSON.NodeToClientVersion: error parsing NodeToClientVersion: " ++ show x)
 

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Shelley.hs
@@ -20,7 +20,7 @@
 module Cardano.Tracing.OrphanInstances.Shelley () where
 
 import           Cardano.Api (textShow)
-import qualified Cardano.Api.Shelley as Api
+import qualified Cardano.Api as Api
 
 import qualified Cardano.Crypto.Hash.Class as Crypto
 import qualified Cardano.Crypto.VRF.Class as Crypto
@@ -859,9 +859,6 @@ instance
   ) => ToObject (ShelleyNewEpochPredFailure ledgerera) where
   toObject verb (EpochFailure f) = toObject verb f
   toObject verb (MirFailure f) = toObject verb f
-  toObject _verb (CorruptRewardUpdate update) =
-    mconcat [ "kind" .= String "CorruptRewardUpdate"
-             , "update" .= String (textShow update) ]
 
 
 instance
@@ -1326,6 +1323,7 @@ instance ToJSON ShelleyNodeToClientVersion where
   toJSON ShelleyNodeToClientVersion10 = String "ShelleyNodeToClientVersion10"
   toJSON ShelleyNodeToClientVersion11 = String "ShelleyNodeToClientVersion11"
   toJSON ShelleyNodeToClientVersion12 = String "ShelleyNodeToClientVersion12"
+  toJSON ShelleyNodeToClientVersion13 = String "ShelleyNodeToClientVersion13"
 
 instance Core.Crypto c => ToObject (PraosChainSelectView c) where
   toObject _ PraosChainSelectView {

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -553,6 +553,7 @@ mkTracers _ _ _ _ _ enableP2P =
       , Consensus.forgeTracer = nullTracer
       , Consensus.blockchainTimeTracer = nullTracer
       , Consensus.consensusErrorTracer = nullTracer
+      , Consensus.kesAgentTracer = nullTracer
       , Consensus.gsmTracer = nullTracer
       , Consensus.csjTracer = nullTracer
       , Consensus.dbfTracer = nullTracer
@@ -859,6 +860,7 @@ mkConsensusTracers mbEKGDirect trSel verb tr nodeKern fStats = do
           traceWith (toLogObject tr) (readableTraceBlockchainTimeEvent ev)
     , Consensus.consensusErrorTracer =
         Tracer $ \err -> traceWith (toLogObject tr) (ConsensusStartupException err)
+    , Consensus.kesAgentTracer = contramap show $ tracerOnOff (traceKESAgent trSel) verb "KESAgent" tr
     , Consensus.gsmTracer = tracerOnOff (traceGsm trSel) verb "GSM" tr
     , Consensus.csjTracer = tracerOnOff (traceCsj trSel) verb "CSJ" tr
     , Consensus.dbfTracer = tracerOnOff (traceDevotedBlockFetch trSel) verb "DevotedBlockFetch" tr


### PR DESCRIPTION
# Description

WIP: Integrates the KES agent (https://github.com/input-output-hk/kes-agent) functionality into the node. This includes:
- A new command-line flag, `--shelley-kes-agent-socket`, taking a path to a running KES agent socket
- support for the new traces emitted by the KES agent client within consensus

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
