### PR TITLE
Predictable ledger state snapshots

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -108,3 +108,10 @@ if impl(ghc >= 9.12)
       proto-lens-tests-dep
       proto-lens-tests
       proto-lens
+
+source-repository-package
+  type: git
+  location: https://github.com/IntersectMBO/ouroboros-consensus
+  tag: 3c557b3d997709e92ddcee055b415227d0c4a82d
+  --sha256: sha256-z9ADSqguJFPzIjFaNk4sj+AHMeRPW6ZC52miuUMEqTA=
+  subdir: .

--- a/cabal.project
+++ b/cabal.project
@@ -86,3 +86,13 @@ allow-newer:
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
+
+-- points to a temporary branch geo2a/ledger-snaphot-param-revision-for-node
+-- The changes from that branch are already on ouroboros-consensus/main, but
+-- the preceding changes on main are not yet integrated into the cardano-node/main
+source-repository-package
+  type: git
+  location: https://github.com/IntersectMBO/ouroboros-consensus
+  tag: d1a31119402e6237c58a87e5940d246af59427e6
+  --sha256: sha256-jX4Gav8StCSBDuqso2OJ1maTYU0oRQpUfCelIaHtbxo=
+  subdir: .

--- a/cardano-node/src/Cardano/Node/Configuration/LedgerDB.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/LedgerDB.hs
@@ -73,8 +73,7 @@ noDeprecatedOptions = DeprecatedOptions []
 
 data LedgerDbConfiguration =
     LedgerDbConfiguration
-      NumOfDiskSnapshots
-      SnapshotInterval
+      SnapshotPolicyArgs
       QueryBatchSize
       LedgerDbSelectorFlag
       DeprecatedOptions

--- a/cardano-node/src/Cardano/Node/Configuration/POM.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/POM.hs
@@ -28,6 +28,7 @@ module Cardano.Node.Configuration.POM
 where
 
 import           Cardano.Crypto (RequiresNetworkMagic (..))
+import           Cardano.Ledger.BaseTypes
 import           Cardano.Logging.Types
 import           Cardano.Network.ConsensusMode (ConsensusMode (..), defaultConsensusMode)
 import qualified Cardano.Network.Diffusion.Configuration as Cardano
@@ -48,7 +49,9 @@ import           Ouroboros.Consensus.Node.Genesis (GenesisConfig, GenesisConfigF
                    defaultGenesisConfigFlags, mkGenesisConfig)
 import           Ouroboros.Consensus.Storage.LedgerDB.Args (QueryBatchSize (..))
 import           Ouroboros.Consensus.Storage.LedgerDB.Snapshots (NumOfDiskSnapshots (..),
-                   SnapshotInterval (..))
+                   SnapshotDelayRange (..), SnapshotFrequency (..), SnapshotFrequencyArgs (..),
+                   SnapshotPolicyArgs (..), defaultSnapshotPolicyArgs)
+import           Ouroboros.Consensus.Util.Args (OverrideOrDefault (..))
 import           Ouroboros.Consensus.Storage.LedgerDB.V1.Args (FlushFrequency (..))
 import           Ouroboros.Network.Diffusion.Configuration as Configuration
 import qualified Ouroboros.Network.Diffusion.Configuration as Ouroboros
@@ -510,8 +513,14 @@ instance FromJSON PartialNodeConfiguration where
               Nothing -> return Nothing
 
       parseLedgerDbConfig v = do
-        let snapInterval x = fmap (RequestedSnapshotInterval . secondsToDiffTime) <$> x .:? "SnapshotInterval"
-            snapNum x      = fmap RequestedNumOfDiskSnapshots <$> x .:? "NumOfDiskSnapshots"
+        -- TODO maybe don't silently convert old format (which was in seconds)
+        -- to new format (which is in slots), despite these being the same on
+        -- mainnet?
+        let snapInterval x = do
+              si <- x .:? "SnapshotInterval"
+              when (any (<= 0) si) $ fail $ "Non-positive SnapshotInterval: " <> show si
+              pure $ Override . SlotNo <$> si
+            snapNum x      = fmap (Override . NumOfDiskSnapshots) <$> x .:? "NumOfDiskSnapshots"
 
         mTopLevelSnapInterval <- snapInterval v
         mTopLevelSnapNum <- snapNum v
@@ -525,12 +534,32 @@ instance FromJSON PartialNodeConfiguration where
         mLedgerDB <- v .:? "LedgerDB"
         case mLedgerDB of
            Nothing -> do
-             let si = fromMaybe DefaultSnapshotInterval mTopLevelSnapInterval
-                 sn = fromMaybe DefaultNumOfDiskSnapshots mTopLevelSnapNum
-             return $ Just $ LedgerDbConfiguration sn si DefaultQueryBatchSize V2InMemory deprecatedOpts
+             let si = fromMaybe UseDefault mTopLevelSnapInterval
+                 sn = fromMaybe UseDefault mTopLevelSnapNum
+                 sf = SnapshotFrequencyArgs {
+                     sfaInterval = unsafeNonZero . unSlotNo <$> si
+                   , sfaOffset = UseDefault
+                   , sfaRateLimit = UseDefault
+                   , sfaDelaySnapshotRange = UseDefault
+                   }
+                 spArgs = SnapshotPolicyArgs (SnapshotFrequency sf) sn
+             return $ Just $ LedgerDbConfiguration spArgs DefaultQueryBatchSize V2InMemory deprecatedOpts
            Just ledgerDB -> flip (withObject "LedgerDB") ledgerDB $ \o -> do
-             ldbSnapInterval <- (getLast . (Last mTopLevelSnapInterval <>) . Last <$> snapInterval o) .!= DefaultSnapshotInterval
-             ldbSnapNum      <- (getLast . (Last mTopLevelSnapNum <>) . Last <$> snapNum o)           .!= DefaultNumOfDiskSnapshots
+             ldbSnapInterval <- (getLast . (Last mTopLevelSnapInterval <>) . Last <$> snapInterval o) .!= UseDefault
+             ldbSnapNum      <- (getLast . (Last mTopLevelSnapNum <>) . Last <$> snapNum o)           .!= UseDefault
+             ldbSnapOffset   <- (fmap Override <$> o .:? "SlotOffset") .!= UseDefault
+             ldbSnapRateLimit<- (fmap (Override . secondsToDiffTime) <$> o .:? "RateLimit") .!= UseDefault
+             ldbSnapMinDelay <- o .:? "MinDelay"
+             ldbSnapMaxDelay <- o .:? "MaxDelay"
+             ldbSnapDelayRange <-
+                   case (ldbSnapMinDelay, ldbSnapMaxDelay) of
+                     (Just minDelay, Just maxDelay) ->
+                       if minDelay <= maxDelay then
+                         pure (Override (SnapshotDelayRange (secondsToDiffTime minDelay) (secondsToDiffTime maxDelay)))
+                       else fail $ "Invalid ledger snapshot delay range, MinDelay > MaxDelay: "
+                                 <> show minDelay <> " > " <> show maxDelay
+                     -- use the default delay range if either min or max is unspecified
+                     _ -> pure UseDefault
              qsize           <- (fmap RequestedQueryBatchSize <$> o .:? "QueryBatchSize") .!= DefaultQueryBatchSize
              backend         <- o .:? "Backend" .!= "V2InMemory"
              selector        <- case backend of
@@ -545,7 +574,14 @@ instance FromJSON PartialNodeConfiguration where
                  lsmPath :: Maybe FilePath <- o .:? "LSMDatabasePath"
                  pure $ V2LSM lsmPath
                _ -> fail $ "Malformed LedgerDB Backend: " <> backend
-             pure $ Just $ LedgerDbConfiguration ldbSnapNum ldbSnapInterval qsize selector deprecatedOpts
+             let sf = SnapshotFrequencyArgs {
+                     sfaInterval = unsafeNonZero . unSlotNo <$> ldbSnapInterval
+                   , sfaOffset = ldbSnapOffset
+                   , sfaRateLimit = ldbSnapRateLimit
+                   , sfaDelaySnapshotRange = ldbSnapDelayRange
+                   }
+                 spArgs = SnapshotPolicyArgs (SnapshotFrequency sf) ldbSnapNum
+             pure $ Just $ LedgerDbConfiguration spArgs qsize selector deprecatedOpts
 
       parseByronProtocol v = do
         primary   <- v .:? "ByronGenesisFile"
@@ -712,8 +748,7 @@ defaultPartialNodeConfiguration =
     , pncLedgerDbConfig =
         Last $ Just $
           LedgerDbConfiguration
-            DefaultNumOfDiskSnapshots
-            DefaultSnapshotInterval
+            defaultSnapshotPolicyArgs
             DefaultQueryBatchSize
             V2InMemory
             noDeprecatedOptions

--- a/cardano-node/src/Cardano/Node/Configuration/POM.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/POM.hs
@@ -48,7 +48,7 @@ import           Ouroboros.Consensus.Node.Genesis (GenesisConfig, GenesisConfigF
 import           Ouroboros.Consensus.Storage.LedgerDB.Args (QueryBatchSize (..))
 import           Ouroboros.Consensus.Storage.LedgerDB.Snapshots (NumOfDiskSnapshots (..),
                    SnapshotDelayRange (..), SnapshotFrequency (..), SnapshotFrequencyArgs (..),
-                   SnapshotPolicyArgs (..), defaultSnapshotPolicyArgs)
+                   SnapshotPolicyArgs (..), defaultSnapshotPolicyArgs, mithrilSnapshotPolicyArgs)
 import           Ouroboros.Consensus.Util.Args (OverrideOrDefault (..))
 import           Ouroboros.Consensus.Storage.LedgerDB.V1.Args (FlushFrequency (..))
 import           Ouroboros.Network.Diffusion.Configuration as Configuration
@@ -67,6 +67,7 @@ import           Data.Hashable (Hashable)
 import           Data.Maybe
 import           Data.Monoid (Last (..))
 import           Data.Text (Text)
+import qualified Data.Text as Text
 import           Data.Time.Clock (DiffTime, secondsToDiffTime)
 import           Data.Yaml (decodeFileThrow)
 import           GHC.Generics (Generic)
@@ -547,8 +548,16 @@ instance FromJSON PartialNodeConfiguration where
 
              mSnapshotsVal <- o .:? "Snapshots"
              spArgs <- case mSnapshotsVal of
+               -- A named snapshot policy selects a predefined set of snapshot
+               -- policy arguments as a whole.
+               Just (String name) -> case name of
+                 "Mithril" -> pure mithrilSnapshotPolicyArgs
+                 _ -> fail $ "Unknown named ledger snapshot policy: " <> Text.unpack name
+                          <> ". Expected \"Mithril\" or an object with snapshot options."
+               -- the modern case of the snapshot policy specified under the "Snapshots" key
+               Just sv -> withObject "Snapshots" parseSnapshotOpts sv
+               -- the legacy case of the snapshot policy specified at the top-level
                Nothing -> parseSnapshotOpts o
-               Just sv -> flip (withObject "Snapshots") sv parseSnapshotOpts
 
              qsize           <- (fmap RequestedQueryBatchSize <$> o .:? "QueryBatchSize") .!= DefaultQueryBatchSize
              backend         <- o .:? "Backend" .!= "V2InMemory"

--- a/cardano-node/src/Cardano/Node/Configuration/POM.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/POM.hs
@@ -488,16 +488,13 @@ instance FromJSON PartialNodeConfiguration where
               Nothing -> return Nothing
 
       parseLedgerDbConfig v = do
-        -- TODO maybe don't silently convert old format (which was in seconds)
-        -- to new format (which is in slots), despite these being the same on
-        -- mainnet?
-        let snapInterval x = do
+        let snapIntervalSlots x = do
               si <- x .:? "SnapshotInterval"
               when (any (<= 0) si) $ fail $ "Non-positive SnapshotInterval: " <> show si
               pure $ Override . SlotNo <$> si
             snapNum x      = fmap (Override . NumOfDiskSnapshots) <$> x .:? "NumOfDiskSnapshots"
 
-        mTopLevelSnapInterval <- snapInterval v
+        mTopLevelSnapInterval <- snapIntervalSlots v
         mTopLevelSnapNum <- snapNum v
 
         let topLevelOptionsSet =
@@ -523,7 +520,7 @@ instance FromJSON PartialNodeConfiguration where
              -- Parse snapshot options from the "Snapshots" sub-object if present,
              -- otherwise fall back to the LedgerDB object for backward compatibility.
              let parseSnapshotOpts s = do
-                   sInterval  <- (getLast . (Last mTopLevelSnapInterval <>) . Last <$> snapInterval s) .!= UseDefault
+                   sInterval  <- (getLast . (Last mTopLevelSnapInterval <>) . Last <$> snapIntervalSlots s) .!= UseDefault
                    sNum       <- (getLast . (Last mTopLevelSnapNum <>) . Last <$> snapNum s)           .!= UseDefault
                    sOffset    <- (fmap Override <$> s .:? "SlotOffset") .!= UseDefault
                    sRateLimit <- (fmap (Override . secondsToDiffTime) <$> s .:? "RateLimit") .!= UseDefault

--- a/cardano-node/src/Cardano/Node/Configuration/POM.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/POM.hs
@@ -28,6 +28,7 @@ module Cardano.Node.Configuration.POM
 where
 
 import           Cardano.Crypto (RequiresNetworkMagic (..))
+import           Cardano.Ledger.BaseTypes
 import           Cardano.Logging.Types
 import           Cardano.Network.ConsensusMode (ConsensusMode (..), defaultConsensusMode)
 import qualified Cardano.Network.Diffusion.Configuration as Cardano
@@ -46,7 +47,9 @@ import           Ouroboros.Consensus.Node.Genesis (GenesisConfig, GenesisConfigF
                    defaultGenesisConfigFlags, mkGenesisConfig)
 import           Ouroboros.Consensus.Storage.LedgerDB.Args (QueryBatchSize (..))
 import           Ouroboros.Consensus.Storage.LedgerDB.Snapshots (NumOfDiskSnapshots (..),
-                   SnapshotInterval (..))
+                   SnapshotDelayRange (..), SnapshotFrequency (..), SnapshotFrequencyArgs (..),
+                   SnapshotPolicyArgs (..), defaultSnapshotPolicyArgs)
+import           Ouroboros.Consensus.Util.Args (OverrideOrDefault (..))
 import           Ouroboros.Consensus.Storage.LedgerDB.V1.Args (FlushFrequency (..))
 import           Ouroboros.Network.Diffusion.Configuration as Configuration
 import qualified Ouroboros.Network.Diffusion.Configuration as Ouroboros
@@ -484,8 +487,14 @@ instance FromJSON PartialNodeConfiguration where
               Nothing -> return Nothing
 
       parseLedgerDbConfig v = do
-        let snapInterval x = fmap (RequestedSnapshotInterval . secondsToDiffTime) <$> x .:? "SnapshotInterval"
-            snapNum x      = fmap RequestedNumOfDiskSnapshots <$> x .:? "NumOfDiskSnapshots"
+        -- TODO maybe don't silently convert old format (which was in seconds)
+        -- to new format (which is in slots), despite these being the same on
+        -- mainnet?
+        let snapInterval x = do
+              si <- x .:? "SnapshotInterval"
+              when (any (<= 0) si) $ fail $ "Non-positive SnapshotInterval: " <> show si
+              pure $ Override . SlotNo <$> si
+            snapNum x      = fmap (Override . NumOfDiskSnapshots) <$> x .:? "NumOfDiskSnapshots"
 
         mTopLevelSnapInterval <- snapInterval v
         mTopLevelSnapNum <- snapNum v
@@ -499,12 +508,48 @@ instance FromJSON PartialNodeConfiguration where
         mLedgerDB <- v .:? "LedgerDB"
         case mLedgerDB of
            Nothing -> do
-             let si = fromMaybe DefaultSnapshotInterval mTopLevelSnapInterval
-                 sn = fromMaybe DefaultNumOfDiskSnapshots mTopLevelSnapNum
-             return $ Just $ LedgerDbConfiguration sn si DefaultQueryBatchSize V2InMemory deprecatedOpts
+             let si = fromMaybe UseDefault mTopLevelSnapInterval
+                 sn = fromMaybe UseDefault mTopLevelSnapNum
+                 sf = SnapshotFrequencyArgs {
+                     sfaInterval = unsafeNonZero . unSlotNo <$> si
+                   , sfaOffset = UseDefault
+                   , sfaRateLimit = UseDefault
+                   , sfaDelaySnapshotRange = UseDefault
+                   }
+                 spArgs = SnapshotPolicyArgs (SnapshotFrequency sf) sn
+             return $ Just $ LedgerDbConfiguration spArgs DefaultQueryBatchSize V2InMemory deprecatedOpts
            Just ledgerDB -> flip (withObject "LedgerDB") ledgerDB $ \o -> do
-             ldbSnapInterval <- (getLast . (Last mTopLevelSnapInterval <>) . Last <$> snapInterval o) .!= DefaultSnapshotInterval
-             ldbSnapNum      <- (getLast . (Last mTopLevelSnapNum <>) . Last <$> snapNum o)           .!= DefaultNumOfDiskSnapshots
+             -- Parse snapshot options from the "Snapshots" sub-object if present,
+             -- otherwise fall back to the LedgerDB object for backward compatibility.
+             let parseSnapshotOpts s = do
+                   sInterval  <- (getLast . (Last mTopLevelSnapInterval <>) . Last <$> snapInterval s) .!= UseDefault
+                   sNum       <- (getLast . (Last mTopLevelSnapNum <>) . Last <$> snapNum s)           .!= UseDefault
+                   sOffset    <- (fmap Override <$> s .:? "SlotOffset") .!= UseDefault
+                   sRateLimit <- (fmap (Override . secondsToDiffTime) <$> s .:? "RateLimit") .!= UseDefault
+                   sMinDelay  <- s .:? "MinDelay"
+                   sMaxDelay  <- s .:? "MaxDelay"
+                   sDelayRange <-
+                         case (sMinDelay, sMaxDelay) of
+                           (Just minDelay, Just maxDelay) ->
+                             if minDelay <= maxDelay then
+                               pure (Override (SnapshotDelayRange (secondsToDiffTime minDelay) (secondsToDiffTime maxDelay)))
+                             else fail $ "Invalid ledger snapshot delay range, MinDelay > MaxDelay: "
+                                       <> show minDelay <> " > " <> show maxDelay
+                           -- use the default delay range if either min or max is unspecified
+                           _ -> pure UseDefault
+                   let sf = SnapshotFrequencyArgs {
+                           sfaInterval = unsafeNonZero . unSlotNo <$> sInterval
+                         , sfaOffset = sOffset
+                         , sfaRateLimit = sRateLimit
+                         , sfaDelaySnapshotRange = sDelayRange
+                         }
+                   pure $ SnapshotPolicyArgs (SnapshotFrequency sf) sNum
+
+             mSnapshotsVal <- o .:? "Snapshots"
+             spArgs <- case mSnapshotsVal of
+               Nothing -> parseSnapshotOpts o
+               Just sv -> flip (withObject "Snapshots") sv parseSnapshotOpts
+
              qsize           <- (fmap RequestedQueryBatchSize <$> o .:? "QueryBatchSize") .!= DefaultQueryBatchSize
              backend         <- o .:? "Backend" .!= "V2InMemory"
              selector        <- case backend of
@@ -519,7 +564,7 @@ instance FromJSON PartialNodeConfiguration where
                  lsmPath :: Maybe FilePath <- o .:? "LSMDatabasePath"
                  pure $ V2LSM lsmPath
                _ -> fail $ "Malformed LedgerDB Backend: " <> backend
-             pure $ Just $ LedgerDbConfiguration ldbSnapNum ldbSnapInterval qsize selector deprecatedOpts
+             pure $ Just $ LedgerDbConfiguration spArgs qsize selector deprecatedOpts
 
       parseByronProtocol v = do
         primary   <- v .:? "ByronGenesisFile"
@@ -683,8 +728,7 @@ defaultPartialNodeConfiguration =
     , pncLedgerDbConfig =
         Last $ Just $
           LedgerDbConfiguration
-            DefaultNumOfDiskSnapshots
-            DefaultSnapshotInterval
+            defaultSnapshotPolicyArgs
             DefaultQueryBatchSize
             V2InMemory
             noDeprecatedOptions

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -656,14 +656,10 @@ handleSimpleNode blockType runP tracers nc networkMagic onKernel = do
         Just version_ -> Map.takeWhileAntitone (<= version_)
 
   LedgerDbConfiguration
-    snapInterval
-    numSnaps
+    snapshotPolicyArgs
     queryBatchSize
     ldbBackend
     deprecatedOpts = ncLedgerDbConfig nc
-
-  snapshotPolicyArgs :: SnapshotPolicyArgs
-  snapshotPolicyArgs = SnapshotPolicyArgs numSnaps snapInterval
 
 --------------------------------------------------------------------------------
 -- SIGHUP Handlers

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -561,14 +561,10 @@ handleSimpleNode blockType runP tracers nc networkMagic onKernel = do
         Just version_ -> Map.takeWhileAntitone (<= version_)
 
   LedgerDbConfiguration
-    snapInterval
-    numSnaps
+    snapshotPolicyArgs
     queryBatchSize
     ldbBackend
     deprecatedOpts = ncLedgerDbConfig nc
-
-  snapshotPolicyArgs :: SnapshotPolicyArgs
-  snapshotPolicyArgs = SnapshotPolicyArgs numSnaps snapInterval
 
 --------------------------------------------------------------------------------
 -- SIGHUP Handlers

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
@@ -60,6 +60,7 @@ import           Ouroboros.Network.Block (MaxSlotNo (..))
 import           Data.Aeson (Object, Value (String), object, toJSON, (.=))
 import qualified Data.ByteString.Base16 as B16
 import           Data.Int (Int64)
+import qualified Data.List.NonEmpty as NonEmpty
 import           Data.SOP (All, K (..), hcmap, hcollapse)
 import           Data.Text (Text)
 import qualified Data.Text as Text
@@ -1772,6 +1773,14 @@ instance ( StandardHash blk
           LedgerDB.MetadataBackendMismatch ->
              " Snapshot was created for a different backend. Convert it with `snapshot-converter`."
         _ -> ""
+  forHuman (LedgerDB.SnapshotRequestDelayed _snapshotRequestTime delayBeforeSnapshotting slots) =
+    Text.unwords ["Scheduling to take ledger state snapshots at slots "
+                 , showT (NonEmpty.toList slots)
+                 , ", with a randomised delay of"
+                 , showT delayBeforeSnapshotting
+                 ]
+  forHuman (LedgerDB.SnapshotRequestCompleted) = "Completed taking a ledger state snapshot"
+
 
   forMachine dtals (LedgerDB.TookSnapshot snap pt enclosedTiming) =
     mconcat [ "kind" .= String "TookSnapshot"
@@ -1786,11 +1795,23 @@ instance ( StandardHash blk
     mconcat [ "kind" .= String "InvalidSnapshot"
             , "snapshot" .= forMachine dtals snap
             , "failure" .= show failure ]
+  forMachine _dtals (LedgerDB.SnapshotRequestDelayed snapshotRequestTime delayBeforeSnapshotting slots) =
+    mconcat [ "kind" .= String "TraceLedgerDBEvent.LedgerDBSnapshotEvent.SnapshotRequestDelayed"
+             , "requestTime" .= show snapshotRequestTime
+             , "delayBeforeSnapshotting " .= show delayBeforeSnapshotting
+             , "slots" .= show slots
+             ]
+  forMachine _dtals (LedgerDB.SnapshotRequestCompleted) =
+    mconcat [ "kind" .= String "TraceLedgerDBEvent.LedgerDBSnapshotEvent.SnapshotRequestCompleted"
+             ]
+
 
 instance MetaTrace (LedgerDB.TraceSnapshotEvent blk) where
     namespaceFor LedgerDB.TookSnapshot {} = Namespace [] ["TookSnapshot"]
     namespaceFor LedgerDB.DeletedSnapshot {} = Namespace [] ["DeletedSnapshot"]
     namespaceFor LedgerDB.InvalidSnapshot {} = Namespace [] ["InvalidSnapshot"]
+    namespaceFor LedgerDB.SnapshotRequestDelayed {}  = Namespace [] ["SnapshotRequestDelayed"]
+    namespaceFor LedgerDB.SnapshotRequestCompleted {} = Namespace [] ["SnapshotRequestCompleted"]
 
     severityFor  (Namespace _ ["TookSnapshot"]) _ = Just Info
     severityFor  (Namespace _ ["DeletedSnapshot"]) _ = Just Debug
@@ -1809,6 +1830,10 @@ instance MetaTrace (LedgerDB.TraceSnapshotEvent blk) where
          , " seems to be from an old node or different backend, it will"
          , " be deleted"
          ]
+    documentFor (Namespace _ ["SnapshotRequestDelayed"]) = Just
+        "A delayed snapshot requested was issued. The snapshot will be initiated at the specified timestamp, with the specified delay and for the specified slots"
+    documentFor (Namespace _ ["SnapshotRequestCompleted"]) = Just
+        "The delayed snapshot request was completed"
     documentFor _ = Nothing
 
     allNamespaces =

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
@@ -49,6 +49,7 @@ import qualified Ouroboros.Consensus.Storage.LedgerDB.V2.Backend as V2
 import qualified Ouroboros.Consensus.Storage.LedgerDB.V2.InMemory as InMemory
 import qualified Ouroboros.Consensus.Storage.LedgerDB.V2.LSM as LSM
 import qualified Ouroboros.Consensus.Storage.PerasCertDB.Impl as PerasCertDB
+import qualified Ouroboros.Consensus.Storage.PerasVoteDB.Impl as PerasVoteDB
 import qualified Ouroboros.Consensus.Storage.VolatileDB as VolDB
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util.Condense (condense)
@@ -121,6 +122,7 @@ instance (  LogFormatting (Header blk)
         ChainDB.ChainSelStarvation (FallingEdgeWith pt) ->
           "Chain Selection was unstarved by " <> renderRealPoint pt
   forHuman (ChainDB.TracePerasCertDbEvent ev) = forHuman ev
+  forHuman (ChainDB.TracePerasVoteDbEvent ev) = forHuman ev
   forHuman (ChainDB.TraceAddPerasCertEvent ev) = forHuman ev
 
   forMachine _ ChainDB.TraceLastShutdownUnclean =
@@ -153,6 +155,8 @@ instance (  LogFormatting (Header blk)
     forMachine details v
   forMachine details (ChainDB.TracePerasCertDbEvent v) =
     forMachine details v
+  forMachine details (ChainDB.TracePerasVoteDbEvent v) =
+    forMachine details v
   forMachine details (ChainDB.TraceAddPerasCertEvent v) =
     forMachine details v
 
@@ -170,6 +174,7 @@ instance (  LogFormatting (Header blk)
   asMetrics (ChainDB.TraceImmutableDBEvent v)       = asMetrics v
   asMetrics (ChainDB.TraceVolatileDBEvent v)        = asMetrics v
   asMetrics (ChainDB.TracePerasCertDbEvent v)       = asMetrics v
+  asMetrics (ChainDB.TracePerasVoteDbEvent v)       = asMetrics v
   asMetrics (ChainDB.TraceAddPerasCertEvent v)      = asMetrics v
 
 
@@ -200,6 +205,8 @@ instance MetaTrace  (ChainDB.TraceEvent blk) where
      nsPrependInner "VolatileDbEvent" (namespaceFor ev)
   namespaceFor (ChainDB.TracePerasCertDbEvent ev) =
     nsPrependInner "PerasCertDbEvent" (namespaceFor ev)
+  namespaceFor (ChainDB.TracePerasVoteDbEvent ev) =
+    nsPrependInner "PerasVoteDbEvent" (namespaceFor ev)
   namespaceFor (ChainDB.TraceAddPerasCertEvent ev) =
     nsPrependInner "AddPerasCertEvent" (namespaceFor ev)
 
@@ -249,6 +256,10 @@ instance MetaTrace  (ChainDB.TraceEvent blk) where
     severityFor (Namespace out tl) (Just ev')
   severityFor (Namespace out ("PerasCertDbEvent" : tl)) Nothing =
     severityFor (Namespace out tl :: Namespace (PerasCertDB.TraceEvent blk)) Nothing
+  severityFor (Namespace out ("PerasVoteDbEvent" : tl)) (Just (ChainDB.TracePerasVoteDbEvent ev')) =
+    severityFor (Namespace out tl) (Just ev')
+  severityFor (Namespace out ("PerasVoteDbEvent" : tl)) Nothing =
+    severityFor (Namespace out tl :: Namespace (PerasVoteDB.TraceEvent blk)) Nothing
   severityFor (Namespace out ("AddPerasCertEvent" : tl)) (Just (ChainDB.TraceAddPerasCertEvent ev')) =
     severityFor (Namespace out tl) (Just ev')
   severityFor (Namespace out ("AddPerasCertEvent" : tl)) Nothing =
@@ -301,6 +312,10 @@ instance MetaTrace  (ChainDB.TraceEvent blk) where
     privacyFor (Namespace out tl) (Just ev')
   privacyFor (Namespace out ("PerasCertDbEvent" : tl)) Nothing =
     privacyFor (Namespace out tl :: Namespace (PerasCertDB.TraceEvent blk)) Nothing
+  privacyFor (Namespace out ("PerasVoteDbEvent" : tl)) (Just (ChainDB.TracePerasVoteDbEvent ev')) =
+    privacyFor (Namespace out tl) (Just ev')
+  privacyFor (Namespace out ("PerasVoteDbEvent" : tl)) Nothing =
+    privacyFor (Namespace out tl :: Namespace (PerasVoteDB.TraceEvent blk)) Nothing
   privacyFor (Namespace out ("AddPerasCertEvent" : tl)) (Just (ChainDB.TraceAddPerasCertEvent ev')) =
     privacyFor (Namespace out tl) (Just ev')
   privacyFor (Namespace out ("AddPerasCertEvent" : tl)) Nothing =
@@ -353,6 +368,10 @@ instance MetaTrace  (ChainDB.TraceEvent blk) where
     detailsFor (Namespace out tl) (Just ev')
   detailsFor (Namespace out ("PerasCertDbEvent" : tl)) Nothing =
     detailsFor (Namespace out tl :: Namespace (PerasCertDB.TraceEvent blk)) Nothing
+  detailsFor (Namespace out ("PerasVoteDbEvent" : tl)) (Just (ChainDB.TracePerasVoteDbEvent ev')) =
+    detailsFor (Namespace out tl) (Just ev')
+  detailsFor (Namespace out ("PerasVoteDbEvent" : tl)) Nothing =
+    detailsFor (Namespace out tl :: Namespace (PerasVoteDB.TraceEvent blk)) Nothing
   detailsFor (Namespace out ("AddPerasCertEvent" : tl)) (Just (ChainDB.TraceAddPerasCertEvent ev')) =
     detailsFor (Namespace out tl) (Just ev')
   detailsFor (Namespace out ("AddPerasCertEvent" : tl)) Nothing =
@@ -412,6 +431,8 @@ instance MetaTrace  (ChainDB.TraceEvent blk) where
     documentFor (Namespace out tl :: Namespace (VolDB.TraceEvent blk))
   documentFor (Namespace out ("PerasCertDbEvent" : tl)) =
     documentFor (Namespace out tl :: Namespace (PerasCertDB.TraceEvent blk))
+  documentFor (Namespace out ("PerasVoteDbEvent" : tl)) =
+    documentFor (Namespace out tl :: Namespace (PerasVoteDB.TraceEvent blk))
   documentFor (Namespace out ("AddPerasCertEvent" : tl)) =
     documentFor (Namespace out tl :: Namespace (ChainDB.TraceAddPerasCertEvent blk))
   documentFor _ = Nothing
@@ -441,6 +462,8 @@ instance MetaTrace  (ChainDB.TraceEvent blk) where
                   (allNamespaces :: [Namespace (VolDB.TraceEvent blk)])
           ++ map  (nsPrependInner "PerasCertDbEvent")
                   (allNamespaces :: [Namespace (PerasCertDB.TraceEvent blk)])
+          ++ map  (nsPrependInner "PerasVoteDbEvent")
+                  (allNamespaces :: [Namespace (PerasVoteDB.TraceEvent blk)])
           ++ map  (nsPrependInner "AddPerasCertEvent")
                   (allNamespaces :: [Namespace (ChainDB.TraceAddPerasCertEvent blk)])
             )
@@ -3084,25 +3107,35 @@ instance (Show (PBFT.PBftVerKeyHash c))
 
 -- PerasCertDB.TraceEvent instances
 instance LogFormatting (PerasCertDB.TraceEvent blk) where
-  forHuman (PerasCertDB.AddedPerasCert _cert _peer) = "Added Peras certificate to database"
-  forHuman (PerasCertDB.IgnoredCertAlreadyInDB _cert _peer) = "Ignored Peras certificate already in database"
-  forHuman PerasCertDB.OpenedPerasCertDB = "Opened Peras certificate database"
-  forHuman PerasCertDB.ClosedPerasCertDB = "Closed Peras certificate database"
-  forHuman (PerasCertDB.AddingPerasCert _cert _peer) = "Adding Peras certificate to database"
+  forHuman (PerasCertDB.AddCert roundNo _cert result) =
+    "Peras certificate for round " <> Text.pack (show roundNo) <> ": " <> Text.pack (show result)
+  forHuman (PerasCertDB.GarbageCollected slotNo) =
+    "Peras certificate DB garbage collected at slot " <> Text.pack (show slotNo)
 
-  forMachine _dtal (PerasCertDB.AddedPerasCert cert _peer) =
-    mconcat ["kind" .= String "AddedPerasCert",
-             "cert" .= String (Text.pack $ show cert)]
-  forMachine _dtal (PerasCertDB.IgnoredCertAlreadyInDB cert _peer) =
-    mconcat ["kind" .= String "IgnoredCertAlreadyInDB",
-             "cert" .= String (Text.pack $ show cert)]
-  forMachine _dtal PerasCertDB.OpenedPerasCertDB =
-    mconcat ["kind" .= String "OpenedPerasCertDB"]
-  forMachine _dtal PerasCertDB.ClosedPerasCertDB =
-    mconcat ["kind" .= String "ClosedPerasCertDB"]
-  forMachine _dtal (PerasCertDB.AddingPerasCert cert _peer) =
-    mconcat ["kind" .= String "AddingPerasCert",
-             "cert" .= String (Text.pack $ show cert)]
+  forMachine _dtal (PerasCertDB.AddCert roundNo _cert result) =
+    mconcat ["kind" .= String "AddCert",
+             "round" .= String (Text.pack $ show roundNo),
+             "result" .= String (Text.pack $ show result)]
+  forMachine _dtal (PerasCertDB.GarbageCollected slotNo) =
+    mconcat ["kind" .= String "GarbageCollected",
+             "slot" .= String (Text.pack $ show slotNo)]
+
+  asMetrics _ = []
+
+-- PerasVoteDB.TraceEvent instances
+instance StandardHash blk => LogFormatting (PerasVoteDB.TraceEvent blk) where
+  forHuman (PerasVoteDB.AddVote voteId _vote result) =
+    "Peras vote " <> Text.pack (show voteId) <> ": " <> Text.pack (show result)
+  forHuman (PerasVoteDB.GarbageCollected slotNo) =
+    "Peras vote DB garbage collected at slot " <> Text.pack (show slotNo)
+
+  forMachine _dtal (PerasVoteDB.AddVote voteId _vote result) =
+    mconcat ["kind" .= String "AddVote",
+             "voteId" .= String (Text.pack $ show voteId),
+             "result" .= String (Text.pack $ show result)]
+  forMachine _dtal (PerasVoteDB.GarbageCollected slotNo) =
+    mconcat ["kind" .= String "GarbageCollected",
+             "slot" .= String (Text.pack $ show slotNo)]
 
   asMetrics _ = []
 
@@ -3164,51 +3197,57 @@ instance ConvertRawHash blk => LogFormatting (ChainDB.TraceAddPerasCertEvent blk
 
 -- PerasCertDB.TraceEvent MetaTrace instance
 instance MetaTrace (PerasCertDB.TraceEvent blk) where
-  namespaceFor (PerasCertDB.AddedPerasCert _ _) =
-    Namespace [] ["AddedPerasCert"]
-  namespaceFor (PerasCertDB.IgnoredCertAlreadyInDB _ _) =
-    Namespace [] ["IgnoredCertAlreadyInDB"]
-  namespaceFor PerasCertDB.OpenedPerasCertDB =
-    Namespace [] ["OpenedPerasCertDB"]
-  namespaceFor PerasCertDB.ClosedPerasCertDB =
-    Namespace [] ["ClosedPerasCertDB"]
-  namespaceFor (PerasCertDB.AddingPerasCert _ _) =
-    Namespace [] ["AddingPerasCert"]
+  namespaceFor (PerasCertDB.AddCert _ _ _) =
+    Namespace [] ["AddCert"]
+  namespaceFor (PerasCertDB.GarbageCollected _) =
+    Namespace [] ["GarbageCollected"]
 
-  severityFor (Namespace _ ["AddedPerasCert"]) _ = Just Info
-  severityFor (Namespace _ ["IgnoredCertAlreadyInDB"]) _ = Just Info
-  severityFor (Namespace _ ["OpenedPerasCertDB"]) _ = Just Info
-  severityFor (Namespace _ ["ClosedPerasCertDB"]) _ = Just Info
-  severityFor (Namespace _ ["AddingPerasCert"]) _ = Just Debug
+  severityFor (Namespace _ ["AddCert"]) _ = Just Info
+  severityFor (Namespace _ ["GarbageCollected"]) _ = Just Debug
   severityFor _ _ = Nothing
 
-  privacyFor (Namespace _ ["AddedPerasCert"]) _ = Just Public
-  privacyFor (Namespace _ ["IgnoredCertAlreadyInDB"]) _ = Just Public
-  privacyFor (Namespace _ ["OpenedPerasCertDB"]) _ = Just Public
-  privacyFor (Namespace _ ["ClosedPerasCertDB"]) _ = Just Public
-  privacyFor (Namespace _ ["AddingPerasCert"]) _ = Just Public
+  privacyFor (Namespace _ ["AddCert"]) _ = Just Public
+  privacyFor (Namespace _ ["GarbageCollected"]) _ = Just Public
   privacyFor _ _ = Nothing
 
-  detailsFor (Namespace _ ["AddedPerasCert"]) _ = Just DNormal
-  detailsFor (Namespace _ ["IgnoredCertAlreadyInDB"]) _ = Just DNormal
-  detailsFor (Namespace _ ["OpenedPerasCertDB"]) _ = Just DNormal
-  detailsFor (Namespace _ ["ClosedPerasCertDB"]) _ = Just DNormal
-  detailsFor (Namespace _ ["AddingPerasCert"]) _ = Just DDetailed
+  detailsFor (Namespace _ ["AddCert"]) _ = Just DNormal
+  detailsFor (Namespace _ ["GarbageCollected"]) _ = Just DNormal
   detailsFor _ _ = Nothing
 
-  documentFor (Namespace _ ["AddedPerasCert"]) = Just "Certificate added to Peras certificate database"
-  documentFor (Namespace _ ["IgnoredCertAlreadyInDB"]) = Just "Certificate ignored as it was already in the database"
-  documentFor (Namespace _ ["OpenedPerasCertDB"]) = Just "Peras certificate database opened"
-  documentFor (Namespace _ ["ClosedPerasCertDB"]) = Just "Peras certificate database closed"
-  documentFor (Namespace _ ["AddingPerasCert"]) = Just "Adding certificate to Peras certificate database"
+  documentFor (Namespace _ ["AddCert"]) = Just "Certificate added to Peras certificate database"
+  documentFor (Namespace _ ["GarbageCollected"]) = Just "Garbage collection performed on Peras certificate database"
   documentFor _ = Nothing
 
   allNamespaces =
-    [Namespace [] ["AddedPerasCert"],
-     Namespace [] ["IgnoredCertAlreadyInDB"],
-     Namespace [] ["OpenedPerasCertDB"],
-     Namespace [] ["ClosedPerasCertDB"],
-     Namespace [] ["AddingPerasCert"]]
+    [Namespace [] ["AddCert"],
+     Namespace [] ["GarbageCollected"]]
+
+-- PerasVoteDB.TraceEvent MetaTrace instance
+instance MetaTrace (PerasVoteDB.TraceEvent blk) where
+  namespaceFor (PerasVoteDB.AddVote _ _ _) =
+    Namespace [] ["AddVote"]
+  namespaceFor (PerasVoteDB.GarbageCollected _) =
+    Namespace [] ["GarbageCollected"]
+
+  severityFor (Namespace _ ["AddVote"]) _ = Just Info
+  severityFor (Namespace _ ["GarbageCollected"]) _ = Just Debug
+  severityFor _ _ = Nothing
+
+  privacyFor (Namespace _ ["AddVote"]) _ = Just Public
+  privacyFor (Namespace _ ["GarbageCollected"]) _ = Just Public
+  privacyFor _ _ = Nothing
+
+  detailsFor (Namespace _ ["AddVote"]) _ = Just DNormal
+  detailsFor (Namespace _ ["GarbageCollected"]) _ = Just DNormal
+  detailsFor _ _ = Nothing
+
+  documentFor (Namespace _ ["AddVote"]) = Just "Vote added to Peras vote database"
+  documentFor (Namespace _ ["GarbageCollected"]) = Just "Garbage collection performed on Peras vote database"
+  documentFor _ = Nothing
+
+  allNamespaces =
+    [Namespace [] ["AddVote"],
+     Namespace [] ["GarbageCollected"]]
 
 -- ChainDB.TraceAddPerasCertEvent MetaTrace instance
 instance MetaTrace (ChainDB.TraceAddPerasCertEvent blk) where

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
@@ -1796,13 +1796,13 @@ instance ( StandardHash blk
             , "snapshot" .= forMachine dtals snap
             , "failure" .= show failure ]
   forMachine _dtals (LedgerDB.SnapshotRequestDelayed snapshotRequestTime delayBeforeSnapshotting slots) =
-    mconcat [ "kind" .= String "TraceLedgerDBEvent.LedgerDBSnapshotEvent.SnapshotRequestDelayed"
+    mconcat [ "kind" .= String "SnapshotRequestDelayed"
              , "requestTime" .= show snapshotRequestTime
-             , "delayBeforeSnapshotting " .= show delayBeforeSnapshotting
-             , "slots" .= show slots
+             , "delayBeforeSnapshotting" .= show delayBeforeSnapshotting
+             , "slots" .= toJSON (NonEmpty.toList slots)
              ]
-  forMachine _dtals (LedgerDB.SnapshotRequestCompleted) =
-    mconcat [ "kind" .= String "TraceLedgerDBEvent.LedgerDBSnapshotEvent.SnapshotRequestCompleted"
+  forMachine _dtals LedgerDB.SnapshotRequestCompleted =
+    mconcat [ "kind" .= String "SnapshotRequestCompleted"
              ]
 
 
@@ -1816,6 +1816,8 @@ instance MetaTrace (LedgerDB.TraceSnapshotEvent blk) where
     severityFor  (Namespace _ ["TookSnapshot"]) _ = Just Info
     severityFor  (Namespace _ ["DeletedSnapshot"]) _ = Just Debug
     severityFor  (Namespace _ ["InvalidSnapshot"]) _ = Just Error
+    severityFor  (Namespace _ ["SnapshotRequestDelayed"]) _ = Just Debug
+    severityFor  (Namespace _ ["SnapshotRequestCompleted"]) _ = Just Debug
     severityFor _ _ = Nothing
 
     documentFor (Namespace _ ["TookSnapshot"]) = Just $ mconcat
@@ -1840,6 +1842,8 @@ instance MetaTrace (LedgerDB.TraceSnapshotEvent blk) where
       [ Namespace [] ["TookSnapshot"]
       , Namespace [] ["DeletedSnapshot"]
       , Namespace [] ["InvalidSnapshot"]
+      , Namespace [] ["SnapshotRequestDelayed"]
+      , Namespace [] ["SnapshotRequestCompleted"]
       ]
 
 --------------------------------------------------------------------------------

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
@@ -60,6 +60,7 @@ import           Ouroboros.Network.Block (MaxSlotNo (..))
 import           Data.Aeson (Object, ToJSON, Value (Object, String), object, toJSON, (.=))
 import qualified Data.ByteString.Base16 as B16
 import           Data.Int (Int64)
+import qualified Data.List.NonEmpty as NonEmpty
 import           Data.SOP (All, K (..), hcmap, hcollapse)
 import           Data.Text (Text)
 import qualified Data.Text as Text
@@ -1772,6 +1773,14 @@ instance ( StandardHash blk
           LedgerDB.MetadataBackendMismatch ->
              " Snapshot was created for a different backend. Convert it with `snapshot-converter`."
         _ -> ""
+  forHuman (LedgerDB.SnapshotRequestDelayed _snapshotRequestTime delayBeforeSnapshotting slots) =
+    Text.unwords ["Scheduling to take ledger state snapshots at slots "
+                 , showT (NonEmpty.toList slots)
+                 , ", with a randomised delay of"
+                 , showT delayBeforeSnapshotting
+                 ]
+  forHuman LedgerDB.SnapshotRequestCompleted = "Completed taking a ledger state snapshot"
+
 
   forMachine dtals (LedgerDB.TookSnapshot snap pt enclosedTiming) =
     mconcat [ "kind" .= String "TookSnapshot"
@@ -1786,11 +1795,23 @@ instance ( StandardHash blk
     mconcat [ "kind" .= String "InvalidSnapshot"
             , "snapshot" .= forMachine dtals snap
             , "failure" .= show failure ]
+  forMachine _dtals (LedgerDB.SnapshotRequestDelayed snapshotRequestTime delayBeforeSnapshotting slots) =
+    mconcat [ "kind" .= String "TraceLedgerDBEvent.LedgerDBSnapshotEvent.SnapshotRequestDelayed"
+             , "requestTime" .= show snapshotRequestTime
+             , "delayBeforeSnapshotting " .= show delayBeforeSnapshotting
+             , "slots" .= show slots
+             ]
+  forMachine _dtals (LedgerDB.SnapshotRequestCompleted) =
+    mconcat [ "kind" .= String "TraceLedgerDBEvent.LedgerDBSnapshotEvent.SnapshotRequestCompleted"
+             ]
+
 
 instance MetaTrace (LedgerDB.TraceSnapshotEvent blk) where
     namespaceFor LedgerDB.TookSnapshot {} = Namespace [] ["TookSnapshot"]
     namespaceFor LedgerDB.DeletedSnapshot {} = Namespace [] ["DeletedSnapshot"]
     namespaceFor LedgerDB.InvalidSnapshot {} = Namespace [] ["InvalidSnapshot"]
+    namespaceFor LedgerDB.SnapshotRequestDelayed {}  = Namespace [] ["SnapshotRequestDelayed"]
+    namespaceFor LedgerDB.SnapshotRequestCompleted {} = Namespace [] ["SnapshotRequestCompleted"]
 
     severityFor  (Namespace _ ["TookSnapshot"]) _ = Just Info
     severityFor  (Namespace _ ["DeletedSnapshot"]) _ = Just Debug
@@ -1809,6 +1830,10 @@ instance MetaTrace (LedgerDB.TraceSnapshotEvent blk) where
          , " seems to be from an old node or different backend, it will"
          , " be deleted"
          ]
+    documentFor (Namespace _ ["SnapshotRequestDelayed"]) = Just
+        "A delayed snapshot requested was issued. The snapshot will be initiated at the specified timestamp, with the specified delay and for the specified slots"
+    documentFor (Namespace _ ["SnapshotRequestCompleted"]) = Just
+        "The delayed snapshot request was completed"
     documentFor _ = Nothing
 
     allNamespaces =

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
@@ -49,6 +49,7 @@ import qualified Ouroboros.Consensus.Storage.LedgerDB.V2.Backend as V2
 import qualified Ouroboros.Consensus.Storage.LedgerDB.V2.InMemory as InMemory
 import qualified Ouroboros.Consensus.Storage.LedgerDB.V2.LSM as LSM
 import qualified Ouroboros.Consensus.Storage.PerasCertDB.Impl as PerasCertDB
+import qualified Ouroboros.Consensus.Storage.PerasVoteDB.Impl as PerasVoteDB
 import qualified Ouroboros.Consensus.Storage.VolatileDB as VolDB
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util.Condense (condense)
@@ -120,6 +121,7 @@ instance (  LogFormatting (Header blk)
         ChainDB.ChainSelStarvation (FallingEdgeWith pt) ->
           "Chain Selection was unstarved by " <> renderRealPoint pt
   forHuman (ChainDB.TracePerasCertDbEvent ev) = forHuman ev
+  forHuman (ChainDB.TracePerasVoteDbEvent ev) = forHuman ev
   forHuman (ChainDB.TraceAddPerasCertEvent ev) = forHuman ev
 
   forMachine _ ChainDB.TraceLastShutdownUnclean =
@@ -152,6 +154,8 @@ instance (  LogFormatting (Header blk)
     forMachine details v
   forMachine details (ChainDB.TracePerasCertDbEvent v) =
     forMachine details v
+  forMachine details (ChainDB.TracePerasVoteDbEvent v) =
+    forMachine details v
   forMachine details (ChainDB.TraceAddPerasCertEvent v) =
     forMachine details v
 
@@ -169,6 +173,7 @@ instance (  LogFormatting (Header blk)
   asMetrics (ChainDB.TraceImmutableDBEvent v)       = asMetrics v
   asMetrics (ChainDB.TraceVolatileDBEvent v)        = asMetrics v
   asMetrics (ChainDB.TracePerasCertDbEvent v)       = asMetrics v
+  asMetrics (ChainDB.TracePerasVoteDbEvent v)       = asMetrics v
   asMetrics (ChainDB.TraceAddPerasCertEvent v)      = asMetrics v
 
 
@@ -199,6 +204,8 @@ instance MetaTrace  (ChainDB.TraceEvent blk) where
      nsPrependInner "VolatileDbEvent" (namespaceFor ev)
   namespaceFor (ChainDB.TracePerasCertDbEvent ev) =
     nsPrependInner "PerasCertDbEvent" (namespaceFor ev)
+  namespaceFor (ChainDB.TracePerasVoteDbEvent ev) =
+    nsPrependInner "PerasVoteDbEvent" (namespaceFor ev)
   namespaceFor (ChainDB.TraceAddPerasCertEvent ev) =
     nsPrependInner "AddPerasCertEvent" (namespaceFor ev)
 
@@ -248,6 +255,10 @@ instance MetaTrace  (ChainDB.TraceEvent blk) where
     severityFor (Namespace out tl) (Just ev')
   severityFor (Namespace out ("PerasCertDbEvent" : tl)) Nothing =
     severityFor (Namespace out tl :: Namespace (PerasCertDB.TraceEvent blk)) Nothing
+  severityFor (Namespace out ("PerasVoteDbEvent" : tl)) (Just (ChainDB.TracePerasVoteDbEvent ev')) =
+    severityFor (Namespace out tl) (Just ev')
+  severityFor (Namespace out ("PerasVoteDbEvent" : tl)) Nothing =
+    severityFor (Namespace out tl :: Namespace (PerasVoteDB.TraceEvent blk)) Nothing
   severityFor (Namespace out ("AddPerasCertEvent" : tl)) (Just (ChainDB.TraceAddPerasCertEvent ev')) =
     severityFor (Namespace out tl) (Just ev')
   severityFor (Namespace out ("AddPerasCertEvent" : tl)) Nothing =
@@ -300,6 +311,10 @@ instance MetaTrace  (ChainDB.TraceEvent blk) where
     privacyFor (Namespace out tl) (Just ev')
   privacyFor (Namespace out ("PerasCertDbEvent" : tl)) Nothing =
     privacyFor (Namespace out tl :: Namespace (PerasCertDB.TraceEvent blk)) Nothing
+  privacyFor (Namespace out ("PerasVoteDbEvent" : tl)) (Just (ChainDB.TracePerasVoteDbEvent ev')) =
+    privacyFor (Namespace out tl) (Just ev')
+  privacyFor (Namespace out ("PerasVoteDbEvent" : tl)) Nothing =
+    privacyFor (Namespace out tl :: Namespace (PerasVoteDB.TraceEvent blk)) Nothing
   privacyFor (Namespace out ("AddPerasCertEvent" : tl)) (Just (ChainDB.TraceAddPerasCertEvent ev')) =
     privacyFor (Namespace out tl) (Just ev')
   privacyFor (Namespace out ("AddPerasCertEvent" : tl)) Nothing =
@@ -352,6 +367,10 @@ instance MetaTrace  (ChainDB.TraceEvent blk) where
     detailsFor (Namespace out tl) (Just ev')
   detailsFor (Namespace out ("PerasCertDbEvent" : tl)) Nothing =
     detailsFor (Namespace out tl :: Namespace (PerasCertDB.TraceEvent blk)) Nothing
+  detailsFor (Namespace out ("PerasVoteDbEvent" : tl)) (Just (ChainDB.TracePerasVoteDbEvent ev')) =
+    detailsFor (Namespace out tl) (Just ev')
+  detailsFor (Namespace out ("PerasVoteDbEvent" : tl)) Nothing =
+    detailsFor (Namespace out tl :: Namespace (PerasVoteDB.TraceEvent blk)) Nothing
   detailsFor (Namespace out ("AddPerasCertEvent" : tl)) (Just (ChainDB.TraceAddPerasCertEvent ev')) =
     detailsFor (Namespace out tl) (Just ev')
   detailsFor (Namespace out ("AddPerasCertEvent" : tl)) Nothing =
@@ -411,6 +430,8 @@ instance MetaTrace  (ChainDB.TraceEvent blk) where
     documentFor (Namespace out tl :: Namespace (VolDB.TraceEvent blk))
   documentFor (Namespace out ("PerasCertDbEvent" : tl)) =
     documentFor (Namespace out tl :: Namespace (PerasCertDB.TraceEvent blk))
+  documentFor (Namespace out ("PerasVoteDbEvent" : tl)) =
+    documentFor (Namespace out tl :: Namespace (PerasVoteDB.TraceEvent blk))
   documentFor (Namespace out ("AddPerasCertEvent" : tl)) =
     documentFor (Namespace out tl :: Namespace (ChainDB.TraceAddPerasCertEvent blk))
   documentFor _ = Nothing
@@ -440,6 +461,8 @@ instance MetaTrace  (ChainDB.TraceEvent blk) where
                   (allNamespaces :: [Namespace (VolDB.TraceEvent blk)])
           ++ map  (nsPrependInner "PerasCertDbEvent")
                   (allNamespaces :: [Namespace (PerasCertDB.TraceEvent blk)])
+          ++ map  (nsPrependInner "PerasVoteDbEvent")
+                  (allNamespaces :: [Namespace (PerasVoteDB.TraceEvent blk)])
           ++ map  (nsPrependInner "AddPerasCertEvent")
                   (allNamespaces :: [Namespace (ChainDB.TraceAddPerasCertEvent blk)])
             )
@@ -3090,25 +3113,35 @@ instance (Show (PBFT.PBftVerKeyHash c))
 
 -- PerasCertDB.TraceEvent instances
 instance LogFormatting (PerasCertDB.TraceEvent blk) where
-  forHuman (PerasCertDB.AddedPerasCert _cert _peer) = "Added Peras certificate to database"
-  forHuman (PerasCertDB.IgnoredCertAlreadyInDB _cert _peer) = "Ignored Peras certificate already in database"
-  forHuman PerasCertDB.OpenedPerasCertDB = "Opened Peras certificate database"
-  forHuman PerasCertDB.ClosedPerasCertDB = "Closed Peras certificate database"
-  forHuman (PerasCertDB.AddingPerasCert _cert _peer) = "Adding Peras certificate to database"
+  forHuman (PerasCertDB.AddCert roundNo _cert result) =
+    "Peras certificate for round " <> Text.pack (show roundNo) <> ": " <> Text.pack (show result)
+  forHuman (PerasCertDB.GarbageCollected slotNo) =
+    "Peras certificate DB garbage collected at slot " <> Text.pack (show slotNo)
 
-  forMachine _dtal (PerasCertDB.AddedPerasCert cert _peer) =
-    mconcat ["kind" .= String "AddedPerasCert",
-             "cert" .= String (Text.pack $ show cert)]
-  forMachine _dtal (PerasCertDB.IgnoredCertAlreadyInDB cert _peer) =
-    mconcat ["kind" .= String "IgnoredCertAlreadyInDB",
-             "cert" .= String (Text.pack $ show cert)]
-  forMachine _dtal PerasCertDB.OpenedPerasCertDB =
-    mconcat ["kind" .= String "OpenedPerasCertDB"]
-  forMachine _dtal PerasCertDB.ClosedPerasCertDB =
-    mconcat ["kind" .= String "ClosedPerasCertDB"]
-  forMachine _dtal (PerasCertDB.AddingPerasCert cert _peer) =
-    mconcat ["kind" .= String "AddingPerasCert",
-             "cert" .= String (Text.pack $ show cert)]
+  forMachine _dtal (PerasCertDB.AddCert roundNo _cert result) =
+    mconcat ["kind" .= String "AddCert",
+             "round" .= String (Text.pack $ show roundNo),
+             "result" .= String (Text.pack $ show result)]
+  forMachine _dtal (PerasCertDB.GarbageCollected slotNo) =
+    mconcat ["kind" .= String "GarbageCollected",
+             "slot" .= String (Text.pack $ show slotNo)]
+
+  asMetrics _ = []
+
+-- PerasVoteDB.TraceEvent instances
+instance StandardHash blk => LogFormatting (PerasVoteDB.TraceEvent blk) where
+  forHuman (PerasVoteDB.AddVote voteId _vote result) =
+    "Peras vote " <> Text.pack (show voteId) <> ": " <> Text.pack (show result)
+  forHuman (PerasVoteDB.GarbageCollected slotNo) =
+    "Peras vote DB garbage collected at slot " <> Text.pack (show slotNo)
+
+  forMachine _dtal (PerasVoteDB.AddVote voteId _vote result) =
+    mconcat ["kind" .= String "AddVote",
+             "voteId" .= String (Text.pack $ show voteId),
+             "result" .= String (Text.pack $ show result)]
+  forMachine _dtal (PerasVoteDB.GarbageCollected slotNo) =
+    mconcat ["kind" .= String "GarbageCollected",
+             "slot" .= String (Text.pack $ show slotNo)]
 
   asMetrics _ = []
 
@@ -3170,51 +3203,57 @@ instance ConvertRawHash blk => LogFormatting (ChainDB.TraceAddPerasCertEvent blk
 
 -- PerasCertDB.TraceEvent MetaTrace instance
 instance MetaTrace (PerasCertDB.TraceEvent blk) where
-  namespaceFor (PerasCertDB.AddedPerasCert _ _) =
-    Namespace [] ["AddedPerasCert"]
-  namespaceFor (PerasCertDB.IgnoredCertAlreadyInDB _ _) =
-    Namespace [] ["IgnoredCertAlreadyInDB"]
-  namespaceFor PerasCertDB.OpenedPerasCertDB =
-    Namespace [] ["OpenedPerasCertDB"]
-  namespaceFor PerasCertDB.ClosedPerasCertDB =
-    Namespace [] ["ClosedPerasCertDB"]
-  namespaceFor (PerasCertDB.AddingPerasCert _ _) =
-    Namespace [] ["AddingPerasCert"]
+  namespaceFor PerasCertDB.AddCert{} =
+    Namespace [] ["AddCert"]
+  namespaceFor PerasCertDB.GarbageCollected{} =
+    Namespace [] ["GarbageCollected"]
 
-  severityFor (Namespace _ ["AddedPerasCert"]) _ = Just Info
-  severityFor (Namespace _ ["IgnoredCertAlreadyInDB"]) _ = Just Info
-  severityFor (Namespace _ ["OpenedPerasCertDB"]) _ = Just Info
-  severityFor (Namespace _ ["ClosedPerasCertDB"]) _ = Just Info
-  severityFor (Namespace _ ["AddingPerasCert"]) _ = Just Debug
+  severityFor (Namespace _ ["AddCert"]) _ = Just Info
+  severityFor (Namespace _ ["GarbageCollected"]) _ = Just Debug
   severityFor _ _ = Nothing
 
-  privacyFor (Namespace _ ["AddedPerasCert"]) _ = Just Public
-  privacyFor (Namespace _ ["IgnoredCertAlreadyInDB"]) _ = Just Public
-  privacyFor (Namespace _ ["OpenedPerasCertDB"]) _ = Just Public
-  privacyFor (Namespace _ ["ClosedPerasCertDB"]) _ = Just Public
-  privacyFor (Namespace _ ["AddingPerasCert"]) _ = Just Public
+  privacyFor (Namespace _ ["AddCert"]) _ = Just Public
+  privacyFor (Namespace _ ["GarbageCollected"]) _ = Just Public
   privacyFor _ _ = Nothing
 
-  detailsFor (Namespace _ ["AddedPerasCert"]) _ = Just DNormal
-  detailsFor (Namespace _ ["IgnoredCertAlreadyInDB"]) _ = Just DNormal
-  detailsFor (Namespace _ ["OpenedPerasCertDB"]) _ = Just DNormal
-  detailsFor (Namespace _ ["ClosedPerasCertDB"]) _ = Just DNormal
-  detailsFor (Namespace _ ["AddingPerasCert"]) _ = Just DDetailed
+  detailsFor (Namespace _ ["AddCert"]) _ = Just DNormal
+  detailsFor (Namespace _ ["GarbageCollected"]) _ = Just DNormal
   detailsFor _ _ = Nothing
 
-  documentFor (Namespace _ ["AddedPerasCert"]) = Just "Certificate added to Peras certificate database"
-  documentFor (Namespace _ ["IgnoredCertAlreadyInDB"]) = Just "Certificate ignored as it was already in the database"
-  documentFor (Namespace _ ["OpenedPerasCertDB"]) = Just "Peras certificate database opened"
-  documentFor (Namespace _ ["ClosedPerasCertDB"]) = Just "Peras certificate database closed"
-  documentFor (Namespace _ ["AddingPerasCert"]) = Just "Adding certificate to Peras certificate database"
+  documentFor (Namespace _ ["AddCert"]) = Just "Certificate added to Peras certificate database"
+  documentFor (Namespace _ ["GarbageCollected"]) = Just "Garbage collection performed on Peras certificate database"
   documentFor _ = Nothing
 
   allNamespaces =
-    [Namespace [] ["AddedPerasCert"],
-     Namespace [] ["IgnoredCertAlreadyInDB"],
-     Namespace [] ["OpenedPerasCertDB"],
-     Namespace [] ["ClosedPerasCertDB"],
-     Namespace [] ["AddingPerasCert"]]
+    [Namespace [] ["AddCert"],
+     Namespace [] ["GarbageCollected"]]
+
+-- PerasVoteDB.TraceEvent MetaTrace instance
+instance MetaTrace (PerasVoteDB.TraceEvent blk) where
+  namespaceFor PerasVoteDB.AddVote{} =
+    Namespace [] ["AddVote"]
+  namespaceFor PerasVoteDB.GarbageCollected{} =
+    Namespace [] ["GarbageCollected"]
+
+  severityFor (Namespace _ ["AddVote"]) _ = Just Info
+  severityFor (Namespace _ ["GarbageCollected"]) _ = Just Debug
+  severityFor _ _ = Nothing
+
+  privacyFor (Namespace _ ["AddVote"]) _ = Just Public
+  privacyFor (Namespace _ ["GarbageCollected"]) _ = Just Public
+  privacyFor _ _ = Nothing
+
+  detailsFor (Namespace _ ["AddVote"]) _ = Just DNormal
+  detailsFor (Namespace _ ["GarbageCollected"]) _ = Just DNormal
+  detailsFor _ _ = Nothing
+
+  documentFor (Namespace _ ["AddVote"]) = Just "Vote added to Peras vote database"
+  documentFor (Namespace _ ["GarbageCollected"]) = Just "Garbage collection performed on Peras vote database"
+  documentFor _ = Nothing
+
+  allNamespaces =
+    [Namespace [] ["AddVote"],
+     Namespace [] ["GarbageCollected"]]
 
 -- ChainDB.TraceAddPerasCertEvent MetaTrace instance
 instance MetaTrace (ChainDB.TraceAddPerasCertEvent blk) where

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
@@ -91,6 +91,7 @@ import           Data.Aeson (Value (..))
 import qualified Data.Aeson as Aeson
 import           Data.Foldable (Foldable (..))
 import           Data.Function (on)
+import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Proxy
 import           Data.Text (Text, pack)
 import qualified Data.Text as Text
@@ -185,6 +186,8 @@ instance HasSeverityAnnotation (ChainDB.TraceEvent blk) where
         LedgerDB.InitFailureRead (LedgerDB.ReadMetadataError _ LedgerDB.MetadataBackendMismatch) -> Warning
         LedgerDB.InitFailureRead (LedgerDB.ReadMetadataError _ LedgerDB.MetadataFileDoesNotExist) -> Warning
         _ -> Error
+      LedgerDB.SnapshotRequestDelayed {} -> Info
+      LedgerDB.SnapshotRequestCompleted -> Info
     LedgerDB.LedgerReplayEvent {} -> Info
     LedgerDB.LedgerDBForkerEvent {} -> Debug
     LedgerDB.LedgerDBFlavorImplEvent {} -> Debug
@@ -629,6 +632,11 @@ instance ( ConvertRawHash blk
             ", duration: " <> showT t
           LedgerDB.DeletedSnapshot snap ->
             "Deleted old snapshot " <> showT snap
+          LedgerDB.SnapshotRequestDelayed _snapshotRequestTime delayBeforeSnapshotting slots ->
+            "Scheduling to take ledger state snapshots at slots " <> showT (NonEmpty.toList slots)
+            <> ", with randomised delay of"
+            <> showT delayBeforeSnapshotting
+          LedgerDB.SnapshotRequestCompleted -> "Completed taking a ledger state snapshot"
         LedgerDB.LedgerReplayEvent ev' -> case ev' of
           LedgerDB.TraceReplayStartEvent ev'' -> case ev'' of
             LedgerDB.ReplayFromGenesis ->
@@ -1110,6 +1118,14 @@ instance ( ConvertRawHash blk
         mconcat [ "kind" .= String "TraceLedgerDBEvent.LedgerDBSnapshotEvent.InvalidSnapshot"
                  , "snapshot" .= toObject verb snap
                  , "failure" .= show failure ]
+      LedgerDB.SnapshotRequestDelayed snapshotRequestTime delayBeforeSnapshotting slots ->
+        mconcat [ "kind" .= String "TraceLedgerDBEvent.LedgerDBSnapshotEvent.SnapshotRequestDelayed"
+                 , "requestTime" .= show snapshotRequestTime
+                 , "delayBeforeSnapshotting " .= show delayBeforeSnapshotting
+                 , "slots" .= show slots]
+      LedgerDB.SnapshotRequestCompleted ->
+        mconcat [ "kind" .= String "TraceLedgerDBEvent.LedgerDBSnapshotEvent.SnapshotRequestCompleted"
+                 ]
     LedgerDB.LedgerReplayEvent ev' -> case ev' of
       LedgerDB.TraceReplayStartEvent ev'' -> case ev'' of
         LedgerDB.ReplayFromGenesis ->

--- a/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
+++ b/cardano-node/src/Cardano/Tracing/OrphanInstances/Consensus.hs
@@ -255,6 +255,7 @@ instance HasSeverityAnnotation (ChainDB.TraceEvent blk) where
   getSeverityAnnotation ChainDB.TraceChainSelStarvationEvent{} = Debug
 
   getSeverityAnnotation ChainDB.TracePerasCertDbEvent{} = Info
+  getSeverityAnnotation ChainDB.TracePerasVoteDbEvent{} = Info
   getSeverityAnnotation ChainDB.TraceAddPerasCertEvent{} = Info
 
 instance HasSeverityAnnotation (LedgerEvent blk) where
@@ -795,6 +796,7 @@ instance ( ConvertRawHash blk
         ChainDB.ChainSelStarvation RisingEdge -> "Chain Selection was starved."
         ChainDB.ChainSelStarvation (FallingEdgeWith pt) -> "Chain Selection was unstarved by " <> renderRealPoint pt
       ChainDB.TracePerasCertDbEvent ev -> showT ev
+      ChainDB.TracePerasVoteDbEvent ev -> showT ev
       ChainDB.TraceAddPerasCertEvent ev -> showT ev
      where showProgressT :: Int -> Int -> Text
            showProgressT chunkNo outOf =
@@ -1081,6 +1083,10 @@ instance ( ConvertRawHash blk
 
   toObject _verb (ChainDB.TracePerasCertDbEvent ev) =
     mconcat [ "kind" .= String "TracePerasCertDbEvent"
+            , "event" .= show ev
+            ]
+  toObject _verb (ChainDB.TracePerasVoteDbEvent ev) =
+    mconcat [ "kind" .= String "TracePerasVoteDbEvent"
             , "event" .= show ev
             ]
   toObject _verb (ChainDB.TraceAddPerasCertEvent ev) =

--- a/cardano-node/test/Test/Cardano/Node/POM.hs
+++ b/cardano-node/test/Test/Cardano/Node/POM.hs
@@ -24,8 +24,7 @@ import           Cardano.Tracing.Config (PartialTraceOptions (..), defaultPartia
 import           Ouroboros.Consensus.Node (NodeDatabasePaths (..))
 import           Ouroboros.Consensus.Node.Genesis (disableGenesisConfig)
 import           Ouroboros.Consensus.Storage.LedgerDB.Args
-import           Ouroboros.Consensus.Storage.LedgerDB.Snapshots (NumOfDiskSnapshots (..),
-                   SnapshotInterval (..))
+import           Ouroboros.Consensus.Storage.LedgerDB.Snapshots (defaultSnapshotPolicyArgs)
 import           Ouroboros.Network.Block (SlotNo (..))
 import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
 import           Ouroboros.Network.TxSubmission.Inbound.V2.Types
@@ -297,7 +296,7 @@ eExpectedConfig = do
     , ncConsensusMode = PraosMode
     , ncGenesisConfig = disableGenesisConfig
     , ncResponderCoreAffinityPolicy = NoResponderCoreAffinity
-    , ncLedgerDbConfig = LedgerDbConfiguration DefaultNumOfDiskSnapshots DefaultSnapshotInterval DefaultQueryBatchSize V2InMemory noDeprecatedOptions
+    , ncLedgerDbConfig = LedgerDbConfiguration defaultSnapshotPolicyArgs DefaultQueryBatchSize V2InMemory noDeprecatedOptions
     , ncRpcConfig
     , ncTxSubmissionLogicVersion = TxSubmissionLogicV1
     , ncTxSubmissionInitDelay = defaultTxSubmissionInitDelay

--- a/cardano-node/test/Test/Cardano/Node/POM.hs
+++ b/cardano-node/test/Test/Cardano/Node/POM.hs
@@ -23,7 +23,8 @@ import           Cardano.Rpc.Server.Config (makeRpcConfig)
 import           Ouroboros.Consensus.Node (NodeDatabasePaths (..))
 import           Ouroboros.Consensus.Node.Genesis (disableGenesisConfig)
 import           Ouroboros.Consensus.Storage.LedgerDB.Args
-import           Ouroboros.Consensus.Storage.LedgerDB.Snapshots (defaultSnapshotPolicyArgs)
+import           Ouroboros.Consensus.Storage.LedgerDB.Snapshots (defaultSnapshotPolicyArgs,
+                   mithrilSnapshotPolicyArgs)
 import           Ouroboros.Network.Block (SlotNo (..))
 import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
 import           Ouroboros.Network.TxSubmission.Inbound.V2.Types
@@ -316,17 +317,31 @@ prop_legacySnapshotFormat_POM =
     legacyConfig :: PartialNodeConfiguration <- evalEither $ eitherDecode legacyJson
     newConfig    :: PartialNodeConfiguration <- evalEither $ eitherDecode newJson
     pncLedgerDbConfig legacyConfig === pncLedgerDbConfig newConfig
-  where
-    dummyRequiredValues :: LBS.ByteString
-    dummyRequiredValues = mconcat
-      [ "\"ByronGenesisFile\": \"x\""
-      , ", \"ShelleyGenesisFile\": \"x\""
-      , ", \"AlonzoGenesisFile\": \"x\""
-      , ", \"ConwayGenesisFile\": \"x\""
-      , ", \"LastKnownBlockVersion-Major\": 0"
-      , ", \"LastKnownBlockVersion-Minor\": 0"
-      , ", \"LastKnownBlockVersion-Alt\": 0"
-      ]
+
+-- | Test that the named \"Mithril\" snapshot policy selects
+-- 'mithrilSnapshotPolicyArgs' as a whole.
+prop_mithrilSnapshotPolicy_POM :: Property
+prop_mithrilSnapshotPolicy_POM =
+  withTests 1 . Hedgehog.property $ do
+    let json = "{ " <> dummyRequiredValues <> ", "
+          <> "\"LedgerDB\": {"
+          <> "  \"Backend\": \"V2InMemory\","
+          <> "  \"Snapshots\": \"Mithril\""
+          <> "} }"
+    config :: PartialNodeConfiguration <- evalEither $ eitherDecode json
+    getLast (pncLedgerDbConfig config) ===
+      Just (LedgerDbConfiguration mithrilSnapshotPolicyArgs DefaultQueryBatchSize V2InMemory noDeprecatedOptions)
+
+dummyRequiredValues :: LBS.ByteString
+dummyRequiredValues = mconcat
+  [ "\"ByronGenesisFile\": \"x\""
+  , ", \"ShelleyGenesisFile\": \"x\""
+  , ", \"AlonzoGenesisFile\": \"x\""
+  , ", \"ConwayGenesisFile\": \"x\""
+  , ", \"LastKnownBlockVersion-Major\": 0"
+  , ", \"LastKnownBlockVersion-Minor\": 0"
+  , ", \"LastKnownBlockVersion-Alt\": 0"
+  ]
 
 -- -----------------------------------------------------------------------------
 

--- a/cardano-node/test/Test/Cardano/Node/POM.hs
+++ b/cardano-node/test/Test/Cardano/Node/POM.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
@@ -22,17 +23,18 @@ import           Cardano.Rpc.Server.Config (makeRpcConfig)
 import           Ouroboros.Consensus.Node (NodeDatabasePaths (..))
 import           Ouroboros.Consensus.Node.Genesis (disableGenesisConfig)
 import           Ouroboros.Consensus.Storage.LedgerDB.Args
-import           Ouroboros.Consensus.Storage.LedgerDB.Snapshots (NumOfDiskSnapshots (..),
-                   SnapshotInterval (..))
+import           Ouroboros.Consensus.Storage.LedgerDB.Snapshots (defaultSnapshotPolicyArgs)
 import           Ouroboros.Network.Block (SlotNo (..))
 import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
 import           Ouroboros.Network.TxSubmission.Inbound.V2.Types
 
 import           Data.Bifunctor (first)
+import qualified Data.ByteString.Lazy as LBS
 import           Data.Monoid (Last (..))
 import           Data.String
 import           Data.Text (Text)
 
+import           Data.Aeson (eitherDecode)
 import           Hedgehog (Property, discover, withTests, (===))
 import qualified Hedgehog
 import           Hedgehog.Internal.Property (evalEither, failWith)
@@ -284,11 +286,47 @@ eExpectedConfig = do
     , ncConsensusMode = PraosMode
     , ncGenesisConfig = disableGenesisConfig
     , ncResponderCoreAffinityPolicy = NoResponderCoreAffinity
-    , ncLedgerDbConfig = LedgerDbConfiguration DefaultNumOfDiskSnapshots DefaultSnapshotInterval DefaultQueryBatchSize V2InMemory noDeprecatedOptions
+    , ncLedgerDbConfig = LedgerDbConfiguration defaultSnapshotPolicyArgs DefaultQueryBatchSize V2InMemory noDeprecatedOptions
     , ncRpcConfig
     , ncTxSubmissionLogicVersion = TxSubmissionLogicV1
     , ncTxSubmissionInitDelay = defaultTxSubmissionInitDelay
     }
+
+-- | Test that the legacy flat LedgerDB snapshot config format (options directly
+-- under LedgerDB) parses identically to the new nested Snapshots format.
+--
+-- TODO: this test could be removed once the old format is deprecated.
+prop_legacySnapshotFormat_POM :: Property
+prop_legacySnapshotFormat_POM =
+  withTests 1 . Hedgehog.property $ do
+    let legacyJson = "{ " <> dummyRequiredValues <> ", "
+          <> "\"LedgerDB\": {"
+          <> "  \"Backend\": \"V2InMemory\","
+          <> "  \"SnapshotInterval\": 4320,"
+          <> "  \"NumOfDiskSnapshots\": 2"
+          <> "} }"
+        newJson = "{ " <> dummyRequiredValues <> ", "
+          <> "\"LedgerDB\": {"
+          <> "  \"Backend\": \"V2InMemory\","
+          <> "  \"Snapshots\": {"
+          <> "    \"SnapshotInterval\": 4320,"
+          <> "    \"NumOfDiskSnapshots\": 2"
+          <> "  }"
+          <> "} }"
+    legacyConfig :: PartialNodeConfiguration <- evalEither $ eitherDecode legacyJson
+    newConfig    :: PartialNodeConfiguration <- evalEither $ eitherDecode newJson
+    pncLedgerDbConfig legacyConfig === pncLedgerDbConfig newConfig
+  where
+    dummyRequiredValues :: LBS.ByteString
+    dummyRequiredValues = mconcat
+      [ "\"ByronGenesisFile\": \"x\""
+      , ", \"ShelleyGenesisFile\": \"x\""
+      , ", \"AlonzoGenesisFile\": \"x\""
+      , ", \"ConwayGenesisFile\": \"x\""
+      , ", \"LastKnownBlockVersion-Major\": 0"
+      , ", \"LastKnownBlockVersion-Minor\": 0"
+      , ", \"LastKnownBlockVersion-Alt\": 0"
+      ]
 
 -- -----------------------------------------------------------------------------
 

--- a/configuration/cardano/mainnet-config-legacy.json
+++ b/configuration/cardano/mainnet-config-legacy.json
@@ -13,9 +13,11 @@
   "LastKnownBlockVersion-Minor": 0,
   "LedgerDB": {
     "Backend": "V2InMemory",
-    "NumOfDiskSnapshots": 2,
     "QueryBatchSize": 100000,
-    "SnapshotInterval": 4320
+    "Snapshots": {
+      "NumOfDiskSnapshots": 2,
+      "SnapshotInterval": 4320
+    }
   },
   "MaxKnownMajorProtocolVersion": 2,
   "MinNodeVersion": "10.7.0",

--- a/configuration/cardano/mainnet-config.json
+++ b/configuration/cardano/mainnet-config.json
@@ -13,9 +13,11 @@
   "LastKnownBlockVersion-Minor": 0,
   "LedgerDB": {
     "Backend": "V2InMemory",
-    "NumOfDiskSnapshots": 2,
     "QueryBatchSize": 100000,
-    "SnapshotInterval": 4320
+    "Snapshots": {
+      "NumOfDiskSnapshots": 2,
+      "SnapshotInterval": 4320
+    }
   },
   "MaxKnownMajorProtocolVersion": 2,
   "MinNodeVersion": "10.7.0",

--- a/configuration/cardano/mainnet-config.yaml
+++ b/configuration/cardano/mainnet-config.yaml
@@ -91,7 +91,7 @@ LedgerDB:
   # Instead of an object with individual options, a predefined snapshot
   # policy can be selected by name, e.g. `Snapshots: Mithril`.
   Snapshots:
-    # The time interval between snapshots, in seconds.
+    # The time interval between snapshots, in slots.
     SnapshotInterval: 4320
 
     # The number of disk snapshots to keep.

--- a/configuration/cardano/mainnet-config.yaml
+++ b/configuration/cardano/mainnet-config.yaml
@@ -80,19 +80,20 @@ ConsensusMode: PraosMode
 # Additional configuration options can be found at:
 # https://ouroboros-consensus.cardano.intersectmbo.org/docs/for-developers/utxo-hd/migrating
 LedgerDB:
-  # The time interval between snapshots, in seconds.
-  SnapshotInterval: 4320
-
-  # The number of disk snapshots to keep.
-  NumOfDiskSnapshots: 2
+  # The backend can either be in memory with `V2InMemory` or on disk with
+  # `V1LMDB`.
+  Backend: V2InMemory
 
   # When querying the store for a big range of UTxOs (such as with
   # QueryUTxOByAddress), the store will be read in batches of this size.
   QueryBatchSize: 100000
 
-  # The backend can either be in memory with `V2InMemory` or on disk with
-  # `V1LMDB`.
-  Backend: V2InMemory
+  Snapshots:
+    # The time interval between snapshots, in seconds.
+    SnapshotInterval: 4320
+
+    # The number of disk snapshots to keep.
+    NumOfDiskSnapshots: 2
 
 ##### Version Information #####
 

--- a/configuration/cardano/mainnet-config.yaml
+++ b/configuration/cardano/mainnet-config.yaml
@@ -88,6 +88,8 @@ LedgerDB:
   # QueryUTxOByAddress), the store will be read in batches of this size.
   QueryBatchSize: 100000
 
+  # Instead of an object with individual options, a predefined snapshot
+  # policy can be selected by name, e.g. `Snapshots: Mithril`.
   Snapshots:
     # The time interval between snapshots, in seconds.
     SnapshotInterval: 4320

--- a/configuration/cardano/testnet-template-config-legacy.json
+++ b/configuration/cardano/testnet-template-config-legacy.json
@@ -12,9 +12,11 @@
   "LastKnownBlockVersion-Minor": 1,
   "LedgerDB": {
     "Backend": "V2InMemory",
-    "NumOfDiskSnapshots": 2,
     "QueryBatchSize": 100000,
-    "SnapshotInterval": 216
+    "Snapshots": {
+      "NumOfDiskSnapshots": 2,
+      "SnapshotInterval": 216
+    }
   },
   "MaxConcurrencyDeadline": 4,
   "MaxKnownMajorProtocolVersion": 2,

--- a/configuration/cardano/testnet-template-config.json
+++ b/configuration/cardano/testnet-template-config.json
@@ -13,9 +13,11 @@
   "LastKnownBlockVersion-Minor": 1,
   "LedgerDB": {
     "Backend": "V2InMemory",
-    "NumOfDiskSnapshots": 2,
     "QueryBatchSize": 100000,
-    "SnapshotInterval": 216
+    "Snapshots": {
+      "NumOfDiskSnapshots": 2,
+      "SnapshotInterval": 216
+    }
   },
   "MaxConcurrencyDeadline": 4,
   "MaxKnownMajorProtocolVersion": 2,

--- a/nix/workbench/service/nodes.nix
+++ b/nix/workbench/service/nodes.nix
@@ -1,30 +1,28 @@
-{ pkgs
-, workbenchNix
-
-## The cardano-node config used as baseline:
-, baseNodeConfig
-
-, backend
-, profile
-, profiling
-, nodeSpecs
-
-# Derivations used to generate the topology projections
-, profileJsonPath, topologyJsonPath
+{
+  pkgs,
+  workbenchNix,
+  ## The cardano-node config used as baseline:
+  baseNodeConfig,
+  backend,
+  profile,
+  profiling,
+  nodeSpecs,
+  # Derivations used to generate the topology projections
+  profileJsonPath,
+  topologyJsonPath,
 }:
-
-with pkgs.lib;
-
-let
-  readJSONMay = fp:
-    let fv = __tryEval (__readFile fp);
-    in if fv.success
-       then __fromJSON fv.value
-       else {};
+with pkgs.lib; let
+  readJSONMay = fp: let
+    fv = __tryEval (__readFile fp);
+  in
+    if fv.success
+    then __fromJSON fv.value
+    else {};
 
   profileName = profile.name;
 
-  eras = [ ## This defines the order of eras -- which is important.
+  eras = [
+    ## This defines the order of eras -- which is important.
     "byron"
     "shelley"
     "allegra"
@@ -34,24 +32,26 @@ let
     "conway"
   ];
 
-  configHardforksIntoEra = era:
-    let go = acc: curEra: rest:
-          let ret = acc // eraSetupHardforks.${curEra};
-          in if curEra == era
-             then ret
-             else go ret (__head rest) (__tail rest);
-        eraSetupHardforks = {
-          byron   = {};
-          shelley = { TestShelleyHardForkAtEpoch = 0; };
-          allegra = { TestAllegraHardForkAtEpoch = 0; };
-          mary    = { TestMaryHardForkAtEpoch    = 0; };
-          alonzo  = { TestAlonzoHardForkAtEpoch  = 0; };
-          babbage = { TestBabbageHardForkAtEpoch = 0; };
-          conway  = { TestConwayHardForkAtEpoch  = 0; };
-        };
-    in if __hasAttr era eraSetupHardforks
-       then go {} (__head eras) (__tail eras)
-       else throw "configHardforksIntoEra:  unknown era '${era}'";
+  configHardforksIntoEra = era: let
+    go = acc: curEra: rest: let
+      ret = acc // eraSetupHardforks.${curEra};
+    in
+      if curEra == era
+      then ret
+      else go ret (__head rest) (__tail rest);
+    eraSetupHardforks = {
+      byron = {};
+      shelley = {TestShelleyHardForkAtEpoch = 0;};
+      allegra = {TestAllegraHardForkAtEpoch = 0;};
+      mary = {TestMaryHardForkAtEpoch = 0;};
+      alonzo = {TestAlonzoHardForkAtEpoch = 0;};
+      babbage = {TestBabbageHardForkAtEpoch = 0;};
+      conway = {TestConwayHardForkAtEpoch = 0;};
+    };
+  in
+    if __hasAttr era eraSetupHardforks
+    then go {} (__head eras) (__tail eras)
+    else throw "configHardforksIntoEra:  unknown era '${era}'";
 
   liveTablesPath = i:
     if (profile.node ? "ssd_directory" && profile.node.ssd_directory != null)
@@ -61,24 +61,30 @@ let
   ##
   ## nodeServiceConfig :: NodeSpec -> ServiceConfig
   ##
-  nodeServiceConfig =
-    { name, i, kind, port, isProducer, ... }@nodeSpec: valency:
+  nodeServiceConfig = {
+    name,
+    i,
+    kind,
+    port,
+    isProducer,
+    ...
+  } @ nodeSpec: valency:
     {
       inherit isProducer port;
       inherit (profile.node) rts_flags_override;
 
-      nodeId         = i;
-      databasePath   = "db";
-      socketPath     = "node.socket";
-      topology       = "topology.json";
+      nodeId = i;
+      databasePath = "db";
+      socketPath = "node.socket";
+      topology = "topology.json";
       nodeConfigFile = "config.json";
 
       # Allow for local clusters to have multiple LMDB directories in the same physical ssd_directory;
       # non-block producers (like the explorer node) keep using the in-memory backend
-      withUtxoHdLmdb   = profile.node.utxo_lmdb && isProducer;
-      withUtxoHdLsmt   = profile.node.utxo_lsmt && isProducer;
+      withUtxoHdLmdb = profile.node.utxo_lmdb && isProducer;
+      withUtxoHdLsmt = profile.node.utxo_lsmt && isProducer;
       lmdbDatabasePath = liveTablesPath i;
-      lsmDatabasePath  = liveTablesPath i;
+      lsmDatabasePath = liveTablesPath i;
 
       ## Combine:
       ##   0. baseNodeConfig (coming cardanoLib's testnet environ)
@@ -88,123 +94,146 @@ let
       ##   4. tracing backend's config
       nodeConfig =
         import ./tracing.nix
-          {
-            inherit (pkgs) lib;
-            inherit nodeSpec;
-            inherit (profile.node) tracing_backend tracer;
-          }
+        {
+          inherit (pkgs) lib;
+          inherit nodeSpec;
+          inherit (profile.node) tracing_backend tracer;
+        }
+        (recursiveUpdate
           (recursiveUpdate
-            (recursiveUpdate
+            (
+              recursiveUpdate
               (removeAttrs
                 baseNodeConfig
-                [ ## Let the genesis hashes be auto-computed by the node:
+                [
+                  ## Let the genesis hashes be auto-computed by the node:
                   "ByronGenesisHash"
                   "ShelleyGenesisHash"
                   "AlonzoGenesisHash"
                   "ConwayGenesisHash"
                   "DijkstraGenesisHash"
-                ] //
-                {
+                ]
+                // {
                   ExperimentalHardForksEnabled = true;
                   ExperimentalProtocolsEnabled = true;
-                  TurnOnLogMetrics             = true;
-                  SnapshotInterval             = 4230;
-                  ChainSyncIdleTimeout         = 0;
-                  PeerSharing                  = false;
+                  TurnOnLogMetrics = true;
+                  ChainSyncIdleTimeout = 0;
+                  PeerSharing = false;
 
                   ## defaults taken from: ouroboros-network/src/Ouroboros/Network/Diffusion/Configuration.hs
                   ## NB. the following inequality must hold: known >= established >= active >= 0
-                  SyncTargetNumberOfActivePeers      = max 15 valency;     # set to same value as TargetNumberOfActivePeers
+                  SyncTargetNumberOfActivePeers = max 15 valency; # set to same value as TargetNumberOfActivePeers
                   SyncTargetNumberOfEstablishedPeers = max 40 valency;
-                  TargetNumberOfActivePeers          = max 15 valency;
-                  TargetNumberOfEstablishedPeers     = max 40 valency;
+                  TargetNumberOfActivePeers = max 15 valency;
+                  TargetNumberOfEstablishedPeers = max 40 valency;
 
-                  ByronGenesisFile             = "../genesis/byron/genesis.json";
-                  ShelleyGenesisFile           = "../genesis/genesis-shelley.json";
-                  AlonzoGenesisFile            = "../genesis/genesis.alonzo.json";
-                  ConwayGenesisFile            = "../genesis/genesis.conway.json";
-                  DijkstraGenesisFile          = "../genesis/genesis.dijkstra.json";
-                } // optionalAttrs (profile.node.utxo_lsmt && isProducer)
+                  ByronGenesisFile = "../genesis/byron/genesis.json";
+                  ShelleyGenesisFile = "../genesis/genesis-shelley.json";
+                  AlonzoGenesisFile = "../genesis/genesis.alonzo.json";
+                  ConwayGenesisFile = "../genesis/genesis.conway.json";
+                  DijkstraGenesisFile = "../genesis/genesis.dijkstra.json";
+                }
+                // optionalAttrs (profile.node.utxo_lsmt && isProducer)
                 {
                   LedgerDB = {
                     Backend = "V2LSM";
                     LSMDatabasePath = liveTablesPath i;
                   };
-                } // optionalAttrs (profile.node.utxo_lmdb && isProducer)
+                }
+                // optionalAttrs (profile.node.utxo_lmdb && isProducer)
                 {
                   LedgerDB = {
                     Backend = "V1LMDB";
                     LiveTablesPath = liveTablesPath i;
                   };
                 })
-              (if __hasAttr "preset" profile && profile.preset != null
-               ## It's either an undisturbed preset,
-               ## or a hardforked setup.
-               then readJSONMay (../profile/presets + "/${profile.preset}/config.json")
-               else configHardforksIntoEra profile.era))
-            profile.node.verbatim);
+              {
+                ## This LedgerDB attrset is defined regardless of backend choice.
+                ## It assumes the Backend default to be "V2InMemory"; it must not overwrite any of the above, more specfic choices.
+                LedgerDB = {
+                  Snapshots = {
+                    SnapshotInterval = 4230;
+                    # Disable the randomised delay for kicking off snapshots:
+                    # For benchmarks, exact timing needs to be reproducible, and identical for all nodes.
+                    MinDelay = 0;
+                    MaxDelay = 0;
+                  };
+                };
+              }
+            )
+            (
+              if __hasAttr "preset" profile && profile.preset != null
+              ## It's either an undisturbed preset,
+              ## or a hardforked setup.
+              then readJSONMay (../profile/presets + "/${profile.preset}/config.json")
+              else configHardforksIntoEra profile.era
+            ))
+          profile.node.verbatim);
 
       extraArgs =
-        [ "+RTS" "-scardano-node.gcstats" "-RTS" ]
-        ++
-        optionals (nodeSpec.shutdown_on_block_synced != null) [
+        ["+RTS" "-scardano-node.gcstats" "-RTS"]
+        ++ optionals (nodeSpec.shutdown_on_block_synced != null) [
           "--shutdown-on-block-synced"
           (toString nodeSpec.shutdown_on_block_synced)
-        ] ++
-        optionals (nodeSpec.shutdown_on_slot_synced != null) [
+        ]
+        ++ optionals (nodeSpec.shutdown_on_slot_synced != null) [
           "--shutdown-on-slot-synced"
           (toString nodeSpec.shutdown_on_slot_synced)
         ];
-    } // optionalAttrs ((profiling.profilingTypeParam or "none") != "none") {
+    }
+    // optionalAttrs ((profiling.profilingTypeParam or "none") != "none") {
       # Add the profiling `-h*` RTS option.
       profiling = profiling.profilingTypeParam;
-    } // optionalAttrs (profiling.eventlog or false) {
+    }
+    // optionalAttrs (profiling.eventlog or false) {
       # Add the `-l` RTS param with profiling.
       eventlog = true;
-    # Decide where the executable comes from:
-    #########################################
-    } // optionalAttrs (!backend.useCabalRun) {
-      package    = workbenchNix.haskellProject.exes.cardano-node;
-    } // optionalAttrs   backend.useCabalRun  {
+      # Decide where the executable comes from:
+      #########################################
+    }
+    // optionalAttrs (!backend.useCabalRun) {
+      package = workbenchNix.haskellProject.exes.cardano-node;
+    }
+    // optionalAttrs backend.useCabalRun {
       # Allow the shell function to take precedence.
       executable = "cardano-node";
-    #########################################
-    } // optionalAttrs isProducer {
+      #########################################
+    }
+    // optionalAttrs isProducer {
       operationalCertificate = "../genesis/node-keys/node${toString i}.opcert";
-      kesKey                 = "../genesis/node-keys/node-kes${toString i}.skey";
-      vrfKey                 = "../genesis/node-keys/node-vrf${toString i}.skey";
-    } // optionalAttrs profile.node.tracer {
+      kesKey = "../genesis/node-keys/node-kes${toString i}.skey";
+      vrfKey = "../genesis/node-keys/node-vrf${toString i}.skey";
+    }
+    // optionalAttrs profile.node.tracer {
       tracerSocketPathConnect = mkDefault "../tracer/tracer.socket";
     };
 
-    time_fmtstr =
-      "{ " + escape [''"''] (concatStringsSep ''\n, '' time_entries) + " }";
-    time_entries = [
-      ''"wall_clock_s":       %e''
-      ''"user_cpu_s":         %U''
-      ''"sys_cpu_s":          %S''
-      ''"avg_cpu_pct":       "%P"''
-      ''"rss_peak_kb":        %M''
-      ''"signals_received":   %k''
-      ''"ctxsw_involuntary":  %c''
-      ''"ctxsw_volunt_waits": %w''
-      ''"pageflt_major":      %F''
-      ''"pageflt_minor":      %R''
-      ''"swaps":              %W''
-      ''"io_fs_reads":        %I''
-      ''"io_fs_writes":       %O''
-      ''"cmdline":           "%C"''
-      ''"exit_code":          %x''
-    ];
+  time_fmtstr =
+    "{ " + escape [''"''] (concatStringsSep ''\n, '' time_entries) + " }";
+  time_entries = [
+    ''"wall_clock_s":       %e''
+    ''"user_cpu_s":         %U''
+    ''"sys_cpu_s":          %S''
+    ''"avg_cpu_pct":       "%P"''
+    ''"rss_peak_kb":        %M''
+    ''"signals_received":   %k''
+    ''"ctxsw_involuntary":  %c''
+    ''"ctxsw_volunt_waits": %w''
+    ''"pageflt_major":      %F''
+    ''"pageflt_minor":      %R''
+    ''"swaps":              %W''
+    ''"io_fs_reads":        %I''
+    ''"io_fs_writes":       %O''
+    ''"cmdline":           "%C"''
+    ''"exit_code":          %x''
+  ];
 
   ## Given an env config, evaluate it and produce the node service.
   ## Call the given function on this service.
   ##
   ## evalServiceConfigToService :: NodeServiceConfig -> NodeService
   ##
-  evalServiceConfigToService =
-    serviceConfig:
-    let
+  evalServiceConfigToService = serviceConfig: let
     systemdCompat.options = {
       systemd.services = mkOption {};
       systemd.sockets = mkOption {};
@@ -215,98 +244,108 @@ let
     };
     eval = let
       extra = {
-        services.cardano-node = {
-          enable = true;
-        } // serviceConfig;
+        services.cardano-node =
+          {
+            enable = true;
+          }
+          // serviceConfig;
       };
-    in evalModules {
-      prefix = [];
-      modules = import ../../nixos/module-list.nix
-                ++ [ systemdCompat extra
-                     { config._module.args = { inherit pkgs; }; }
-                   ]
-                ++ [ backend.service-modules.node or {} ];
-    };
     in
-      eval.config.services.cardano-node;
+      evalModules {
+        prefix = [];
+        modules =
+          import ../../nixos/module-list.nix
+          ++ [
+            systemdCompat
+            extra
+            {config._module.args = {inherit pkgs;};}
+          ]
+          ++ [backend.service-modules.node or {}];
+      };
+  in
+    eval.config.services.cardano-node;
 
- topologiesJsonPaths =
-    let projections =
-          pkgs.runCommand "workbench-profile-files-${profileName}-topologies"
-            { nativeBuildInputs = with pkgs;
-              # A workbench with only the dependencies needed for this command.
-              [ workbenchNix.workbench
-                jq
-                workbenchNix.haskellProject.exes.cardano-topology
-              ];
-            }
-            ''
-            mkdir "$out"
-            ${builtins.concatStringsSep
-              "\n"
-              (pkgs.lib.mapAttrsToList
-                (name: nodeSpec: ''
-                    wb topology projection-for     \
-                    "local-${nodeSpec.kind}"       \
-                    "${toString nodeSpec.i}"       \
-                    "${profileJsonPath}"           \
-                    "${topologyJsonPath}"          \
-                    "${toString backend.basePort}" \
-                  > "$out"/"topology-${name}.json"
-                '')
-                nodeSpecs
-              )
-            }
-            ''
-        ;
-    in  pkgs.lib.mapAttrs
-          (name: _: "${projections}/topology-${name}.json")
-          nodeSpecs
-  ;
+  topologiesJsonPaths = let
+    projections =
+      pkgs.runCommand "workbench-profile-files-${profileName}-topologies"
+      {
+        nativeBuildInputs = with pkgs;
+        # A workbench with only the dependencies needed for this command.
+          [
+            workbenchNix.workbench
+            jq
+            workbenchNix.haskellProject.exes.cardano-topology
+          ];
+      }
+      ''
+        mkdir "$out"
+        ${
+          builtins.concatStringsSep
+          "\n"
+          (
+            pkgs.lib.mapAttrsToList
+            (name: nodeSpec: ''
+                wb topology projection-for     \
+                "local-${nodeSpec.kind}"       \
+                "${toString nodeSpec.i}"       \
+                "${profileJsonPath}"           \
+                "${topologyJsonPath}"          \
+                "${toString backend.basePort}" \
+              > "$out"/"topology-${name}.json"
+            '')
+            nodeSpecs
+          )
+        }
+      '';
+  in
+    pkgs.lib.mapAttrs
+    (name: _: "${projections}/topology-${name}.json")
+    nodeSpecs;
 
-  nodeService =
-    { name, i, mode ? null, ... }@nodeSpec:
-    let
-      modeIdSuffix  = if mode == null then "" else "." + mode;
-      serviceConfig = nodeServiceConfig nodeSpec valency;
-      service       = evalServiceConfigToService serviceConfig;
+  nodeService = {
+    name,
+    i,
+    mode ? null,
+    ...
+  } @ nodeSpec: let
+    modeIdSuffix =
+      if mode == null
+      then ""
+      else "." + mode;
+    serviceConfig = nodeServiceConfig nodeSpec valency;
+    service = evalServiceConfigToService serviceConfig;
 
-      topology =
-         rec {
-           JSON  = topologiesJsonPaths.${name};
-           value = __fromJSON (__readFile JSON);
-         }
-      ;
-
-      valency =
-        let
-          topo = topology.value;
-          val  = if hasAttr "localRoots" topo && __length topo.localRoots > 0
-                  then let lr = head topo.localRoots; in lr.valency
-                  else length (topo.Producers or []);
-        in val;
-
-    in {
-      start =
-        ''
-        #!${pkgs.stdenv.shell}
-
-        export TRACE_DISPATCHER_LOGGING_HOSTNAME=${name}
-
-        ${service.script}
-        ''
-      ;
-
-      config = service.nodeConfig;
-
-      inherit topology;
+    topology = rec {
+      JSON = topologiesJsonPaths.${name};
+      value = __fromJSON (__readFile JSON);
     };
+
+    valency = let
+      topo = topology.value;
+      val =
+        if hasAttr "localRoots" topo && __length topo.localRoots > 0
+        then let lr = head topo.localRoots; in lr.valency
+        else length (topo.Producers or []);
+    in
+      val;
+  in {
+    start = ''
+      #!${pkgs.stdenv.shell}
+
+      export TRACE_DISPATCHER_LOGGING_HOSTNAME=${name}
+
+      ${service.script}
+    '';
+
+    config = service.nodeConfig;
+
+    inherit topology;
+  };
 
   ##
   ## node-services :: Map NodeName (NodeSpec, ServiceConfig, Service, NodeConfig, Script)
   ##
   node-services = mapAttrs (_: nodeService) nodeSpecs;
-in
-{
+in {
   inherit node-services;
 }


### PR DESCRIPTION
# Description

This PR brings in the Consensus feature of **predictable ledger state snapshots**:
- snapshots will be taken by all nodes at the same deterministic slots numbers, rather then depending on a node's start time.
- to avoid the thundering herd effect, when all nodes take the snapshot at the same time and stop the network, every node will introduce a randomised time delay before taking a snapshot.

## Changes to `cardano-node` configuration

The `LedgerDB` section of the `config.yaml` file is re-worked to have the following parameters:

```yaml
LedgerDB:
  # remains as-is
  Backend: V2InMemory
  Snapshots:

    # start taking the snaphots at slot 172800, after Byron
    SlotOffset: 172800

    # take snapshots every 432000 slots, at the end of every Shelley epoch
    SnapshotInterval: 432000

    # A minimum duration between snapshots, in seconds (used to avoid excessive snapshots while syncing).
    RateLimit: 0 # default is 10 minutes

    # randomised snapshot delay range, in seconds.
    # Both Min and Max need to be specified, otherwise the default delay of (5min, 10min) will be used
    MinDelay: 60
    MaxDelay: 120
```
Alternatively, instead of an object with individual options, Snapshots can name a predefined
  snapshot policy, which is then used as a whole:

```yaml
LedgerDB:
  Backend: V2InMemory
  Snapshots: Mithril
```

Currently the only named policy is Mithril, intended for nodes producing snapshots for Mithril.

Note that the snapshot-related options are now grouped under "LedgerDB->Snapshot". The legacy format is still supported, but it has slightly changed it's meaning: the `SnapshotInterval` parameter is interpreted as *slots*, rather than *seconds*.

## New tracing events

- `SnapshotRequestDelayed snapshotRequestTime delayBeforeSnapshotting slots` --- traces the fact that a snapshot was requested for `slots`, but the request will be executed after `delayBeforeSnapshotting`.
- `SnapshotRequestCompleted` signifies the completion of a delayed snapshot request.

# Manual Testing

This feature is a little tricky to test automatically, and I have not found any end-to-end tests for the ledger state snapshot functionality. I've done some manual testing by analysing the logs. This process could be automated using `cardano-testnet`, but I'm afraid that the test could be flaky and very verbose.

To test the feature, I've ran started a sync with mainnet and used Claude Code to grep the logs and construct a table that verifies that the snapshots are indeed taken at the announces slots after the expected delay:

| #  | SnapshotRequestDelayed   | Scheduled Slots                        | TookSnapshot             | Taken Slot | Reported Delay (s) | Actual Delta (s) |
|----|--------------------------|----------------------------------------|--------------------------|------------|--------------------|------------------|
| 1  | 2026-04-10 12:21:49.5021 | 4492799                                | 2026-04-10 12:23:02.5057 | 4492799    | 73                 | 73.0036          |
| 2  | 2026-04-10 12:23:03.3550 | 4924780                                | 2026-04-10 12:24:07.3566 | 4924780    | 64                 | 64.0016          |
| 3  | 2026-04-10 12:24:08.6039 | 5356780, 5788780                       | 2026-04-10 12:25:56.6049 | 5356780    | 108                | 108.0010         |
|    |                          |                                        | 2026-04-10 12:25:58.6811 | 5788780    |                    | 110.0772         |
| 4  | 2026-04-10 12:26:00.0986 | 6220777, 6652775, 7084774              | 2026-04-10 12:27:13.1009 | 6220777    | 73                 | 73.0023          |
|    |                          |                                        | 2026-04-10 12:27:15.2028 | 6652775    |                    | 75.1042          |
|    |                          |                                        | 2026-04-10 12:27:16.2926 | 7084774    |                    | 76.1940          |
| 5  | 2026-04-10 12:27:17.9178 | 7516773, 7948772, 8380772              | 2026-04-10 12:28:40.9199 | 7516773    | 83                 | 83.0021          |
|    |                          |                                        | 2026-04-10 12:28:42.1981 | 7948772    |                    | 84.2803          |
|    |                          |                                        | 2026-04-10 12:28:43.6356 | 8380772    |                    | 85.7178          |

The relevant fragment of the log file is attached:

<details>
[2026-04-10 12:21:49.5021Z][geo2a-workstation:ChainDB.LedgerEvent.Snapshot.SnapshotRequestDelayed](Info,30) Scheduling to take ledger state snapshots at slots  [SlotNo 4492799] , with a randomised delay of 73s
[2026-04-10 12:23:02.5057Z][geo2a-workstation:ChainDB.LedgerEvent.Snapshot.TookSnapshot](Info,30) Taking ledger snapshot DiskSnapshot {dsNumber = 4492799, dsSuffix = Nothing} at f8084c61b6a238acec985b59310b6ecec49c0ab8352249afd7268da5cff2a457 at slot 4492799
[2026-04-10 12:23:03.2456Z][geo2a-workstation:ChainDB.LedgerEvent.Snapshot.TookSnapshot](Info,30) Took ledger snapshot DiskSnapshot {dsNumber = 4492799, dsSuffix = Nothing} at f8084c61b6a238acec985b59310b6ecec49c0ab8352249afd7268da5cff2a457 at slot 4492799 , duration: 0.739851377s
[2026-04-10 12:23:03.2530Z][geo2a-workstation:ChainDB.LedgerEvent.Snapshot.SnapshotRequestCompleted](Info,30) Completed taking a ledger state snapshot
[2026-04-10 12:23:03.3550Z][geo2a-workstation:ChainDB.LedgerEvent.Snapshot.SnapshotRequestDelayed](Info,30) Scheduling to take ledger state snapshots at slots  [SlotNo 4924780] , with a randomised delay of 64s
[2026-04-10 12:24:07.3566Z][geo2a-workstation:ChainDB.LedgerEvent.Snapshot.TookSnapshot](Info,30) Taking ledger snapshot DiskSnapshot {dsNumber = 4924780, dsSuffix = Nothing} at a0805ae8e52318f0e499be7f85d3f1d5c7dddeacdca0dab9e9d9a8ae6c49a22c at slot 4924780
[2026-04-10 12:24:08.2799Z][geo2a-workstation:ChainDB.LedgerEvent.Snapshot.TookSnapshot](Info,30) Took ledger snapshot DiskSnapshot {dsNumber = 4924780, dsSuffix = Nothing} at a0805ae8e52318f0e499be7f85d3f1d5c7dddeacdca0dab9e9d9a8ae6c49a22c at slot 4924780 , duration: 0.923355707s
[2026-04-10 12:24:08.2872Z][geo2a-workstation:ChainDB.LedgerEvent.Snapshot.SnapshotRequestCompleted](Info,30) Completed taking a ledger state snapshot
[2026-04-10 12:24:08.6039Z][geo2a-workstation:ChainDB.LedgerEvent.Snapshot.SnapshotRequestDelayed](Info,30) Scheduling to take ledger state snapshots at slots  [SlotNo 5356780,SlotNo 5788780] , with a randomised delay of 108s
[2026-04-10 12:25:56.6049Z][geo2a-workstation:ChainDB.LedgerEvent.Snapshot.TookSnapshot](Info,30) Taking ledger snapshot DiskSnapshot {dsNumber = 5356780, dsSuffix = Nothing} at 4ddf277b3aff32931843da9f7900f5ef2fffed15b124891c485be4b3a06fca72 at slot 5356780
[2026-04-10 12:25:58.6810Z][geo2a-workstation:ChainDB.LedgerEvent.Snapshot.TookSnapshot](Info,30) Took ledger snapshot DiskSnapshot {dsNumber = 5356780, dsSuffix = Nothing} at 4ddf277b3aff32931843da9f7900f5ef2fffed15b124891c485be4b3a06fca72 at slot 5356780 , duration: 2.076082693s
[2026-04-10 12:25:58.6811Z][geo2a-workstation:ChainDB.LedgerEvent.Snapshot.TookSnapshot](Info,30) Taking ledger snapshot DiskSnapshot {dsNumber = 5788780, dsSuffix = Nothing} at 9e6fc811d9b09f7c8c6d7a23dc8b3360a9c4a3930ba640ce107e944d5e2750e2 at slot 5788780
[2026-04-10 12:25:59.7608Z][geo2a-workstation:ChainDB.LedgerEvent.Snapshot.TookSnapshot](Info,30) Took ledger snapshot DiskSnapshot {dsNumber = 5788780, dsSuffix = Nothing} at 9e6fc811d9b09f7c8c6d7a23dc8b3360a9c4a3930ba640ce107e944d5e2750e2 at slot 5788780 , duration: 1.079557458s
[2026-04-10 12:25:59.7861Z][geo2a-workstation:ChainDB.LedgerEvent.Snapshot.SnapshotRequestCompleted](Info,30) Completed taking a ledger state snapshot
[2026-04-10 12:26:00.0986Z][geo2a-workstation:ChainDB.LedgerEvent.Snapshot.SnapshotRequestDelayed](Info,30) Scheduling to take ledger state snapshots at slots  [SlotNo 6220777,SlotNo 6652775,SlotNo 7084774] , with a randomised delay of 73s
[2026-04-10 12:27:13.1009Z][geo2a-workstation:ChainDB.LedgerEvent.Snapshot.TookSnapshot](Info,30) Taking ledger snapshot DiskSnapshot {dsNumber = 6220777, dsSuffix = Nothing} at bc98eda36819d00f424e63aeb4eb43950bd5eacf37f2c35a2b8f807aa68cd895 at slot 6220777
[2026-04-10 12:27:15.2022Z][geo2a-workstation:ChainDB.LedgerEvent.Snapshot.TookSnapshot](Info,30) Took ledger snapshot DiskSnapshot {dsNumber = 6220777, dsSuffix = Nothing} at bc98eda36819d00f424e63aeb4eb43950bd5eacf37f2c35a2b8f807aa68cd895 at slot 6220777 , duration: 2.101244366s
[2026-04-10 12:27:15.2028Z][geo2a-workstation:ChainDB.LedgerEvent.Snapshot.TookSnapshot](Info,30) Taking ledger snapshot DiskSnapshot {dsNumber = 6652775, dsSuffix = Nothing} at 6707ef3c2e885c25d5081a1aa0dd03e81492e21c5955208f23eee3d92ae28f9f at slot 6652775
[2026-04-10 12:27:16.2922Z][geo2a-workstation:ChainDB.LedgerEvent.Snapshot.TookSnapshot](Info,30) Took ledger snapshot DiskSnapshot {dsNumber = 6652775, dsSuffix = Nothing} at 6707ef3c2e885c25d5081a1aa0dd03e81492e21c5955208f23eee3d92ae28f9f at slot 6652775 , duration: 1.089450966s
[2026-04-10 12:27:16.2926Z][geo2a-workstation:ChainDB.LedgerEvent.Snapshot.TookSnapshot](Info,30) Taking ledger snapshot DiskSnapshot {dsNumber = 7084774, dsSuffix = Nothing} at 057c01d0a0f0b6c554589ac5baf6b72b63cd22b2d668ee86f7421199eab1c46c at slot 7084774
[2026-04-10 12:27:17.4298Z][geo2a-workstation:ChainDB.LedgerEvent.Snapshot.TookSnapshot](Info,30) Took ledger snapshot DiskSnapshot {dsNumber = 7084774, dsSuffix = Nothing} at 057c01d0a0f0b6c554589ac5baf6b72b63cd22b2d668ee86f7421199eab1c46c at slot 7084774 , duration: 1.137220622s
[2026-04-10 12:27:17.4573Z][geo2a-workstation:ChainDB.LedgerEvent.Snapshot.SnapshotRequestCompleted](Info,30) Completed taking a ledger state snapshot
[2026-04-10 12:27:17.9178Z][geo2a-workstation:ChainDB.LedgerEvent.Snapshot.SnapshotRequestDelayed](Info,30) Scheduling to take ledger state snapshots at slots  [SlotNo 7516773,SlotNo 7948772,SlotNo 8380772] , with a randomised delay of 83s
[2026-04-10 12:28:40.9199Z][geo2a-workstation:ChainDB.LedgerEvent.Snapshot.TookSnapshot](Info,30) Taking ledger snapshot DiskSnapshot {dsNumber = 7516773, dsSuffix = Nothing} at cd0dad9ea278cc82d9c3dbefa1769ddbfb9358dc800e4a70a4cc1e671489c493 at slot 7516773
[2026-04-10 12:28:42.1979Z][geo2a-workstation:ChainDB.LedgerEvent.Snapshot.TookSnapshot](Info,30) Took ledger snapshot DiskSnapshot {dsNumber = 7516773, dsSuffix = Nothing} at cd0dad9ea278cc82d9c3dbefa1769ddbfb9358dc800e4a70a4cc1e671489c493 at slot 7516773 , duration: 1.277999016s
[2026-04-10 12:28:42.1981Z][geo2a-workstation:ChainDB.LedgerEvent.Snapshot.TookSnapshot](Info,30) Taking ledger snapshot DiskSnapshot {dsNumber = 7948772, dsSuffix = Nothing} at cff7c23b9f62ad48a2436b2270a10bb9286999a721f1da3bde35f6f1579d1464 at slot 7948772
[2026-04-10 12:28:43.6354Z][geo2a-workstation:ChainDB.LedgerEvent.Snapshot.TookSnapshot](Info,30) Took ledger snapshot DiskSnapshot {dsNumber = 7948772, dsSuffix = Nothing} at cff7c23b9f62ad48a2436b2270a10bb9286999a721f1da3bde35f6f1579d1464 at slot 7948772 , duration: 1.43729202s
[2026-04-10 12:28:43.6356Z][geo2a-workstation:ChainDB.LedgerEvent.Snapshot.TookSnapshot](Info,30) Taking ledger snapshot DiskSnapshot {dsNumber = 8380772, dsSuffix = Nothing} at 47fef957a7152647dacbcff13242b3ef3c416930e23cd55722c36c1fd126c721 at slot 8380772
[2026-04-10 12:28:45.5275Z][geo2a-workstation:ChainDB.LedgerEvent.Snapshot.TookSnapshot](Info,30) Took ledger snapshot DiskSnapshot {dsNumber = 8380772, dsSuffix = Nothing} at 47fef957a7152647dacbcff13242b3ef3c416930e23cd55722c36c1fd126c721 at slot 8380772 , duration: 1.891909794s
[2026-04-10 12:28:45.5622Z][geo2a-workstation:ChainDB.LedgerEvent.Snapshot.SnapshotRequestCompleted](Info,30) Completed taking a ledger state snapshot
</details>
# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
