### PR TITLE
Limit parallel test execution for `cardano-testnet` in flake

### DIFF
--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -286,6 +286,8 @@ let
                   export PATH=${macOS-security}/bin:$PATH
                           ''
                      else '''');
+              # We disable parallel testnet-test running to avoid filling the Hydra runners' RAM and reduce hanging
+              packages.cardano-testnet.components.tests.cardano-testnet-test.testFlags = [ "--num-threads=4" ];
               packages.cardano-testnet.components.tests.cardano-testnet-golden.preCheck =
                 let
                   # This define files included in the directory that will be passed to `H.getProjectBase` for this test:


### PR DESCRIPTION
# Description

Testnet tests in Hydra hang often and hang in a way that prevents even restarting them until they have timed out, which takes 2 hours. This PR aims to avoid that issue by preventing `cardano-testnet` tests to be ran all at once, which should help in case the problem is that the RAM memory of the workers is getting full.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff
