### PR TITLE
cardano-tracer: handle SIGINT same as cardano-node; ignore overflow in Forwarder backend lacking socket config

### DIFF
--- a/cardano-tracer/src/Cardano/Tracer/Run.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Run.hs
@@ -154,8 +154,8 @@ doRunCardanoTracer config rtViewStateDir tr protocolsBrake dpRequestors = do
     traceWith tr TracerShutdownInitiated
 #if RTVIEW
     backupAllHistory tracerEnv tracerEnvRTView
-#endif
     traceWith tr TracerShutdownHistBackup
+#endif
     applyBrake (teProtocolsBrake tracerEnv)
     traceWith tr TracerShutdownComplete
 


### PR DESCRIPTION
# Description

Two commits:
* *cardano-tracer*: Use same signal handler for SIGINT as SIGTERM.
* *trace-dispatcher*: Ignores overflow when there is no socket address specified.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] CI passes. See note on CI.  The following CI checks are required:
  - [X] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [X] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [X] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [X] Self-reviewed the diff
