### PR TITLE
cardano-submit-api | Use next available port for the metrics server if the specified one is not available

### DIFF
--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -52,6 +52,7 @@ library
                       , ouroboros-network ^>= 0.21.2
                       , ouroboros-network-protocols
                       , prometheus >= 2.2.4
+                      , safe-exceptions
                       , servant
                       , servant-server
                       , streaming-commons

--- a/cardano-submit-api/src/Cardano/TxSubmit/CLI/Parsers.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/CLI/Parsers.hs
@@ -54,7 +54,9 @@ pSocketPath' =
 pMetricsPort :: Int -> Parser Int
 pMetricsPort defaultValue = Opt.option Opt.auto
   (   Opt.long "metrics-port"
-  <>  Opt.help "Metrics port"
+  <>  Opt.help ("Port for exposing metrics. If unavailable, the next free port is used. If no port can be allocated, "
+      <> "the transaction submission API starts without metrics endpoint.")
   <>  Opt.metavar "PORT"
   <>  Opt.value defaultValue
+  <>  Opt.showDefault
   )

--- a/cardano-submit-api/src/Cardano/TxSubmit/Metrics.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Metrics.hs
@@ -1,13 +1,22 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Cardano.TxSubmit.Metrics
-  ( TxSubmitMetrics(..)
+  ( TxSubmitMetrics (..)
   , makeMetrics
   , registerMetricsServer
-  ) where
+  )
+where
 
-import           Control.Concurrent.Async (Async, async)
-import           Control.Monad.Reader (MonadIO (liftIO), MonadReader (ask), ReaderT (runReaderT))
+import           Cardano.Api.Pretty (textShow)
+
+import           Cardano.BM.Data.Trace (Trace)
+import           Cardano.BM.Trace (logError, logInfo, logWarning)
+
+import           Control.Exception.Safe
+import           Control.Monad.Reader (MonadReader (ask), ReaderT (runReaderT))
+import           Data.Text (Text)
+import qualified Data.Text as T
 import           System.Metrics.Prometheus.Concurrent.RegistryT (RegistryT (..), registerGauge,
                    runRegistryT, unRegistryT)
 import           System.Metrics.Prometheus.Http.Scrape (serveMetricsT)
@@ -18,15 +27,40 @@ data TxSubmitMetrics = TxSubmitMetrics
   , tsmFailCount :: Gauge
   }
 
-registerMetricsServer :: Int -> IO (TxSubmitMetrics, Async ())
-registerMetricsServer metricsPort =
+-- | Register metrics server. Returns metrics and an IO action which starts metrics server and should
+-- be passed to 'withAsync'.
+registerMetricsServer
+  :: Trace IO Text
+  -> Int
+  -> IO (TxSubmitMetrics, IO ())
+registerMetricsServer tracer metricsPort =
   runRegistryT $ do
     metrics <- makeMetrics
     registry <- RegistryT ask
-    server <- liftIO . async $ runReaderT (unRegistryT $ serveMetricsT metricsPort []) registry
-    pure (metrics, server)
+    let runServer =
+          tryWithPort metricsPort $ \port -> do
+            logInfo tracer $ "Starting metrics server on port " <> textShow port
+            flip runReaderT registry . unRegistryT $ serveMetricsT port []
+    pure (metrics, runServer)
+ where
+  -- try opening the metrics server on the specified port, if it fails, try using next. Gives up after 1000 attempts and disables metrics server.
+  tryWithPort :: Int -> (Int -> IO ()) -> IO ()
+  tryWithPort startingPort f = go startingPort
+   where
+    go port = do
+      catch @_ @IOException (f port) $ \e -> do
+        logWarning tracer $ T.pack $ "Metrics server error: " <> displayException e
+        if port <= (startingPort + 1000)
+          then do
+            logWarning tracer $ "Could not allocate metrics server port " <> textShow port <> " - trying next available..."
+            go $ port + 1
+          else do
+            logError tracer $
+              "Could not allocate any metrics port until " <> textShow port <> " - metrics endpoint disabled"
+            pure ()
 
 makeMetrics :: RegistryT IO TxSubmitMetrics
-makeMetrics = TxSubmitMetrics
-  <$> registerGauge "tx_submit_count" mempty
-  <*> registerGauge "tx_submit_fail_count" mempty
+makeMetrics =
+  TxSubmitMetrics
+    <$> registerGauge "tx_submit_count" mempty
+    <*> registerGauge "tx_submit_fail_count" mempty

--- a/cardano-submit-api/src/Cardano/TxSubmit/Rest/Web.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Rest/Web.hs
@@ -2,14 +2,16 @@
 
 module Cardano.TxSubmit.Rest.Web
   ( runSettings
-  ) where
+  )
+where
+
+import           Cardano.Api.Pretty (textShow)
 
 import           Cardano.BM.Trace (Trace, logInfo)
 
 import           Control.Exception (bracket)
 import           Data.Streaming.Network (bindPortTCP)
 import           Data.Text (Text)
-import qualified Data.Text as T
 import           Network.Socket (close, getSocketName, withSocketsDo)
 import           Network.Wai.Handler.Warp (Settings, getHost, getPort, runSettingsSocket)
 
@@ -17,10 +19,13 @@ import           Servant (Application)
 
 -- | Like 'Network.Wai.Handler.Warp.runSettings', except with better logging.
 runSettings :: Trace IO Text -> Settings -> Application -> IO ()
-runSettings trace settings app = withSocketsDo $ bracket
-  (bindPortTCP (getPort settings) (getHost settings))
-  close
-  (\socket -> do
-    addr <- getSocketName socket
-    logInfo trace $ "Running server on " <> T.pack (show addr)
-    runSettingsSocket settings socket app)
+runSettings trace settings app =
+  withSocketsDo $
+    bracket
+      (bindPortTCP (getPort settings) (getHost settings))
+      close
+      ( \socket -> do
+          addr <- getSocketName socket
+          logInfo trace $ "Web API listening on port " <> textShow addr
+          runSettingsSocket settings socket app
+      )

--- a/cardano-submit-api/src/Cardano/TxSubmit/Util.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Util.hs
@@ -8,7 +8,7 @@ import           Cardano.BM.Trace (Trace, logError)
 
 import           Prelude
 
-import           Control.Exception (SomeException, catch, throwIO)
+import           Control.Exception.Safe (SomeException, catch, throwIO)
 import           Data.Text (Text)
 
 -- | ouroboros-network catches 'SomeException' and if a 'nullTracer' is passed into that

--- a/cardano-submit-api/src/Cardano/TxSubmit/Web.hs
+++ b/cardano-submit-api/src/Cardano/TxSubmit/Web.hs
@@ -78,7 +78,7 @@ runTxSubmitServer
   -> SocketPath
   -> IO ()
 runTxSubmitServer trace metrics webserverConfig protocol networkId socketPath = do
-  logException trace "tx-submit-webapi." $
+  logException trace "TxSubmit WebAPI: " $
     Web.runSettings trace (toWarpSettings webserverConfig) $ txSubmitApp trace metrics protocol networkId socketPath
   logInfo trace "txSubmitApp: exiting"
 


### PR DESCRIPTION
# Description

Fixes: https://github.com/IntersectMBO/cardano-node/issues/5985

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
