### PR TITLE
Add snapshot-converter to node OCI image

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -487,7 +487,16 @@
             customConfig.haskellNix
           ];
         cardanoNodePackages = mkCardanoNodePackages final.cardanoNodeProject;
-        inherit (final.cardanoNodePackages) cardano-node cardano-cli cardano-submit-api cardano-tracer bech32 locli db-analyser tx-generator;
+        inherit (final.cardanoNodePackages)
+          bech32
+          cardano-cli
+          cardano-node
+          cardano-submit-api
+          cardano-tracer
+          db-analyser
+          locli
+          snapshot-converter
+          tx-generator;
       };
       nixosModules = {
         cardano-node = {

--- a/nix/docker/README.md
+++ b/nix/docker/README.md
@@ -209,6 +209,29 @@ docker volume inspect opt-cardano
 sudo tree /var/lib/docker/volumes/opt-cardano/_data
 ```
 
+## Cardano Ledger Snapshot Conversion
+The snapshot-converter utility is included in the cardano-node image at path
+`/usr/local/bin/snapshot-converter`.  It can be used to convert between ledger
+state types as needed, without relying on host level tooling or full
+chain ledger replays.
+
+An example follows to convert preprod ledger state in a named docker volume in
+snapshot `295420` from `Legacy` to `Mem` when node is not already
+running:
+```
+docker run -v preprod-data:/data --rm -it --entrypoint=bash ghcr.io/intersectmbo/cardano-node:dev -c '
+  mv /data/db/ledger /data/db/ledger-old \
+    && mkdir -p /data/db/ledger \
+    && snapshot-converter Legacy /data/db/ledger-old/295420 Mem /data/db/ledger/295420 cardano --config /opt/cardano/config/preprod/config.json
+'
+```
+
+Note that once ledger state is converted, the cardano-node container will need
+to be run with a node configuration aligned with the new ledger state type,
+otherwise ledger replay from genesis will re-occur.
+
+For more info, see the [UTxO Migration Guide](https://ouroboros-consensus.cardano.intersectmbo.org/docs/for-developers/utxo-hd/migrating/).
+
 
 ## Legacy Tracing System
 Cardano-node now defaults to using the new tracing system.  The legacy tracing

--- a/nix/docker/default.nix
+++ b/nix/docker/default.nix
@@ -18,6 +18,7 @@
 # The main contents of the image.
 , cardano-cli
 , cardano-node
+, snapshot-converter
 , scripts
 
 # Set gitrev to null, to ensure the version below is used
@@ -161,6 +162,7 @@ in
       cp -v ${context}/bin/* usr/local/bin
       ln -sv ${cardano-node}/bin/cardano-node usr/local/bin/cardano-node
       ln -sv ${cardano-cli}/bin/cardano-cli usr/local/bin/cardano-cli
+      ln -sv ${snapshot-converter}/bin/snapshot-converter usr/local/bin/snapshot-converter
       ln -sv ${jq}/bin/jq usr/local/bin/jq
 
       # Create iohk-nix network configs, organized by network directory.


### PR DESCRIPTION
# Description

* Adds the `snapshot-converter` binary to the nix overlay and the node OCI container
* Adds documentation on how to use the snapshot-converter within the image for changing ledger state type

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] CI passes. See note on CI.  The following CI checks are required:
- [X] Self-reviewed the diff