### PR TITLE
New Tracing: Failure to init `PrometheusSimple` handled leniently

### DIFF
--- a/trace-dispatcher/CHANGELOG.md
+++ b/trace-dispatcher/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.10.0 -- July, 2025
 * Forwarding protocol supports connections over TCP socket, in addition to Unix domain sockets.
+* Failure to initialise the `PrometheusSimple` backend is now lenient - i.e., won't result in an exception being propagated.
 
 ## 2.9.2 -- May 2025
 * New config field `traceOptionLedgerMetricsFrequency`.


### PR DESCRIPTION
# Description

When the Node fails to start `PrometheusSimple` backend in new tracing, it currently results in an exception being thrown, ending the Node process.

This change aligns it more closely with legacy tracing: An error will be logged, the backend will be disabled, and Node startup continues unimpeded.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff