### PR TITLE
Bump `cardano-cli-10.12.0.0` and `cardano-api-10.18.0.0`

### DIFF
--- a/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
+++ b/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
@@ -82,7 +82,7 @@ library
   -- IOG dependencies
   --------------------------
   build-depends:
-    , cardano-api             ^>=10.17
+    , cardano-api             ^>=10.18
     , plutus-ledger-api       ^>=1.45
     , plutus-tx               ^>=1.45
     , plutus-tx-plugin        ^>=1.45

--- a/bench/tx-generator/src/Cardano/TxGenerator/Setup/Plutus.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Setup/Plutus.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 {-|
 Module      : Cardano.TxGenerator.Setup.Plutus
@@ -23,7 +24,7 @@ import           Control.Monad.Trans.Except
 import           Control.Monad.Trans.Except.Extra
 import           Control.Monad.Writer (runWriter)
 
-import           Cardano.CLI.Read (readFileScriptInAnyLang)
+import           Cardano.CLI.Read (readFileScriptInAnyLang, ScriptDecodeError)
 
 import           Cardano.Api
 import           Cardano.Ledger.Plutus.TxInfo (exBudgetToExUnits)
@@ -71,7 +72,7 @@ readPlutusScript (Left s)
     doLoad fp  = second (second (const $ ResolvedToFallback asFileName)) <$> readPlutusScript (Right fp)
 readPlutusScript (Right fp)
   = runExceptT $ do
-    script <- firstExceptT ApiError $
+    script <- firstExceptT (ApiError @ScriptDecodeError) $
       readFileScriptInAnyLang fp
     case script of
       ScriptInAnyLang (PlutusScriptLanguage _) _ -> pure (script, ResolvedToFileName fp)

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -113,9 +113,9 @@ library
                       , attoparsec-aeson
                       , base16-bytestring
                       , bytestring
-                      , cardano-api ^>= 10.17
+                      , cardano-api ^>= 10.18
                       , cardano-binary
-                      , cardano-cli ^>= 10.11
+                      , cardano-cli ^>= 10.12
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
                       , cardano-data

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2025-06-24T21:06:59Z
-  , cardano-haskell-packages 2025-07-01T09:22:51Z
+  , cardano-haskell-packages 2025-09-18T12:21:32Z
 
 packages:
   cardano-node

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -90,5 +90,5 @@ test-suite chairman-tests
   ghc-options:          -threaded -rtsopts "-with-rtsopts=-N -T"
 
   build-tool-depends:   cardano-node:cardano-node
-                      , cardano-cli:cardano-cli ^>= 10.11
+                      , cardano-cli:cardano-cli ^>= 10.12
                       , cardano-node-chairman:cardano-node-chairman

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -142,7 +142,7 @@ library
                       , async
                       , base16-bytestring
                       , bytestring
-                      , cardano-api ^>= 10.17.1
+                      , cardano-api ^>= 10.18
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
                       , cardano-git-rev ^>=0.2.2

--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -39,9 +39,9 @@ library
                       , aeson
                       , async
                       , bytestring
-                      , cardano-api ^>= 10.17
+                      , cardano-api ^>= 10.18
                       , cardano-binary
-                      , cardano-cli ^>= 10.11.1
+                      , cardano-cli ^>= 10.12
                       , cardano-crypto-class ^>= 2.2
                       , http-media
                       , iohk-monitoring

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -266,6 +266,7 @@ test-suite cardano-testnet-test
                       , mtl
                       , process
                       , regex-compat
+                      , rio
                       , tasty ^>= 1.5
                       , text
                       , time

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -40,8 +40,8 @@ library
                       , aeson-pretty
                       , ansi-terminal
                       , bytestring
-                      , cardano-api ^>= 10.17
-                      , cardano-cli:{cardano-cli, cardano-cli-test-lib} ^>= 10.11.1
+                      , cardano-api ^>= 10.18
+                      , cardano-cli:{cardano-cli, cardano-cli-test-lib} ^>= 10.12
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
                       , cardano-git-rev ^>= 0.2.2

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Query.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Query.hs
@@ -62,6 +62,7 @@ import           Testnet.Property.Util (integrationWorkspace)
 import           Testnet.Start.Types (GenesisOptions (..), NumPools (..), cardanoNumPools)
 import           Testnet.TestQueryCmds (TestQueryCmds (..), forallQueryCommands)
 import           Testnet.Types
+import           RIO (runRIO)
 
 import           Hedgehog
 import qualified Hedgehog as H
@@ -481,7 +482,6 @@ hprop_cli_queries = integrationWorkspace "cli-queries" $ \tempAbsBasePath' -> H.
   readVerificationKeyFromFile
     :: ( HasCallStack
        , MonadIO m
-       , MonadCatch m
        , MonadTest m
        , HasTextEnvelope (VerificationKey keyrole)
        , SerialiseAsBech32 (VerificationKey keyrole)
@@ -490,7 +490,7 @@ hprop_cli_queries = integrationWorkspace "cli-queries" $ \tempAbsBasePath' -> H.
     -> File content direction
     -> m (VerificationKey keyrole)
   readVerificationKeyFromFile work =
-    H.evalEitherM . liftIO . runExceptT . readVerificationKeyOrFile . VerificationKeyFilePath . File . (work </>) . unFile
+    H.evalIO . runRIO () . readVerificationKeyOrFile . VerificationKeyFilePath . File . (work </>) . unFile
 
   _verificationStakeKeyToStakeAddress :: Int -> VerificationKey StakeKey -> StakeAddress
   _verificationStakeKeyToStakeAddress testnetMagic delegatorVKey =

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1751362725,
-        "narHash": "sha256-RQpTHF6VDPWELM4MHQahZrpEtv6ZxSx8oceWGAzJKco=",
+        "lastModified": 1758727647,
+        "narHash": "sha256-J0PlznW05SByIJZvP90JvFMvnHsP+Rs/qwLogpConI4=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "4a6a3769c8cc8297ae8722e51fa5a4700b2db759",
+        "rev": "bbf172e0d11e3842e543df101dee223f05a2332e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Description

This PR bumps `cardano-cli` to version `10.12.0.0`, initially to check whether it compiles and tests.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff
