### PR TITLE
Add First Full-Round Metrics Test Case

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2025-06-24T21:06:59Z
-  , cardano-haskell-packages 2025-09-18T12:21:32Z
+  , cardano-haskell-packages 2025-10-07T11:20:00Z
 
 packages:
   cardano-node
@@ -31,11 +31,6 @@ packages:
   trace-dispatcher
   trace-resources
   trace-forward
-
-source-repository-package
-  type: git
-  location: https://github.com/jutaro/cardano-prometheus-tracker.git
-  tag: af73c6217850ac6bf07ad26d8faa985f391eddf3
 
 -- Needed when cross compiling
 extra-packages: alex

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1758727647,
-        "narHash": "sha256-J0PlznW05SByIJZvP90JvFMvnHsP+Rs/qwLogpConI4=",
+        "lastModified": 1759837865,
+        "narHash": "sha256-g8SMcVN1v51Muz6a+xJkB92mPx1jsg+sjHKvQ3Wj/jY=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "bbf172e0d11e3842e543df101dee223f05a2332e",
+        "rev": "9a46cacd941c108492cd4cee5d29735e8cd8ee65",
         "type": "github"
       },
       "original": {
@@ -104,6 +104,9 @@
     "cardano-automation": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "hackageNix": [
+          "hackageNix"
+        ],
         "haskellNix": [
           "haskellNix"
         ],
@@ -112,11 +115,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750923974,
-        "narHash": "sha256-PXB1aro2KalRw6OZkcbICl6Ge7HB4yEl5O3epm9VZl8=",
+        "lastModified": 1759830003,
+        "narHash": "sha256-j5C9yqLzvOEfNcxBUP9QA2baIhWsk0vcLGrbpxCvND8=",
         "owner": "input-output-hk",
         "repo": "cardano-automation",
-        "rev": "64bf80a78102787790bac96075ef4109ff7de36e",
+        "rev": "d2017cf99d9c98b0acb4383d03ecfa8f9fdc2aac",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,7 @@
     cardano-automation = {
       url = "github:input-output-hk/cardano-automation";
       inputs = {
+        hackageNix.follows = "hackageNix";
         haskellNix.follows = "haskellNix";
         nixpkgs.follows = "nixpkgs";
       };

--- a/trace-dispatcher/trace-dispatcher.cabal
+++ b/trace-dispatcher/trace-dispatcher.cabal
@@ -105,27 +105,19 @@ test-suite trace-dispatcher-prometheus-simple-test
   main-is:              trace-dispatcher-prometheus-simple-test.hs
   build-depends:        base >=4.12 && <5
                       , aeson
-                      , async
-                      , bytestring
-                      , containers
-                      , deepseq
-                      , ekg-core
-                      , generic-data
-                      , hostname
-                      , http-client == 0.7.19
-                      , stm
-                      , tasty
-                      , tasty-hunit
-                      , tasty-quickcheck
-                      , text
-                      , time
-                      , trace-dispatcher
-                      , unordered-containers
-                      , utf8-string
-                      , unix
-                      , yaml
-                      , QuickCheck
                       , cardano-prometheus-tracker
+                      , containers
+                      , ekg-core
+                      , http-client
+                      , text
+                      , trace-dispatcher
+
+  ghc-options:
+    -threaded
+    -Wunused-packages
+
+  if !(os(linux) || os(darwin) || os(freebsd))
+    buildable: False
 
 test-suite trace-dispatcher-test
   import:               project-config
@@ -143,7 +135,6 @@ test-suite trace-dispatcher-test
                         Cardano.Logging.Test.Unit.Documentation
                         Cardano.Logging.Test.Unit.EKG
                         Cardano.Logging.Test.Unit.FrequencyLimiting
-                        Cardano.Logging.Test.Unit.PrometheusSimple
                         Cardano.Logging.Test.Unit.Routing
                         Cardano.Logging.Test.Unit.TestObjects
                         Cardano.Logging.Test.Unit.Trivial
@@ -157,7 +148,6 @@ test-suite trace-dispatcher-test
                       , ekg-core
                       , generic-data
                       , hostname
-                      , http-client == 0.7.19
                       , stm
                       , tasty
                       , tasty-hunit
@@ -167,7 +157,7 @@ test-suite trace-dispatcher-test
                       , trace-dispatcher
                       , unordered-containers
                       , utf8-string
-                      , unix
+                      , unix-compat
                       , yaml
                       , QuickCheck
                       , cardano-prometheus-tracker


### PR DESCRIPTION
## Summary

This PR introduces an end-to-end test for the metrics pipeline, covering everything from tracing a metric to scraping it via the Prometheus endpoint and validating the result. It is the first full-round verification of our metrics infrastructure.

## Motivation

Until now, our metrics tests were mostly unit-level or partial integration checks. This new test ensures that:

* The **Prometheus simple server** actually serves the metrics we trace.
* Our **tracer configuration** and **formatter** properly register and emit metrics.
* The **scraping path** produces the expected value, closing the loop between producer and consumer.

This increases confidence in the observability layer, especially ahead of future instrumentation work.

## What the Test Does

* Thread 1

  * Starts a Prometheus simple server bound to `localhost:9090`.
  * Sets up an `ekgTracer` and configures it.
  * Emits a `Measure 42` metric.
  * Spawns Thread 2.
  * Waits for completion or shutdown signal.

* Thread 2

  * Scrapes `http://localhost:9090/metrics`.
  * Parses the metric output into a map.
  * Looks up the `"measure"` metric and asserts its value is `42`.
  * Fails early if the metric is missing or has an unexpected value.

* On success, prints `Got correct metric value ✔`.

