### PR TITLE
[cardano-testnet] Extract cardano-testnet-paths micro-package

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -38,6 +38,7 @@ packages:
   cardano-node-chairman
   cardano-submit-api
   cardano-testnet
+  cardano-testnet/cardano-testnet-paths
   cardano-tracer
   bench/cardano-profile
   bench/cardano-topology

--- a/cardano-testnet/cardano-testnet-paths/LICENSE
+++ b/cardano-testnet/cardano-testnet-paths/LICENSE
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/cardano-testnet/cardano-testnet-paths/NOTICE
+++ b/cardano-testnet/cardano-testnet-paths/NOTICE
@@ -1,0 +1,14 @@
+Copyright 2021-2023 Input Output Global Inc (IOG), 2023-2026 Intersect.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+

--- a/cardano-testnet/cardano-testnet-paths/cardano-testnet-paths.cabal
+++ b/cardano-testnet/cardano-testnet-paths/cardano-testnet-paths.cabal
@@ -1,0 +1,38 @@
+cabal-version: 3.0
+
+name:                   cardano-testnet-paths
+version:                10.2.0
+synopsis:               Shared path conventions for cardano-testnet output directories
+description:            Defines the directory layout and file naming conventions used by
+                        cardano-testnet when creating testnets. Other packages (e.g.
+                        tx-generator) depend on this to discover testnet infrastructure.
+copyright:              2021-2023 Input Output Global Inc (IOG), 2023-2026 Intersect.
+author:                 IOHK
+maintainer:             operations@iohk.io
+category:               Cardano,
+                        Test,
+license:                Apache-2.0
+license-files:          LICENSE
+                        NOTICE
+build-type:             Simple
+
+common project-config
+  default-language:     Haskell2010
+  build-depends:        base >= 4.14 && < 5
+
+  ghc-options:          -Wall
+                        -Wcompat
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wno-unticked-promoted-constructors
+                        -Wpartial-fields
+                        -Wredundant-constraints
+                        -Wunused-packages
+
+library
+  import:               project-config
+
+  build-depends:        filepath
+
+  hs-source-dirs:       src
+  exposed-modules:      Testnet.Paths

--- a/cardano-testnet/cardano-testnet-paths/src/Testnet/Paths.hs
+++ b/cardano-testnet/cardano-testnet-paths/src/Testnet/Paths.hs
@@ -1,0 +1,64 @@
+-- | Shared path conventions for cardano-testnet output directories.
+--
+-- Both @cardano-testnet@ (producer) and consumers of generated
+-- testnet configurations depend on this module so that directory
+-- layout changes are kept in sync at compile time.
+module Testnet.Paths
+  ( defaultNodeName
+  , defaultNodeDataDir
+  , defaultUtxoKeyDir
+  , defaultUtxoSKeyPath
+  , defaultUtxoVKeyPath
+  , defaultUtxoAddrPath
+  , defaultSocketDir
+  , defaultSocketName
+  , defaultSocketPath
+  , defaultConfigFile
+  , defaultPortFile
+  ) where
+
+import           System.FilePath ((</>))
+
+-- | The name of a node: @\"node\" <> show n@
+defaultNodeName :: Int -> String
+defaultNodeName n = "node" <> show n
+
+-- | Relative path to a node's data directory: @\"node-data\" </> defaultNodeName n@
+defaultNodeDataDir :: Int -> FilePath
+defaultNodeDataDir n = "node-data" </> defaultNodeName n
+
+-- | Relative path to a UTxO key directory: @\"utxo-keys\" </> \"utxo\" <> show n@
+defaultUtxoKeyDir :: Int -> FilePath
+defaultUtxoKeyDir n = "utxo-keys" </> "utxo" <> show n
+
+-- | Relative path to a UTxO signing key: @defaultUtxoKeyDir n </> \"utxo.skey\"@
+defaultUtxoSKeyPath :: Int -> FilePath
+defaultUtxoSKeyPath n = defaultUtxoKeyDir n </> "utxo.skey"
+
+-- | Relative path to a UTxO verification key: @defaultUtxoKeyDir n </> \"utxo.vkey\"@
+defaultUtxoVKeyPath :: Int -> FilePath
+defaultUtxoVKeyPath n = defaultUtxoKeyDir n </> "utxo.vkey"
+
+-- | Relative path to a UTxO address file: @defaultUtxoKeyDir n </> \"utxo.addr\"@
+defaultUtxoAddrPath :: Int -> FilePath
+defaultUtxoAddrPath n = defaultUtxoKeyDir n </> "utxo.addr"
+
+-- | Socket directory name: @\"socket\"@
+defaultSocketDir :: FilePath
+defaultSocketDir = "socket"
+
+-- | Socket file name: @\"sock\"@
+defaultSocketName :: FilePath
+defaultSocketName = "sock"
+
+-- | Relative path to a node's socket: @defaultSocketDir </> defaultNodeName n </> defaultSocketName@
+defaultSocketPath :: Int -> FilePath
+defaultSocketPath n = defaultSocketDir </> defaultNodeName n </> defaultSocketName
+
+-- | Main node configuration file name: @\"configuration.yaml\"@
+defaultConfigFile :: FilePath
+defaultConfigFile = "configuration.yaml"
+
+-- | Relative path to a node's port file: @defaultNodeDataDir n </> \"port\"@
+defaultPortFile :: Int -> FilePath
+defaultPortFile n = defaultNodeDataDir n </> "port"

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -43,6 +43,7 @@ library
                       , bytestring
                       , cardano-api ^>= 10.25
                       , cardano-cli:{cardano-cli, cardano-cli-test-lib} ^>= 10.15.0.1
+                      , cardano-testnet-paths
                       , cardano-crypto-class ^>=2.3
                       , cardano-crypto-wrapper
                       , cardano-git-rev ^>= 0.2.2

--- a/cardano-testnet/changelog.d/20260407_180351_palas_extract_testnet_paths.md
+++ b/cardano-testnet/changelog.d/20260407_180351_palas_extract_testnet_paths.md
@@ -1,0 +1,5 @@
+
+### Maintenance
+
+- Extracted `cardano-testnet-paths` micro-package with shared path conventions for testnet output directories.
+

--- a/cardano-testnet/src/Testnet/Defaults.hs
+++ b/cardano-testnet/src/Testnet/Defaults.hs
@@ -99,6 +99,8 @@ import           Numeric.Natural
 import           System.FilePath ((</>))
 
 import           Test.Cardano.Ledger.Core.Rational
+import           Testnet.Paths (defaultNodeName, defaultNodeDataDir, defaultUtxoSKeyPath,
+                   defaultUtxoVKeyPath)
 import           Testnet.Start.Types
 import           Testnet.Types
 
@@ -568,14 +570,6 @@ defaultSpoColdSKeyFp n = defaultSpoKeysDir n </> "cold.skey"
 defaultSpoName :: Int -> String
 defaultSpoName n = "pool" <> show n
 
