### PR TITLE
Remove optparse-applicative-fork dependency where not depending on cardano-cli

### DIFF
--- a/bench/cardano-profile/app/cardano-profile.hs
+++ b/bench/cardano-profile/app/cardano-profile.hs
@@ -15,7 +15,7 @@ import           Data.Aeson.Encode.Pretty as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL8
 -- Package: containers.
 import qualified Data.Map.Strict as Map
--- Package: optparse-applicative-fork.
+-- Package: optparse-applicative.
 import qualified Options.Applicative as OA
 -- Package: self.
 import qualified Cardano.Benchmarking.Profile as Profile

--- a/bench/cardano-profile/cardano-profile.cabal
+++ b/bench/cardano-profile/cardano-profile.cabal
@@ -92,7 +92,7 @@ executable cardano-profile
                       , vector
                       , bytestring
                       , containers
-                      , optparse-applicative-fork
+                      , optparse-applicative
                       , text
                       , cardano-profile
 

--- a/bench/cardano-topology/cardano-topology.cabal
+++ b/bench/cardano-topology/cardano-topology.cabal
@@ -65,7 +65,7 @@ executable cardano-topology
                       , bytestring
                       , containers
                       , graphviz
-                      , optparse-applicative-fork
+                      , optparse-applicative
                       , split
                       , text
                       , cardano-topology

--- a/bench/locli/locli.cabal
+++ b/bench/locli/locli.cabal
@@ -124,7 +124,7 @@ library
                       , filepath
                       , fingertree == 0.1.5.0
                       , hashable
-                      , optparse-applicative-fork >= 0.18.1
+                      , optparse-applicative
                       , ouroboros-consensus
                       , ouroboros-network-api ^>= 0.16
                       , sop-core
@@ -156,7 +156,7 @@ executable locli
   build-depends:        aeson
                       , cardano-prelude
                       , locli
-                      , optparse-applicative-fork
+                      , optparse-applicative
                       , text
                       , text-short
                       , transformers

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -139,7 +139,7 @@ library
                       , mtl
                       , network
                       , network-mux
-                      , optparse-applicative-fork
+                      , optparse-applicative
                       , ouroboros-consensus >= 0.6
                       , ouroboros-consensus-cardano >= 0.5
                       , ouroboros-consensus-diffusion >= 0.7.0
@@ -202,7 +202,7 @@ executable calibrate-script
                       , directory
                       , extra
                       , filepath
-                      , optparse-applicative-fork
+                      , optparse-applicative
                       , cardano-api
                       , text
                       , transformers
@@ -235,7 +235,7 @@ test-suite tx-generator-apitest
                       , directory
                       , extra
                       , filepath
-                      , optparse-applicative-fork
+                      , optparse-applicative
                       , cardano-api
                       , cardano-cli
                       , cardano-node

--- a/cardano-node-capi/cardano-node-capi.cabal
+++ b/cardano-node-capi/cardano-node-capi.cabal
@@ -24,5 +24,5 @@ library
                       , aeson
                       , bytestring
                       , cardano-node
-                      , optparse-applicative-fork
+                      , optparse-applicative
   hs-source-dirs:       src

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -50,7 +50,7 @@ executable cardano-node-chairman
                       , containers
                       , contra-tracer
                       , io-classes:{io-classes, strict-stm, si-timers}
-                      , optparse-applicative-fork
+                      , optparse-applicative
                       , ouroboros-consensus
                       , ouroboros-consensus-cardano
                       , ouroboros-network-api

--- a/cardano-node/app/cardano-node.hs
+++ b/cardano-node/app/cardano-node.hs
@@ -18,8 +18,8 @@ import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import           Data.Version (showVersion)
 import           Options.Applicative
+import           Options.Applicative.Help.Pretty
 import qualified Options.Applicative as Opt
-import           Options.Applicative.Help ((<$$>))
 import           System.Info (arch, compilerName, compilerVersion, os)
 import           System.IO (hPutStrLn, stderr)
 
