### PR TITLE
Hotfix - Cleanup release bins

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -292,12 +292,27 @@
         exes;
 
       ciJobs = let
+        releaseBins = [
+          "bech32"
+          "cardano-cli"
+          "cardano-node"
+          "cardano-submit-api"
+          "cardano-testnet"
+          "cardano-tracer"
+          "db-analyser"
+          "db-synthesizer"
+          "db-truncater"
+          "snapshot-converter"
+          "tx-generator"
+        ];
+
         ciJobsVariants =
           mapAttrs (
             _: p:
               (mkFlakeAttrs (pkgs.extend (prev: final: {cardanoNodeProject = p;}))).ciJobs
           )
           project.projectVariants;
+
         ciJobs =
           {
             cardano-deployment = pkgs.cardanoLib.mkConfigHtml {inherit (pkgs.cardanoLib.environments) mainnet preview preprod;};
@@ -331,7 +346,9 @@
                   inherit pkgs;
                   inherit (exes.cardano-node.identifier) version;
                   platform = "linux";
-                  exes = lib.collect lib.isDerivation projectExes;
+                  exes = lib.collect lib.isDerivation (
+                    lib.filterAttrs (n: _: builtins.elem n releaseBins) projectExes
+                  );
                 };
                 internal.roots.project = muslProject.roots;
                 variants = mapAttrs (_: v: removeAttrs v.musl ["variants"]) ciJobsVariants;
@@ -347,7 +364,9 @@
                   inherit pkgs;
                   inherit (exes.cardano-node.identifier) version;
                   platform = "win64";
-                  exes = lib.collect lib.isDerivation projectExes;
+                  exes = lib.collect lib.isDerivation (
+                    lib.filterAttrs (n: _: builtins.elem n releaseBins) projectExes
+                  );
                 };
                 internal.roots.project = windowsProject.roots;
                 variants = mapAttrs (_: v: removeAttrs v.windows ["variants"]) ciJobsVariants;
@@ -365,7 +384,9 @@
                   inherit pkgs;
                   inherit (exes.cardano-node.identifier) version;
                   platform = "macos";
-                  exes = lib.collect lib.isDerivation (collectExes project);
+                  exes = lib.collect lib.isDerivation (
+                    lib.filterAttrs (n: _: builtins.elem n releaseBins) (collectExes project)
+                  );
                 };
                 shells = removeAttrs devShells ["profiled"];
                 internal = {
@@ -375,6 +396,7 @@
                 variants = mapAttrs (_: v: removeAttrs v.native ["variants"]) ciJobsVariants;
               };
           };
+
         nonRequiredPaths =
           [
             # FIXME: cardano-tracer-test for windows should probably be disabled in haskell.nix config:

--- a/flake.nix
+++ b/flake.nix
@@ -340,10 +340,7 @@
                   inherit pkgs;
                   inherit (exes.cardano-node.identifier) version;
                   platform = "win64";
-                  exes = lib.collect lib.isDerivation (
-                    # FIXME: restore tx-generator once plutus-scripts-bench is fixed for windows:
-                    removeAttrs projectExes ["tx-generator"]
-                  );
+                  exes = lib.collect lib.isDerivation projectExes;
                 };
                 internal.roots.project = windowsProject.roots;
                 variants = mapAttrs (_: v: removeAttrs v.windows ["variants"]) ciJobsVariants;
@@ -375,8 +372,6 @@
           [
             # FIXME: cardano-tracer-test for windows should probably be disabled in haskell.nix config:
             "windows\\.(.*\\.)?checks\\.cardano-tracer\\.cardano-tracer-test"
-            # FIXME: plutus-scripts-bench (dep of tx-generator) does not compile for windows:
-            "windows\\.(.*\\.)?tx-generator.*"
             # hlint required status is controlled via the github action:
             "native\\.(.*\\.)?checks/hlint"
             # system-tests are build and run separately:

--- a/flake.nix
+++ b/flake.nix
@@ -324,16 +324,7 @@
                   inherit pkgs;
                   inherit (exes.cardano-node.identifier) version;
                   platform = "linux";
-                  exes = lib.collect lib.isDerivation (
-                    # FIXME: restore tx-generator and gen-plutus once
-                    #        plutus-scripts-bench is fixed for musl
-                    #
-                    # It stands to question though, whether or not we want those to be
-                    # in the cardano-node-linux as executables anyway?
-                    #
-                    # Also explicitly excluded from musl in nix/haskell.nix.
-                    removeAttrs projectExes ["tx-generator" "gen-plutus"]
-                  );
+                  exes = lib.collect lib.isDerivation projectExes;
                 };
                 internal.roots.project = muslProject.roots;
                 variants = mapAttrs (_: v: removeAttrs v.musl ["variants"]) ciJobsVariants;
@@ -386,9 +377,6 @@
             "windows\\.(.*\\.)?checks\\.cardano-tracer\\.cardano-tracer-test"
             # FIXME: plutus-scripts-bench (dep of tx-generator) does not compile for windows:
             "windows\\.(.*\\.)?tx-generator.*"
-            # FIXME: plutus-scripts-bench's gen-plutus does not compile for musl
-            "musl\\.(.*\\.)?tx-generator.*"
-            "musl\\.(.*\\.)?gen-plutus.*"
             # hlint required status is controlled via the github action:
             "native\\.(.*\\.)?checks/hlint"
             # system-tests are build and run separately:

--- a/flake.nix
+++ b/flake.nix
@@ -131,7 +131,7 @@
         # Add some executables from other relevant packages
         inherit (bech32.components.exes) bech32;
         inherit (ouroboros-consensus-cardano.components.exes) db-analyser db-synthesizer db-truncater snapshot-converter;
-        # Add cardano-node and cardano-cli with their git revision stamp.
+        # Add cardano-node, cardano-cli and tx-generator with their git revision stamp.
         # Keep available an alternative without the git revision, like the other
         # passthru (profiled and asserted in nix/haskell.nix) that
         # have no git revision but for the same compilation alternative.
@@ -142,10 +142,17 @@
                {passthru = {noGitRev = node;};}
         ;
         cardano-cli =
-          let cli  = cardano-cli.components.exes.cardano-cli;
+          let cli = cardano-cli.components.exes.cardano-cli;
           in lib.recursiveUpdate
                (set-git-rev cli)
                {passthru = {noGitRev = cli;};}
+        ;
+      } // optionalAttrs (project.exes ? tx-generator) {
+        tx-generator =
+          let tx-gen = project.exes.tx-generator;
+          in lib.recursiveUpdate
+               (set-git-rev tx-gen)
+               {passthru = {noGitRev = tx-gen;};}
         ;
       });
 
@@ -458,7 +465,7 @@
             customConfig.haskellNix
           ];
         cardanoNodePackages = mkCardanoNodePackages final.cardanoNodeProject;
-        inherit (final.cardanoNodePackages) cardano-node cardano-cli cardano-submit-api cardano-tracer bech32 locli db-analyser;
+        inherit (final.cardanoNodePackages) cardano-node cardano-cli cardano-submit-api cardano-tracer bech32 locli db-analyser tx-generator;
       };
       nixosModules = {
         cardano-node = {

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -116,7 +116,6 @@ let
           ({ lib, pkgs, ... }: {
             packages.cardano-node-chairman.components.tests.chairman-tests.buildable = lib.mkForce pkgs.stdenv.hostPlatform.isUnix;
             packages.plutus-tx-plugin.components.library.platforms = with lib.platforms; [ linux darwin ];
-            packages.tx-generator.package.buildable = with pkgs.stdenv.hostPlatform; !isMusl;
 
             packages.fs-api.components.library.doHaddock = false;
             packages.cardano-ledger-allegra.components.library.doHaddock = false;

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -114,7 +114,6 @@ let
       modules =
         [
           ({ lib, pkgs, ... }: {
-            packages.cardano-tracer.package.buildable = with pkgs.stdenv.hostPlatform; lib.mkForce (!isMusl);
             packages.cardano-node-chairman.components.tests.chairman-tests.buildable = lib.mkForce pkgs.stdenv.hostPlatform.isUnix;
             packages.plutus-tx-plugin.components.library.platforms = with lib.platforms; [ linux darwin ];
             packages.tx-generator.package.buildable = with pkgs.stdenv.hostPlatform; !isMusl;

--- a/nix/nixos/tx-generator-service.nix
+++ b/nix/nixos/tx-generator-service.nix
@@ -57,7 +57,8 @@ in pkgs.commonLib.defServiceModule
 
       svcPackageSelector =
         pkgs: ## Local:
-              pkgs.cardanoNodePackages.tx-generator
+              ## Avoid rebuilding on every commit because of `set-git-rev`.
+              pkgs.cardanoNodePackages.tx-generator.passthru.noGitRev
               ## Imported by another repo, that adds an overlay:
                 or pkgs.tx-generator;
               ## TODO:  that's actually a bit ugly and could be improved.

--- a/nix/workbench/backend/nomad.nix
+++ b/nix/workbench/backend/nomad.nix
@@ -166,9 +166,9 @@ let
       };
       tx-generator = rec {
         # Local reference only used if not "cloud".
-        nix-store-path = pkgs.cardanoNodePackages.tx-generator;
+        nix-store-path = pkgs.cardanoNodePackages.tx-generator.passthru.noGitRev;
         flake-reference = "github:intersectmbo/cardano-node";
-        flake-output = "cardanoNodePackages.tx-generator";
+        flake-output = "cardanoNodePackages.tx-generator.passthru.noGitRev";
       };
     }
   ;

--- a/nix/workbench/shell.nix
+++ b/nix/workbench/shell.nix
@@ -144,7 +144,7 @@ project.shellFor {
        cardano-topology
        cardano-tracer
        locli
-       tx-generator
+       tx-generator.passthru.noGitRev
      ]
   # Include the workbench as a derivation or use the sources directly ?
   ++ lib.optionals (!workbenchDevMode) [ workbench.workbench ]


### PR DESCRIPTION
# Description

* Adds cardano-tracer, tx-generator to the release bins
* Cleans up the release bins with an allowList approach
* Cherry picked from PRs:
  * https://github.com/IntersectMBO/cardano-node/pull/6271 (all commits)
  * https://github.com/IntersectMBO/cardano-node/pull/6133 (1 commit)

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] CI passes. See note on CI.  The following CI checks are required:
- [X] Self-reviewed the diff