### PR TITLE
cardano-node-10.5.4 with ourboros-network-0.21.6.0

### DIFF
--- a/bench/locli/locli.cabal
+++ b/bench/locli/locli.cabal
@@ -126,7 +126,7 @@ library
                       , hashable
                       , optparse-applicative-fork >= 0.18.1
                       , ouroboros-consensus
-                      , ouroboros-network-api ^>= 0.14.1
+                      , ouroboros-network-api ^>= 0.14.2
                       , sop-core
                       , split
                       , sqlite-easy >= 1.1.0.1

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2025-06-03T08:07:10Z
-  , cardano-haskell-packages 2025-11-20T19:55:27Z
+  , cardano-haskell-packages 2026-01-05T11:07:19Z
 
 packages:
   cardano-node

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.8
 
 name:                   cardano-node
-version:                10.5.3
+version:                10.5.4
 synopsis:               The cardano full node
 description:            The cardano full node.
 category:               Cardano,
@@ -197,8 +197,8 @@ library
                       , ouroboros-consensus-cardano ^>= 0.25
                       , ouroboros-consensus-diffusion ^>= 0.23
                       , ouroboros-consensus-protocol
-                      , ouroboros-network-api ^>= 0.14.1
-                      , ouroboros-network ^>= 0.21.4
+                      , ouroboros-network-api ^>= 0.14.2
+                      , ouroboros-network ^>= 0.21.5
                       , ouroboros-network-framework ^>= 0.18
                       , ouroboros-network-protocols ^>= 0.14
                       , prettyprinter

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/P2P.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/P2P.hs
@@ -313,13 +313,14 @@ instance LogFormatting (TracePeerSelection Cardano.DebugPeerSelectionState PeerT
              , "targetLocalEstablished" .= tLocalEst
              , "selectedPeers" .= toJSONList (toList sp)
              ]
-  forMachine _dtal (TracePromoteColdFailed tEst aEst p d err) =
+  forMachine _dtal (TracePromoteColdFailed tEst aEst p d err forgotten) =
     mconcat [ "kind" .= String "PromoteColdFailed"
              , "targetEstablished" .= tEst
              , "actualEstablished" .= aEst
              , "peer" .= toJSON p
              , "delay" .= toJSON d
              , "reason" .= show err
+             , "forgotten" .= forgotten
              ]
   forMachine _dtal (TracePromoteColdDone tEst aEst p) =
     mconcat [ "kind" .= String "PromoteColdDone"
@@ -333,13 +334,14 @@ instance LogFormatting (TracePeerSelection Cardano.DebugPeerSelectionState PeerT
              , "actualEstablished" .= actualKnown
              , "selectedPeers" .= toJSONList (toList sp)
              ]
-  forMachine _dtal (TracePromoteColdBigLedgerPeerFailed tEst aEst p d err) =
+  forMachine _dtal (TracePromoteColdBigLedgerPeerFailed tEst aEst p d err forgotten) =
     mconcat [ "kind" .= String "PromoteColdBigLedgerPeerFailed"
              , "targetEstablished" .= tEst
              , "actualEstablished" .= aEst
              , "peer" .= toJSON p
              , "delay" .= toJSON d
              , "reason" .= show err
+             , "forgotten" .= forgotten
              ]
   forMachine _dtal (TracePromoteColdBigLedgerPeerDone tEst aEst p) =
     mconcat [ "kind" .= String "PromoteColdBigLedgerPeerDone"

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Network.hs
@@ -1913,13 +1913,14 @@ instance ToObject (TracePeerSelection Cardano.DebugPeerSelectionState PeerTrusta
              , "targetLocalEstablished" .= tLocalEst
              , "selectedPeers" .= Aeson.toJSONList (toList sp)
              ]
-  toObject _verb (TracePromoteColdFailed tEst aEst p d err) =
+  toObject _verb (TracePromoteColdFailed tEst aEst p d err forgotten) =
     mconcat [ "kind" .= String "PromoteColdFailed"
              , "targetEstablished" .= tEst
              , "actualEstablished" .= aEst
              , "peer" .= toJSON p
              , "delay" .= toJSON d
              , "reason" .= show err
+             , "forgoeten" .= forgotten
              ]
   toObject _verb (TracePromoteColdDone tEst aEst p) =
     mconcat [ "kind" .= String "PromoteColdDone"
@@ -1933,13 +1934,14 @@ instance ToObject (TracePeerSelection Cardano.DebugPeerSelectionState PeerTrusta
              , "actualEstablished" .= actualKnown
              , "selectedPeers" .= Aeson.toJSONList (toList sp)
              ]
-  toObject _verb (TracePromoteColdBigLedgerPeerFailed tEst aEst p d err) =
+  toObject _verb (TracePromoteColdBigLedgerPeerFailed tEst aEst p d err forgotten) =
     mconcat [ "kind" .= String "PromoteColdBigLedgerPeerFailed"
              , "targetEstablished" .= tEst
              , "actualEstablished" .= aEst
              , "peer" .= toJSON p
              , "delay" .= toJSON d
              , "reason" .= show err
+             , "forgotten" .= forgotten
              ]
   toObject _verb (TracePromoteColdBigLedgerPeerDone tEst aEst p) =
     mconcat [ "kind" .= String "PromoteColdBigLedgerPeerDone"

--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -49,7 +49,7 @@ library
                       , network
                       , optparse-applicative-fork
                       , ouroboros-consensus-cardano
-                      , ouroboros-network ^>= 0.21.4
+                      , ouroboros-network ^>= 0.21.5
                       , ouroboros-network-protocols
                       , prometheus >= 2.2.4
                       , servant

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -72,7 +72,7 @@ library
                       , network
                       , network-mux
                       , optparse-applicative-fork
-                      , ouroboros-network ^>= 0.21.4
+                      , ouroboros-network ^>= 0.21.5
                       , ouroboros-network-api
                       , prettyprinter
                       , process

--- a/cardano-tracer/cardano-tracer.cabal
+++ b/cardano-tracer/cardano-tracer.cabal
@@ -183,8 +183,8 @@ library
                       , mime-mail
                       , network-mux >= 0.8
                       , optparse-applicative
-                      , ouroboros-network ^>= 0.21.4
-                      , ouroboros-network-api ^>= 0.14.1
+                      , ouroboros-network ^>= 0.21.5
+                      , ouroboros-network-api ^>= 0.14.2
                       , ouroboros-network-framework
                       , signal
                       , slugify
@@ -250,7 +250,7 @@ library demo-forwarder-lib
                       , generic-data
                       , network-mux
                       , optparse-applicative-fork >= 0.18.1
-                      , ouroboros-network-api ^>= 0.14.1
+                      , ouroboros-network-api ^>= 0.14.2
                       , ouroboros-network-framework
                       , tasty-quickcheck
                       , time
@@ -293,7 +293,7 @@ library demo-acceptor-lib
                       , filepath
                       , generic-data
                       , optparse-applicative-fork >= 0.18.1
-                      , ouroboros-network-api ^>= 0.14.1
+                      , ouroboros-network-api ^>= 0.14.2
                       , stm <2.5.2 || >=2.5.3
                       , text
                       , tasty-quickcheck
@@ -352,7 +352,7 @@ test-suite cardano-tracer-test
                       , generic-data
                       , network-mux
                       , optparse-applicative-fork >= 0.18.1
-                      , ouroboros-network-api ^>= 0.14.1
+                      , ouroboros-network-api ^>= 0.14.2
                       , ouroboros-network-framework
                       , stm <2.5.2 || >=2.5.3
                       , tasty
@@ -411,8 +411,8 @@ test-suite cardano-tracer-test-ext
                       , Glob
                       , network-mux
                       , optparse-applicative-fork >= 0.18.1
-                      , ouroboros-network ^>= 0.21.4
-                      , ouroboros-network-api ^>= 0.14.1
+                      , ouroboros-network ^>= 0.21.5
+                      , ouroboros-network-api ^>= 0.14.2
                       , ouroboros-network-framework
                       , process
                       , QuickCheck

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1763670101,
-        "narHash": "sha256-3S6OSnW0Nn+YBVmuV0XnYQRAuS3i0F9lRdH4KQiN1uI=",
+        "lastModified": 1767613196,
+        "narHash": "sha256-+YMGLWk1IKQms4XbwwJUsW+n/LXm74H2MgBeuZSpnD8=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "d341a38325d5d65cde10fa92af125b226c51615f",
+        "rev": "d78f79845cfcde6497c0afef650a51a1cff01777",
         "type": "github"
       },
       "original": {

--- a/trace-dispatcher/trace-dispatcher.cabal
+++ b/trace-dispatcher/trace-dispatcher.cabal
@@ -73,7 +73,7 @@ library
                       , network
                       , network-mux
                       , optparse-applicative-fork
-                      , ouroboros-network ^>= 0.21.4
+                      , ouroboros-network ^>= 0.21.5
                       , ouroboros-network-api
                       , ouroboros-network-framework
                       , serialise


### PR DESCRIPTION
# Description

Release `cardano-node-10.5.4` with [`ouroboros-network-0.21.6.0`]

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [ ] Self-reviewed the diff

[`ouroboros-network-0.21.6.0`]: https://github.com/orgs/IntersectMBO/projects/5/views/18
