### PR TITLE
Do not retain ShelleyGenesis on benchmarks

### DIFF
--- a/cardano-node/src/Cardano/Node/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Startup.hs
@@ -158,7 +158,7 @@ data BasicInfoCommon = BasicInfoCommon {
 data BasicInfoShelleyBased = BasicInfoShelleyBased {
     bisEra               :: Text
   , bisSystemStartTime   :: UTCTime
-  , bisSlotLength        :: NominalDiffTime
+  , bisSlotLength        :: !NominalDiffTime
   , bisEpochLength       :: Word64
   , bisSlotsPerKESPeriod :: Word64
   }


### PR DESCRIPTION
ShelleyGenesis contains stuffed UTxOs, and they are retained by this field.

