### PR TITLE
PrometheusSimple backend robustness improvements

### DIFF
--- a/trace-dispatcher/CHANGELOG.md
+++ b/trace-dispatcher/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.11.1 -- Dez 2025
 
+* Increase `PrometheusSimple` robustness by restarting the backend upon crash, adding start/stop traces and more eagerly reaping of dangling sockets
 * Removed `TraceConfig.tcPeerFrequency` and hence `TraceOptionPeerFrequency` from config representation
 * Removed unused module `Cardano.Logging.Types.NodePeers`
 


### PR DESCRIPTION
# Description

This PR addresses issue #6389. It aims to mitigate unresponsiveness or even crashes of the Node's internal `PrometheusSimple` metrics backend that may be caused by factors in the host environment.

It contains the following changes to the backend, improving robustness:

* Make the backend auto-retry/-restart when startup fails or its thread receives an exception
* Trace start and stop events of the backend to provide basic observability
* Be more eager in reaping dangling socket connections
* Fine-tune the backend's DoS protection settings somewhat

It has no impact on Node configuration or CLI arguments.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff
