### PR TITLE
cardano-testnet enableP2P in config file

### DIFF
--- a/cardano-testnet/src/Testnet/Defaults.hs
+++ b/cardano-testnet/src/Testnet/Defaults.hs
@@ -108,13 +108,13 @@ newtype AlonzoGenesisError
   = AlonzoGenErrTooMuchPrecision Rational
   deriving Show
 
-instance Exception AlonzoGenesisError where 
+instance Exception AlonzoGenesisError where
   displayException = Api.docToString . Api.prettyError
 
 
 defaultAlonzoGenesis :: Either AlonzoGenesisError AlonzoGenesis
 defaultAlonzoGenesis = do
-  let genesis = Api.alonzoGenesisDefaults  
+  let genesis = Api.alonzoGenesisDefaults
       prices = Ledger.agPrices genesis
 
   -- double check that prices have correct values - they're set using unsafeBoundedRational in cardano-api
@@ -325,6 +325,9 @@ defaultYamlConfig =
 
     -- Turn logging on or off
     , ("EnableLogging", Aeson.Bool True)
+
+    -- Configuration for the node's P2P network topology
+    , ("EnableP2P", Aeson.Bool True)
 
     -- Genesis filepaths
     , ("ByronGenesisFile", genesisPath ByronEra)

--- a/cardano-testnet/src/Testnet/Filepath.hs
+++ b/cardano-testnet/src/Testnet/Filepath.hs
@@ -38,11 +38,12 @@ newtype TmpAbsolutePath = TmpAbsolutePath
 instance Display TmpAbsolutePath where
   textDisplay = fromString . unTmpAbsPath
 
-makeTmpRelPath :: TmpAbsolutePath -> FilePath
-makeTmpRelPath (TmpAbsolutePath fp) = makeRelative (makeTmpBaseAbsPath (TmpAbsolutePath fp)) fp
-
 makeSocketDir :: TmpAbsolutePath -> FilePath
-makeSocketDir fp = makeTmpRelPath fp </> "socket"
+makeSocketDir (TmpAbsolutePath fp) =
+  let relPath = makeRelative (takeDirectory fp) fp
+  in if relPath == "."
+     then "socket"
+     else relPath </> "socket"
 
 makeTmpBaseAbsPath :: TmpAbsolutePath -> FilePath
 makeTmpBaseAbsPath (TmpAbsolutePath fp) = addTrailingPathSeparator $ takeDirectory fp

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/node_default_config.json
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/node_default_config.json
@@ -5,6 +5,7 @@
     "DijkstraGenesisFile": "dijkstra-genesis.json",
     "EnableLogMetrics": false,
     "EnableLogging": true,
+    "EnableP2P": true,
     "ExperimentalHardForksEnabled": true,
     "ExperimentalProtocolsEnabled": true,
     "LastKnownBlockVersion-Alt": 0,


### PR DESCRIPTION
# Description

- Add `EnableP2P: true` networking in the default testnet node configuration.                                                                                                                                            
- Add retry logic to `--params-mainnet` HTTP request: retries up to 3 times with a 2-second delay, logging each failure to stderr, and wraps the final failure in a descriptive `MainnetParamsFetchError`   
  instead of an opaque exception
- Improve CLI output after testnet startup

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
