### PR TITLE
Refactor `cardanoTestnet` to no longer use GenesisOptions

### DIFF
--- a/cardano-testnet/src/Parsers/Run.hs
+++ b/cardano-testnet/src/Parsers/Run.hs
@@ -87,12 +87,11 @@ runCardanoOptions CardanoTestnetCliOptions
           createTestnetEnv
             testnetOptions genesisOptions def
             conf
-          cardanoTestnet testnetOptions genesisOptions conf
+          cardanoTestnet testnetOptions conf
       UserProvidedEnv nodeEnvPath ->
         -- Run cardano-testnet in the sandbox provided by the user
         -- In that case, 'cardanoOutputDir' is not used
         runTestnet (UserProvidedEnv nodeEnvPath) $ \conf ->
           cardanoTestnet
             testnetOptions
-            genesisOptions
             conf{updateTimestamps=updateTimestamps}

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/DumpConfig.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/DumpConfig.hs
@@ -69,6 +69,6 @@ hprop_dump_config = integrationRetryWorkspace 2 "dump-config-files" $ \tmpDir ->
   H.lbsWriteFile shelleyGenesisFile $ encodePretty shelleyGenesis
 
   -- Run testnet with generated config
-  runtime <- cardanoTestnet testnetOptions genesisOptions conf
+  runtime <- cardanoTestnet testnetOptions conf
 
   nodesProduceBlocks tmpDir runtime

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs
@@ -112,7 +112,7 @@ hprop_gov_no_confidence = integrationWorkspace "no-confidence" $ \tempAbsBasePat
     , testnetNodes
     , wallets=wallet0:_wallet1:_
     , configurationFile
-    } <- cardanoTestnet fastTestnetOptions genesisOptions conf
+    } <- cardanoTestnet fastTestnetOptions conf
 
   poolNode1 <- H.headM testnetNodes
   poolSprocket1 <- H.noteShow $ nodeSprocket poolNode1

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/MainnetParams.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/MainnetParams.hs
@@ -45,7 +45,7 @@ hprop_mainnet_params = integrationRetryWorkspace 2 "mainnet-params" $ \tmpDir ->
   TestnetRuntime
     { testnetNodes
     , testnetMagic
-    } <- cardanoTestnet testnetOptions genesisOptions conf
+    } <- cardanoTestnet testnetOptions conf
 
   -- Get a running node
   TestnetNode{nodeSprocket} <- H.headM testnetNodes

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/P2PTopology.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/P2PTopology.hs
@@ -43,6 +43,6 @@ hprop_p2p_topology = integrationRetryWorkspace 2 "p2p-topology" $ \tmpDir -> H.r
   (_topology :: P2P.NetworkTopology NodeId) <- H.leftFail eTopology
 
   -- Run testnet with generated config
-  runtime <- cardanoTestnet testnetOptions genesisOptions conf
+  runtime <- cardanoTestnet testnetOptions conf
 
   nodesProduceBlocks tmpDir runtime

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/UpdateTimeStamps.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/UpdateTimeStamps.hs
@@ -45,9 +45,6 @@ hprop_update_time_stamps = integrationRetryWorkspace 2 "update-time-stamps" $ \t
   H.threadDelay $ double2Int $ realToFrac startTimeOffsetSeconds * 1_000_000 * 1.2
 
   -- Run testnet and specify to update time stamps before starting
-  runtime <- cardanoTestnet
-    testnetOptions
-    genesisOptions
-    conf{updateTimestamps = UpdateTimestamps}
+  runtime <- cardanoTestnet testnetOptions conf{updateTimestamps = UpdateTimestamps}
 
   nodesProduceBlocks tmpDir runtime


### PR DESCRIPTION
Since `createTestnetEnv` is now responsible for creating the sandbox environment, `cardanoTestnet` no longer needs Genesis information. This commit removes the dependency, and gets the needed information from the sandbox environment instead.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff