### PR TITLE
Leios: Build against backward-compatible block decoder

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -121,8 +121,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/IntersectMBO/ouroboros-consensus
-  tag: 5ef140601cd2d3a96846f630456f82ab7c68ec45
-  --sha256: sha256-+lDspbkHZSWWcrQ3PaBKxQsM8cKy/rCPWdD2WPcbWGY=
+  tag: da4408f57a119c623a29c0a9796308af8bafc7f8
+  --sha256: sha256-qvJrC2BPHe5GSreU9iBmv9S0TP0fNJA+Z+zn1qDTLNI=
   subdir:
     ouroboros-consensus
     ouroboros-consensus-cardano
@@ -134,13 +134,12 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/IntersectMBO/cardano-ledger.git
-  tag: 1327573bfb86f7e596151f77d03fc38982be8749
-  --sha256: sha256-CzA6eucrpsc8WMAtG9aNP0DcGtCxghHe0HSX+Yxvcd8=
+  tag: 22d32274ca2657f2966873b225aa9604852c4c77
+  --sha256: sha256-TnHTS2FDeUQoa3dIPSZwZ16svGw990arktNVx7z7aWY=
   subdir:
     eras/alonzo/impl
     eras/conway/impl
     eras/shelley/impl
-    eras/shelley/test-suite
     libs/cardano-ledger-core
 
 -- Points to ouroboros-network/leios-prototype


### PR DESCRIPTION
Bumps dependencies to use https://github.com/IntersectMBO/cardano-ledger/pull/5721