### PR TITLE
Fix protocol version in configuration

### DIFF
--- a/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Cardano.hs
@@ -100,7 +100,8 @@ mkSomeConsensusProtocolCardano NodeByronProtocolConfiguration {
                              npcTestAlonzoHardForkAtEpoch,
                              npcTestBabbageHardForkAtEpoch,
                              npcTestConwayHardForkAtEpoch,
-                             npcTestDijkstraHardForkAtEpoch
+                             npcTestDijkstraHardForkAtEpoch,
+                             npcExperimentalHardForksEnabled
                            }
                            checkpointsConfiguration
                            files = do
@@ -177,7 +178,9 @@ mkSomeConsensusProtocolCardano NodeByronProtocolConfiguration {
                                             shelleyGenesisHash,
           shelleyBasedLeaderCredentials = shelleyLeaderCredentials
         }
-      , Consensus.cardanoProtocolVersion = ProtVer (natVersion @10) 7
+      , Consensus.cardanoProtocolVersion = if npcExperimentalHardForksEnabled
+                                           then ProtVer (natVersion @11) 0
+                                           else ProtVer (natVersion @10) 7
         -- The remaining arguments specify the parameters needed to transition between two eras
       , Consensus.cardanoLedgerTransitionConfig =
           Ledger.mkLatestTransitionConfig


### PR DESCRIPTION
# Description

This PR addresses this issue: https://github.com/IntersectMBO/cardano-node/issues/6382

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff
