### PR TITLE
Fix option rendering from services.cardano-node

### DIFF
--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -5,7 +5,7 @@
 
 with lib; with builtins;
 let
-  inherit (types) attrs attrsOf bool either enum functionTo int listOf package nullOr str;
+  inherit (types) attrs attrsOf bool either enum functionTo int listOf path package nullOr str;
 
   cfg = config.services.cardano-node;
   envConfig = cfg.environments.${cfg.environment};


### PR DESCRIPTION
# Description

In `cardano.nix` we generate documentation pages from services,cardano-node, and evaluation failed with:

`error: expected a set but found the built-in function 'path': «primop path»`

(That happens because `type = path` expect lib.type.path and not builtins.path)

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
