### PR TITLE
Reverse Dependency: trace-dispatcher no longer depends on trace-forward

### DIFF
--- a/bench/tx-generator/src/Cardano/Benchmarking/Tracer.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Tracer.hs
@@ -48,8 +48,8 @@ import qualified Data.Text as Text
 import           Data.Time.Clock
 import           GHC.Generics
 
-import           Trace.Forward.Utils.DataPoint
 import           Trace.Forward.Utils.TraceObject
+import Trace.Forward.Forwarding (initForwardingDelayed)
 
 pattern TracerNameBench     :: Text
 pattern TracerNameBench     = "Benchmark"
@@ -120,7 +120,7 @@ initTxGenTracers mbForwarding = do
   prepareForwardingTracer = forM mbForwarding $
     \(iomgr, networkId, tracerSocket) -> do
         let forwardingConf = fromMaybe defaultForwarder (tcForwarder initialTraceConfig)
-        (forwardSink :: ForwardSink TraceObject, dpStore, kickoffForwarder) <-
+        (forwardSink, dpStore, kickoffForwarder) <-
             initForwardingDelayed iomgr forwardingConf (toNetworkMagic networkId) Nothing $ Just (tracerSocket, Initiator)
 
         -- we need to provide NodeInfo DataPoint, to forward generator's name
@@ -133,7 +133,7 @@ initTxGenTracers mbForwarding = do
         traceWith nodeInfoTracer genInfo
 
         kickoffForwarder
-        pure $ forwardTracer forwardSink
+        pure $ forwardTracer (writeToSink forwardSink)
 
   prepareGenInfo :: IO NodeInfo
   prepareGenInfo =

--- a/cardano-node/src/Cardano/Node/Tracing/API.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/API.hs
@@ -50,6 +50,8 @@ import           Data.Time.Clock (getCurrentTime)
 import           Network.Mux.Trace (TraceLabelPeer (..))
 import           Network.Socket (HostName)
 import           System.Metrics as EKG
+import Trace.Forward.Forwarding (initForwardingDelayed)
+import Trace.Forward.Utils.TraceObject (writeToSink)
 
 
 initTraceDispatcher ::
@@ -124,7 +126,7 @@ initTraceDispatcher nc p networkMagic nodeKernel p2pMode noBlockForging = do
             let tracerSocketMode = Just . first unFile =<< ncTraceForwardSocket nc
                 forwardingConf = fromMaybe defaultForwarder (tcForwarder trConfig)
             initForwardingDelayed iomgr forwardingConf networkMagic (Just ekgStore) tracerSocketMode
-          pure (forwardTracer forwardSink, dataPointTracer dpStore, kickoffForwarder)
+          pure (forwardTracer (writeToSink forwardSink), dataPointTracer dpStore, kickoffForwarder)
         else
           -- Since 'Forwarder' backend isn't enabled, there is no forwarding.
           -- So we use nullTracers to ignore 'TraceObject's and 'DataPoint's.

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
@@ -73,8 +73,6 @@ import           Data.Proxy (Proxy (..))
 import           Network.Mux.Trace (TraceLabelPeer (..))
 import           Network.Socket (SockAddr)
 
-import           Trace.Forward.Utils.DataPoint (DataPoint)
-
 -- | Construct tracers for all system components.
 --
 mkDispatchTracers

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/ReForwarder.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/ReForwarder.hs
@@ -15,7 +15,7 @@ module Cardano.Tracer.Handlers.ReForwarder
   ( initReForwarder
   ) where
 
-import           Cardano.Logging.Forwarding
+import           Trace.Forward.Forwarding
 import           Cardano.Logging.Trace
 import           Cardano.Logging.Tracer.DataPoint
 import qualified Cardano.Logging.Types as Log
@@ -28,8 +28,8 @@ import           Control.Monad (when)
 import           Data.List (isPrefixOf)
 import qualified Data.Text as Text
 
-import           Trace.Forward.Utils.DataPoint
-import           Trace.Forward.Utils.TraceObject (ForwardSink, writeToSink)
+import           Trace.Forward.Utils.TraceObject (writeToSink)
+import Trace.Forward.Utils.ForwardSink (ForwardSink)
 
 -- | Initialize the reforwarding service if configured to be active.
 --   Returns

--- a/cardano-tracer/test/Cardano/Tracer/Test/Forwarder.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/Forwarder.hs
@@ -63,6 +63,7 @@ import           Trace.Forward.Run.DataPoint.Forwarder
 import           Trace.Forward.Run.TraceObject.Forwarder
 import           Trace.Forward.Utils.DataPoint
 import           Trace.Forward.Utils.TraceObject
+import Trace.Forward.Utils.ForwardSink (ForwardSink)
 
 data ForwardersMode = Initiator | Responder
 

--- a/trace-dispatcher/src/Cardano/Logging.hs
+++ b/trace-dispatcher/src/Cardano/Logging.hs
@@ -7,7 +7,6 @@ import           Cardano.Logging.ConfigurationParser as X
 import           Cardano.Logging.Consistency as X
 import           Cardano.Logging.DocuGenerator as X
 import           Cardano.Logging.Formatter as X
-import           Cardano.Logging.Forwarding as X
 import           Cardano.Logging.FrequencyLimiter as X
 import           Cardano.Logging.Trace as X
 import           Cardano.Logging.TraceDispatcherMessage as X

--- a/trace-dispatcher/src/Cardano/Logging/DocuGenerator.hs
+++ b/trace-dispatcher/src/Cardano/Logging/DocuGenerator.hs
@@ -45,8 +45,6 @@ import           Data.Text.Lazy (toStrict)
 import           Data.Text.Lazy.Builder (Builder, fromString, fromText, singleton)
 import           Data.Time (getZonedTime)
 
-import           Trace.Forward.Utils.DataPoint (DataPoint (..))
-
 type InconsistencyWarning = Text
 
 utf16CircledT :: Text
@@ -351,7 +349,7 @@ docTracer backendConfig = Trace $ TR.arrow $ TR.emit output
 
 docTracerDatapoint :: MonadIO m =>
      BackendConfig
-  -> Trace m DataPoint
+  -> Trace m a
 docTracerDatapoint backendConfig = Trace $ TR.arrow $ TR.emit output
   where
     output p@(_, Left TCDocument {}) =

--- a/trace-dispatcher/src/Cardano/Logging/Tracer/DataPoint.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Tracer/DataPoint.hs
@@ -1,12 +1,13 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE GADTs #-}
 
 module Cardano.Logging.Tracer.DataPoint
   (
     DataPoint (..)
+  , DataPointName
   , DataPointStore
   , initDataPointStore
   , writeToStore
@@ -18,15 +19,14 @@ import           Cardano.Logging.DocuGenerator
 import           Cardano.Logging.Trace
 import           Cardano.Logging.Types
 
-import Control.DeepSeq ( NFData, NFData, deepseq )
-import           Control.Monad.IO.Class
-import qualified Control.Tracer as NT
-import           Data.Text (Text, intercalate)
-
 import           Control.Concurrent.STM (atomically)
 import           Control.Concurrent.STM.TVar
+import           Control.DeepSeq (NFData, deepseq)
+import           Control.Monad.IO.Class
+import qualified Control.Tracer as NT
 import           Data.Aeson
 import qualified Data.Map.Strict as M
+import           Data.Text (Text, intercalate)
 
 ---------------------------------------------------------------------------
 --

--- a/trace-dispatcher/test/Cardano/Logging/Test/Unit/DataPoint.hs
+++ b/trace-dispatcher/test/Cardano/Logging/Test/Unit/DataPoint.hs
@@ -20,9 +20,6 @@ import qualified Data.Map.Strict as M
 import           GHC.Conc
 import           GHC.Generics (Generic)
 
-import           Trace.Forward.Protocol.DataPoint.Type (DataPointName)
-import           Trace.Forward.Utils.DataPoint (DataPoint (..))
-
 
 data BaseStats = BaseStats {
     bsMeasure :: Double,

--- a/trace-dispatcher/trace-dispatcher.cabal
+++ b/trace-dispatcher/trace-dispatcher.cabal
@@ -35,7 +35,7 @@ common project-config
                         -Wno-incomplete-patterns
 
   if impl(ghc >= 9.8)
-    ghc-options:        -Wno-x-partial  
+    ghc-options:        -Wno-x-partial
 
 
 library
@@ -47,7 +47,6 @@ library
                       Cardano.Logging.Consistency
                       Cardano.Logging.DocuGenerator
                       Cardano.Logging.Formatter
-                      Cardano.Logging.Forwarding
                       Cardano.Logging.FrequencyLimiter
                       Cardano.Logging.Prometheus.Exposition
                       Cardano.Logging.Prometheus.NetworkRun
@@ -94,7 +93,6 @@ library
                       , text
                       , time
                       , time-manager
-                      , trace-forward
                       , unagi-chan >= 0.4.1.4
                       , unix-compat
                       , unliftio
@@ -146,7 +144,6 @@ test-suite trace-dispatcher-test
                       , tasty-quickcheck
                       , time
                       , trace-dispatcher
-                      , trace-forward
                       , unagi-chan
                       , unliftio
                       , unliftio-core

--- a/trace-forward/src/Trace/Forward/Configuration/DataPoint.hs
+++ b/trace-forward/src/Trace/Forward/Configuration/DataPoint.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PackageImports #-}
+
 module Trace.Forward.Configuration.DataPoint
   ( AcceptorConfiguration (..)
   , ForwarderConfiguration (..)
@@ -6,7 +8,7 @@ module Trace.Forward.Configuration.DataPoint
 import           Ouroboros.Network.Driver (TraceSendRecv)
 
 import           Control.Concurrent.STM.TVar (TVar)
-import           Control.Tracer (Tracer)
+import           "contra-tracer" Control.Tracer (Tracer)
 
 import           Trace.Forward.Protocol.DataPoint.Type
 

--- a/trace-forward/src/Trace/Forward/Configuration/TraceObject.hs
+++ b/trace-forward/src/Trace/Forward/Configuration/TraceObject.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PackageImports #-}
+
 module Trace.Forward.Configuration.TraceObject
   ( AcceptorConfiguration (..)
   , ForwarderConfiguration (..)
@@ -6,7 +8,7 @@ module Trace.Forward.Configuration.TraceObject
 import           Ouroboros.Network.Driver (TraceSendRecv)
 
 import           Control.Concurrent.STM.TVar (TVar)
-import           Control.Tracer (Tracer)
+import           "contra-tracer" Control.Tracer (Tracer)
 
 import           Trace.Forward.Protocol.TraceObject.Type
 

--- a/trace-forward/src/Trace/Forward/Forwarding.hs
+++ b/trace-forward/src/Trace/Forward/Forwarding.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE PackageImports #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Cardano.Logging.Forwarding
+module Trace.Forward.Forwarding
   (
     initForwarding
   , initForwardingDelayed
@@ -52,6 +52,7 @@ import           Trace.Forward.Run.DataPoint.Forwarder
 import           Trace.Forward.Run.TraceObject.Forwarder
 import           Trace.Forward.Utils.DataPoint
 import           Trace.Forward.Utils.TraceObject
+import Trace.Forward.Utils.ForwardSink (ForwardSink)
 
 initForwarding :: forall m. (MonadIO m)
   => IOManager

--- a/trace-forward/src/Trace/Forward/Protocol/DataPoint/Type.hs
+++ b/trace-forward/src/Trace/Forward/Protocol/DataPoint/Type.hs
@@ -18,13 +18,13 @@ module Trace.Forward.Protocol.DataPoint.Type
   , SingDataPointForward (..)
   ) where
 
-import           Data.Singletons
-import           Network.TypedProtocol.Core
+import           Cardano.Logging.Tracer.DataPoint (DataPointName)
 import           Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
 
 import qualified Data.ByteString.Lazy as LBS
 import           Data.Kind (Type)
-import           Data.Text (Text)
+import           Data.Singletons
+import           Network.TypedProtocol.Core
 
 -- | A kind to identify our protocol, and the types of the states in the state
 -- transition diagram of the protocol.
@@ -41,7 +41,6 @@ import           Data.Text (Text)
 --    After the connection is established, the acceptor asks for 'DataPoint's,
 --    the forwarder replies to it.
 
-type DataPointName   = Text
 type DataPointValue  = LBS.ByteString
 type DataPointValues = [(DataPointName, Maybe DataPointValue)]
 

--- a/trace-forward/src/Trace/Forward/Run/TraceObject/Forwarder.hs
+++ b/trace-forward/src/Trace/Forward/Run/TraceObject/Forwarder.hs
@@ -18,6 +18,7 @@ import           Trace.Forward.Configuration.TraceObject (ForwarderConfiguration
 import qualified Trace.Forward.Protocol.TraceObject.Codec as Forwarder
 import qualified Trace.Forward.Protocol.TraceObject.Forwarder as Forwarder
 import           Trace.Forward.Utils.TraceObject
+import Trace.Forward.Utils.ForwardSink (ForwardSink)
 
 forwardTraceObjectsInit
   :: (CBOR.Serialise lo,

--- a/trace-forward/src/Trace/Forward/Utils/DataPoint.hs
+++ b/trace-forward/src/Trace/Forward/Utils/DataPoint.hs
@@ -17,40 +17,12 @@ module Trace.Forward.Utils.DataPoint
 import           Control.Concurrent.STM (atomically, check, orElse)
 import           Control.Concurrent.STM.TMVar
 import           Control.Concurrent.STM.TVar
-import           Control.DeepSeq (NFData, deepseq)
 import           Data.Aeson
 import qualified Data.Map.Strict as M
 
+import Cardano.Logging.Tracer.DataPoint
 import           Trace.Forward.Protocol.DataPoint.Forwarder
 import           Trace.Forward.Protocol.DataPoint.Type
-
--- | Type wrapper for some value of type 'v'. The only reason we need this
---   wrapper is an ability to store different values in the same 'DataPointStore'.
---
---   Please note that when the acceptor application will read the value of type 'v'
---   from the store, this value is just as unstructured JSON, but not Haskell
---   value of type 'v'. That's why 'FromJSON' instance for type 'v' should be
---   available for the acceptor application, to decode unstructured JSON.
---
-data DataPoint where
-  DataPoint :: (ToJSON v, NFData v) => v -> DataPoint
-
-type DataPointStore = TVar (M.Map DataPointName DataPoint)
-
-initDataPointStore :: IO DataPointStore
-initDataPointStore = newTVarIO M.empty
-
--- | Write 'DataPoint' to the store.
-writeToStore
-  :: DataPointStore
-  -> DataPointName
-  -> DataPoint
-  -> IO ()
-writeToStore dpStore dpName (DataPoint obj) = atomically $
-  modifyTVar' dpStore $ \store ->
-    if dpName `M.member` store
-      then M.adjust (const (DataPoint (deepseq obj obj))) dpName store
-      else M.insert dpName (DataPoint (deepseq obj obj)) store
 
 -- | Read 'DataPoint's from the store. Please note that we don't care what's
 --   inside of 'DataPoint', we just know it can be encoded to JSON.

--- a/trace-forward/src/Trace/Forward/Utils/ForwardSink.hs
+++ b/trace-forward/src/Trace/Forward/Utils/ForwardSink.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+
+module Trace.Forward.Utils.ForwardSink
+  ( ForwardSink (..)
+  ) where
+
+import           Control.Concurrent.STM.TBQueue
+import           Control.Concurrent.STM.TVar
+
+data ForwardSink lo = ForwardSink
+  { forwardQueue     :: !(TVar (TBQueue lo))
+  , disconnectedSize :: !Word
+  , connectedSize    :: !Word
+  , wasUsed          :: !(TVar Bool)
+  , overflowCallback :: !([lo] -> IO ())
+  }

--- a/trace-forward/src/Trace/Forward/Utils/TraceObject.hs
+++ b/trace-forward/src/Trace/Forward/Utils/TraceObject.hs
@@ -4,8 +4,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 
 module Trace.Forward.Utils.TraceObject
-  ( ForwardSink (..)
-  , initForwardSink
+  ( initForwardSink
   , writeToSink
   , readFromSink
   , getTraceObjectsFromReply
@@ -22,15 +21,8 @@ import           Data.Word (Word16)
 import           Trace.Forward.Configuration.TraceObject
 import qualified Trace.Forward.Protocol.TraceObject.Forwarder as Forwarder
 import           Trace.Forward.Protocol.TraceObject.Type
+import Trace.Forward.Utils.ForwardSink (ForwardSink(..))
 
-
-data ForwardSink lo = ForwardSink
-  { forwardQueue     :: !(TVar (TBQueue lo))
-  , disconnectedSize :: !Word
-  , connectedSize    :: !Word
-  , wasUsed          :: !(TVar Bool)
-  , overflowCallback :: !([lo] -> IO ())
-  }
 
 initForwardSink
   :: ForwarderConfiguration lo

--- a/trace-forward/trace-forward.cabal
+++ b/trace-forward/trace-forward.cabal
@@ -43,6 +43,7 @@ library
                         Trace.Forward.Protocol.TraceObject.Codec
                         Trace.Forward.Protocol.TraceObject.Forwarder
                         Trace.Forward.Protocol.TraceObject.Type
+                        Trace.Forward.Forwarding
 
                         Trace.Forward.Run.DataPoint.Acceptor
                         Trace.Forward.Run.DataPoint.Forwarder
@@ -54,6 +55,7 @@ library
 
                         Trace.Forward.Utils.DataPoint
                         Trace.Forward.Utils.TraceObject
+                        Trace.Forward.Utils.ForwardSink
 
   build-depends:        aeson
                       , async
@@ -61,11 +63,12 @@ library
                       , cborg
                       , containers
                       , contra-tracer
-                      , deepseq
                       , extra
                       , io-classes
                       , network-mux
                       , ouroboros-network-api
+                      , ekg-core
+                      , ekg-forward
                       , singletons ^>= 3.0
                       , ouroboros-network-framework ^>= 0.18.0.1
                       , serialise
@@ -73,6 +76,7 @@ library
                       , text
                       , typed-protocols ^>= 0.3
                       , typed-protocols-cborg
+                      , trace-dispatcher
 
 test-suite test
   import:               project-config
@@ -85,6 +89,7 @@ test-suite test
                         Test.Trace.Forward.Protocol.TraceObject.Examples
                         Test.Trace.Forward.Protocol.TraceObject.Item
                         Test.Trace.Forward.Protocol.TraceObject.Tests
+                        Trace.Forward.Forwaring
 
                         Test.Trace.Forward.Protocol.DataPoint.Codec
                         Test.Trace.Forward.Protocol.DataPoint.Direct
@@ -108,6 +113,8 @@ test-suite test
                       , tasty-quickcheck
                       , typed-protocols
                       , text
+                      , ekg-core
+                      , ekg-forward
 
   ghc-options:          -rtsopts
                         -threaded

--- a/trace-forward/trace-forward.cabal
+++ b/trace-forward/trace-forward.cabal
@@ -73,7 +73,6 @@ library
                       , ouroboros-network-framework ^>= 0.18.0.1
                       , serialise
                       , stm
-                      , text
                       , typed-protocols ^>= 0.3
                       , typed-protocols-cborg
                       , trace-dispatcher
@@ -89,7 +88,6 @@ test-suite test
                         Test.Trace.Forward.Protocol.TraceObject.Examples
                         Test.Trace.Forward.Protocol.TraceObject.Item
                         Test.Trace.Forward.Protocol.TraceObject.Tests
-                        Trace.Forward.Forwaring
 
                         Test.Trace.Forward.Protocol.DataPoint.Codec
                         Test.Trace.Forward.Protocol.DataPoint.Direct
@@ -113,8 +111,6 @@ test-suite test
                       , tasty-quickcheck
                       , typed-protocols
                       , text
-                      , ekg-core
-                      , ekg-forward
 
   ghc-options:          -rtsopts
                         -threaded


### PR DESCRIPTION
This PR decouples `trace-dispatcher` from `trace-forward`, thereby removing its dependency on network-related libraries and Cardano-specific modules.


### Motivation

Previously, `trace-dispatcher` depended on `trace-forward`, which in turn pulled in `network` and a substantial portion of the Cardano ecosystem. This entanglement made it cumbersome to use `trace-dispatcher` in simpler or non-Cardano settings.

### What Changed

* Removed the direct dependency on `trace-forward`
* Refactored or restructured any modules or types that required it
* Ensured that `trace-dispatcher` remains focused on its core responsibility: **dispatching traces**, not networking

### Benefits

* **Lighter dependency footprint**
* **Easier reuse** of `trace-dispatcher` in new projects or different ecosystems
* Paves the way for more modular and maintainable tracing infrastructure
