### PR TITLE
Change to allowList for release bins and add tx-generator

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -74,8 +74,9 @@
     utils,
     ...
   } @ input: let
+    inherit (builtins) elem match;
     inherit (nixpkgs) lib;
-    inherit (lib) head mapAttrs recursiveUpdate optionalAttrs;
+    inherit (lib) collect getAttr genAttrs filterAttrs hasPrefix head isDerivation mapAttrs optionalAttrs optionals recursiveUpdate ;
     inherit (utils.lib) eachSystem flattenTree;
     inherit (iohkNix.lib) prefixNamesWith;
     removeRecurse = lib.filterAttrsRecursive (n: _: n != "recurseForDerivations");
@@ -135,20 +136,20 @@
         # have no git revision but for the same compilation alternative.
         cardano-node =
           let node = project.exes.cardano-node;
-          in lib.recursiveUpdate
+          in recursiveUpdate
                (set-git-rev node)
                {passthru = {noGitRev = node;};}
         ;
         cardano-cli =
           let cli = cardano-cli.components.exes.cardano-cli;
-          in lib.recursiveUpdate
+          in recursiveUpdate
                (set-git-rev cli)
                {passthru = {noGitRev = cli;};}
         ;
       } // optionalAttrs (project.exes ? tx-generator) {
         tx-generator =
           let tx-gen = project.exes.tx-generator;
-          in lib.recursiveUpdate
+          in recursiveUpdate
                (set-git-rev tx-gen)
                {passthru = {noGitRev = tx-gen;};}
         ;
@@ -278,7 +279,7 @@
         // (prefixNamesWith "checks/" checks);
 
       apps =
-        lib.mapAttrs (n: p: {
+        mapAttrs (n: p: {
           type = "app";
           program =
             p.exePath
@@ -325,11 +326,11 @@
                   roots.project = project.roots;
                   plan-nix.project = project.plan-nix;
                 };
-                profiled = lib.genAttrs ["cardano-node" "tx-generator" "locli"] (
+                profiled = genAttrs ["cardano-node" "tx-generator" "locli"] (
                   n:
                     packages.${n}.passthru.profiled
                 );
-                asserted = lib.genAttrs ["cardano-node"] (
+                asserted = genAttrs ["cardano-node"] (
                   n:
                     packages.${n}.passthru.asserted
                 );
@@ -345,8 +346,8 @@
                   inherit pkgs;
                   inherit (exes.cardano-node.identifier) version;
                   platform = "linux";
-                  exes = lib.collect lib.isDerivation (
-                    lib.filterAttrs (n: _: builtins.elem n releaseBins) projectExes
+                  exes = collect isDerivation (
+                    filterAttrs (n: _: elem n releaseBins) projectExes
                   );
                 };
                 internal.roots.project = muslProject.roots;
@@ -363,8 +364,8 @@
                   inherit pkgs;
                   inherit (exes.cardano-node.identifier) version;
                   platform = "win64";
-                  exes = lib.collect lib.isDerivation (
-                    lib.filterAttrs (n: _: builtins.elem n releaseBins) projectExes
+                  exes = collect isDerivation (
+                    filterAttrs (n: _: elem n releaseBins) projectExes
                   );
                 };
                 internal.roots.project = windowsProject.roots;
@@ -373,18 +374,18 @@
           }
           // optionalAttrs (system == "x86_64-darwin") {
             native =
-              lib.filterAttrs
+              filterAttrs
               (n: _:
                 # Only build docker images once on linux:
-                  !(lib.hasPrefix "dockerImage" n))
+                  !(hasPrefix "dockerImage" n))
               packages
               // {
                 cardano-node-macos = import ./nix/binary-release.nix {
                   inherit pkgs;
                   inherit (exes.cardano-node.identifier) version;
                   platform = "macos";
-                  exes = lib.collect lib.isDerivation (
-                    lib.filterAttrs (n: _: builtins.elem n releaseBins) (collectExes project)
+                  exes = collect isDerivation (
+                    filterAttrs (n: _: elem n releaseBins) (collectExes project)
                   );
                 };
                 shells = removeAttrs devShells ["profiled"];
@@ -405,7 +406,7 @@
             # system-tests are build and run separately:
             "native\\.(.*\\.)?system-tests"
           ]
-          ++ lib.optionals (system == "x86_64-darwin") [
+          ++ optionals (system == "x86_64-darwin") [
             # FIXME: make variants nonrequired for macos until CI has more capacity for macos builds
             "native\\.variants\\..*"
             "native\\.checks/cardano-testnet/cardano-testnet-test"
@@ -414,7 +415,7 @@
         pkgs.callPackages iohkNix.utils.ciJobsAggregates
         {
           inherit ciJobs;
-          nonRequiredPaths = map (r: p: builtins.match r p != null) nonRequiredPaths;
+          nonRequiredPaths = map (r: p: match r p != null) nonRequiredPaths;
         }
         // ciJobs;
     };
@@ -462,7 +463,7 @@
           inherit
             (pkgs.callPackages iohkNix.utils.ciJobsAggregates {
               ciJobs =
-                lib.mapAttrs (_: lib.getAttr "required") flake.ciJobs
+                mapAttrs (_: getAttr "required") flake.ciJobs
                 // {
                   # Ensure hydra notify:
                   gitrev = pkgs.writeText "gitrev" pkgs.gitrev;

--- a/flake.nix
+++ b/flake.nix
@@ -129,7 +129,7 @@
         # Add some executables from other relevant packages
         inherit (bech32.components.exes) bech32;
         inherit (ouroboros-consensus-cardano.components.exes) db-analyser db-synthesizer db-truncater snapshot-converter;
-        # Add cardano-node and cardano-cli with their git revision stamp.
+        # Add cardano-node, cardano-cli and tx-generator with their git revision stamp.
         # Keep available an alternative without the git revision, like the other
         # passthru (profiled and asserted in nix/haskell.nix) that
         # have no git revision but for the same compilation alternative.
@@ -140,10 +140,17 @@
                {passthru = {noGitRev = node;};}
         ;
         cardano-cli =
-          let cli  = cardano-cli.components.exes.cardano-cli;
+          let cli = cardano-cli.components.exes.cardano-cli;
           in lib.recursiveUpdate
                (set-git-rev cli)
                {passthru = {noGitRev = cli;};}
+        ;
+      } // optionalAttrs (project.exes ? tx-generator) {
+        tx-generator =
+          let tx-gen = project.exes.tx-generator;
+          in lib.recursiveUpdate
+               (set-git-rev tx-gen)
+               {passthru = {noGitRev = tx-gen;};}
         ;
       });
 
@@ -457,7 +464,7 @@
             customConfig.haskellNix
           ];
         cardanoNodePackages = mkCardanoNodePackages final.cardanoNodeProject;
-        inherit (final.cardanoNodePackages) cardano-node cardano-cli cardano-submit-api cardano-tracer bech32 locli db-analyser;
+        inherit (final.cardanoNodePackages) cardano-node cardano-cli cardano-submit-api cardano-tracer bech32 locli db-analyser tx-generator;
       };
       nixosModules = {
         cardano-node = {

--- a/flake.nix
+++ b/flake.nix
@@ -323,16 +323,7 @@
                   inherit pkgs;
                   inherit (exes.cardano-node.identifier) version;
                   platform = "linux";
-                  exes = lib.collect lib.isDerivation (
-                    # FIXME: restore tx-generator and gen-plutus once
-                    #        plutus-scripts-bench is fixed for musl
-                    #
-                    # It stands to question though, whether or not we want those to be
-                    # in the cardano-node-linux as executables anyway?
-                    #
-                    # Also explicitly excluded from musl in nix/haskell.nix.
-                    removeAttrs projectExes ["tx-generator" "gen-plutus"]
-                  );
+                  exes = lib.collect lib.isDerivation projectExes;
                 };
                 internal.roots.project = muslProject.roots;
                 variants = mapAttrs (_: v: removeAttrs v.musl ["variants"]) ciJobsVariants;
@@ -385,9 +376,6 @@
             "windows\\.(.*\\.)?checks\\.cardano-tracer\\.cardano-tracer-test"
             # FIXME: plutus-scripts-bench (dep of tx-generator) does not compile for windows:
             "windows\\.(.*\\.)?tx-generator.*"
-            # FIXME: plutus-scripts-bench's gen-plutus does not compile for musl
-            "musl\\.(.*\\.)?tx-generator.*"
-            "musl\\.(.*\\.)?gen-plutus.*"
             # hlint required status is controlled via the github action:
             "native\\.(.*\\.)?checks/hlint"
             # system-tests are build and run separately:

--- a/flake.nix
+++ b/flake.nix
@@ -339,10 +339,7 @@
                   inherit pkgs;
                   inherit (exes.cardano-node.identifier) version;
                   platform = "win64";
-                  exes = lib.collect lib.isDerivation (
-                    # FIXME: restore tx-generator once plutus-scripts-bench is fixed for windows:
-                    removeAttrs projectExes ["tx-generator"]
-                  );
+                  exes = lib.collect lib.isDerivation projectExes;
                 };
                 internal.roots.project = windowsProject.roots;
                 variants = mapAttrs (_: v: removeAttrs v.windows ["variants"]) ciJobsVariants;
@@ -374,8 +371,6 @@
           [
             # FIXME: cardano-tracer-test for windows should probably be disabled in haskell.nix config:
             "windows\\.(.*\\.)?checks\\.cardano-tracer\\.cardano-tracer-test"
-            # FIXME: plutus-scripts-bench (dep of tx-generator) does not compile for windows:
-            "windows\\.(.*\\.)?tx-generator.*"
             # hlint required status is controlled via the github action:
             "native\\.(.*\\.)?checks/hlint"
             # system-tests are build and run separately:

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -126,7 +126,6 @@ let
             packages.cardano-node-chairman.components.tests.chairman-tests.buildable = lib.mkForce pkgs.stdenv.hostPlatform.isUnix;
             package-keys = ["plutus-tx-plugin"];
             packages.plutus-tx-plugin.components.library.platforms = with lib.platforms; [ linux darwin ];
-            packages.tx-generator.package.buildable = with pkgs.stdenv.hostPlatform; !isMusl;
 
             packages.fs-api.components.library.doHaddock = false;
             packages.cardano-ledger-allegra.components.library.doHaddock = false;

--- a/nix/nixos/tx-generator-service.nix
+++ b/nix/nixos/tx-generator-service.nix
@@ -57,7 +57,8 @@ in pkgs.commonLib.defServiceModule
 
       svcPackageSelector =
         pkgs: ## Local:
-              pkgs.cardanoNodePackages.tx-generator
+              ## Avoid rebuilding on every commit because of `set-git-rev`.
+              pkgs.cardanoNodePackages.tx-generator.passthru.noGitRev
               ## Imported by another repo, that adds an overlay:
                 or pkgs.tx-generator;
               ## TODO:  that's actually a bit ugly and could be improved.

--- a/nix/workbench/backend/nomad.nix
+++ b/nix/workbench/backend/nomad.nix
@@ -166,9 +166,9 @@ let
       };
       tx-generator = rec {
         # Local reference only used if not "cloud".
-        nix-store-path = pkgs.cardanoNodePackages.tx-generator;
+        nix-store-path = pkgs.cardanoNodePackages.tx-generator.passthru.noGitRev;
         flake-reference = "github:intersectmbo/cardano-node";
-        flake-output = "cardanoNodePackages.tx-generator";
+        flake-output = "cardanoNodePackages.tx-generator.passthru.noGitRev";
       };
     }
   ;

--- a/nix/workbench/shell.nix
+++ b/nix/workbench/shell.nix
@@ -144,7 +144,7 @@ project.shellFor {
        cardano-topology
        cardano-tracer
        locli
-       tx-generator
+       tx-generator.passthru.noGitRev
      ]
   # Include the workbench as a derivation or use the sources directly ?
   ++ lib.optionals (!workbenchDevMode) [ workbench.workbench ]


### PR DESCRIPTION
# Description

This PR adds `tx-generator` and removes several release binaries.
To do so, musl builds needed to be added and git hash stamping was applied to set commit version in the binary.
Workbench use of tx-generator was changed to a passthru noGitRev package version to avoid redundant building of the same source because of differing commit hash.

Release bin filtering was changed from a denyList to an acceptList  approach to avoid inclusion creep if the denyList isn't maintained.

# Checklist
- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] CI passes. See note on CI.  The following CI checks are required:
- [X] Self-reviewed the diff