--- | The name of a node (which doesn't have to be a SPO)
-defaultNodeName :: Int -> String
-defaultNodeName n = "node" <> show n
-
--- | The relative path of the node data dir, where the database is stored
-defaultNodeDataDir :: Int -> String
-defaultNodeDataDir n = "node-data" </> defaultNodeName n
-
 -- | The relative path where the SPO keys for the node are stored
 defaultSpoKeysDir :: Int -> String
 defaultSpoKeysDir n = "pools-keys" </> defaultSpoName n
@@ -619,8 +613,8 @@ defaultDelegatorStakeKeyPair n =
 defaultUtxoKeys :: Int -> KeyPair PaymentKey
 defaultUtxoKeys n =
   KeyPair
-    { verificationKey = File $ "utxo-keys" </> "utxo" <> show n </> "utxo.vkey"
-    , signingKey = File $ "utxo-keys" </> "utxo" <> show n </> "utxo.skey"
+    { verificationKey = File $ defaultUtxoVKeyPath n
+    , signingKey = File $ defaultUtxoSKeyPath n
     }
 
 

--- a/cardano-testnet/src/Testnet/Filepath.hs
+++ b/cardano-testnet/src/Testnet/Filepath.hs
@@ -20,6 +20,8 @@ import           Hedgehog.Extras.Stock.IO.Network.Sprocket (Sprocket (..))
 
 import           RIO (Display (..))
 
+import           Testnet.Paths (defaultSocketDir)
+
 
 makeSprocket
   :: TmpAbsolutePath
@@ -42,7 +44,7 @@ makeTmpRelPath :: TmpAbsolutePath -> FilePath
 makeTmpRelPath (TmpAbsolutePath fp) = makeRelative (makeTmpBaseAbsPath (TmpAbsolutePath fp)) fp
 
 makeSocketDir :: TmpAbsolutePath -> FilePath
-makeSocketDir fp = makeTmpRelPath fp </> "socket"
+makeSocketDir fp = makeTmpRelPath fp </> defaultSocketDir
 
 makeTmpBaseAbsPath :: TmpAbsolutePath -> FilePath
 makeTmpBaseAbsPath (TmpAbsolutePath fp) = addTrailingPathSeparator $ takeDirectory fp

--- a/cardano-testnet/src/Testnet/Runtime.hs
+++ b/cardano-testnet/src/Testnet/Runtime.hs
@@ -53,6 +53,7 @@ import qualified System.Process as IO
 import           System.Process (waitForProcess)
 
 import           Testnet.Filepath
+import           Testnet.Paths (defaultSocketName)
 import qualified Testnet.Ping as Ping
 import           Testnet.Process.Run (ProcessError (..), initiateProcess)
 import           Testnet.Process.RunIO (execCli_, execKesAgentControl_, liftIOAnnotated,
@@ -135,7 +136,7 @@ startNode tp node ipv4 port _testnetMagic nodeCmd = GHC.withFrozenCallStack $ do
   let nodeStdoutFile = logDir </> node </> "stdout.log"
       nodeStderrFile = logDir </> node </> "stderr.log"
       nodePidFile = logDir </> node </> "node.pid"
-      socketRelPath = socketDir </> node </> "sock"
+      socketRelPath = socketDir </> node </> defaultSocketName
       sprocket = Sprocket tempBaseAbsPath socketRelPath
 
   hNodeStdout <- retryOpenFile nodeStdoutFile IO.WriteMode

--- a/cardano-testnet/src/Testnet/Start/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Start/Cardano.hs
@@ -65,6 +65,7 @@ import           System.FilePath ((</>))
 import           Testnet.Components.Configuration
 import qualified Testnet.Defaults as Defaults
 import           Testnet.Filepath
+import           Testnet.Paths (defaultConfigFile, defaultUtxoAddrPath)
 import           Testnet.Handlers (interruptNodesOnSigINT)
 import           Testnet.Orphans ()
 import           Testnet.Process.RunIO (execCli', execCli_, liftIOAnnotated, mkExecConfig)
@@ -131,7 +132,7 @@ createTestnetEnv
     testnetOptions genesisOptions onChainParams
     (TmpAbsolutePath tmpAbsPath)
 
-  let configurationFile = tmpAbsPath </> "configuration.yaml"
+  let configurationFile = tmpAbsPath </> defaultConfigFile
   -- Add Byron, Shelley and Alonzo genesis hashes to node configuration
   config <- case genesisHashesPolicy of
     WithHashes -> createConfigJson (TmpAbsolutePath tmpAbsPath) sbe
@@ -247,7 +248,7 @@ cardanoTestnet
         , cardanoKESSource
         } = testnetOptions
       nPools = cardanoNumPools testnetOptions
-      nodeConfigFile = tmpAbsPath </> "configuration.yaml"
+      nodeConfigFile = tmpAbsPath </> defaultConfigFile
       byronGenesisFile = tmpAbsPath </> "byron-genesis.json"
       shelleyGenesisFile = tmpAbsPath </> "shelley-genesis.json"
 
@@ -260,7 +261,7 @@ cardanoTestnet
 
   wallets <- forM [1..3] $ \idx -> do
     let utxoKeys@KeyPair{verificationKey} = makePathsAbsolute $ Defaults.defaultUtxoKeys idx
-    let paymentAddrFile = tmpAbsPath </> "utxo-keys" </> "utxo" <> show idx </> "utxo.addr"
+    let paymentAddrFile = tmpAbsPath </> defaultUtxoAddrPath idx
 
     execCli_
       [ "latest", "address", "build"


### PR DESCRIPTION
# Description

Extracts shared path conventions from `cardano-testnet` into a new lightweight `cardano-testnet-paths` micro-package. This enables other packages (e.g. `tx-generator`) to depend on the same path definitions without pulling in the full `cardano-testnet` dependency tree.

This refactoring is necessary to enable the realisation of #6511 in a way that is robust (statically checked). Check #6510 for more details.

This PR is meant to be a pure refactoring — there should be no behaviour changes.

Closes #6512 (part 1 of #6510).

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff