### PR TITLE
Bump hackage & CHaP. Update cardano-api-10.24.1.0 cardano-cli-10.15.0.1

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -36,21 +36,23 @@ jobs:
       fail-fast: false
       matrix:
         # If you edit these versions, make sure the version in the lonely macos-latest job below is updated accordingly
-        # TODO add 9.8 again to the versions list when GHC-9.8 gets released with stm > 2.5.2,
-        # see https://github.com/haskell/stm/issues/76
-        ghc: ["9.6", "9.12"]
-        cabal: ["3.12"]
+        ghc: [&ghc-stable "9.6", &ghc-latest "9.12"]
+        cabal: [&cabal-version "3.16"]
         sys:
-          - { os: windows-latest, shell: 'C:/msys64/usr/bin/bash.exe -e {0}' }
           - { os: ubuntu-latest, shell: bash }
         include:
           # Using include, to make sure there will only be one macOS job, even if the matrix gets expanded later on.
           # We want a single job, because macOS runners are scarce.
-          - cabal: "3.12"
-            ghc: "9.6"
+          - ghc: *ghc-stable
+            cabal: *cabal-version
             sys:
               os: macos-latest
               shell: bash
+          - ghc: *ghc-latest
+            cabal: *cabal-version
+            sys:
+              os: windows-latest
+              shell: 'C:/msys64/usr/bin/bash.exe -e {0}'
     defaults:
       run:
         shell: ${{ matrix.sys.shell }}
@@ -99,66 +101,11 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    - name: Cabal update
-      run: cabal update
-
-    - name: Configure build
-      run: |
-        cp .github/workflows/cabal.project.local.ci cabal.project.local
-        echo "# cabal.project.local"
-        cat cabal.project.local
-
-    # A dry run `build all` operation does *NOT* downlaod anything, it just looks at the package
-    # indices to generate an install plan.
-    - name: Build dry run
-      run: cabal build all --enable-tests --dry-run --minimize-conflict-set
-
-    # From the install plan we generate a dependency list.
-    - name: Record dependencies
-      id: record-deps
-      run: |
-        cat dist-newstyle/cache/plan.json | jq -r '."install-plan"[] | select(.style != "local") | .id' | sort | uniq > dependencies.txt
-
-    # Use a fresh cache each month
-    - name: Store month number and GHC version as environment variables used in cache version
-      run: |
-        cat <<EOF >> $GITHUB_ENV
-        MONTHNUM=$(date -u '+%m')
-        GHC=$(ghc --numeric-version)
-        EOF
-
-    # From the dependency list we restore the cached dependencies.
-    # We use the hash of `dependencies.txt` as part of the cache key because that will be stable
-    # until the `index-state` values in the `cabal.project` file changes.
-    - name: Restore cached dependencies
-      uses: actions/cache/restore@v4
-      id: cache
+    - name: Cache and install Cabal dependencies
+      uses: intersectmbo/cardano-api/.github/actions/cabal-cache@a7bd74dfa6ccb1eb04f69791f978a3b9e0cc63ca
       with:
-        path: |
-          ${{ steps.setup-haskell.outputs.cabal-store }}
-          dist-newstyle
-        key:
-          cache-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ env.GHC }}-${{ env.MONTHNUM }}-${{ hashFiles('dependencies.txt') }}
-        # try to restore previous cache from this month if there's no cache for the dependencies set
-        restore-keys: |
-          cache-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ env.GHC }}-${{ env.MONTHNUM }}-
-
-    # Now we install the dependencies. If the cache was found and restored in the previous step,
-    # this should be a no-op, but if the cache key was not found we need to build stuff so we can
-    # cache it for the next step.
-    - name: Install dependencies
-      run: cabal build all --enable-tests --only-dependencies -j --ghc-option=-j4
-
-    # Always store the cabal cache.
-    # This can fail (benign failure) if there is already a hash at that key.
-    - name: Cache Cabal store
-      uses: actions/cache/save@v4
-      with:
-        path: |
-          ${{ steps.setup-haskell.outputs.cabal-store }}
-          dist-newstyle
-        key:
-          ${{ steps.cache.outputs.cache-primary-key }}
+        cabal-store: ${{ steps.setup-haskell.outputs.cabal-store }}
+        cache-version: ${{ env.CABAL_CACHE_VERSION }}
 
     # Now we build.
     - name: Build all
@@ -184,7 +131,7 @@ jobs:
       if: ${{ failure() }}
       uses: actions/upload-artifact@v4
       with:
-        name: failed-test-workspaces-${{ matrix.sys.os }}-ghc${{ env.GHC }}-cabal${{ matrix.cabal }}.tgz
+        name: failed-test-workspaces-${{ matrix.sys.os }}-ghc${{ matrix.ghc }}-cabal${{ matrix.cabal }}.tgz
         path: ${{ runner.temp }}/workspaces.tgz
 
     - name: "Tar artifacts"
@@ -215,7 +162,7 @@ jobs:
       if: ${{ always() }}
       continue-on-error: true
       with:
-        name: chairman-test-artifacts-${{ matrix.sys.os }}-${{ env.GHC }}
+        name: chairman-test-artifacts-${{ matrix.sys.os }}-${{ matrix.ghc }}
         path: ${{ runner.temp }}/chairman/
 
     # Uncomment the following back in for debugging. Remember to launch a `pwsh` from
@@ -230,9 +177,9 @@ jobs:
     # and will silently fail if msys2 is not in path. See the "Run tests" step.
     #
     # - name: Setup tmate session
-    #  if: ${{ failure() }}
-    #  uses: mxschmitt/action-tmate@v3
-    #  with:
+    #   if: ${{ failure() }}
+    #   uses: mxschmitt/action-tmate@v3
+    #   with:
     #     limit-access-to-actor: true
 
   build-complete:

--- a/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
+++ b/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
@@ -82,10 +82,10 @@ library
   -- IOG dependencies
   --------------------------
   build-depends:
-    , cardano-api             ^>=10.23
-    , plutus-ledger-api       ^>=1.57
-    , plutus-tx               ^>=1.57
-    , plutus-tx-plugin        ^>=1.57
+    , cardano-api             ^>=10.24.1
+    , plutus-ledger-api       ^>=1.58
+    , plutus-tx               ^>=1.58
+    , plutus-tx-plugin        ^>=1.58
 
   ------------------------
   -- Non-IOG dependencies

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -108,9 +108,9 @@ library
                       , attoparsec-aeson
                       , base16-bytestring
                       , bytestring
-                      , cardano-api ^>= 10.23
+                      , cardano-api ^>= 10.24.1
                       , cardano-binary
-                      , cardano-cli ^>= 10.15
+                      , cardano-cli ^>= 10.15.0.1
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
                       , cardano-data

--- a/cabal.project
+++ b/cabal.project
@@ -13,11 +13,12 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state:
-  , hackage.haskell.org 2025-09-29T13:55:56Z
-  , cardano-haskell-packages 2026-02-09T17:36:58Z
+  , hackage.haskell.org 2026-02-06T20:27:32Z
+  , cardano-haskell-packages 2026-03-03T10:50:34Z
 
 constraints:
-  crypton-x509-system ==1.6.7
+  -- haskell.nix patch does not work for 1.6.8
+  , any.crypton-x509-system < 1.6.8
 
 packages:
   cardano-node
@@ -65,7 +66,7 @@ package plutus-scripts-bench
 allow-newer:
   , katip:Win32
 
-if impl (ghc >= 9.12)
+if impl(ghc >= 9.12)
   allow-newer:
     -- https://github.com/kapralVV/Unique/issues/11
     , Unique:hashable
@@ -76,4 +77,3 @@ if impl (ghc >= 9.12)
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
-

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -88,5 +88,5 @@ test-suite chairman-tests
   ghc-options:          -threaded -rtsopts "-with-rtsopts=-N -T"
 
   build-tool-depends:   cardano-node:cardano-node
-                      , cardano-cli:cardano-cli ^>= 10.15
+                      , cardano-cli:cardano-cli ^>= 10.15.0.1
                       , cardano-node-chairman:cardano-node-chairman

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -138,7 +138,7 @@ library
                       , async
                       , base16-bytestring
                       , bytestring
-                      , cardano-api ^>= 10.23
+                      , cardano-api ^>= 10.24.1
                       , cardano-crypto-class ^>=2.2.3.2
                       , cardano-crypto-wrapper
                       , cardano-git-rev ^>=0.2.2

--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -39,9 +39,9 @@ library
                       , aeson
                       , async
                       , bytestring
-                      , cardano-api ^>= 10.23
+                      , cardano-api ^>= 10.24.1
                       , cardano-binary
-                      , cardano-cli ^>= 10.15
+                      , cardano-cli ^>= 10.15.0.1
                       , cardano-crypto-class ^>=2.2.3.2
                       , containers
                       , ekg-core

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -41,8 +41,8 @@ library
                       , annotated-exception
                       , ansi-terminal
                       , bytestring
-                      , cardano-api ^>= 10.23
-                      , cardano-cli:{cardano-cli, cardano-cli-test-lib} ^>= 10.15
+                      , cardano-api ^>= 10.24.1
+                      , cardano-cli:{cardano-cli, cardano-cli-test-lib} ^>= 10.15.0.1
                       , cardano-crypto-class ^>=2.2.3.2
                       , cardano-crypto-wrapper
                       , cardano-git-rev ^>= 0.2.2

--- a/cardano-testnet/changelog.d/20260303_115948_mgalazyn_bump_cardano_api_cardano_cli.md
+++ b/cardano-testnet/changelog.d/20260303_115948_mgalazyn_bump_cardano_api_cardano_cli.md
@@ -1,0 +1,6 @@
+
+### Maintenance
+
+- Bump `cardano-api` to `^>= 10.24.1`
+- Bump `cardano-cli` to `^>= 10.15.0.1`
+

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction/RegisterDeregisterStakeAddress.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction/RegisterDeregisterStakeAddress.hs
@@ -28,7 +28,7 @@ import           Testnet.Process.Cli.Keys
 import           Testnet.Process.Cli.SPO (createStakeKeyDeregistrationCertificate,
                    createStakeKeyRegistrationCertificate)
 import           Testnet.Process.Run (execCli', execCliAny, mkExecConfig)
-import           Testnet.Property.Util (integrationWorkspace)
+import           Testnet.Property.Util (integrationRetryWorkspace)
 import           Testnet.Start.Types
 import           Testnet.Types
 
@@ -40,7 +40,7 @@ import qualified Hedgehog.Extras as H
 -- | Execute me with:
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/register deregister stake address in transaction build/"'@
 hprop_tx_register_deregister_stake_address :: Property
-hprop_tx_register_deregister_stake_address = integrationWorkspace "register-deregister-stake-addr" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
+hprop_tx_register_deregister_stake_address = integrationRetryWorkspace 2 "register-deregister-stake-addr" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   -- Start a local test net
   conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1770667523,
-        "narHash": "sha256-NTZeJP2ETCS/9hAUottupnhI7b5RmYKiB4jJqhyvHhs=",
+        "lastModified": 1772623894,
+        "narHash": "sha256-95NCPKIcDnQ+vja6ofTsnFJKoH9AjT0opOj8zdGvWSw=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "da32b7c7513f0f5383d233a0f97e03538b0c7726",
+        "rev": "e140e457e9c9db8591f0d8b0c35597ffb65955fc",
         "type": "github"
       },
       "original": {
@@ -273,11 +273,11 @@
     "hackageNix_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1768311066,
-        "narHash": "sha256-g2WdhScDFQNkJs2GBjWIGG49upIQuBshgaeAxddujrE=",
+        "lastModified": 1772713531,
+        "narHash": "sha256-XPoLj/4nHhOc8tPEkrOhpmCjDvNZ7ZYcda0e4TY2RI4=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "adbb09d536f3a2797f9bd0762a0577a30672b8b1",
+        "rev": "ee54e2182f57a1e937b33eb64bcce67b81722ef7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -87,6 +87,13 @@
       (import ./nix/custom-config.nix customConfig)
       input.customConfig;
 
+    abseilOverlay = final: prev:
+      prev.lib.optionalAttrs prev.stdenv.hostPlatform.isWindows {
+        abseil-cpp = prev.abseil-cpp.overrideAttrs (finalAttrs: previousAttrs: {
+          buildInputs = previousAttrs.buildInputs ++ [prev.pkgs.windows.pthreads];
+        });
+      };
+
     overlays = [
       # Crypto needs to come before haskell.nix.
       # FIXME: _THIS_IS_BAD_
@@ -98,7 +105,7 @@
       iohkNix.overlays.utils
       (final: prev: {
         inherit customConfig;
-        bench-data-publish = cardano-automation.outputs.packages.${final.system}."bench-data-publish:exe:bench-data-publish";
+        bench-data-publish = cardano-automation.outputs.packages.${final.stdenv.hostPlatform.system}."bench-data-publish:exe:bench-data-publish";
         gitrev = final.customConfig.gitrev or self.rev or "0000000000000000000000000000000000000000";
         commonLib =
           lib
@@ -107,6 +114,7 @@
           // import ./nix/svclib.nix {inherit (final) pkgs;};
       })
       (import ./nix/pkgs.nix)
+      abseilOverlay
       self.overlay
     ];
 
@@ -157,7 +165,7 @@
       };
 
     mkFlakeAttrs = pkgs: rec {
-      inherit (pkgs) system;
+      system = pkgs.stdenv.hostPlatform.system;
       inherit (pkgs.haskell-nix) haskellLib;
       inherit (haskellLib) collectChecks' collectComponents';
       inherit (pkgs.commonLib) eachEnv environments mkSupervisordCluster;
@@ -510,7 +518,7 @@
           ...
         }: {
           imports = [./nix/nixos/cardano-node-service.nix];
-          services.cardano-node.cardanoNodePackages = lib.mkDefault (mkCardanoNodePackages flake.project.${pkgs.system});
+          services.cardano-node.cardanoNodePackages = lib.mkDefault (mkCardanoNodePackages flake.project.${pkgs.stdenv.hostPlatform.system});
         };
         cardano-submit-api = {
           pkgs,
@@ -518,7 +526,7 @@
           ...
         }: {
           imports = [./nix/nixos/cardano-submit-api-service.nix];
-          services.cardano-submit-api.cardanoNodePackages = lib.mkDefault (mkCardanoNodePackages flake.project.${pkgs.system});
+          services.cardano-submit-api.cardanoNodePackages = lib.mkDefault (mkCardanoNodePackages flake.project.${pkgs.stdenv.hostPlatform.system});
         };
         cardano-tracer = {
           pkgs,
@@ -526,7 +534,7 @@
           ...
         }: {
           imports = [./nix/nixos/cardano-tracer-service.nix];
-          services.cardano-tracer.cardanoNodePackages = lib.mkDefault (mkCardanoNodePackages flake.project.${pkgs.system});
+          services.cardano-tracer.cardanoNodePackages = lib.mkDefault (mkCardanoNodePackages flake.project.${pkgs.stdenv.hostPlatform.system});
         };
       };
     };

--- a/nix/cardanolib-py/default.nix
+++ b/nix/cardanolib-py/default.nix
@@ -10,4 +10,6 @@ python3Packages.buildPythonPackage {
   propagatedBuildInputs = [
     cardano-cli
   ];
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
 }

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -62,7 +62,7 @@ let
           cabal
           actionlint
           shellcheck
-          scriv
+          # scriv # TODO broken - reenable
           stylish-haskell
         ];
 

--- a/nix/nixos/cardano-tracer-service.nix
+++ b/nix/nixos/cardano-tracer-service.nix
@@ -166,7 +166,7 @@ in {
 
       cardanoNodePackages = mkOption {
         type = attrs;
-        default = pkgs.cardanoNodePackages or (import ../. {inherit (pkgs) system;}).cardanoNodePackages;
+        default = pkgs.cardanoNodePackages or (import ../. {inherit (pkgs.stdenv.hostPlatform) system;}).cardanoNodePackages;
         defaultText = "cardano-node packages";
         description = ''
           The cardano-node packages and library that should be used. The main

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -214,4 +214,14 @@ in with final;
       });
     };
   };
+
+  # Apply upstream patch to scriv for Click 8.2+ compatibility (NixOS/nixpkgs#467359)
+  scriv = prev.scriv.overrideAttrs (old: {
+    patches = (old.patches or []) ++ [
+      (prev.fetchpatch {
+        url = "https://github.com/nedbat/scriv/commit/04ac45da9e1adb24a95ad9643099fe537b3790fd.diff";
+        hash = "sha256-Gle3zWC/WypGHsKmVlqedRAZVWsBjGpzMq3uKuG9+SY=";
+      })
+    ];
+  });
 }

--- a/nix/workbench/genesis/genesis.sh
+++ b/nix/workbench/genesis/genesis.sh
@@ -1,4 +1,5 @@
 # shellcheck shell=bash
+# shellcheck disable=SC2154  # global_basedir is set externally by the sourcing script (wb)
 
 global_genesis_format_version=October-13-2025
 

--- a/nix/workbench/shell.nix
+++ b/nix/workbench/shell.nix
@@ -121,7 +121,7 @@ project.shellFor {
   # Packages in need of a newer versions compared to flake's nixpkgs.
   # Pinning "nixos-25.11" to avoid cache misses when entering the shell.
   # To update use `curl -L https://channels.nixos.org/nixos-25.11/git-revision`
-  ++ (with (builtins.getFlake "github:NixOS/nixpkgs/999ca0e5484922624254294ea1adc2b90081579e").legacyPackages.${pkgs.system}; [
+  ++ (with (builtins.getFlake "github:NixOS/nixpkgs/999ca0e5484922624254294ea1adc2b90081579e").legacyPackages.${pkgs.stdenv.hostPlatform.system}; [
        # Will be removed once nixpkgs is bumped to a suitable version.
        typst
      ])


### PR DESCRIPTION
# Description

This PR updates cardano-api to 10.24.1 and cardano-cli to 10.15.0.1.

Reusable actions are used for caching in GHA workflows.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
