### PR TITLE
[cardano-testnet] Move testnet path conventions into cardano-node

### DIFF
--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -84,6 +84,7 @@ library
                         Cardano.Node.Run
                         Cardano.Node.Startup
                         Cardano.Node.STM
+                        Cardano.Node.Testnet.Paths
                         Cardano.Node.TraceConstraints
                         Cardano.Node.Tracing
                         Cardano.Node.Tracing.API

--- a/cardano-node/src/Cardano/Node/Testnet/Paths.hs
+++ b/cardano-node/src/Cardano/Node/Testnet/Paths.hs
@@ -1,0 +1,64 @@
+-- | Shared path conventions for cardano-testnet output directories.
+--
+-- Both @cardano-testnet@ (producer) and consumers of generated
+-- testnet configurations depend on this module so that directory
+-- layout changes are kept in sync at compile time.
+module Cardano.Node.Testnet.Paths
+  ( defaultNodeName
+  , defaultNodeDataDir
+  , defaultUtxoKeyDir
+  , defaultUtxoSKeyPath
+  , defaultUtxoVKeyPath
+  , defaultUtxoAddrPath
+  , defaultSocketDir
+  , defaultSocketName
+  , defaultSocketPath
+  , defaultConfigFile
+  , defaultPortFile
+  ) where
+
+import           System.FilePath ((</>))
+
+-- | The name of a node: @"node" <> show n@
+defaultNodeName :: Int -> String
+defaultNodeName n = "node" <> show n
+
+-- | Relative path to a node's data directory: @"node-data" </> defaultNodeName n@
+defaultNodeDataDir :: Int -> FilePath
+defaultNodeDataDir n = "node-data" </> defaultNodeName n
+
+-- | Relative path to a UTxO key directory: @"utxo-keys" </> "utxo" <> show n@
+defaultUtxoKeyDir :: Int -> FilePath
+defaultUtxoKeyDir n = "utxo-keys" </> "utxo" <> show n
+
+-- | Relative path to a UTxO signing key: @defaultUtxoKeyDir n </> "utxo.skey"@
+defaultUtxoSKeyPath :: Int -> FilePath
+defaultUtxoSKeyPath n = defaultUtxoKeyDir n </> "utxo.skey"
+
+-- | Relative path to a UTxO verification key: @defaultUtxoKeyDir n </> "utxo.vkey"@
+defaultUtxoVKeyPath :: Int -> FilePath
+defaultUtxoVKeyPath n = defaultUtxoKeyDir n </> "utxo.vkey"
+
+-- | Relative path to a UTxO address file: @defaultUtxoKeyDir n </> "utxo.addr"@
+defaultUtxoAddrPath :: Int -> FilePath
+defaultUtxoAddrPath n = defaultUtxoKeyDir n </> "utxo.addr"
+
+-- | Socket directory name: @"socket"@
+defaultSocketDir :: FilePath
+defaultSocketDir = "socket"
+
+-- | Socket file name: @"sock"@
+defaultSocketName :: FilePath
+defaultSocketName = "sock"
+
+-- | Relative path to a node's socket: @defaultSocketDir </> defaultNodeName n </> defaultSocketName@
+defaultSocketPath :: Int -> FilePath
+defaultSocketPath n = defaultSocketDir </> defaultNodeName n </> defaultSocketName
+
+-- | Main node configuration file name: @"configuration.yaml"@
+defaultConfigFile :: FilePath
+defaultConfigFile = "configuration.yaml"
+
+-- | Relative path to a node's port file: @defaultNodeDataDir n </> "port"@
+defaultPortFile :: Int -> FilePath
+defaultPortFile n = defaultNodeDataDir n </> "port"

--- a/cardano-testnet/changelog.d/20260409_move_testnet_paths_to_node.md
+++ b/cardano-testnet/changelog.d/20260409_move_testnet_paths_to_node.md
@@ -1,0 +1,4 @@
+
+### Maintenance
+
+- Moved shared testnet path conventions into `Cardano.Node.Testnet.Paths` module in `cardano-node`, and replaced some inline string literals.

--- a/cardano-testnet/src/Testnet/Defaults.hs
+++ b/cardano-testnet/src/Testnet/Defaults.hs
@@ -99,6 +99,8 @@ import           Numeric.Natural
 import           System.FilePath ((</>))
 
 import           Test.Cardano.Ledger.Core.Rational
+import           Cardano.Node.Testnet.Paths (defaultNodeName, defaultNodeDataDir, defaultUtxoSKeyPath,
+                   defaultUtxoVKeyPath)
 import           Testnet.Start.Types
 import           Testnet.Types
 
@@ -568,14 +570,6 @@ defaultSpoColdSKeyFp n = defaultSpoKeysDir n </> "cold.skey"
 defaultSpoName :: Int -> String
 defaultSpoName n = "pool" <> show n
 
--- | The name of a node (which doesn't have to be a SPO)
-defaultNodeName :: Int -> String
-defaultNodeName n = "node" <> show n
-
--- | The relative path of the node data dir, where the database is stored
-defaultNodeDataDir :: Int -> String
-defaultNodeDataDir n = "node-data" </> defaultNodeName n
-
 -- | The relative path where the SPO keys for the node are stored
 defaultSpoKeysDir :: Int -> String
 defaultSpoKeysDir n = "pools-keys" </> defaultSpoName n
@@ -619,8 +613,8 @@ defaultDelegatorStakeKeyPair n =
 defaultUtxoKeys :: Int -> KeyPair PaymentKey
 defaultUtxoKeys n =
   KeyPair
-    { verificationKey = File $ "utxo-keys" </> "utxo" <> show n </> "utxo.vkey"
-    , signingKey = File $ "utxo-keys" </> "utxo" <> show n </> "utxo.skey"
+    { verificationKey = File $ defaultUtxoVKeyPath n
+    , signingKey = File $ defaultUtxoSKeyPath n
     }
 
 

--- a/cardano-testnet/src/Testnet/Filepath.hs
+++ b/cardano-testnet/src/Testnet/Filepath.hs
@@ -20,6 +20,8 @@ import           Hedgehog.Extras.Stock.IO.Network.Sprocket (Sprocket (..))
 
 import           RIO (Display (..))
 
+import           Cardano.Node.Testnet.Paths (defaultSocketDir)
+
 
 makeSprocket
   :: TmpAbsolutePath
@@ -42,7 +44,7 @@ makeTmpRelPath :: TmpAbsolutePath -> FilePath
 makeTmpRelPath (TmpAbsolutePath fp) = makeRelative (makeTmpBaseAbsPath (TmpAbsolutePath fp)) fp
 
 makeSocketDir :: TmpAbsolutePath -> FilePath
-makeSocketDir fp = makeTmpRelPath fp </> "socket"
+makeSocketDir fp = makeTmpRelPath fp </> defaultSocketDir
 
 makeTmpBaseAbsPath :: TmpAbsolutePath -> FilePath
 makeTmpBaseAbsPath (TmpAbsolutePath fp) = addTrailingPathSeparator $ takeDirectory fp

--- a/cardano-testnet/src/Testnet/Runtime.hs
+++ b/cardano-testnet/src/Testnet/Runtime.hs
@@ -53,6 +53,7 @@ import qualified System.Process as IO
 import           System.Process (waitForProcess)
 
 import           Testnet.Filepath
+import           Cardano.Node.Testnet.Paths (defaultSocketName)
 import qualified Testnet.Ping as Ping
 import           Testnet.Process.Run (ProcessError (..), initiateProcess)
 import           Testnet.Process.RunIO (execCli_, execKesAgentControl_, liftIOAnnotated,
@@ -135,7 +136,7 @@ startNode tp node ipv4 port _testnetMagic nodeCmd = GHC.withFrozenCallStack $ do
   let nodeStdoutFile = logDir </> node </> "stdout.log"
       nodeStderrFile = logDir </> node </> "stderr.log"
       nodePidFile = logDir </> node </> "node.pid"
-      socketRelPath = socketDir </> node </> "sock"
+      socketRelPath = socketDir </> node </> defaultSocketName
       sprocket = Sprocket tempBaseAbsPath socketRelPath
 
   hNodeStdout <- retryOpenFile nodeStdoutFile IO.WriteMode

--- a/cardano-testnet/src/Testnet/Start/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Start/Cardano.hs
@@ -64,6 +64,8 @@ import           System.FilePath ((</>))
 
 import           Testnet.Components.Configuration
 import qualified Testnet.Defaults as Defaults
+import           Cardano.Node.Testnet.Paths (defaultConfigFile, defaultPortFile,
+                   defaultUtxoAddrPath)
 import           Testnet.Filepath
 import           Testnet.Handlers (interruptNodesOnSigINT)
 import           Testnet.Orphans ()
@@ -131,7 +133,7 @@ createTestnetEnv
     testnetOptions genesisOptions onChainParams
     (TmpAbsolutePath tmpAbsPath)
 
-  let configurationFile = tmpAbsPath </> "configuration.yaml"
+  let configurationFile = tmpAbsPath </> defaultConfigFile
   -- Add Byron, Shelley and Alonzo genesis hashes to node configuration
   config <- case genesisHashesPolicy of
     WithHashes -> createConfigJson (TmpAbsolutePath tmpAbsPath) sbe
@@ -152,7 +154,7 @@ createTestnetEnv
 
     -- Write port file
     case Map.lookup i portNumbersMap of
-      Just port -> liftIOAnnotated $ writeFile (nodeDataDir </> "port") (show port)
+      Just port -> liftIOAnnotated $ writeFile (tmpAbsPath </> defaultPortFile i) (show port)
       Nothing -> throwString $ "Port not found for node " <> show i
 
     producers <- mapM (idToRemoteAddressP2P portNumbersMap) $ NodeId <$> NEL.filter (/= i) nodeIds
@@ -247,7 +249,7 @@ cardanoTestnet
         , cardanoKESSource
         } = testnetOptions
       nPools = cardanoNumPools testnetOptions
-      nodeConfigFile = tmpAbsPath </> "configuration.yaml"
+      nodeConfigFile = tmpAbsPath </> defaultConfigFile
       byronGenesisFile = tmpAbsPath </> "byron-genesis.json"
       shelleyGenesisFile = tmpAbsPath </> "shelley-genesis.json"
 
@@ -260,7 +262,7 @@ cardanoTestnet
 
   wallets <- forM [1..3] $ \idx -> do
     let utxoKeys@KeyPair{verificationKey} = makePathsAbsolute $ Defaults.defaultUtxoKeys idx
-    let paymentAddrFile = tmpAbsPath </> "utxo-keys" </> "utxo" <> show idx </> "utxo.addr"
+    let paymentAddrFile = tmpAbsPath </> defaultUtxoAddrPath idx
 
     execCli_
       [ "latest", "address", "build"
@@ -279,7 +281,7 @@ cardanoTestnet
   -- Read port numbers from disk (written by createTestnetEnv)
   portNumbers <- forM (NEL.zip (1 :| [2..]) cardanoNodes) $ \(i, _nodeOption) -> do
     let nodeDataDir = tmpAbsPath </> Defaults.defaultNodeDataDir i
-        portPath = nodeDataDir </> "port"
+        portPath = tmpAbsPath </> defaultPortFile i
     portStr <- liftIOAnnotated $ readFile portPath
     let port = read portStr :: PortNumber
     let topologyPath = nodeDataDir </> "topology.json"


### PR DESCRIPTION
# Description

Moves shared testnet path conventions from inline string literals in `cardano-testnet` into a new `Cardano.Node.Testnet.Paths` module in the `cardano-node` library. This enables other packages (e.g. `tx-generator`) to depend on the same path definitions without pulling in the full `cardano-testnet` dependency tree, and without introducing a new micro-package.

Both `cardano-testnet` and `tx-generator` already depend on `cardano-node`, so no new dependency edges are introduced. GHC dead-code eliminates the path definitions from the node executable since it doesn't reference them.

This refactoring is necessary to enable the realisation of #6511 in a way that is robust (statically checked). Check #6510 for more details.

This PR is meant to be a pure refactoring — there should be no behaviour changes.

Closes #6517 (part 1 of #6510). Supersedes #6512 / #6514.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff