### PR TITLE
legacy tracing: fix mempool timeout metric names

### DIFF
--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -548,7 +548,7 @@ notifyTxsMempoolTimeoutHard mbEKGDirect = case mbEKGDirect of
   Nothing -> nullTracer
   Just ekgDirect -> Tracer $ \ev -> do
     when (DiffusionTracers.impliesMempoolTimeoutHard ev) $ do
-      sendEKGDirectCounter ekgDirect DiffusionTracers.txsMempoolTimeoutHardCounterName
+      sendEKGDirectCounter ekgDirect $ "cardano.node.metrics." <> DiffusionTracers.txsMempoolTimeoutHardCounterName
 
 muxTracer
   :: Maybe EKGDirect
@@ -1278,7 +1278,7 @@ notifyTxsMempoolTimeoutSoft mbEKGDirect = case mbEKGDirect of
   Nothing -> nullTracer
   Just ekgDirect -> Tracer $ \ev -> do
     when (ConsensusTracers.impliesMempoolTimeoutSoft ev) $ do
-      sendEKGDirectCounter ekgDirect ConsensusTracers.txsMempoolTimeoutSoftCounterName
+      sendEKGDirectCounter ekgDirect $ "cardano.node.metrics." <> ConsensusTracers.txsMempoolTimeoutSoftCounterName
 
 notifyTxsProcessed :: ForgingStats -> Trace IO Text -> Tracer IO (TraceEventMempool blk)
 notifyTxsProcessed fStats tr = Tracer $ \case


### PR DESCRIPTION
# Description

This PR fixes the Known Issue on `10.6.2`:
* Old tracing system: The new metrics counting soft and hard mempool timeouts are missing the common node metrics prefix `cardano.node.metrics`.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff