### PR TITLE
Change pkgs.system to pkgs.stdenv.hostPlatform.system in cardano-node-service.nix

### DIFF
--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -265,7 +265,7 @@ in {
 
       cardanoNodePackages = mkOption {
         type = attrs;
-        default = pkgs.cardanoNodePackages or (import ../. { inherit (pkgs) system; }).cardanoNodePackages;
+        default = pkgs.cardanoNodePackages or (import ../. { inherit (pkgs.stdenv.hostPlatform) system; }).cardanoNodePackages;
         defaultText = "cardano-node packages";
         description = ''
           The cardano-node packages and library that should be used. The main


### PR DESCRIPTION
# Description

This fixes the following evaluation warning on recent nixpkgs releases:
```
evaluation warning: 'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'
```
We use the `cardano-node-service.nix` module in our NixOS config like so:
```
  imports = [
    ./ax41-nvme.nix
    ./common.nix
    "${inputs.cardano-node}/nix/nixos/cardano-node-service.nix"
  ];
 ```
 This PR makes the warning disappear.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff

