### PR TITLE
Cardano Tracer library

### DIFF
--- a/cardano-tracer/CHANGELOG.md
+++ b/cardano-tracer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## NEXT
+* Cardano-tracer library functionality, allows shutting down and sending signals to running
+  instances through channels.
+
 ## 0.3.6 (November 2025)
 * Implement Prometheus HTTP service discovery (SD) under the URL `/targets`
 * Add optional config field `"prometheusLabels": { "<labelname>": "<labelvalue>", ... }` for custom labels to be attached with Prometheus SD

--- a/cardano-tracer/app/cardano-tracer.hs
+++ b/cardano-tracer/app/cardano-tracer.hs
@@ -1,14 +1,23 @@
-import           Cardano.Tracer.CLI (TracerParams, parseTracerParams)
+{-# LANGUAGE OverloadedRecordDot #-}
+
+import           Cardano.Tracer.CLI (TracerParams(..), parseTracerParams)
+import           Cardano.Tracer.MetaTrace
 import           Cardano.Tracer.Run (runCardanoTracer)
 
+import           Data.Functor (void)
 import           Data.Version (showVersion)
 import           Options.Applicative
 
 import           Paths_cardano_tracer (version)
 
 main :: IO ()
-main =
-  runCardanoTracer =<< customExecParser (prefs showHelpOnEmpty) tracerInfo
+main = void do
+  tracerParams :: TracerParams
+     <- customExecParser (prefs showHelpOnEmpty) tracerInfo
+  trace :: Trace IO TracerTrace <-
+    -- Default `Nothing' severity filter to Info.
+    mkTracerTracer $ SeverityF (tracerParams.logSeverity <|> Just Info)
+  runCardanoTracer trace tracerParams
 
 tracerInfo :: ParserInfo TracerParams
 tracerInfo = info
@@ -21,7 +30,9 @@ tracerInfo = info
 
 versionOption :: Parser (a -> a)
 versionOption = infoOption
-  (showVersion version)
-  (long "version" <>
-   short 'v' <>
-   help "Show version")
+  do showVersion version
+  do mconcat
+       [ long  "version"
+       , short 'v'
+       , help  "Show version"
+       ]

--- a/cardano-tracer/bench/cardano-tracer-bench.hs
+++ b/cardano-tracer/bench/cardano-tracer-bench.hs
@@ -19,6 +19,7 @@ import           Control.Concurrent.Extra (newLock)
 #if RTVIEW
 import           Control.Concurrent.STM.TVar (newTVarIO)
 #endif
+import           Control.Concurrent.Chan.Unagi (newChan)
 import           Control.DeepSeq
 import qualified Data.List.NonEmpty as NE
 import           Data.Time.Clock (UTCTime, getCurrentTime)
@@ -63,6 +64,8 @@ main = do
 
   tracer <- mkTracerTracer $ SeverityF $ Just Warning
 
+  (inChan, _outChan) <- newChan
+
   let tracerEnv :: TracerConfig -> HandleRegistry -> TracerEnv
       tracerEnv config handleRegistry = TracerEnv
         { teConfig                = config
@@ -74,6 +77,7 @@ main = do
         , teDPRequestors          = dpRequestors
         , teProtocolsBrake        = protocolsBrake
         , teTracer                = tracer
+        , teInChan                = inChan
         , teReforwardTraceObjects = \_-> pure ()
         , teRegistry              = handleRegistry
         , teStateDir              = Nothing

--- a/cardano-tracer/cardano-tracer.cabal
+++ b/cardano-tracer/cardano-tracer.cabal
@@ -203,6 +203,7 @@ library
                       , trace-dispatcher ^>= 2.11.0
                       , trace-forward ^>= 2.4.0
                       , trace-resources ^>= 0.2.4
+                      , unagi-chan
                       , wai ^>= 3.2
                       , warp ^>= 3.4
                       , yaml
@@ -297,6 +298,7 @@ library demo-acceptor-lib
   exposed-modules:      Cardano.Tracer.Test.Acceptor
 
   build-depends:        bytestring
+                      , QuickCheck
                       , cardano-tracer
                       , containers
                       , extra
@@ -309,9 +311,9 @@ library demo-acceptor-lib
                       , text
                       , trace-dispatcher
                       , trace-forward
+                      , unagi-chan
                       , vector
                       , vector-algorithms
-                      , QuickCheck
 
 executable demo-acceptor
   import:               project-config
@@ -455,12 +457,13 @@ benchmark cardano-tracer-bench
     build-depends:      stm <2.5.2 || >=2.5.3
   build-depends:        cardano-tracer
                       , criterion
-                      , directory
                       , deepseq
+                      , directory
                       , extra
                       , filepath
                       , time
                       , trace-dispatcher
+                      , unagi-chan
 
   ghc-options:          -threaded
                         -rtsopts

--- a/cardano-tracer/src/Cardano/Tracer/Environment.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Environment.hs
@@ -1,11 +1,38 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE ExplicitNamespaces #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 
 module Cardano.Tracer.Environment
   ( TracerEnv (..)
   , TracerEnvRTView (..)
+  , RawMessage (..)
+  , InternalMessage (..)
+  , Tag (..)
+  , CardanoTracerMessage
+  , onRawMessage
+  , onInternal
+  , onUser
+  , blockUntilShutdown
+  , dieOnShutdown
+  , forever'til
+  , forever'tilShutdown
+
+  , type MessageHandler
+  , handleInternal
+  , handleMessage
+  , handleMessageWithShutdown
+  , handleMessages
+  , handleMessagesWithShutdown
+  , handleNoop
+  , handleShutdown
+  , handleTerminateOnShutdown
+  , handleUser
   ) where
 
 import           Cardano.Logging.Types
+import           Cardano.Logging.Resources.Types (ResourceStats)
 import           Cardano.Tracer.Configuration
 #if RTVIEW
 import           Cardano.Tracer.Handlers.Notifications.Types
@@ -16,10 +43,14 @@ import           Cardano.Tracer.Handlers.State.TraceObjects
 import           Cardano.Tracer.MetaTrace
 import           Cardano.Tracer.Types
 
+import           Control.Concurrent (myThreadId)
+import           Control.Exception (AsyncException(ThreadKilled), Exception, throwTo, throwIO, catch)
+import           Control.Concurrent.Chan.Unagi (InChan, OutChan, readChan, tryReadChan, tryRead)
 import           Control.Concurrent.Extra (Lock)
+import           Data.Foldable (traverse_)
 import           Data.Text (Text)
 import           Data.Text.Lazy.Builder (Builder)
-
+import           Data.Kind (Type)
 
 -- | Environment for all functions.
 data TracerEnv = TracerEnv
@@ -36,6 +67,7 @@ data TracerEnv = TracerEnv
   , teRegistry              :: !HandleRegistry
   , teStateDir              :: !(Maybe FilePath)
   , teMetricsHelp           :: ![(Text, Builder)]
+  , teInChan                :: !(InChan (CardanoTracerMessage ()))
   }
 
 #if RTVIEW
@@ -51,3 +83,203 @@ data TracerEnvRTView = TracerEnvRTView
 #else
 data TracerEnvRTView = TracerEnvRTView
 #endif
+
+type CardanoTracerMessage userMsg = RawMessage InternalMessage userMsg
+
+type RawMessage :: Type -> Type -> Type
+data RawMessage internal user
+  = Shutdown
+  | InternalMessage internal
+  | UserMessage     user
+
+type InternalMessage :: Type
+data InternalMessage where
+  HandleInternalMessage :: Tag ex -> (ex -> IO ()) -> InternalMessage
+
+type Tag :: Type -> Type
+data Tag a where
+  ResourceStatsTag :: Tag (ResourceStats, Trace IO TracerTrace)
+
+-- | Polls the channel until a @Shutdown@ message is received.
+blockUntilShutdown :: OutChan (RawMessage internal user) -> IO ()
+blockUntilShutdown outChan = go where
+  go :: IO ()
+  go = readChan outChan >>= \case
+         Shutdown -> pure ()
+         _        -> go
+
+-- | Serves a channel with a composable `MessageHandler'-function.
+--
+-- @
+-- onInternal    = handleMessageWithShutdown . handleInternal
+-- onUser        = handleMessageWithShutdown . handleUser
+-- dieOnShutdown = handleMessageWithShutdown mempty
+-- @
+--
+-- These handlers are composable with the function Monoid instance.
+--
+-- @
+--   handleMessage  (handleInternal handle1 <> handleUser handle2)
+-- = handleMessages [handleInternal handle1, handleUser handle2]
+-- @
+--
+-- Where @handleMessage (a <> b <> c)@ is equivalent to @handleMessages [a, b, c]@.
+--
+-- Instantiations:
+--
+-- @
+-- handleMessage :: (RawMessage internal user -> IO ()) -> OutChan (RawMessage internal user) -> IO ()
+-- handleMessage :: MessageHandler internal user        -> OutChan (RawMessage internal user) -> IO ()
+-- @
+handleMessage :: (chan -> IO ()) -> OutChan chan -> IO ()
+handleMessage handler outChan = do
+  (element, _out) <- tryReadChan outChan
+  tryRead element >>= traverse_ @Maybe handler
+
+handleMessages :: [MessageHandler internal user] -> OutChan (RawMessage internal user) -> IO ()
+handleMessages = handleMessage . mconcat
+
+handleMessageWithShutdown :: MessageHandler internal user -> OutChan (RawMessage internal user) -> IO ()
+handleMessageWithShutdown handler = handleMessage (handler <> handleShutdown)
+
+handleMessagesWithShutdown :: [MessageHandler internal user] -> OutChan (RawMessage internal user) -> IO ()
+handleMessagesWithShutdown = handleMessageWithShutdown . mconcat
+
+onRawMessage :: (internal -> IO ()) -> (user -> IO ()) -> OutChan (RawMessage internal user) -> IO ()
+onRawMessage internal user = handleMessagesWithShutdown
+  [ handleInternal internal
+  , handleUser user
+  ]
+
+-- onInternal = (`onRawMessage` mempty)
+onInternal :: (internal -> IO ()) -> OutChan (RawMessage internal user) -> IO ()
+onInternal = handleMessageWithShutdown . handleInternal
+
+-- onUser = (mempty `onRawMessage`)
+onUser :: (user -> IO ()) -> OutChan (RawMessage internal user) -> IO ()
+onUser = handleMessageWithShutdown . handleUser
+
+-- dieOnShutdown = onRawMessage mempty mempty
+dieOnShutdown :: OutChan (RawMessage internal user) -> IO ()
+dieOnShutdown = handleMessagesWithShutdown []
+
+-- | An infinite loop (@forever@) that runs an action every iteration,
+-- after checking for a message from the out-channel. If a message is
+-- received it is handled by the message handler.
+--
+-- To terminate the loop use handler like @handleTerminateOnShutdown@
+-- that throws a @Terminate@ exception.
+forever'til :: MessageHandler internal user -> OutChan (RawMessage internal user) -> IO () -> IO ()
+forever'til handler outChan action = do
+  (element, _out) <- tryReadChan outChan -- non-blocking
+  tryRead element >>= \case
+    -- Channel empty, returns Nothing immediately if channel is empty.
+    Nothing -> do
+      action
+      forever'til handler outChan action
+    Just message -> do
+      catch (handler message *> action *> forever'til handler outChan action) \Terminate ->
+        pure ()
+
+forever'tilShutdown :: MessageHandler internal user -> OutChan (RawMessage internal user) -> IO () -> IO ()
+forever'tilShutdown handler = forever'til (handleTerminateOnShutdown <> handler)
+
+-- | Composable handlers, with a functional Monoidal instance.
+--
+-- Monoid instance via 'Ap (RawMessage internal user ->) (IO ())'.
+--
+-- @
+--   instance Semigroup (MessageHandler internal user) where
+--     (<>) = liftA2 (<>)
+--   instance Monoid (MessageHandler internal user) where
+--     mempty = pure mempty
+-- @
+--
+-- The handler functions are composed together, the incoming argument
+-- gets passed pointwise to each function.
+--
+-- @
+--   (handleShutdown <> handleInternal internal <> handleUser user) Shutdown
+-- = handleShutdown Shutdown <> handleInternal internal Shutdown <> handleUser user Shutdown
+-- = handleShutdown Shutdown <> mempty <> mempty
+-- = myThreadId >>= (`throwTo` ThreadKilled)
+--
+--   (handleShutdown <> handleInternal internal <> handleUser user) (InternalMessage message)
+-- = handleShutdown (InternalMessage message) <> handleInternal internal (InternalMessage message) <> handleUser user (InternalMessage message)
+-- = internal message
+-- @
+
+type MessageHandler :: Type -> Type -> Type
+type MessageHandler internal user = RawMessage internal user -> IO ()
+
+-- | Exception that terminates.
+data MessageException = Terminate
+  deriving stock Show
+  deriving anyclass Exception
+
+handleShutdown :: MessageHandler internal user
+handleShutdown = \case
+  Shutdown -> myThreadId >>= (`throwTo` ThreadKilled)
+  _        -> mempty
+
+-- | Message handler for internal messages.
+--
+-- @
+-- handleInternal :: Monoid m => (internal -> m) -> RawMessage internal user -> m
+-- @
+handleInternal :: (internal -> IO ()) -> MessageHandler internal user
+handleInternal handler = \case
+  InternalMessage internal -> handler internal
+  _                        -> mempty
+
+-- | Message handler for user messages.
+--
+-- @
+-- handleUser :: Monoid m => (user -> m) -> RawMessage internal user -> m
+-- @
+handleUser :: (user -> IO ()) -> MessageHandler internal user
+handleUser handler = \case
+  UserMessage user -> handler user
+  _                -> mempty
+
+-- | Message handler that throws a @Terminate@ exception on @Shutdown@.
+handleTerminateOnShutdown :: MessageHandler internal user
+handleTerminateOnShutdown Shutdown = throwIO Terminate
+handleTerminateOnShutdown _        = pure ()
+
+handleNoop :: MessageHandler internal user
+handleNoop = mempty
+
+{- | UNSAFE shorthand
+
+  doing \case
+    A -> res
+
+is shorthand for
+
+  \case
+    A -> res
+    _ -> mempty
+
+-- mapMaybe' = mapMaybe . partialBinding
+-- Just 10 >>= partialBinding \10 -> "10"
+partialBinding :: (a -> b) -> (a -> Maybe b)
+partialBinding f a = unsafePerformIO do
+  try @PatternMatchFail (evaluate (f a)) >>= \case
+    Left (PatternMatchFail err)
+      | any (`isSuffixOf` err)
+          [ ": Non-exhaustive patterns in lambda\n"
+          , ": Non-exhaustive patterns in \\case\n"
+          , ": Non-exhaustive patterns in \\cases\n"
+          ]
+     -> pure @IO (Nothing)
+    Left err ->
+      throwIO err
+    Right b ->
+      pure @IO (Just b)
+
+doing :: Monoid m => (a -> m) -> (a -> m)
+doing f a = case partialBinding f a of
+  Nothing -> mempty
+  Just b -> b
+-}

--- a/cardano-tracer/src/Cardano/Tracer/Handlers/Logs/Rotator.hs
+++ b/cardano-tracer/src/Cardano/Tracer/Handlers/Logs/Rotator.hs
@@ -6,7 +6,7 @@ module Cardano.Tracer.Handlers.Logs.Rotator
   ) where
 
 import           Cardano.Tracer.Configuration
-import           Cardano.Tracer.Environment
+import           Cardano.Tracer.Environment (TracerEnv (..), handleNoop, forever'tilShutdown)
 import           Cardano.Tracer.Handlers.Logs.Utils (createOrUpdateEmptyLog, getTimeStampFromLog,
                    isItLog)
 import           Cardano.Tracer.MetaTrace
@@ -14,8 +14,9 @@ import           Cardano.Tracer.Types (HandleRegistry, HandleRegistryKey, NodeNa
 import           Cardano.Tracer.Utils (showProblemIfAny, readRegistry)
 
 import           Control.Concurrent.Async (forConcurrently_)
+import           Control.Concurrent.Chan.Unagi (dupChan)
 import           Control.Concurrent.Extra (Lock)
-import           Control.Monad (forM_, forever, unless, when)
+import           Control.Monad (forM_, unless, when)
 import           Control.Monad.Extra (whenJust, whenM)
 import           Data.Foldable (for_)
 import           Data.List (nub, sort)
@@ -33,38 +34,40 @@ import           System.Time.Extra (sleep)
 
 -- | Runs rotation mechanism for the log files.
 runLogsRotator :: TracerEnv -> IO ()
-runLogsRotator TracerEnv
-  { teConfig = TracerConfig{rotation, verbosity, logging}
-  , teCurrentLogLock
-  , teTracer
-  , teRegistry
-  } = do
-  whenJust rotation \rotParams -> do
+runLogsRotator tracerEnv@TracerEnv { teConfig = TracerConfig{rotation}, teTracer } = do
+  whenJust rotation \rot -> do
     traceWith teTracer TracerStartedLogRotator
-    launchRotator loggingParamsForFiles rotParams verbosity teTracer teRegistry teCurrentLogLock
- where
+    launchRotator tracerEnv rot
+
+launchRotator
+  :: TracerEnv
+  -> RotationParams
+  -> IO ()
+launchRotator tracerEnv rot@RotationParams{rpFrequencySecs} = do
+  whenNonEmpty loggingParamsForFiles do
+    outChan <- dupChan teInChan
+    forever'tilShutdown handleNoop outChan do
+      showProblemIfAny verbosity teTracer do
+        forM_ loggingParamsForFiles \loggingParam -> do
+          checkRootDir teCurrentLogLock teRegistry rot loggingParam
+      sleep (fromIntegral rpFrequencySecs)
+  where
+  whenNonEmpty :: Applicative f => [a] -> f () -> f ()
+  whenNonEmpty = unless . null
+
+  TracerEnv
+    { teConfig = TracerConfig{verbosity, logging}
+    , teCurrentLogLock
+    , teRegistry
+    , teInChan
+    , teTracer
+    } = tracerEnv
+
   loggingParamsForFiles :: [LoggingParams]
   loggingParamsForFiles = nub (NE.filter filesOnly logging)
 
   filesOnly :: LoggingParams -> Bool
   filesOnly LoggingParams{logMode} = logMode == FileMode
-
-launchRotator
-  :: [LoggingParams]
-  -> RotationParams
-  -> Maybe Verbosity
-  -> Trace IO TracerTrace
-  -> HandleRegistry
-  -> Lock
-  -> IO ()
-launchRotator [] _ _ _ _ _ = return ()
-launchRotator loggingParamsForFiles
-              rotParams@RotationParams{rpFrequencySecs} verb tracer registry currentLogLock =
-  forever do
-    showProblemIfAny verb tracer do
-      forM_ loggingParamsForFiles \loggingParam -> do
-        checkRootDir currentLogLock registry rotParams loggingParam
-    sleep $ fromIntegral rpFrequencySecs
 
 -- | All the logs with 'TraceObject's received from particular node
 --   will be stored in a separate subdirectory in the root directory.

--- a/cardano-tracer/test/Cardano/Tracer/Test/Acceptor.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/Acceptor.hs
@@ -19,6 +19,7 @@ import           Cardano.Tracer.MetaTrace
 import           Cardano.Tracer.Types
 import           Cardano.Tracer.Utils
 
+import           Control.Concurrent.Chan.Unagi (newChan)
 import           Control.Concurrent.Extra (newLock)
 #if RTVIEW
 import           Control.Concurrent.STM.TVar (newTVarIO, readTVarIO)
@@ -67,6 +68,8 @@ launchAcceptorsSimple mode localSock dpName = do
 
   registry <- newRegistry
 
+  (inChan, _outChan) <- newChan
+
   let tracerEnv :: TracerEnv
       tracerEnv = TracerEnv
         { teConfig                = mkConfig
@@ -82,6 +85,7 @@ launchAcceptorsSimple mode localSock dpName = do
         , teRegistry              = registry
         , teStateDir              = Nothing
         , teMetricsHelp           = []
+        , teInChan                = inChan
         }
 
       tracerEnvRTView :: TracerEnvRTView

--- a/cardano-tracer/test/Cardano/Tracer/Test/Forwarder.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/Forwarder.hs
@@ -18,7 +18,7 @@ module Cardano.Tracer.Test.Forwarder
 import           Cardano.Logging (DetailLevel (..), SeverityS (..), TraceObject (..))
 import           Cardano.Logging.Types (HowToConnect)
 import qualified Cardano.Logging.Types as Net
-import           Cardano.Logging.Utils (runInLoop)
+import           Cardano.Logging.Utils (RunInLoopTermination(TerminateNever), runInLoop)
 import           Cardano.Tracer.Configuration (Verbosity (..))
 import           Cardano.Tracer.Test.TestSetup
 import           Cardano.Tracer.Test.Utils
@@ -95,7 +95,7 @@ launchForwardersSimple
   -> Word
   -> IO ()
 launchForwardersSimple ts mode howToConnect queueSize = withIOManager \iomgr ->
-  runInLoop (launchForwardersSimple' ts iomgr mode howToConnect queueSize) handleInterruption 1 60
+  runInLoop (launchForwardersSimple' ts iomgr mode howToConnect queueSize) TerminateNever handleInterruption 1 60
   where
     handleInterruption = const $ pure ()
 

--- a/cardano-tracer/test/Cardano/Tracer/Test/Restart/Tests.hs
+++ b/cardano-tracer/test/Cardano/Tracer/Test/Restart/Tests.hs
@@ -20,6 +20,7 @@ import           Ouroboros.Network.Magic (NetworkMagic (..))
 import           Control.Concurrent.Async (asyncBound, uninterruptibleCancel)
 import           Control.Monad (forM_)
 import           Control.Monad.Extra (ifM)
+import           Data.Functor (void)
 import qualified Data.List.NonEmpty as NE
 import           System.Directory (removePathForcibly)
 import           System.Directory.Extra (listDirectories)
@@ -41,8 +42,8 @@ propNetworkForwarder ts rootDir localSock = do
   brake <- initProtocolsBrake
   dpRequestors <- initDataPointRequestors
   propNetwork' ts rootDir
-    ( launchForwardersSimple ts Initiator (Net.LocalPipe localSock) 10000
-    , doRunCardanoTracer config (Just $ rootDir <> "/../state") stderrShowTracer brake dpRequestors
+    ( launchForwardersSimple ts Initiator (Net.LocalPipe localSock) 1000
+    , void $ doRunCardanoTracer config (Just $ rootDir <> "/../state") stderrShowTracer brake dpRequestors
     )
 
 propNetwork'

--- a/trace-dispatcher/src/Cardano/Logging/Utils.hs
+++ b/trace-dispatcher/src/Cardano/Logging/Utils.hs
@@ -6,7 +6,7 @@ module Cardano.Logging.Utils
 
 
 import           Control.Concurrent (threadDelay)
-import           Control.Concurrent.Async (concurrently_)
+import           Control.Concurrent.Async (concurrently_, race_)
 import           Control.Exception (SomeAsyncException (..), SomeException, fromException, tryJust)
 import           Data.IORef
 import qualified Data.Text as T
@@ -16,15 +16,18 @@ import qualified Data.Text.Lazy.Builder.Int as T
 import qualified Data.Text.Lazy.Builder.RealFloat as T (realFloat)
 import           GHC.Conc (labelThread, myThreadId)
 
+data RunInLoopTermination 
+  = TerminateNever
+  | TerminateWhenNoLongerBlocking (IO ())
 
 -- | Run an IO action which may throw an exception in a loop.
 --   On exception, the action will be re-run after a pause.
 --   That pause doubles which each exception, but is reset when the action runs long enough.
-runInLoop :: IO () -> (SomeException -> IO ()) -> Word -> Word -> IO ()
-runInLoop action handleInterruption initialDelay maxDelay
-  | initialDelay == 0         = runInLoop action handleInterruption 1 maxDelay
-  | maxDelay < initialDelay   = runInLoop action handleInterruption initialDelay initialDelay
-  | otherwise                 = newIORef (fromIntegral initialDelay) >>= go
+runInLoop :: IO () -> RunInLoopTermination -> (SomeException -> IO ()) -> Word -> Word -> IO ()
+runInLoop action runInLoopTermination handleInterruption initialDelay maxDelay
+  | initialDelay == 0         = runInLoop action runInLoopTermination handleInterruption 1 maxDelay
+  | maxDelay < initialDelay   = runInLoop action runInLoopTermination handleInterruption initialDelay initialDelay
+  | otherwise                 = newIORef (fromIntegral initialDelay) >>= interpret
   where
     go :: IORef Int -> IO ()
     go currentDelay =
@@ -35,6 +38,11 @@ runInLoop action handleInterruption initialDelay maxDelay
           threadDelay $ 1_000_000 * waitForSecs
           go currentDelay
         Right _ -> return ()
+
+    interpret :: IORef Int -> IO ()
+    interpret currentDelay = case runInLoopTermination of
+      TerminateNever -> go currentDelay
+      TerminateWhenNoLongerBlocking blocking -> race_ blocking (go currentDelay)
 
     -- if the action runs at least maxDelay seconds, the pause is reset
     actionResettingDelay currentDelay = concurrently_ action $ do

--- a/trace-forward/src/Trace/Forward/Forwarding.hs
+++ b/trace-forward/src/Trace/Forward/Forwarding.hs
@@ -16,7 +16,7 @@ module Trace.Forward.Forwarding
   ) where
 
 import           Cardano.Logging.Types
-import           Cardano.Logging.Utils (runInLoop)
+import           Cardano.Logging.Utils (runInLoop, RunInLoopTermination(..))
 import           Ouroboros.Network.Driver.Limits (ProtocolTimeLimits)
 import           Ouroboros.Network.IOManager (IOManager)
 import           Ouroboros.Network.Magic (NetworkMagic)
@@ -208,6 +208,7 @@ launchForwarders iomgr forwarding
              sink
              initEKGStore
              dpStore)
+          TerminateNever
           (fromMaybe (const $ pure ()) initOnForwardInterruption)
           1
           maxReconnectDelay


### PR DESCRIPTION
# Description

Define a library for _cardano-tracer_ including functionality to clean up a previously started instance (`cleanupCardanoTracer`). 

Uses channels to communicate shutdown.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] New tests are added if needed and existing tests are updated. 
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [X] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