@@ -70,10 +70,12 @@ main = do
 
       nodeCliHelpMain :: String
       nodeCliHelpMain = renderHelpDoc 80 $
-        parserHelpHeader "cardano-node" nodeCLIParser
-        <$$> ""
-        <$$> parserHelpOptions nodeCLIParser
-
+        mconcat [ parserHelpHeader "cardano-node" nodeCLIParser
+                , line'
+                , ""
+                , line'
+                , parserHelpOptions nodeCLIParser
+                ]
 
 data Command = RunCmd PartialNodeConfiguration
              | TraceDocumentation TraceDocumentationCmd

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -184,7 +184,7 @@ library
                       , network
                       , network-mux >= 0.8
                       , nothunks
-                      , optparse-applicative-fork >= 0.18.1
+                      , optparse-applicative
                       , ouroboros-consensus ^>= 0.28
                       , ouroboros-consensus-cardano ^>= 0.26
                       , ouroboros-consensus-diffusion ^>= 0.24
@@ -236,7 +236,7 @@ executable cardano-node
                       , cardano-crypto-class
                       , cardano-git-rev
                       , cardano-node
-                      , optparse-applicative-fork
+                      , optparse-applicative
                       , text
 
 test-suite cardano-node-test

--- a/cardano-node/src/Cardano/Node/Parsers.hs
+++ b/cardano-node/src/Cardano/Node/Parsers.hs
@@ -38,6 +38,7 @@ import           Options.Applicative hiding (str, switch)
 -- file.  See `parseStartAsNonProducingNode` and `parseValidateDB`.
 import qualified Options.Applicative as Opt
 import qualified Options.Applicative.Help as OptI
+import qualified Prettyprinter.Internal as PP
 import           System.Posix.Types (Fd (..))
 import           Text.Read (readMaybe)
 
@@ -433,4 +434,4 @@ parserHelpOptions = fromMaybe mempty . OptI.unChunk . OptI.fullDesc (Opt.prefs m
 -- | Render the help pretty document.
 renderHelpDoc :: Int -> OptI.Doc -> String
 renderHelpDoc cols =
-  (`OptI.renderShowS` "") . OptI.layoutPretty (OptI.LayoutOptions (OptI.AvailablePerLine cols 1.0))
+  (`PP.renderShowS` "") . OptI.layoutPretty (OptI.LayoutOptions (OptI.AvailablePerLine cols 1.0))

--- a/cardano-tracer/cardano-tracer.cabal
+++ b/cardano-tracer/cardano-tracer.cabal
@@ -257,7 +257,7 @@ library demo-forwarder-lib
                       , generic-data
                       , network
                       , network-mux
-                      , optparse-applicative-fork >= 0.18.1
+                      , optparse-applicative
                       , ouroboros-network-api
                       , ouroboros-network-framework
                       , tasty-quickcheck
@@ -302,7 +302,7 @@ library demo-acceptor-lib
                       , extra
                       , filepath
                       , generic-data
-                      , optparse-applicative-fork >= 0.18.1
+                      , optparse-applicative
                       , ouroboros-network-api
                       , stm <2.5.2 || >=2.5.3
                       , tasty-quickcheck
@@ -363,7 +363,7 @@ test-suite cardano-tracer-test
                       , generic-data
                       , network
                       , network-mux
-                      , optparse-applicative-fork >= 0.18.1
+                      , optparse-applicative
                       , ouroboros-network-api
                       , ouroboros-network-framework
                       , stm <2.5.2 || >=2.5.3
@@ -423,7 +423,7 @@ test-suite cardano-tracer-test-ext
                       , Glob
                       , network
                       , network-mux
-                      , optparse-applicative-fork >= 0.18.1
+                      , optparse-applicative
                       , ouroboros-network ^>= 0.22.4
                       , ouroboros-network-api
                       , ouroboros-network-framework


### PR DESCRIPTION
# Description

Replace optparse-applicative-fork with optparse-applicative where the fork is not necesary.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
