### PR TITLE
Bump dependencies for ouroboros-network 0.21.3

### DIFF
--- a/bench/locli/locli.cabal
+++ b/bench/locli/locli.cabal
@@ -126,7 +126,7 @@ library
                       , hashable
                       , optparse-applicative-fork >= 0.18.1
                       , ouroboros-consensus
-                      , ouroboros-network-api ^>= 0.14
+                      , ouroboros-network-api ^>= 0.14.1
                       , sop-core
                       , split
                       , sqlite-easy >= 1.1.0.1

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2025-06-03T08:07:10Z
-  , cardano-haskell-packages 2025-06-03T08:30:50Z
+  , cardano-haskell-packages 2025-07-17T12:00:21Z
 
 packages:
   cardano-node
@@ -92,9 +92,7 @@ if impl (ghc >= 9.12)
     , servant:base
     , servant-server:base
 
-    , cardano-ping:base
-    , network-mux:base
-    , ouroboros-network:base
-    , ouroboros-network-api:base
-    , ouroboros-network-framework:base
     , ouroboros-network-protocols:base
+
+constraints:
+    hedgehog-extras == 0.7.0.0

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -197,9 +197,9 @@ library
                       , ouroboros-consensus-cardano ^>= 0.25
                       , ouroboros-consensus-diffusion ^>= 0.23
                       , ouroboros-consensus-protocol
-                      , ouroboros-network-api ^>= 0.14
-                      , ouroboros-network ^>= 0.21.2
-                      , ouroboros-network-framework ^>= 0.18.0.1
+                      , ouroboros-network-api ^>= 0.14.1
+                      , ouroboros-network ^>= 0.21.3
+                      , ouroboros-network-framework ^>= 0.18
                       , ouroboros-network-protocols ^>= 0.14
                       , prettyprinter
                       , prettyprinter-ansi-terminal

--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -49,7 +49,7 @@ library
                       , network
                       , optparse-applicative-fork
                       , ouroboros-consensus-cardano
-                      , ouroboros-network ^>= 0.21.2
+                      , ouroboros-network ^>= 0.21.3
                       , ouroboros-network-protocols
                       , prometheus >= 2.2.4
                       , servant

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -72,7 +72,7 @@ library
                       , network
                       , network-mux
                       , optparse-applicative-fork
-                      , ouroboros-network ^>= 0.21
+                      , ouroboros-network ^>= 0.21.3
                       , ouroboros-network-api
                       , prettyprinter
                       , process

--- a/cardano-tracer/cardano-tracer.cabal
+++ b/cardano-tracer/cardano-tracer.cabal
@@ -183,8 +183,8 @@ library
                       , mime-mail
                       , network-mux >= 0.8
                       , optparse-applicative
-                      , ouroboros-network ^>= 0.21.2
-                      , ouroboros-network-api ^>= 0.14
+                      , ouroboros-network ^>= 0.21.3
+                      , ouroboros-network-api ^>= 0.14.1
                       , ouroboros-network-framework
                       , signal
                       , slugify
@@ -250,7 +250,7 @@ library demo-forwarder-lib
                       , generic-data
                       , network-mux
                       , optparse-applicative-fork >= 0.18.1
-                      , ouroboros-network-api ^>= 0.14
+                      , ouroboros-network-api ^>= 0.14.1
                       , ouroboros-network-framework
                       , tasty-quickcheck
                       , time
@@ -293,7 +293,7 @@ library demo-acceptor-lib
                       , filepath
                       , generic-data
                       , optparse-applicative-fork >= 0.18.1
-                      , ouroboros-network-api ^>= 0.14
+                      , ouroboros-network-api ^>= 0.14.1
                       , stm <2.5.2 || >=2.5.3
                       , text
                       , tasty-quickcheck
@@ -352,7 +352,7 @@ test-suite cardano-tracer-test
                       , generic-data
                       , network-mux
                       , optparse-applicative-fork >= 0.18.1
-                      , ouroboros-network-api ^>= 0.14
+                      , ouroboros-network-api ^>= 0.14.1
                       , ouroboros-network-framework
                       , stm <2.5.2 || >=2.5.3
                       , tasty
@@ -411,8 +411,8 @@ test-suite cardano-tracer-test-ext
                       , Glob
                       , network-mux
                       , optparse-applicative-fork >= 0.18.1
-                      , ouroboros-network ^>= 0.21.2
-                      , ouroboros-network-api ^>= 0.14
+                      , ouroboros-network ^>= 0.21.3
+                      , ouroboros-network-api ^>= 0.14.1
                       , ouroboros-network-framework
                       , process
                       , QuickCheck

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1748961716,
-        "narHash": "sha256-t4wX4FOTmylk+mRjpJQllF15ntSXBwyXZfU8qLBIS9s=",
+        "lastModified": 1752755491,
+        "narHash": "sha256-LhTRY6kgvg5cGfoQ9FD2v15WucqO4C+VLMHa9JP/Zi4=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "14dfcdcbc66bbb07e00c048210c4002a4dbbfe90",
+        "rev": "fe5f8c99284ca892efe46d91a9ccb00aa76f2525",
         "type": "github"
       },
       "original": {

--- a/trace-dispatcher/trace-dispatcher.cabal
+++ b/trace-dispatcher/trace-dispatcher.cabal
@@ -73,7 +73,7 @@ library
                       , network
                       , network-mux
                       , optparse-applicative-fork
-                      , ouroboros-network ^>= 0.21.2
+                      , ouroboros-network ^>= 0.21.3
                       , ouroboros-network-api
                       , ouroboros-network-framework
                       , serialise

--- a/trace-forward/trace-forward.cabal
+++ b/trace-forward/trace-forward.cabal
@@ -67,7 +67,7 @@ library
                       , network-mux
                       , ouroboros-network-api
                       , singletons ^>= 3.0
-                      , ouroboros-network-framework ^>= 0.18.0.1
+                      , ouroboros-network-framework ^>= 0.18.0.2
                       , serialise
                       , stm
                       , text


### PR DESCRIPTION
# Description

Integrate o-n 0.21.3 patch release

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
