### PR TITLE
bench: fixes

### DIFF
--- a/nix/workbench/backend/nomad.nix
+++ b/nix/workbench/backend/nomad.nix
@@ -166,9 +166,9 @@ let
       };
       tx-generator = rec {
         # Local reference only used if not "cloud".
-        nix-store-path = pkgs.cardanoNodePackages.tx-generator;
+        nix-store-path = pkgs.cardanoNodePackages.tx-generator.passthru.noGitRev;
         flake-reference = "github:intersectmbo/cardano-node";
-        flake-output = "cardanoNodePackages.tx-generator";
+        flake-output = "cardanoNodePackages.tx-generator.passthru.noGitRev";
       };
     }
   ;

--- a/nix/workbench/backend/nomad/cloud.nix
+++ b/nix/workbench/backend/nomad/cloud.nix
@@ -25,7 +25,7 @@ let
         else (import ./patch.nix {})
       )
       # Amazon S3 HTTP to upload/download the genesis tar file.
-      pkgs.awscli
+      pkgs.awscli2
       # Used to download the logs.
       pkgs.rsync
     ]

--- a/nix/workbench/service/generator.nix
+++ b/nix/workbench/service/generator.nix
@@ -57,6 +57,9 @@ let
         ;
       } // optionalAttrs profile.node.tracer {
         tracerSocketPath = "../tracer/tracer.socket";
+      } // optionalAttrs (!backend.useCabalRun) {
+        # Use to `noGitRev` to avoid rebuilding on every commit.
+        executable     = "${pkgs.cardanoNodePackages.tx-generator.passthru.noGitRev}/bin/tx-generator";
       } // optionalAttrs backend.useCabalRun {
         executable     = "tx-generator";
       });


### PR DESCRIPTION
# Description

- Switch to `aws-cli` 2.
- Fix for `tx-generator` while keeping `noGitRev`.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff
