### PR TITLE
wb | allow having workloads that start before the nodes

### DIFF
--- a/bench/cardano-profile/data/all-profiles-coay.json
+++ b/bench/cardano-profile/data/all-profiles-coay.json
@@ -46223,6 +46223,7 @@
         },
         "name": "latency",
         "parameters": {},
+        "before_nodes": false,
         "wait_pools": false
       }
     ]
@@ -46866,6 +46867,7 @@
         },
         "name": "latency",
         "parameters": {},
+        "before_nodes": false,
         "wait_pools": false
       }
     ]
@@ -63098,6 +63100,7 @@
           "submit_vote": true,
           "votes_per_tx": 2
         },
+        "before_nodes": false,
         "wait_pools": true
       }
     ]
@@ -64052,6 +64055,7 @@
           "outs_per_split_transaction": 193,
           "submit_vote": false
         },
+        "before_nodes": false,
         "wait_pools": true
       }
     ]
@@ -65007,6 +65011,7 @@
           "submit_vote": true,
           "votes_per_tx": 1
         },
+        "before_nodes": false,
         "wait_pools": true
       }
     ]
@@ -90532,6 +90537,7 @@
           "pre_generator": null,
           "producers": "cgroup_memory"
         },
+        "before_nodes": true,
         "wait_pools": true
       }
     ]
@@ -91421,6 +91427,7 @@
           "pre_generator": null,
           "producers": "cgroup_memory"
         },
+        "before_nodes": true,
         "wait_pools": true
       }
     ]
@@ -94983,6 +94990,7 @@
           "submit_vote": true,
           "votes_per_tx": 2
         },
+        "before_nodes": false,
         "wait_pools": true
       }
     ]
@@ -95934,6 +95942,7 @@
           "outs_per_split_transaction": 193,
           "submit_vote": false
         },
+        "before_nodes": false,
         "wait_pools": true
       }
     ]
@@ -96886,6 +96895,7 @@
           "submit_vote": true,
           "votes_per_tx": 1
         },
+        "before_nodes": false,
         "wait_pools": true
       }
     ]

--- a/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Types.hs
+++ b/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Types.hs
@@ -557,6 +557,7 @@ data Workload = Workload
   { workloadName :: String
   , parameters :: Aeson.Object
   , entrypoints :: Entrypoints
+  , before_nodes :: Bool
   , wait_pools :: Bool
   }
   deriving (Eq, Show, Generic)
@@ -570,10 +571,11 @@ data Entrypoints = Entrypoints
 instance Aeson.ToJSON Workload where
   toJSON p =
     Aeson.object
-      [ "name"        Aeson..= workloadName p
-      , "parameters"  Aeson..= parameters   p
-      , "entrypoints" Aeson..= entrypoints  p
-      , "wait_pools"  Aeson..= wait_pools   p
+      [ "name"         Aeson..= workloadName p
+      , "parameters"   Aeson..= parameters   p
+      , "entrypoints"  Aeson..= entrypoints  p
+      , "before_nodes" Aeson..= before_nodes p
+      , "wait_pools"   Aeson..= wait_pools   p
       ]
 
 instance Aeson.FromJSON Workload where
@@ -583,6 +585,7 @@ instance Aeson.FromJSON Workload where
         <$> o Aeson..: "name"
         <*> o Aeson..: "parameters"
         <*> o Aeson..: "entrypoints"
+        <*> o Aeson..: "before_nodes"
         <*> o Aeson..: "wait_pools"
 
 instance Aeson.ToJSON Entrypoints

--- a/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Workload/CGroupMemory.hs
+++ b/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Workload/CGroupMemory.hs
@@ -23,5 +23,6 @@ cgroupMemoryWorkload = Types.Workload {
       Types.pre_generator = Nothing
     , Types.producers = "cgroup_memory"
     }
+  , Types.before_nodes = True
   , Types.wait_pools = True
 }

--- a/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Workload/Latency.hs
+++ b/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Workload/Latency.hs
@@ -23,5 +23,6 @@ latencyWorkload = Types.Workload {
       Types.pre_generator = Nothing
     , Types.producers = "latency"
     }
+  , Types.before_nodes = False
   , Types.wait_pools = False
 }

--- a/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Workload/Voting.hs
+++ b/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Workload/Voting.hs
@@ -26,6 +26,7 @@ votingWorkload parameters = Types.Workload {
       Types.pre_generator = Just "workflow_generator"
     , Types.producers = "workflow_producer"
     }
+  , Types.before_nodes = False
   , Types.wait_pools = True
 }
 

--- a/nix/workbench/backend/backend.sh
+++ b/nix/workbench/backend/backend.sh
@@ -52,7 +52,7 @@ case "${op}" in
     start-tracers )              backend_$WB_BACKEND "$@";;
     start-nodes )                backend_$WB_BACKEND "$@";;
     start-generator )            backend_$WB_BACKEND "$@";;
-    start-workloads )            backend_$WB_BACKEND "$@";;
+    start-workload-by-name )     backend_$WB_BACKEND "$@";;
     start-healthchecks )         backend_$WB_BACKEND "$@";;
     # Fine grained
     start-node )                 backend_$WB_BACKEND "$@";;

--- a/nix/workbench/backend/nomad/cloud.sh
+++ b/nix/workbench/backend/nomad/cloud.sh
@@ -146,8 +146,8 @@ backend_nomadcloud() {
       backend_nomad start-generator         "$@"
     ;;
 
-    start-workloads )
-      backend_nomad start-workloads         "$@"
+    start-workload-by-name )
+      backend_nomad start-workload-by-name  "$@"
     ;;
 
     start-healthchecks )

--- a/nix/workbench/backend/nomad/exec.sh
+++ b/nix/workbench/backend/nomad/exec.sh
@@ -107,8 +107,8 @@ backend_nomadexec() {
       backend_nomad start-generator         "$@"
     ;;
 
-    start-workloads )
-      backend_nomad start-workloads         "$@"
+    start-workload-by-name )
+      backend_nomad start-workload-by-name  "$@"
     ;;
 
     start-healthchecks )

--- a/nix/workbench/backend/supervisor.sh
+++ b/nix/workbench/backend/supervisor.sh
@@ -300,28 +300,25 @@ EOF
         fi
         backend_supervisor save-child-pids "$dir";;
 
-    start-workloads )
+    start-workload-by-name )
         local usage="USAGE: wb backend $op RUN-DIR"
         local dir=${1:?$usage}; shift
+        local workload=${1:?$usage}; shift
 
         while test $# -gt 0
         do case "$1" in
                --* ) msg "FATAL:  unknown flag '$1'"; usage_supervisor;;
                * ) break;; esac; shift; done
 
-        # For every workload
-        for workload in $(jq_tolist '.workloads | map(.name)' "$dir"/profile.json)
-        do
-            if ! supervisorctl start "${workload}"
-            then progress "supervisor" "$(red fatal: failed to start) $(white "${workload} workload")"
-                 echo "$(red "${workload}" workload stdout) ----------------------" >&2
-                 cat "$dir"/workloads/"${workload}"/stdout
-                 echo "$(red "${workload}" workload stderr) ----------------------" >&2
-                 cat "$dir"/workloads/"${workload}"/stderr
-                 echo "$(white -------------------------------------------------)" >&2
-                 fatal "could not start $(white "${workload} workload")"
-            fi
-        done
+        if ! supervisorctl start "${workload}"
+        then progress "supervisor" "$(red fatal: failed to start) $(white "${workload} workload")"
+             echo "$(red "${workload}" workload stdout) ----------------------" >&2
+             cat "$dir"/workloads/"${workload}"/stdout
+             echo "$(red "${workload}" workload stderr) ----------------------" >&2
+             cat "$dir"/workloads/"${workload}"/stderr
+             echo "$(white -------------------------------------------------)" >&2
+             fatal "could not start $(white "${workload} workload")"
+        fi
         backend_supervisor save-child-pids "$dir";;
 
     wait-node-stopped )


### PR DESCRIPTION
# Description

Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
