### PR TITLE
Make Dijkstra genesis config optional

### DIFF
--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -4,6 +4,9 @@
 
 * Added EKG metrics for soft and hard timeouts and included defensive mempool
 
+* Allow `ExperimentalHardForksEnabled` configurations to omit `DijkstraGenesisFile`
+  and fall back to the empty Dijkstra genesis.
+
 * Improved `cardano-node --help` output by making it the same as the one shown when calling `cardano-node` without arguments.
 
 * Removed `cardano-node' as a dependency from `cardano-tracer'. This necessitated moving `NodeInfo`

--- a/cardano-node/src/Cardano/Node/Configuration/POM.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/POM.hs
@@ -58,7 +58,7 @@ import           Ouroboros.Network.TxSubmission.Inbound.V2.Types (TxSubmissionIn
                    TxSubmissionLogicVersion (..), defaultTxSubmissionInitDelay)
 
 import           Control.Concurrent (getNumCapabilities)
-import           Control.Monad (unless, void, when)
+import           Control.Monad (forM, unless, void, when)
 import           Data.Aeson
 import qualified Data.Aeson.Types as Aeson
 import           Data.Bifunctor (Bifunctor (..))
@@ -376,7 +376,7 @@ instance FromJSON PartialNodeConfiguration where
                 <*> parseShelleyProtocol v
                 <*> parseAlonzoProtocol v
                 <*> parseConwayProtocol v
-                <*> (if npcExperimentalHardForksEnabled hfp then Just <$> parseDijkstraProtocol v else pure Nothing)
+                <*> (if npcExperimentalHardForksEnabled hfp then parseDijkstraProtocol v else pure Nothing)
                 <*> pure hfp
                 <*> parseCheckpoints v
       pncMaybeMempoolCapacityOverride <- Last <$> parseMempoolCapacityBytesOverride v
@@ -612,12 +612,13 @@ instance FromJSON PartialNodeConfiguration where
              }
 
       parseDijkstraProtocol v = do
-        npcDijkstraGenesisFile     <- v .:  "DijkstraGenesisFile"
-        npcDijkstraGenesisFileHash <- v .:? "DijkstraGenesisHash"
-        pure NodeDijkstraProtocolConfiguration {
-               npcDijkstraGenesisFile
-             , npcDijkstraGenesisFileHash
-             }
+        mNpcDijkstraGenesisFile <- v .:? "DijkstraGenesisFile"
+        forM mNpcDijkstraGenesisFile $ \npcDijkstraGenesisFile -> do
+          npcDijkstraGenesisFileHash <- v .:? "DijkstraGenesisHash"
+          pure NodeDijkstraProtocolConfiguration {
+                 npcDijkstraGenesisFile
+               , npcDijkstraGenesisFileHash
+               }
 
       parseHardForkProtocol v = do
 

--- a/cardano-node/test/Test/Cardano/Node/POM.hs
+++ b/cardano-node/test/Test/Cardano/Node/POM.hs
@@ -30,6 +30,8 @@ import           Ouroboros.Network.Block (SlotNo (..))
 import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
 import           Ouroboros.Network.TxSubmission.Inbound.V2.Types
 
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Types as AesonTypes
 import           Data.Bifunctor (first)
 import           Data.Monoid (Last (..))
 import           Data.String
@@ -56,6 +58,20 @@ prop_sanityCheck_POM =
     case nc of
       Left err -> failWith Nothing $ "Partial Options Monoid sanity check failure: " <> err
       Right config -> config === expectedConfig
+
+prop_parseExperimentalHardForksWithoutDijkstraGenesis :: Property
+prop_parseExperimentalHardForksWithoutDijkstraGenesis =
+  withTests 1 . Hedgehog.property $ do
+    partialConfig <- evalEither $ AesonTypes.parseEither Aeson.parseJSON experimentalHardForkConfigWithoutDijkstra
+    protocolConfig <- evalEither $ extractProtocolConfig partialConfig
+    protocolConfig === testNodeProtocolConfiguration
+
+prop_parseExperimentalHardForksWithDijkstraGenesis :: Property
+prop_parseExperimentalHardForksWithDijkstraGenesis =
+  withTests 1 . Hedgehog.property $ do
+    partialConfig <- evalEither $ AesonTypes.parseEither Aeson.parseJSON experimentalHardForkConfigWithDijkstra
+    protocolConfig <- evalEither $ extractProtocolConfig partialConfig
+    protocolConfig === expectedProtocolConfigWithDijkstra
 
 testNodeByronProtocolConfiguration :: NodeByronProtocolConfiguration
 testNodeByronProtocolConfiguration =
@@ -127,6 +143,59 @@ testNodeProtocolConfiguration =
     Nothing -- Dijkstra configuration
     testNodeHardForkProtocolConfiguration
     testNodeCheckpointsConfiguration
+
+testNodeDijkstraProtocolConfiguration :: NodeDijkstraProtocolConfiguration
+testNodeDijkstraProtocolConfiguration =
+  NodeDijkstraProtocolConfiguration
+    { npcDijkstraGenesisFile = GenesisFile "dummy-dijkstra-genesis-file"
+    , npcDijkstraGenesisFileHash = Nothing
+    }
+
+expectedProtocolConfigWithDijkstra :: NodeProtocolConfiguration
+expectedProtocolConfigWithDijkstra =
+  NodeProtocolConfigurationCardano
+    testNodeByronProtocolConfiguration
+    testNodeShelleyProtocolConfiguration
+    testNodeAlonzoProtocolConfiguration
+    testNodeConwayProtocolConfiguration
+    (Just testNodeDijkstraProtocolConfiguration)
+    testNodeHardForkProtocolConfiguration
+    testNodeCheckpointsConfiguration
+
+experimentalHardForkConfigWithoutDijkstra :: Aeson.Value
+experimentalHardForkConfigWithoutDijkstra =
+  Aeson.object
+    [ "ByronGenesisFile" Aeson..= ("dummmy-genesis-file" :: FilePath)
+    , "ShelleyGenesisFile" Aeson..= ("dummmy-genesis-file" :: FilePath)
+    , "AlonzoGenesisFile" Aeson..= ("dummmy-genesis-file" :: FilePath)
+    , "ConwayGenesisFile" Aeson..= ("dummmy-genesis-file" :: FilePath)
+    , "RequiresNetworkMagic" Aeson..= RequiresNoMagic
+    , "LastKnownBlockVersion-Major" Aeson..= (0 :: Int)
+    , "LastKnownBlockVersion-Minor" Aeson..= (0 :: Int)
+    , "LastKnownBlockVersion-Alt" Aeson..= (0 :: Int)
+    , "ExperimentalHardForksEnabled" Aeson..= True
+    ]
+
+experimentalHardForkConfigWithDijkstra :: Aeson.Value
+experimentalHardForkConfigWithDijkstra =
+  Aeson.object
+    [ "ByronGenesisFile" Aeson..= ("dummmy-genesis-file" :: FilePath)
+    , "ShelleyGenesisFile" Aeson..= ("dummmy-genesis-file" :: FilePath)
+    , "AlonzoGenesisFile" Aeson..= ("dummmy-genesis-file" :: FilePath)
+    , "ConwayGenesisFile" Aeson..= ("dummmy-genesis-file" :: FilePath)
+    , "DijkstraGenesisFile" Aeson..= ("dummy-dijkstra-genesis-file" :: FilePath)
+    , "RequiresNetworkMagic" Aeson..= RequiresNoMagic
+    , "LastKnownBlockVersion-Major" Aeson..= (0 :: Int)
+    , "LastKnownBlockVersion-Minor" Aeson..= (0 :: Int)
+    , "LastKnownBlockVersion-Alt" Aeson..= (0 :: Int)
+    , "ExperimentalHardForksEnabled" Aeson..= True
+    ]
+
+extractProtocolConfig :: PartialNodeConfiguration -> Either Text NodeProtocolConfiguration
+extractProtocolConfig partialConfig =
+  case pncProtocolConfig partialConfig of
+    Last (Just protocolConfig) -> Right protocolConfig
+    Last Nothing -> Left "Missing protocol configuration in parsed partial node configuration"
 
 -- | Example partial configuration theoretically created from a
 -- config yaml file.


### PR DESCRIPTION
• # Description

  I found that `cardano-node` configuration parsing required `DijkstraGenesisFile` whenever `ExperimentalHardForksEnabled = true`, even though protocol instantiation already handled a
  missing Dijkstra config by falling back to the empty Dijkstra genesis.

  That made some experimental configurations fail at parse/startup time even though the runtime path already supported the absence of a Dijkstra genesis file.

  In this PR I make `DijkstraGenesisFile` optional during config parsing so parse-time behavior matches the existing runtime fallback:
  - if `DijkstraGenesisFile` is present, it is parsed and used as before
  - if it is absent, parsing now keeps the Dijkstra configuration as `Nothing`

  I reproduced the issue in the `10.7.0` worktree before making the fix, then verified the fix with:
  - property-style parser regression coverage in `cardano-node/test/Test/Cardano/Node/POM.hs`
  - `cardano-testnet` golden default config verification
  - `cardano-testnet` dump/load integration verification

  Validation used:
  - `nix develop . -c cabal test cardano-node-test`
  - `nix develop . -c cabal test cardano-testnet-golden --test-options '-p "Golden tests.golden_DefaultConfig"'`
  - `nix develop . -c cabal test cardano-testnet-test --test-options '-p dumping'`

  # Checklist

  - [x] Commit sequence broadly makes sense and commits have useful messages
  - [x] New tests are added if needed and existing tests are updated.  These may include:
    - [x] golden tests
    - [x] property tests
    - [ ] roundtrip tests
    - [x] integration tests
    See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
  - [x] Any changes are noted in the `CHANGELOG.md` for affected package
  - [ ] The version bounds in `.cabal` files are updated
  - [ ] CI passes. See note on CI.  The following CI checks are required:
    - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
    - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
    - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
  - [x] Self-reviewed the diff