### PR TITLE
chore: bump cardano-node to 10.6.4 and plutus deps to ^>=1.61

### DIFF
--- a/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
+++ b/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
@@ -83,9 +83,9 @@ library
   --------------------------
   build-depends:
     , cardano-api             ^>=10.23
-    , plutus-ledger-api       ^>=1.57
-    , plutus-tx               ^>=1.57
-    , plutus-tx-plugin        ^>=1.57
+    , plutus-ledger-api       ^>=1.61
+    , plutus-tx               ^>=1.61
+    , plutus-tx-plugin        ^>=1.61
 
   ------------------------
   -- Non-IOG dependencies

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2025-09-29T13:55:56Z
-  , cardano-haskell-packages 2026-03-28T09:44:46Z
+  , cardano-haskell-packages 2026-04-09T12:05:18Z
 
 active-repositories:
   , :rest

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.8
 
 name:                   cardano-node
-version:                10.6.3
+version:                10.6.4
 synopsis:               The cardano full node
 description:            The cardano full node.
 category:               Cardano,

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1774695208,
-        "narHash": "sha256-4GaPRLb1S9pvQnSXBYdKz2xCZzu0m1UgWsItFu9poOk=",
+        "lastModified": 1775738777,
+        "narHash": "sha256-kM7FV8HjWVff1h5AIbn9L1pCcmv70um6A08kTaYQPUk=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "2d51f381c901c7f1a799d65d2de4f2387d07a9e5",
+        "rev": "f3e1087aaa7ec8230913695ddabbaa5816e7bde8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
- Bump cardano-node version from 10.6.3 to 10.6.4
- Bump plutus-ledger-api, plutus-tx, plutus-tx-plugin from ^>=1.57 to ^>=1.61
- Update CHaP index-state to 2026-04-09T12:05:18Z
- Update flake.lock with new CHaP revision

# Description

Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
