### PR TITLE
Update Dijkstra-era script purpose rendering to use Conway rendering logic

### DIFF
--- a/cardano-node/src/Cardano/Node/Tracing/Render.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Render.hs
@@ -208,8 +208,7 @@ renderScriptPurpose =
       Api.AlonzoEraOnwardsAlonzo -> renderAlonzoPlutusPurpose
       Api.AlonzoEraOnwardsBabbage -> renderAlonzoPlutusPurpose
       Api.AlonzoEraOnwardsConway -> renderConwayPlutusPurpose
-      -- TODO: fix
-      Api.AlonzoEraOnwardsDijkstra -> undefined
+      Api.AlonzoEraOnwardsDijkstra -> renderConwayPlutusPurpose
     )
 
 renderAlonzoPlutusPurpose :: ()


### PR DESCRIPTION
Motivation
Updated Dijkstra-era script purpose rendering to use Conway rendering logic instead of undefined, to prevent runtime failures during tracing output.
Description
Replace undefined in cardano-node/src/Cardano/Node/Tracing/Render.hs for: example Api.AlonzoEraOnwardsDijkstra -> undefined to Api.AlonzoEraOnwardsDijkstra -> renderConwayPlutusPurpose
