### PR TITLE
Make `cardano-node --help` show the same help as calling `cardano-node`

### DIFF
--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## Next version
 
+* Improved `cardano-node --help` output by making it the same as the one shown when calling `cardano-node` without arguments.
+
 * Removed `cardano-node' as a dependency from `cardano-tracer'. This necessitated moving `NodeInfo`
   (from `cardano-tracer:Cardano.Node.Startup` to `trace-dispatcher:Cardano.Logging.Types.NodeInfo`), `NodePeers`
   (from `cardano-node:Cardano.Node.Tracing.Peers` to `trace-dispatcher:Cardano.Logging.Types.NodePeers`), and

--- a/cardano-node/app/cardano-node.hs
+++ b/cardano-node/app/cardano-node.hs
@@ -7,8 +7,7 @@ import qualified Cardano.Crypto.Init as Crypto
 import           Cardano.Git.Rev (gitRev)
 import           Cardano.Node.Configuration.POM (PartialNodeConfiguration(..))
 import           Cardano.Node.Handlers.TopLevel
-import           Cardano.Node.Parsers (nodeCLIParser, parserHelpHeader, parserHelpOptions,
-                   renderHelpDoc)
+import           Cardano.Node.Parsers (nodeCLIParser)
 import           Cardano.Node.Run (runNode)
 import           Cardano.Node.Tracing.Documentation (TraceDocumentationCmd (..),
                    parseTraceDocumentationCmd, runTraceDocumentationCmd)
@@ -18,7 +17,6 @@ import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import           Data.Version (showVersion)
 import           Options.Applicative
-import           Options.Applicative.Help.Pretty
 import qualified Options.Applicative as Opt
 import           System.Info (arch, compilerName, compilerVersion, os)
 import           System.IO (hPutStrLn, stderr)
@@ -57,25 +55,12 @@ main = do
         Opt.info (fmap RunCmd nodeCLIParser
                   <|> fmap TraceDocumentation parseTraceDocumentationCmd
                   <|> parseVersionCmd
-                  <**> helperBrief "help" "Show this help text" nodeCliHelpMain)
+                  <**> helper)
 
           ( Opt.fullDesc <>
             Opt.progDesc "Start node of the Cardano blockchain."
           )
 
-      helperBrief :: String -> String -> String -> Parser (a -> a)
-      helperBrief l d helpText = Opt.abortOption (Opt.InfoMsg helpText) $ mconcat
-        [ Opt.long l
-        , Opt.help d ]
-
-      nodeCliHelpMain :: String
-      nodeCliHelpMain = renderHelpDoc 80 $
-        mconcat [ parserHelpHeader "cardano-node" nodeCLIParser
-                , line'
-                , ""
-                , line'
-                , parserHelpOptions nodeCLIParser
-                ]
 
 data Command = RunCmd PartialNodeConfiguration
              | TraceDocumentation TraceDocumentationCmd


### PR DESCRIPTION
# Description

As pointed out by @silky, the command `cardano-node --help` gives a very small and confusing output:

```
Usage: cardano-node run
 
```

But curiously, writing `cardano-node` without parameters gives much better output.

```
Usage: cardano-node run

  Start node of the Cardano blockchain.

Available options:
  --version                Show the cardano-node version
  -h,--help                Show this help text

Run the node
  run                      Run the node.

Miscellaneous commands
  trace-documentation      Generate the trace documentation
  version                  Show the cardano-node version
```

So this PR changes `cardano-node --help` to output the same as `cardano-node` without parameters.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff
