### PR TITLE
Restore scriv in devshell

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -13,13 +13,11 @@ jobs:
       # We want to install Nix to provision shellcheck, so that actionlint doesn't install
       # its own shellcheck. This will also make sure that this pipeline runs using
       # the same shellcheck as the ones in Nix shells of developers.
-      - name: Install Nix with good defaults
+      - name: Install Nix
         uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: |
-            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
-            substituters = https://cache.nixos.org/ https://cache.iog.io/
-          nix_path: nixpkgs=channel:nixos-unstable
+            accept-flake-config = true
       # Make the Nix environment available to next steps
       - uses: rrbutani/use-nix-shell-action@v1
 

--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -32,10 +32,16 @@ jobs:
           skip-label: "no-changelog-needed"
           failure-message: "You modified `cardano-testnet` but are missing a changelog fragment! Please run `scriv create` or apply the `no-changelog-needed` label."
 
+      - name: Install Nix
+        if: steps.filter.outputs.cardano == 'true'
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            accept-flake-config = true
+
       - name: Check scriv fragments are correct
         if: steps.filter.outputs.cardano == 'true'
-        run: |
-          pip install scriv
-          cd cardano-testnet
-          scriv collect --version "CI-CHECK" --keep
+        uses: rrbutani/use-nix-shell-action@v1
+        with:
+          script: cd cardano-testnet && scriv collect --version "CI-CHECK" --keep
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -15,13 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Nix with good defaults
+      - name: Install Nix
         uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: |
-            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
-            substituters = https://cache.nixos.org/ https://cache.iog.io/
-          nix_path: nixpkgs=channel:nixos-unstable
+            accept-flake-config = true
       # Make the Nix environment available to next steps
       - uses: rrbutani/use-nix-shell-action@v1
       - name: shellcheck

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -56,13 +56,14 @@ let
           lmdb
           nix-prefetch-git
           pkg-config
+          git
           hlint
           ghcid
           haskell-language-server
           cabal
           actionlint
           shellcheck
-          # scriv # TODO broken - reenable
+          scriv
           stylish-haskell
         ];
 

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -214,14 +214,4 @@ in with final;
       });
     };
   };
-
-  # Apply upstream patch to scriv for Click 8.2+ compatibility (NixOS/nixpkgs#467359)
-  scriv = prev.scriv.overrideAttrs (old: {
-    patches = (old.patches or []) ++ [
-      (prev.fetchpatch {
-        url = "https://github.com/nedbat/scriv/commit/04ac45da9e1adb24a95ad9643099fe537b3790fd.diff";
-        hash = "sha256-Gle3zWC/WypGHsKmVlqedRAZVWsBjGpzMq3uKuG9+SY=";
-      })
-    ];
-  });
 }


### PR DESCRIPTION
# Description

Fixes: https://github.com/IntersectMBO/cardano-node/issues/6479

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
