### PR TITLE
Test integration of ouroboros-consensus@peras/backport-1780-to-0.28.0.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -72,3 +72,10 @@ if impl (ghc >= 9.12)
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
+
+-- Points to release/ouroboros-consensus-0.28.0.0 + backported #1780
+source-repository-package
+  type: git
+  location: https://github.com/IntersectMBO/ouroboros-consensus.git
+  tag: 223e60ee4ae7a485c41397cde845f77db7c9c210
+  subdir: ouroboros-consensus-diffusion

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -481,6 +481,7 @@ handleSimpleNode blockType runP tracers nc onKernel = do
               onKernel nodeKernel
           , rnPeerSharing    = ncPeerSharing nc
           , rnGetUseBootstrapPeers = readTVar useBootstrapVar
+          , rnFeatureFlags = mempty
           }
 #ifdef UNIX
     -- initial `SIGHUP` handler, which only rereads the topology file but


### PR DESCRIPTION
The purpose of this PR is to test the integration of https://github.com/IntersectMBO/ouroboros-consensus/pull/1780 into `cardano-node@10.6.1`. To simplify things, https://github.com/IntersectMBO/ouroboros-consensus/pull/1780 was trivially [backported](https://github.com/IntersectMBO/ouroboros-consensus/compare/release/ouroboros-consensus-protocol-0.13.0.0...peras/backport-1780-to-0.28.0.0) into `releases/ouroboros-consensus-0.28.0.0`.

Do not merge!