### PR TITLE
Fix Dijkstra-era script purpose rendering

### DIFF
--- a/cardano-node/src/Cardano/Node/Tracing/Render.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Render.hs
@@ -208,8 +208,7 @@ renderScriptPurpose =
       Api.AlonzoEraOnwardsAlonzo -> renderAlonzoPlutusPurpose
       Api.AlonzoEraOnwardsBabbage -> renderAlonzoPlutusPurpose
       Api.AlonzoEraOnwardsConway -> renderConwayPlutusPurpose
-      -- TODO: fix
-      Api.AlonzoEraOnwardsDijkstra -> undefined
+      Api.AlonzoEraOnwardsDijkstra -> renderConwayPlutusPurpose
     )
 
 renderAlonzoPlutusPurpose :: ()


### PR DESCRIPTION
# Description

Replace `undefined` with `renderConwayPlutusPurpose` for `AlonzoEraOnwardsDijkstra` in `renderScriptPurpose`, preventing a runtime crash when tracing script purposes in the Dijkstra era.

Based on #6427 by @Savissy.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [x] CI passes.
- [x] Self-reviewed the diff