### PR TITLE
Extend artifact and edge nixosTests w/ cardano-tracer

### DIFF
--- a/nix/nixos/tests/cardano-node-artifact.nix
+++ b/nix/nixos/tests/cardano-node-artifact.nix
@@ -24,7 +24,7 @@
       };
 
       preStart = ''
-        mkdir config
+        mkdir -p /run/cardano-node
         cp -v /opt/cardano-node-linux/share/${env}/* ./
       '';
 
@@ -34,7 +34,25 @@
           --topology topology.json \
           --database-path db \
           --socket-path node.socket \
+          --tracer-socket-path-connect /tmp/tracer.socket \
           --port 3001
+      '';
+    };
+
+    "cardano-tracer-${env}" = {
+      serviceConfig = {
+        WorkingDirectory = "/var/lib/cardano-tracer-${env}";
+        StateDirectory = "cardano-tracer-${env}";
+      };
+
+      preStart = ''
+        cp -v /opt/cardano-node-linux/share/${env}/* ./
+      '';
+
+      script = ''
+        /opt/cardano-node-linux/bin/cardano-tracer \
+          --config tracer-config.json \
+          --state-dir /var/lib/cardano-tracer
       '';
     };
   };
@@ -42,18 +60,41 @@
   # Only newer nixpkgs have have timeout args for all wait_for_.* fns.
   # Use the generic wait_until_succeeds w/ timeout arg until nixpkgs is bumped.
   mkScriptTest = env: ''
-    machine.systemctl("start cardano-node-${env}")
+    # Cardano-tracer startup
+    machine.systemctl("start cardano-tracer-${env}.service")
+    machine.wait_for_unit("cardano-tracer-${env}.service", timeout=${timeout})
+    machine.wait_until_succeeds("[ -S /tmp/tracer.socket ]", timeout=${timeout})
+    machine.wait_until_succeeds("nc -z localhost 12808", timeout=${timeout})
+    print(machine.succeed("cat /var/lib/cardano-tracer-${env}/tracer-config.json"))
+
+    # Cardano-node startup
+    machine.systemctl("start cardano-node-${env}.service")
+    machine.wait_for_unit("cardano-node-${env}.service", timeout=${timeout})
     machine.wait_until_succeeds("[ -S /var/lib/cardano-node-${env}/node.socket ]", timeout=${timeout})
     machine.wait_until_succeeds("nc -z localhost 12798", timeout=${timeout})
     machine.wait_until_succeeds("nc -z localhost 3001", timeout=${timeout})
+    print(machine.succeed("cat /var/lib/cardano-node-${env}/config.json"))
+
+    # Cardano-node tests
+    machine.succeed("systemctl status cardano-node-${env}.service")
     out = machine.succeed(
       "${getExe cardano-cli} ping -h 127.0.0.1 -c 1 -m ${getMagic env} -q --json | ${getExe jq} -c"
     )
     print("ping ${env}:", out)
-    machine.succeed("systemctl status cardano-node-${env}")
+
+    # Cardano-tracer tests
+    machine.succeed("systemctl status cardano-tracer-${env}.service")
+    machine.succeed("[ -s /tmp/cardano-tracer/machine_3001/node.log ]")
+
+    # Cardano-node stop
     machine.succeed("systemctl stop cardano-node-${env}")
     machine.wait_until_fails("nc -z localhost 12798", timeout=${timeout})
     machine.wait_until_fails("nc -z localhost 3001", timeout=${timeout})
+
+    # Cardano-tracer stop
+    machine.succeed("systemctl stop cardano-tracer-${env}")
+    machine.wait_until_fails("nc -z localhost 12808", timeout=${timeout})
+    print(machine.succeed("rm -rfv /tmp/cardano-tracer /tmp/tracer.socket"))
   '';
 in {
   name = "cardano-node-artifact-test";


### PR DESCRIPTION
# Description

* Adds cardano tracer basic startup and connect tests to hydra job `checks/nixosTests/cardanoNodeArtifact`
* Adds cardano tracer basic startup and connect tests to hydra job `checks/nixosTests/cardanoNodeEdge`

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] New tests are added if needed and existing tests are updated.  This includes:
  - `.#checks/nixosTests/cardanoNodeArtifact`
  - `.#checks/nixosTests/cardanoNodeEdge`
- [X] CI passes. See note on CI.  The following CI checks are required:
- [X] Self-reviewed the diff