### PR TITLE
Keep cardano-testnet running

### DIFF
--- a/cardano-testnet/src/Parsers/Cardano.hs
+++ b/cardano-testnet/src/Parsers/Cardano.hs
@@ -160,7 +160,7 @@ pGenesisOptions =
         )
 
 cmdCardano :: Mod CommandFields CardanoTestnetCliOptions
-cmdCardano = command' "cardano" "Start a testnet in any era" optsTestnet
+cmdCardano = command' "cardano" "Start a testnet and keep it running until stopped" optsTestnet
 
 cmdCreateEnv :: Mod CommandFields CardanoTestnetCreateEnvOptions
 cmdCreateEnv = command' "create-env" "Create a sandbox for Cardano testnet" optsCreateTestnet

--- a/cardano-testnet/src/Parsers/Run.hs
+++ b/cardano-testnet/src/Parsers/Run.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Parsers.Run
@@ -8,22 +10,21 @@ module Parsers.Run
   , pref
   , opts
   ) where
-
 import           Cardano.CLI.Environment
-import           Control.Monad
 
+import           Control.Monad (void)
 import           Data.Default.Class (def)
-import           Data.Foldable
 import           Options.Applicative
 import qualified Options.Applicative as Opt
-import           RIO (runRIO)
-import           RIO.Orphans 
+
 import           Testnet.Start.Cardano
 import           Testnet.Start.Types
 
 import           Parsers.Cardano
 import           Parsers.Help
 import           Parsers.Version
+import           RIO (display, forever, logInfo, runSimpleApp, threadDelay)
+import           UnliftIO.Resource (runResourceT)
 
 pref :: ParserPrefs
 pref = Opt.prefs $ showHelpOnEmpty <> showHelpOnError
@@ -60,7 +61,7 @@ createEnvOptions CardanoTestnetCreateEnvOptions
   , createEnvGenesisOptions=genesisOptions
   , createEnvOutputDir=outputDir
   , createEnvCreateEnvOptions=ceOptions
-  } = do 
+  } = do
       conf <- mkConfigAbs outputDir
       createTestnetEnv
         testnetOptions genesisOptions ceOptions
@@ -74,21 +75,32 @@ runCardanoOptions CardanoTestnetCliOptions
   , cliGenesisOptions=genesisOptions
   , cliNodeEnvironment=env
   , cliUpdateTimestamps=updateTimestamps'
-  } = do 
+  } = do
     case env of
       NoUserProvidedEnv -> do
         -- Create the sandbox, then run cardano-testnet.
         -- It is not necessary to honor `cliUpdateTimestamps` here, because
         -- the genesis files will be created with up-to-date stamps already.
         conf <- mkConfigAbs "testnet"
-        runRIO () $ createTestnetEnv
-                   testnetOptions genesisOptions def
-                   conf
-        withResourceMap (\rm -> void . runRIO rm $ cardanoTestnet testnetOptions conf)
+        runSimpleApp . runResourceT $ do
+          logInfo $ "Creating environment: " <> display (tempAbsPath conf)
+          createTestnetEnv testnetOptions genesisOptions def conf
+          logInfo $ "Starting testnet in environment: " <> display (tempAbsPath conf)
+          void $ cardanoTestnet testnetOptions conf
+          logInfo "Testnet started"
+          waitForShutdown
       UserProvidedEnv nodeEnvPath -> do
         -- Run cardano-testnet in the sandbox provided by the user
         -- In that case, 'cardanoOutputDir' is not used
         conf <- mkConfigAbs nodeEnvPath
-        withResourceMap (\rm -> void . runRIO rm $ cardanoTestnet
+        runSimpleApp . runResourceT $ do
+          logInfo $ "Starting testnet in environment: " <> display (tempAbsPath conf)
+          void $ cardanoTestnet
             testnetOptions
-            conf{updateTimestamps=updateTimestamps'})
+            conf{updateTimestamps=updateTimestamps'}
+          logInfo "Testnet started"
+          waitForShutdown
+  where
+    waitForShutdown = do
+      logInfo "Waiting for shutdown (Ctrl+C)"
+      forever (threadDelay 100_000)

--- a/cardano-testnet/src/Testnet/Filepath.hs
+++ b/cardano-testnet/src/Testnet/Filepath.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -17,6 +18,8 @@ import           System.FilePath
 
 import           Hedgehog.Extras.Stock.IO.Network.Sprocket (Sprocket (..))
 
+import           RIO (Display (..))
+
 
 makeSprocket
   :: TmpAbsolutePath
@@ -31,6 +34,9 @@ makeSprocket tmpAbsPath node
 newtype TmpAbsolutePath = TmpAbsolutePath
   { unTmpAbsPath :: FilePath
   } deriving (Eq, Show, IsString)
+
+instance Display TmpAbsolutePath where
+  textDisplay = fromString . unTmpAbsPath
 
 makeTmpRelPath :: TmpAbsolutePath -> FilePath
 makeTmpRelPath (TmpAbsolutePath fp) = makeRelative (makeTmpBaseAbsPath (TmpAbsolutePath fp)) fp

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
@@ -13,7 +13,7 @@ Usage: cardano-testnet cardano [--num-pool-nodes COUNT]
   [--node-env FILEPATH]
   [--update-time]
 
-  Start a testnet in any era
+  Start a testnet and keep it running until stopped
 
 Usage: cardano-testnet create-env [--num-pool-nodes COUNT]
   [--max-lovelace-supply WORD64]

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/cardano.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/cardano.cli
@@ -11,7 +11,7 @@ Usage: cardano-testnet cardano [--num-pool-nodes COUNT]
   [--node-env FILEPATH]
   [--update-time]
 
-  Start a testnet in any era
+  Start a testnet and keep it running until stopped
 
 Available options:
   --num-pool-nodes COUNT   Number of pool nodes. Note this uses a default node


### PR DESCRIPTION
# Description

This realizes what the command line options promise: "Start a testnet"

Also adds log output to stderr to update the user about what is happening.


# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
