### PR TITLE
Fix Dijkstra-era script purpose rendering

### DIFF
--- a/cardano-node/src/Cardano/Node/Tracing/Render.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Render.hs
@@ -40,6 +40,7 @@ import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
 import           Cardano.Ledger.BaseTypes (Mismatch (..), Relation (..))
 import           Cardano.Ledger.Conway.Scripts (ConwayPlutusPurpose (..))
 import qualified Cardano.Ledger.Core as Ledger
+import           Cardano.Ledger.Dijkstra.Scripts (DijkstraPlutusPurpose (..))
 import qualified Cardano.Ledger.Hashes as Hashes
 import           Cardano.Logging
 import           Cardano.Node.Queries (ConvertTxId (..))
@@ -225,8 +226,7 @@ renderScriptPurpose =
       Api.AlonzoEraOnwardsAlonzo -> renderAlonzoPlutusPurpose
       Api.AlonzoEraOnwardsBabbage -> renderAlonzoPlutusPurpose
       Api.AlonzoEraOnwardsConway -> renderConwayPlutusPurpose
-      -- TODO: fix
-      Api.AlonzoEraOnwardsDijkstra -> undefined
+      Api.AlonzoEraOnwardsDijkstra -> renderDijkstraPlutusPurpose
     )
 
 renderAlonzoPlutusPurpose :: ()
@@ -260,3 +260,23 @@ renderConwayPlutusPurpose = \case
     Aeson.object ["voting" .= Aeson.toJSON voter]
   ConwayProposing proposal ->
     Aeson.object ["proposing" .= Aeson.toJSON proposal]
+
+renderDijkstraPlutusPurpose :: ()
+  => (Ledger.EraPParams era, Aeson.ToJSON (Ledger.TxCert era))
+  => DijkstraPlutusPurpose AsItem era
+  -> Aeson.Value
+renderDijkstraPlutusPurpose = \case
+  DijkstraSpending (AsItem txin) ->
+    Aeson.object ["spending" .= Api.fromShelleyTxIn txin]
+  DijkstraMinting pid ->
+    Aeson.object ["minting" .= Aeson.toJSON pid]
+  DijkstraRewarding (AsItem rwdAcct) ->
+    Aeson.object ["rewarding" .= Aeson.String (Api.serialiseAddress $ Api.fromShelleyStakeAddr rwdAcct)]
+  DijkstraCertifying cert ->
+    Aeson.object ["certifying" .= Aeson.toJSON cert]
+  DijkstraVoting voter ->
+    Aeson.object ["voting" .= Aeson.toJSON voter]
+  DijkstraProposing proposal ->
+    Aeson.object ["proposing" .= Aeson.toJSON proposal]
+  DijkstraGuarding sHash ->
+    Aeson.object ["guarding" .= Aeson.toJSON sHash]


### PR DESCRIPTION
# Description

Replace `undefined` with `renderConwayPlutusPurpose` for `AlonzoEraOnwardsDijkstra` in `renderScriptPurpose`, preventing a runtime crash when tracing script purposes in the Dijkstra era.

Based on #6427 by @Savissy.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [x] CI passes.
- [x] Self-reviewed the diff