### PR TITLE
PeerSharing option

### DIFF
--- a/cardano-node/src/Cardano/Node/Configuration/POM.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/POM.hs
@@ -806,8 +806,7 @@ makeNodeConfiguration pnc = do
   let ncPeerSharing =
         case pncPeerSharing pnc of
           Last Nothing ->
-            if    not startAsNonProducingNode
-               || hasProtocolFile protocolFiles
+            if hasProtocolFile protocolFiles
             then PeerSharingDisabled
             else PeerSharingEnabled
           Last (Just peerSharing) -> peerSharing

--- a/cardano-node/src/Cardano/Node/Parsers.hs
+++ b/cardano-node/src/Cardano/Node/Parsers.hs
@@ -67,7 +67,9 @@ nodeRunParser = do
   shelleyVRFFile  <- optional parseVrfKeyFilePath
   shelleyCertFile <- optional parseOperationalCertFilePath
   shelleyBulkCredsFile <- optional parseBulkCredsFilePath
-  startAsNonProducingNode <- Last <$> parseStartAsNonProducingNode
+  startAsNonProducingNode <- (\depr new -> Last depr <> Last new)
+                         <$> parseStartAsNonProducingNodeDeprecated
+                         <*> parseStartAsNonProducingNode
 
   -- Node Address
   nIPv4Address <- lastOption parseHostIPv4Addr
@@ -394,18 +396,30 @@ parseVrfKeyFilePath =
         <> completer (bashCompleter "file")
     )
 
+parseStartAsNonProducingNodeDeprecated :: Parser (Maybe Bool)
+parseStartAsNonProducingNodeDeprecated =
+  flag Nothing (Just True) $ mconcat
+    [ long "non-producing-node"
+    , help $ mconcat
+        [ "DEPRECATED, use --start-as-non-producing-node instead. "
+        , "This option will be removed in one of the future versions of cardano-node."
+        ]
+    , hidden
+    ]
+
 -- | A parser which returns `Nothing` or `Just True`; the default value is set
 -- in `defaultPartialNodeConfiguration`.  This allows to set this option either
 -- in the configuration file or as command line flag.
 parseStartAsNonProducingNode :: Parser (Maybe Bool)
 parseStartAsNonProducingNode =
   flag Nothing (Just True) $ mconcat
-    [ long "non-producing-node"
+    [ long "start-as-non-producing-node"
     , help $ mconcat
         [ "Start the node as a non block producing node even if "
         , "credentials are specified."
         ]
     ]
+
 
 -- | Produce just the brief help header for a given CLI option parser,
 --   without the options.


### PR DESCRIPTION
# Description

- **peer-sharing: default value only decided based on protocol files**
  _fixes a bug introduced in #6274_
- **Renamed --non-producer-node to --start-as-non-producer-node**
  _backward compatible change_

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
