### PR TITLE
add txsSyncDurationTotal counter

### DIFF
--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## Next version
 
+* Added txsSyncDurationTotal counter for tracking the total time spent syncing the mempool.
+
 * Added EKG metrics for soft and hard timeouts and included defensive mempool
 
 * Improved `cardano-node --help` output by making it the same as the one shown when calling `cardano-node` without arguments.

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
@@ -20,6 +20,7 @@ module Cardano.Node.Tracing.Tracers.Consensus
   , servedBlockLatest
   , ClientMetrics
   , txsMempoolTimeoutSoftCounterName
+  , txsSyncDurationTotalCounterName
   , impliesMempoolTimeoutSoft
   ) where
 
@@ -1087,6 +1088,9 @@ instance MetaTrace (TraceLocalTxSubmissionServerEvent blk) where
 txsMempoolTimeoutSoftCounterName :: Text.Text
 txsMempoolTimeoutSoftCounterName = "txsMempoolTimeoutSoft"
 
+txsSyncDurationTotalCounterName :: Text.Text
+txsSyncDurationTotalCounterName = "txsSyncDurationTotal"
+
 impliesMempoolTimeoutSoft :: TraceEventMempool blk -> Bool
 impliesMempoolTimeoutSoft = \case
   TraceMempoolRejectedTx _tx _txApplyErr details _mpSz ->
@@ -1184,7 +1188,9 @@ instance
     , IntM "mempoolBytes" (fromIntegral . unByteSize32 . msNumBytes $ mpSz)
     ]
   asMetrics (TraceMempoolSynced (FallingEdgeWith duration)) =
-    [ IntM "txsSyncDuration" (round $ 1000 * duration)
+    let durationMs = round (1000 * duration) :: Integer in
+    [ IntM "txsSyncDuration" durationMs
+    , CounterM txsSyncDurationTotalCounterName (Just (fromIntegral durationMs))
     ]
   asMetrics (TraceMempoolSynced RisingEdge) = []
 
@@ -1241,7 +1247,8 @@ instance MetaTrace (TraceEventMempool blk) where
       , ("txsProcessedNum", "")
       ]
     metricsDocFor (Namespace _ ["Synced"]) =
-      [ ("txsSyncDuration", "Time to sync the mempool in ms after block adoption")
+      [ ("txsSyncDuration", "Latest time to sync the mempool in ms after block adoption")
+      , (txsSyncDurationTotalCounterName, "Cumulative time spent syncing the mempool in ms after block adoption")
       ]
     metricsDocFor _ = []
 

--- a/cardano-node/src/Cardano/Tracing/Metrics.hs
+++ b/cardano-node/src/Cardano/Tracing/Metrics.hs
@@ -17,6 +17,7 @@ module Cardano.Tracing.Metrics
   , mapForgingCurrentThreadStats
   , mapForgingCurrentThreadStats_
   , mapForgingStatsTxsProcessed
+  , mapForgingStatsTxsSyncDuration
   , mkForgingStats
   , threadStatsProjection
   ) where
@@ -38,6 +39,8 @@ data ForgingStats
   = ForgingStats
   { fsTxsProcessedNum :: !(IORef Int)
     -- ^ Transactions removed from mempool.
+  , fsTxsSyncDuration :: !(IORef Int)
+    -- ^ Cumulative mempool sync duration in milliseconds.
   , fsState           :: !(TVar (Map ThreadId (TVar ForgeThreadStats)))
   , fsBlocksUncoupled :: !(TVar Int64)
     -- ^ Blocks forged since last restart not on the current chain
@@ -63,6 +66,7 @@ mkForgingStats :: IO ForgingStats
 mkForgingStats =
   ForgingStats
     <$> newIORef 0
+    <*> newIORef 0
     <*> newTVarIO mempty
     <*> newTVarIO 0
 
@@ -73,6 +77,14 @@ mapForgingStatsTxsProcessed ::
 mapForgingStatsTxsProcessed fs f =
   atomicModifyIORef' (fsTxsProcessedNum fs) $
     \txCount -> join (,) $ f txCount
+
+mapForgingStatsTxsSyncDuration ::
+     ForgingStats
+  -> (Int -> Int)
+  -> IO Int
+mapForgingStatsTxsSyncDuration fs f =
+  atomicModifyIORef' (fsTxsSyncDuration fs) $
+    \syncMs -> join (,) $ f syncMs
 
 mapForgingCurrentThreadStats ::
      ForgingStats

--- a/cardano-node/src/Cardano/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Tracing/Tracers.hs
@@ -1312,7 +1312,10 @@ notifyTxsProcessed fStats tr = Tracer $ \case
     updatedTxProcessed <- mapForgingStatsTxsProcessed fStats (+ (length txs))
     traceCounter "txsProcessedNum" tr (fromIntegral updatedTxProcessed)
   TraceMempoolSynced (FallingEdgeWith duration) -> do
-    traceCounter "txsSyncDuration" tr (round $ 1000 * duration :: Int)
+    let durationMs = round $ 1000 * duration :: Int
+    cumulativeSyncMs <- mapForgingStatsTxsSyncDuration fStats (+ durationMs)
+    traceCounter "txsSyncDuration" tr durationMs
+    traceCounter ConsensusTracers.txsSyncDurationTotalCounterName tr cumulativeSyncMs
 
   -- The rest of the constructors.
   _ -> return ()

--- a/cardano-tracer/configuration/metrics_help.json
+++ b/cardano-tracer/configuration/metrics_help.json
@@ -104,5 +104,6 @@
   "systemStartTime": "The UTC time this node was started.",
   "tipBlock": "Values for hash, parent hash and issuer verification key hash",
   "txsInMempool": "Transactions in mempool",
-  "txsSyncDuration": "Time to sync the mempool in ms after block adoption"
+  "txsSyncDuration": "Latest time to sync the mempool in ms after block adoption",
+  "txsSyncDurationTotal": "Cumulative time spent syncing the mempool in ms after block adoption"
 }


### PR DESCRIPTION

# Description

Add a txsSyncDurationTotal counter for tracking the total time spent syncing the mempool.


# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
