### PR TITLE
[tx-generator] Add `--testnet-config-dir` flag to `json_highlevel`

### DIFF
--- a/bench/tx-generator/CHANGELOG.md
+++ b/bench/tx-generator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## 2.16 -- Apr 2026
+
+* Added a `--testnet-config-dir` flag to `tx-generator json_highlevel` that auto-discovers connection settings config (socket path, signing key, node config, target nodes) from a `cardano-testnet` output directory.
+
 ## 2.15 -- Mar 2025
 
 * A new cabal flag `withplutuslib` is added, enabling import and re-compilation of Plutus scripts from `plutus-scripts-bench` - default: false; use for dev/test of new benchmarks only.

--- a/bench/tx-generator/src/Cardano/Benchmarking/Command.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Command.hs
@@ -243,7 +243,7 @@ commandParser
   testnetConfigOpt :: Parser TestnetConfig
   testnetConfigOpt = TestnetConfig
     <$> strOption (long "testnet-config-dir" <> metavar "DIR"
-          <> help "cardano-testnet output directory; discovered infrastructure overrides config file")
+          <> help "cardano-testnet output directory; discovered connection settings override config file")
 
   compileCmd :: Parser Command
   compileCmd = Compile <$> filePath "benchmarking options"

--- a/bench/tx-generator/src/Cardano/Benchmarking/Command.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Command.hs
@@ -28,8 +28,10 @@ import           Cardano.Benchmarking.Script.Selftest (runSelftest)
 import           Cardano.Benchmarking.Version as Version
 import           Cardano.TxGenerator.PlutusContext (readScriptData)
 import           Cardano.TxGenerator.Setup.NixService
+import           Cardano.TxGenerator.Setup.TestnetDiscovery (FillDefaults (..), ForceInfra (..),
+                   TestnetConfig (..), TestnetMergeFlags (..), discoverTestnetConfig)
 import           Cardano.TxGenerator.Types (TxGenPlutusParams (..))
-import           Data.Aeson (fromJSON)
+import           Data.Aeson (Value (..), fromJSON)
 import           Data.ByteString.Lazy as BSL
 import           Data.Foldable (for_)
 import           Data.Maybe (catMaybes)
@@ -73,9 +75,13 @@ deriving instance Show SignalInfo
 deriving instance Show SignalSpecificInfo
 #endif
 
+data JsonHLSource
+  = FullConfig FilePath
+  | TestnetSource TestnetConfig (Maybe FilePath)
+
 data Command
   = Json FilePath
-  | JsonHL FilePath (Maybe FilePath) (Maybe FilePath)
+  | JsonHL JsonHLSource (Maybe FilePath) (Maybe FilePath)
   | Compile FilePath
   | Selftest (Maybe FilePath)
   | VersionCmd
@@ -93,8 +99,14 @@ runCommand' iocp = do
     Json actionFile -> do
       script <- parseScriptFileAeson actionFile
       runScript emptyEnv script envConsts >>= handleError . fst
-    JsonHL nixSvcOptsFile nodeConfigOverwrite cardanoTracerOverwrite -> do
-      opts <- parseJSONFile fromJSON nixSvcOptsFile
+    JsonHL source nodeConfigOverwrite cardanoTracerOverwrite -> do
+      opts <- case source of
+        FullConfig f -> parseJSONFile fromJSON f
+        TestnetSource tc Nothing ->
+          discoverTestnetConfig tc (Object mempty)
+        TestnetSource tc (Just f) -> do
+          userConfig <- parseJSONFile pure f
+          discoverTestnetConfig tc userConfig
       finalOpts <- mangleTracerConfig cardanoTracerOverwrite <$> mangleNodeConfig nodeConfigOverwrite opts
       let consts = envConsts { LogTypes.envNixSvcOpts = Just finalOpts }
 
@@ -223,26 +235,60 @@ commandParser
  where
   cmdParser cmd parser description = command cmd $ info parser $ progDesc description
 
-  filePath :: String -> Parser String
-  filePath helpMsg = strArgument (metavar "FILEPATH" <> help helpMsg)
+  filePath :: String -> String -> Parser String
+  filePath metavarName helpMsg = strArgument (metavar metavarName <> help helpMsg)
 
   jsonCmd :: Parser Command
-  jsonCmd = Json <$> filePath "low-level benchmarking script"
+  jsonCmd = Json <$> filePath "FILEPATH" "low-level benchmarking script"
 
   jsonHLCmd :: Parser Command
-  jsonHLCmd = JsonHL <$> filePath "benchmarking options"
+  jsonHLCmd = JsonHL <$> jsonHLSourceOpt
                      <*> nodeConfigOpt
                      <*> tracerConfigOpt
-  compileCmd :: Parser Command
-  compileCmd = Compile <$> filePath "benchmarking options"
 
-  selfTestCmd = Selftest <$> optional (filePath "output file")
+  jsonHLSourceOpt :: Parser JsonHLSource
+  jsonHLSourceOpt =
+        FullConfig <$> filePath "FULL_CONFIG_FILEPATH" "benchmarking options"
+    <|> testnetSourceOpt
+
+  testnetSourceOpt :: Parser JsonHLSource
+  testnetSourceOpt = TestnetSource
+    <$> testnetConfigOpt
+    <*> optional (filePath "PARTIAL_CONFIG_FILEPATH" "partial config overrides")
+
+  testnetConfigOpt :: Parser TestnetConfig
+  testnetConfigOpt = TestnetConfig
+    <$> strOption (long "testnet-config-dir" <> metavar "DIR"
+          <> help "cardano-testnet output directory")
+    <*> testnetMergeFlagsOpt
+
+  testnetMergeFlagsOpt :: Parser TestnetMergeFlags
+  testnetMergeFlagsOpt = TestnetMergeFlags
+    <$> fillDefaultsOpt
+    <*> forceInfraOpt
+
+  fillDefaultsOpt :: Parser FillDefaults
+  fillDefaultsOpt =
+        flag' FillDefaults   (long "fill-defaults"    <> help "Provide default values for missing tx params (default)")
+    <|> flag' NoFillDefaults (long "no-fill-defaults" <> help "Do not fill missing tx params with defaults")
+    <|> pure FillDefaults
+
+  forceInfraOpt :: Parser ForceInfra
+  forceInfraOpt =
+        flag' ForceInfra   (long "force-infra"    <> help "Force testnet infrastructure fields even if user provided different values")
+    <|> flag' NoForceInfra (long "no-force-infra" <> help "Allow user to override infrastructure fields (default)")
+    <|> pure NoForceInfra
+
+  compileCmd :: Parser Command
+  compileCmd = Compile <$> filePath "FULL_CONFIG_FILEPATH" "benchmarking options"
+
+  selfTestCmd = Selftest <$> optional (filePath "FILEPATH" "output file")
 
   nodeConfigOpt :: Parser (Maybe FilePath)
   nodeConfigOpt = option (Just <$> str)
     ( long "nodeConfig"
       <> short 'n'
-      <> metavar "FILENAME"
+      <> metavar "FILEPATH"
       <> value Nothing
       <> help "the node configfile"
     )

--- a/bench/tx-generator/src/Cardano/Benchmarking/Command.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/Command.hs
@@ -28,6 +28,7 @@ import           Cardano.Benchmarking.Script.Selftest (runSelftest)
 import           Cardano.Benchmarking.Version as Version
 import           Cardano.TxGenerator.PlutusContext (readScriptData)
 import           Cardano.TxGenerator.Setup.NixService
+import           Cardano.TxGenerator.Setup.TestnetDiscovery (TestnetConfig (..), discoverTestnetConfig)
 import           Cardano.TxGenerator.Types (TxGenPlutusParams (..))
 import           Data.Aeson (fromJSON)
 import           Data.ByteString.Lazy as BSL
@@ -75,7 +76,7 @@ deriving instance Show SignalSpecificInfo
 
 data Command
   = Json FilePath
-  | JsonHL FilePath (Maybe FilePath) (Maybe FilePath)
+  | JsonHL FilePath (Maybe TestnetConfig) (Maybe FilePath) (Maybe FilePath)
   | Compile FilePath
   | Selftest (Maybe FilePath)
   | VersionCmd
@@ -93,8 +94,12 @@ runCommand' iocp = do
     Json actionFile -> do
       script <- parseScriptFileAeson actionFile
       runScript emptyEnv script envConsts >>= handleError . fst
-    JsonHL nixSvcOptsFile nodeConfigOverwrite cardanoTracerOverwrite -> do
-      opts <- parseJSONFile fromJSON nixSvcOptsFile
+    JsonHL configFile maybeTestnetConfig nodeConfigOverwrite cardanoTracerOverwrite -> do
+      opts <- case maybeTestnetConfig of
+        Nothing -> parseJSONFile fromJSON configFile
+        Just tc -> do
+          userConfig <- parseJSONFile pure configFile
+          discoverTestnetConfig tc userConfig
       finalOpts <- mangleTracerConfig cardanoTracerOverwrite <$> mangleNodeConfig nodeConfigOverwrite opts
       let consts = envConsts { LogTypes.envNixSvcOpts = Just finalOpts }
 
@@ -231,8 +236,15 @@ commandParser
 
   jsonHLCmd :: Parser Command
   jsonHLCmd = JsonHL <$> filePath "benchmarking options"
+                     <*> optional testnetConfigOpt
                      <*> nodeConfigOpt
                      <*> tracerConfigOpt
+
+  testnetConfigOpt :: Parser TestnetConfig
+  testnetConfigOpt = TestnetConfig
+    <$> strOption (long "testnet-config-dir" <> metavar "DIR"
+          <> help "cardano-testnet output directory; discovered infrastructure overrides config file")
+
   compileCmd :: Parser Command
   compileCmd = Compile <$> filePath "benchmarking options"
 
@@ -242,7 +254,7 @@ commandParser
   nodeConfigOpt = option (Just <$> str)
     ( long "nodeConfig"
       <> short 'n'
-      <> metavar "FILENAME"
+      <> metavar "FILEPATH"
       <> value Nothing
       <> help "the node configfile"
     )

--- a/bench/tx-generator/src/Cardano/TxGenerator/Setup/TestnetDiscovery.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Setup/TestnetDiscovery.hs
@@ -22,6 +22,7 @@ import           Cardano.Node.Types (ConfigYamlFilePath (..), NodeProtocolConfig
                    npcTestStartingEra)
 import           Cardano.TxGenerator.Setup.NixService (NixServiceOptions (..), NodeDescription (..))
 
+import           Cardano.Prelude (unless)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
 import           Data.Char (isDigit)
@@ -35,7 +36,6 @@ import           System.Exit (die)
 import           System.FilePath ((</>), takeDirectory)
 import           Text.Read (readMaybe)
 
-
 -- | Whether to fill in default values for all 'NixServiceOptions' fields
 -- before merging the user-provided configuration.
 data FillDefaults
@@ -46,7 +46,7 @@ data FillDefaults
   | NoFillDefaults
     -- ^ Start from only the discovered infrastructure keys; the user
     -- configuration must supply every other required field.
-  deriving (Show, Eq)
+  deriving (Show, Eq, Bounded, Enum)
 
 -- | Whether discovered infrastructure values (socket path, signing key,
 -- node config file, target nodes) should override the user-provided
@@ -59,7 +59,7 @@ data ForceInfra
   | NoForceInfra
     -- ^ Let the user configuration win for infrastructure keys as well;
     -- discovered values are used only when the user does not provide them.
-  deriving (Show, Eq)
+  deriving (Show, Eq, Bounded, Enum)
 
 -- | Flags that control how the discovered testnet infrastructure is merged
 -- with user-provided JSON configuration in 'discoverTestnetConfig'.

--- a/bench/tx-generator/src/Cardano/TxGenerator/Setup/TestnetDiscovery.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Setup/TestnetDiscovery.hs
@@ -21,7 +21,7 @@ import           Data.List (isPrefixOf)
 import           Data.List.NonEmpty (NonEmpty (..))
 import           Data.Maybe (mapMaybe)
 import           Network.Socket (PortNumber)
-import           System.Directory (doesDirectoryExist, doesFileExist, listDirectory)
+import           System.Directory (doesDirectoryExist, doesPathExist, listDirectory)
 import           System.Exit (die)
 import           System.FilePath ((</>), takeDirectory)
 import           Text.Read (readMaybe)
@@ -123,8 +123,8 @@ mergeValues (Aeson.Object base) (Aeson.Object override) =
 mergeValues _ override = override
 
 
--- | Validate that a file exists, dying with a clear message if not.
+-- | Validate that a path exists (file, socket, etc.), dying with a clear message if not.
 validateFileExists :: FilePath -> String -> IO ()
 validateFileExists path description = do
-  exists <- doesFileExist path
+  exists <- doesPathExist path
   unless exists $ die $ "validateFileExists: required " ++ description ++ " file not found: " ++ path

--- a/bench/tx-generator/src/Cardano/TxGenerator/Setup/TestnetDiscovery.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Setup/TestnetDiscovery.hs
@@ -32,10 +32,10 @@ newtype TestnetConfig = TestnetConfig
   } deriving (Show, Eq)
 
 
--- | Discover testnet infrastructure from a @cardano-testnet@ output directory
--- and merge it with user-provided JSON config.
+-- | Discover testnet connection settings from a @cardano-testnet@ output
+-- directory and merge them with user-provided JSON config.
 --
--- The 4 infrastructure fields (@localNodeSocketPath@, @sigKey@,
+-- The 4 connection settings (@localNodeSocketPath@, @sigKey@,
 -- @nodeConfigFile@, @targetNodes@) are always populated from the testnet
 -- directory and override any values in the user config.  All other fields
 -- must be supplied by the user.
@@ -53,14 +53,14 @@ discoverTestnetConfig TestnetConfig{tcDir} userConfig = do
   validateFileExists sigKeyPath "signing key"
   validateFileExists configPath "configuration"
 
-  let infraJson = object
+  let connectionSettings = object
         [ "localNodeSocketPath" .= socketPath
         , "sigKey"              .= sigKeyPath
         , "nodeConfigFile"      .= configPath
         , "targetNodes"         .= targetNodes
         ]
 
-  let merged = mergeValues userConfig infraJson
+  let merged = mergeValues userConfig connectionSettings
 
   case Aeson.fromJSON merged of
     Aeson.Success opts -> pure opts

--- a/bench/tx-generator/src/Cardano/TxGenerator/Setup/TestnetDiscovery.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Setup/TestnetDiscovery.hs
@@ -42,7 +42,7 @@ newtype TestnetConfig = TestnetConfig
 discoverTestnetConfig :: TestnetConfig -> Aeson.Value -> IO NixServiceOptions
 discoverTestnetConfig TestnetConfig{tcDir} userConfig = do
   dirExists <- doesDirectoryExist tcDir
-  unless dirExists $ die $ "Testnet directory does not exist: " ++ tcDir
+  unless dirExists $ die $ "discoverTestnetConfig: testnet directory does not exist: " ++ tcDir
 
   targetNodes <- discoverNodes tcDir
   let socketPath = tcDir </> defaultSocketPath 1
@@ -64,7 +64,7 @@ discoverTestnetConfig TestnetConfig{tcDir} userConfig = do
 
   case Aeson.fromJSON merged of
     Aeson.Success opts -> pure opts
-    Aeson.Error err    -> die $ "Failed to parse merged config: " ++ err
+    Aeson.Error err    -> die $ "discoverTestnetConfig: failed to parse merged config: " ++ err
 
 
 -- | Discover nodes by scanning for port files in the testnet directory.
@@ -76,13 +76,13 @@ discoverNodes dir = do
   let nodeDataDir = dir </> takeDirectory (defaultNodeDataDir 1)
   exists <- doesDirectoryExist nodeDataDir
   if not exists
-    then die $ "Node data directory does not exist: " ++ nodeDataDir
+    then die $ "discoverNodes: node data directory does not exist: " ++ nodeDataDir
     else do
       entries <- listDirectory nodeDataDir
       let nodeIndices = sort $ mapMaybe parseNodeIndex entries
       nodes <- mapM (readNodeDescription dir) nodeIndices
       case nodes of
-        []     -> die $ "No nodes found in: " ++ nodeDataDir
+        []     -> die $ "discoverNodes: no nodes found in: " ++ nodeDataDir
         (n:ns) -> pure (n :| ns)
 
 
@@ -100,7 +100,7 @@ readNodeDescription dir idx = do
   validateFileExists portPath ("port file for " ++ defaultNodeName idx)
   portStr <- readFile portPath
   case readMaybe portStr :: Maybe PortNumber of
-    Nothing -> die $ "Invalid port number in: " ++ portPath
+    Nothing -> die $ "readNodeDescription: invalid port number in: " ++ portPath
     Just port -> pure NodeDescription
       { ndAddr = mkLocalhostAddr port
       , ndName = defaultNodeName idx
@@ -127,4 +127,4 @@ mergeValues _ override = override
 validateFileExists :: FilePath -> String -> IO ()
 validateFileExists path description = do
   exists <- doesFileExist path
-  unless exists $ die $ "Required " ++ description ++ " file not found: " ++ path
+  unless exists $ die $ "validateFileExists: required " ++ description ++ " file not found: " ++ path

--- a/bench/tx-generator/src/Cardano/TxGenerator/Setup/TestnetDiscovery.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Setup/TestnetDiscovery.hs
@@ -1,0 +1,254 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.TxGenerator.Setup.TestnetDiscovery
+  ( FillDefaults (..)
+  , ForceInfra (..)
+  , TestnetMergeFlags (..)
+  , TestnetConfig (..)
+  , discoverTestnetConfig
+  ) where
+
+import           Cardano.Api (AnyCardanoEra (..), AnyShelleyBasedEra (..), CardanoEra (..),
+                   File (..), toCardanoEra)
+
+import qualified Cardano.Ledger.Coin as L
+import           Cardano.Node.Configuration.NodeAddress (NodeAddress' (..), NodeHostIPv4Address (..),
+                   NodeIPv4Address)
+import           Cardano.Node.Configuration.POM (PartialNodeConfiguration (..), parseNodeConfigurationFP)
+import           Cardano.Node.Testnet.Paths (defaultConfigFile, defaultNodeDataDir, defaultNodeName,
+                   defaultPortFile, defaultSocketPath, defaultUtxoSKeyPath)
+import           Cardano.Node.Types (ConfigYamlFilePath (..), NodeProtocolConfiguration (..),
+                   npcTestStartingEra)
+import           Cardano.TxGenerator.Setup.NixService (NixServiceOptions (..), NodeDescription (..))
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import           Data.Char (isDigit)
+import           Data.List (isPrefixOf, sortOn)
+import           Data.List.NonEmpty (NonEmpty (..))
+import           Data.Maybe (mapMaybe)
+import           Data.Monoid (Last (..))
+import           Network.Socket (PortNumber)
+import           System.Directory (doesDirectoryExist, doesFileExist, listDirectory)
+import           System.Exit (die)
+import           System.FilePath ((</>), takeDirectory)
+import           Text.Read (readMaybe)
+
+
+-- | Whether to fill in default values for all 'NixServiceOptions' fields
+-- before merging the user-provided configuration.
+data FillDefaults
+  = FillDefaults
+    -- ^ Start from a complete 'defaultNixServiceOptions' (with discovered
+    -- infrastructure already applied), so any field the user omits gets a
+    -- sensible default.
+  | NoFillDefaults
+    -- ^ Start from only the discovered infrastructure keys; the user
+    -- configuration must supply every other required field.
+  deriving (Show, Eq)
+
+-- | Whether discovered infrastructure values (socket path, signing key,
+-- node config file, target nodes) should override the user-provided
+-- configuration.
+data ForceInfra
+  = ForceInfra
+    -- ^ After merging the user configuration, force the discovered
+    -- infrastructure keys back on top, so they always reflect the actual
+    -- testnet directory regardless of what the user supplied.
+  | NoForceInfra
+    -- ^ Let the user configuration win for infrastructure keys as well;
+    -- discovered values are used only when the user does not provide them.
+  deriving (Show, Eq)
+
+-- | Flags that control how the discovered testnet infrastructure is merged
+-- with user-provided JSON configuration in 'discoverTestnetConfig'.
+data TestnetMergeFlags = TestnetMergeFlags
+  { fillDefaults :: FillDefaults
+  , forceInfra   :: ForceInfra
+  } deriving (Show, Eq)
+
+-- | Everything 'discoverTestnetConfig' needs to locate a @cardano-testnet@
+-- output directory and decide how to merge its contents with user configuration.
+data TestnetConfig = TestnetConfig
+  { tcDir        :: FilePath
+  , tcMergeFlags :: TestnetMergeFlags
+  } deriving (Show, Eq)
+
+
+-- | Infrastructure fields discovered from a testnet directory.
+testnetSpecificKeys :: [Aeson.Key]
+testnetSpecificKeys =
+  [ "localNodeSocketPath"
+  , "sigKey"
+  , "nodeConfigFile"
+  , "targetNodes"
+  ]
+
+
+-- | Complete default values for all NixServiceOptions fields.
+-- Uses explicit field construction (no wildcards) so that adding a new required
+-- field to NixServiceOptions will cause a compile error here.
+defaultNixServiceOptions :: NixServiceOptions
+defaultNixServiceOptions = NixServiceOptions
+  { _nix_debugMode            = False
+  , _nix_tx_count             = 100
+  , _nix_tps                  = 10
+  , _nix_inputs_per_tx        = 2
+  , _nix_outputs_per_tx       = 2
+  , _nix_tx_fee               = L.Coin 212345
+  , _nix_min_utxo_value       = L.Coin 1000000
+  , _nix_add_tx_size          = 39
+  , _nix_init_cooldown        = 50
+  , _nix_era                  = AnyCardanoEra ConwayEra  -- placeholder, will be overridden
+  , _nix_plutus               = Nothing
+  , _nix_keepalive            = Just 30
+  , _nix_nodeConfigFile       = Nothing
+  , _nix_cardanoTracerSocket  = Nothing
+  , _nix_sigKey               = File ""    -- placeholder, will be overridden
+  , _nix_localNodeSocketPath  = ""         -- placeholder, will be overridden
+  , _nix_targetNodes          = NodeDescription
+      { ndAddr = mkLocalhostAddr 0
+      , ndName = ""
+      } :| []                              -- placeholder, will be overridden
+  }
+
+
+-- | Discover testnet config from a cardano-testnet output directory and merge
+-- it with optional user-provided JSON config according to the merge flags.
+discoverTestnetConfig :: TestnetConfig -> Aeson.Value -> IO NixServiceOptions
+discoverTestnetConfig TestnetConfig{tcDir, tcMergeFlags} userConfig = do
+  -- Validate that the directory exists
+  dirExists <- doesDirectoryExist tcDir
+  unless dirExists $ die $ "Testnet directory does not exist: " ++ tcDir
+
+  -- Discover infrastructure
+  era <- detectEra tcDir
+  targetNodes <- discoverNodes tcDir
+  let socketPath = tcDir </> defaultSocketPath 1
+      sigKeyPath = tcDir </> defaultUtxoSKeyPath 1
+      configPath = tcDir </> defaultConfigFile
+
+  -- Validate critical files
+  validateFileExists socketPath "socket"
+  validateFileExists sigKeyPath "signing key"
+  validateFileExists configPath "configuration"
+
+  -- Build the infra-populated defaults
+  let withInfra = defaultNixServiceOptions
+        { _nix_era                 = era
+        , _nix_localNodeSocketPath = socketPath
+        , _nix_sigKey              = File sigKeyPath
+        , _nix_nodeConfigFile      = Just configPath
+        , _nix_targetNodes         = targetNodes
+        }
+
+  -- Build JSON values for merge
+  let baseConfig       = Aeson.toJSON withInfra
+      testnetInfraOnly = extractInfraKeys baseConfig
+
+  -- Merge logic
+  let TestnetMergeFlags{fillDefaults = fd, forceInfra = fi} = tcMergeFlags
+
+  -- Step 1: Start with full defaults (if FillDefaults) or infra-only
+  let start = case fd of
+        FillDefaults   -> baseConfig
+        NoFillDefaults -> testnetInfraOnly
+
+  -- Step 2: Merge user config on top (user wins)
+  let merged = mergeValues start userConfig
+
+  -- Step 3: If ForceInfra, force infra keys back
+  let final = case fi of
+        ForceInfra   -> mergeValues merged testnetInfraOnly
+        NoForceInfra -> merged
+
+  -- Step 4: Deserialise back to NixServiceOptions
+  case Aeson.fromJSON final of
+    Aeson.Success opts -> pure opts
+    Aeson.Error err    -> die $ "Failed to parse merged config: " ++ err
+
+
+-- | Detect the era from the testnet's configuration.yaml using npcTestStartingEra.
+detectEra :: FilePath -> IO AnyCardanoEra
+detectEra dir = do
+  let configPath = dir </> defaultConfigFile
+  validateFileExists configPath "configuration"
+  pnc <- parseNodeConfigurationFP (Just (ConfigYamlFilePath configPath))
+  case getLast (pncProtocolConfig pnc) of
+    Nothing -> die $ "No protocol configuration found in: " ++ configPath
+    Just (NodeProtocolConfigurationCardano _ _ _ _ _ hfConfig _) ->
+      case npcTestStartingEra hfConfig of
+        Nothing -> die $ "Cannot detect era from config (no instant hard forks configured): " ++ configPath
+        Just (AnyShelleyBasedEra sbe) -> pure $ AnyCardanoEra (toCardanoEra sbe)
+
+
+-- | Discover nodes by scanning for port files in the testnet directory.
+-- cardano-testnet always starts nodes on localhost (see testnetDefaultIpv4Address
+-- in Testnet.Types). If remote/container support is added in the future,
+-- cardano-testnet should write node addresses to a metadata file.
+discoverNodes :: FilePath -> IO (NonEmpty NodeDescription)
+discoverNodes dir = do
+  -- Derive the base "node-data" directory from defaultNodeDataDir
+  let nodeDataDir = dir </> takeDirectory (defaultNodeDataDir 1)
+  exists <- doesDirectoryExist nodeDataDir
+  if not exists
+    then die $ "Node data directory does not exist: " ++ nodeDataDir
+    else do
+      entries <- listDirectory nodeDataDir
+      let nodeIndices = sortOn id $ mapMaybe parseNodeIndex entries
+      nodes <- mapM (readNodeDescription dir) nodeIndices
+      case nodes of
+        []     -> die $ "No nodes found in: " ++ nodeDataDir
+        (n:ns) -> pure (n :| ns)
+
+
+-- | Parse a node index from a directory name like "node1", "node2", etc.
+parseNodeIndex :: String -> Maybe Int
+parseNodeIndex name
+  | "node" `isPrefixOf` name = readMaybe (dropWhile (not . isDigit) name)
+  | otherwise = Nothing
+
+
+-- | Read a node description from its port file.
+readNodeDescription :: FilePath -> Int -> IO NodeDescription
+readNodeDescription dir idx = do
+  let portPath = dir </> defaultPortFile idx
+  validateFileExists portPath ("port file for " ++ defaultNodeName idx)
+  portStr <- readFile portPath
+  case readMaybe portStr :: Maybe PortNumber of
+    Nothing -> die $ "Invalid port number in: " ++ portPath
+    Just port -> pure NodeDescription
+      { ndAddr = mkLocalhostAddr port
+      , ndName = defaultNodeName idx
+      }
+
+-- | Create a localhost NodeIPv4Address at the given port.
+mkLocalhostAddr :: PortNumber -> NodeIPv4Address
+mkLocalhostAddr port = NodeAddress
+  { naHostAddress = NodeHostIPv4Address
+      { unNodeHostIPv4Address = read "127.0.0.1" }
+  , naPort = port
+  }
+
+
+-- | Extract only the infrastructure keys from a JSON value.
+extractInfraKeys :: Aeson.Value -> Aeson.Value
+extractInfraKeys (Aeson.Object obj) =
+  Aeson.Object $ KeyMap.filterWithKey (\k _ -> k `elem` testnetSpecificKeys) obj
+extractInfraKeys v = v
+
+
+-- | Deep merge two JSON values. Objects are merged recursively;
+-- for all other types the override wins.
+mergeValues :: Aeson.Value -> Aeson.Value -> Aeson.Value
+mergeValues (Aeson.Object base) (Aeson.Object override) =
+  Aeson.Object (KeyMap.unionWith mergeValues base override)
+mergeValues _ override = override
+
+
+-- | Validate that a file exists, dying with a clear message if not.
+validateFileExists :: FilePath -> String -> IO ()
+validateFileExists path description = do
+  exists <- doesFileExist path
+  unless exists $ die $ "Required " ++ description ++ " file not found: " ++ path

--- a/bench/tx-generator/src/Cardano/TxGenerator/Setup/TestnetDiscovery.hs
+++ b/bench/tx-generator/src/Cardano/TxGenerator/Setup/TestnetDiscovery.hs
@@ -1,0 +1,130 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.TxGenerator.Setup.TestnetDiscovery
+  ( TestnetConfig (..)
+  , discoverTestnetConfig
+  ) where
+
+import           Cardano.Node.Configuration.NodeAddress (NodeAddress' (..), NodeHostIPv4Address (..),
+                   NodeIPv4Address)
+import           Cardano.Node.Testnet.Paths (defaultConfigFile, defaultNodeDataDir, defaultNodeName,
+                   defaultPortFile, defaultSocketPath, defaultUtxoSKeyPath)
+import           Cardano.TxGenerator.Setup.NixService (NixServiceOptions, NodeDescription (..))
+
+import           Cardano.Prelude ( unless, sort )
+import           Data.Aeson ((.=), object)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import           Data.Char (isDigit)
+import           Data.List (isPrefixOf)
+import           Data.List.NonEmpty (NonEmpty (..))
+import           Data.Maybe (mapMaybe)
+import           Network.Socket (PortNumber)
+import           System.Directory (doesDirectoryExist, doesFileExist, listDirectory)
+import           System.Exit (die)
+import           System.FilePath ((</>), takeDirectory)
+import           Text.Read (readMaybe)
+
+-- | Location of a @cardano-testnet@ output directory.
+newtype TestnetConfig = TestnetConfig
+  { tcDir :: FilePath
+  } deriving (Show, Eq)
+
+
+-- | Discover testnet infrastructure from a @cardano-testnet@ output directory
+-- and merge it with user-provided JSON config.
+--
+-- The 4 infrastructure fields (@localNodeSocketPath@, @sigKey@,
+-- @nodeConfigFile@, @targetNodes@) are always populated from the testnet
+-- directory and override any values in the user config.  All other fields
+-- must be supplied by the user.
+discoverTestnetConfig :: TestnetConfig -> Aeson.Value -> IO NixServiceOptions
+discoverTestnetConfig TestnetConfig{tcDir} userConfig = do
+  dirExists <- doesDirectoryExist tcDir
+  unless dirExists $ die $ "Testnet directory does not exist: " ++ tcDir
+
+  targetNodes <- discoverNodes tcDir
+  let socketPath = tcDir </> defaultSocketPath 1
+      sigKeyPath = tcDir </> defaultUtxoSKeyPath 1
+      configPath = tcDir </> defaultConfigFile
+
+  validateFileExists socketPath "socket"
+  validateFileExists sigKeyPath "signing key"
+  validateFileExists configPath "configuration"
+
+  let infraJson = object
+        [ "localNodeSocketPath" .= socketPath
+        , "sigKey"              .= sigKeyPath
+        , "nodeConfigFile"      .= configPath
+        , "targetNodes"         .= targetNodes
+        ]
+
+  let merged = mergeValues userConfig infraJson
+
+  case Aeson.fromJSON merged of
+    Aeson.Success opts -> pure opts
+    Aeson.Error err    -> die $ "Failed to parse merged config: " ++ err
+
+
+-- | Discover nodes by scanning for port files in the testnet directory.
+-- cardano-testnet always starts nodes on localhost (see testnetDefaultIpv4Address
+-- in Testnet.Types). If remote/container support is added in the future,
+-- cardano-testnet should write node addresses to a metadata file.
+discoverNodes :: FilePath -> IO (NonEmpty NodeDescription)
+discoverNodes dir = do
+  let nodeDataDir = dir </> takeDirectory (defaultNodeDataDir 1)
+  exists <- doesDirectoryExist nodeDataDir
+  if not exists
+    then die $ "Node data directory does not exist: " ++ nodeDataDir
+    else do
+      entries <- listDirectory nodeDataDir
+      let nodeIndices = sort $ mapMaybe parseNodeIndex entries
+      nodes <- mapM (readNodeDescription dir) nodeIndices
+      case nodes of
+        []     -> die $ "No nodes found in: " ++ nodeDataDir
+        (n:ns) -> pure (n :| ns)
+
+
+-- | Parse a node index from a directory name like "node1", "node2", etc.
+parseNodeIndex :: String -> Maybe Int
+parseNodeIndex name
+  | "node" `isPrefixOf` name = readMaybe (dropWhile (not . isDigit) name)
+  | otherwise = Nothing
+
+
+-- | Read a node description from its port file.
+readNodeDescription :: FilePath -> Int -> IO NodeDescription
+readNodeDescription dir idx = do
+  let portPath = dir </> defaultPortFile idx
+  validateFileExists portPath ("port file for " ++ defaultNodeName idx)
+  portStr <- readFile portPath
+  case readMaybe portStr :: Maybe PortNumber of
+    Nothing -> die $ "Invalid port number in: " ++ portPath
+    Just port -> pure NodeDescription
+      { ndAddr = mkLocalhostAddr port
+      , ndName = defaultNodeName idx
+      }
+
+-- | Create a localhost NodeIPv4Address at the given port.
+mkLocalhostAddr :: PortNumber -> NodeIPv4Address
+mkLocalhostAddr port = NodeAddress
+  { naHostAddress = NodeHostIPv4Address
+      { unNodeHostIPv4Address = read "127.0.0.1" }
+  , naPort = port
+  }
+
+
+-- | Deep merge two JSON values. Objects are merged recursively;
+-- for all other types the override wins.
+mergeValues :: Aeson.Value -> Aeson.Value -> Aeson.Value
+mergeValues (Aeson.Object base) (Aeson.Object override) =
+  Aeson.Object (KeyMap.unionWith mergeValues base override)
+mergeValues _ override = override
+
+
+-- | Validate that a file exists, dying with a clear message if not.
+validateFileExists :: FilePath -> String -> IO ()
+validateFileExists path description = do
+  exists <- doesFileExist path
+  unless exists $ die $ "Required " ++ description ++ " file not found: " ++ path

--- a/bench/tx-generator/test/Main.hs
+++ b/bench/tx-generator/test/Main.hs
@@ -8,6 +8,7 @@ import           Test.Tasty
 import           Test.Tasty.HUnit
 
 import           Cardano.Benchmarking.GeneratorTx.SizedMetadata
+import           TestnetDiscoveryTest (testnetDiscoveryTests)
 
 main :: IO ()
 main = defaultMain tests
@@ -16,6 +17,7 @@ tests :: TestTree
 tests =  testGroup "cardano-tx-generator"
   [
     sizedMetadata
+  , testnetDiscoveryTests
   ]
 
 sizedMetadata :: TestTree

--- a/bench/tx-generator/test/TestnetDiscoveryTest.hs
+++ b/bench/tx-generator/test/TestnetDiscoveryTest.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
 
@@ -8,44 +9,258 @@ module TestnetDiscoveryTest
 
 import           Prelude
 
-import           Data.Aeson (Value, (.=), encode, fromJSON, object, toJSON)
-import           Data.Aeson.Types (Result (..))
+import           Control.Exception (bracket, evaluate, try, SomeException)
+import           Data.Aeson (FromJSON, Value (..), (.=), (.:), encode, fromJSON, object, toJSON,
+                   withObject)
+import           Data.Aeson.KeyMap qualified as KM (member)
+import           Data.Aeson.Key (Key, fromString)
+import           Data.Aeson.Types (Result (..), parseMaybe)
 import           Data.ByteString.Lazy as LBS (writeFile)
+import           Data.Monoid.Extra (mwhen)
+import           Data.Either (isLeft)
+import           Data.List (isSuffixOf)
+import           GHC.IO.Handle (hDuplicate, hDuplicateTo)
 import           System.Directory (createDirectoryIfMissing)
 import           System.FilePath (takeDirectory, (</>))
+import           System.IO (IOMode (..), hClose, openFile, stderr)
 import           System.IO.Temp (withSystemTempDirectory)
 import           Test.Tasty
 import           Test.Tasty.HUnit
+import           Test.Tasty.QuickCheck (testProperty)
+import           Test.QuickCheck hiding (Success, expectFailure)
 
+import           Cardano.Api (AnyCardanoEra (..), CardanoEra (..))
 import           Cardano.Node.Testnet.Paths (defaultConfigFile, defaultPortFile,
                    defaultSocketPath, defaultUtxoSKeyPath)
+import           Cardano.TxGenerator.Setup.NixService (NixServiceOptions (..))
 import           Cardano.TxGenerator.Setup.TestnetDiscovery (FillDefaults (..), ForceInfra (..),
                    TestnetConfig (..), TestnetMergeFlags (..), discoverTestnetConfig)
+import           Cardano.Node.Configuration.NodeAddress (unFile)
 
 
 testnetDiscoveryTests :: TestTree
 testnetDiscoveryTests = testGroup "TestnetDiscovery"
-  [ testCase "round-trip: discoverTestnetConfig result survives JSON serialization" roundTripTest
+  [ testCase "round-trip: JSON serialization" roundTripTest
+  , testProperty "merge flags produce predictable results" prop_mergeFlags
   ]
 
 
--- | Create a mock testnet directory with the minimum files needed by discoverTestnetConfig,
--- then verify that the discovered NixServiceOptions survives a JSON round-trip.
+-- | Verify that the discovered NixServiceOptions survives a JSON round-trip.
 roundTripTest :: Assertion
-roundTripTest = withSystemTempDirectory "mock-testnet" $ \tmpDir -> do
-  setupMockTestnetDir tmpDir
+roundTripTest = withMockTestnet $ \tmpDir -> do
+  opts <- discover tmpDir FillDefaults NoForceInfra (object mempty)
+  let json = toJSON opts
+  case fromJSON json of
+    Error err -> assertFailure $ "JSON round-trip failed: " ++ err ++ "\nJSON: " ++ show json
+    Success opts' -> opts @?= opts'
 
-  let tc = TestnetConfig
-        { tcDir = tmpDir
-        , tcMergeFlags = TestnetMergeFlags FillDefaults NoForceInfra
-        }
-  opts <- discoverTestnetConfig tc (object mempty)
 
-  case fromJSON (toJSON opts) of
-    Error err ->
-      assertFailure $ "JSON round-trip deserialization failed: " ++ err
-    Success opts' ->
-      opts @?= opts'
+-- Property test --
+
+-- | Non-probe required field names.
+baseFieldNames :: [String]
+baseFieldNames = [ "debugMode", "era", "inputs_per_tx", "outputs_per_tx"
+                 , "tx_fee", "min_utxo_value", "add_tx_size", "init_cooldown" ]
+
+-- | Required probe fields (non-infra, checked in the property).
+requiredProbeNames :: [String]
+requiredProbeNames = ["tps", "tx_count"]
+
+-- | Infra probe field (discovery always provides it, but user may override).
+infraProbeNames :: [String]
+infraProbeNames = ["localNodeSocketPath"]
+
+-- | All probe field names.
+probeFieldNames :: [String]
+probeFieldNames = requiredProbeNames ++ infraProbeNames
+
+-- | All field names subject to the biased selection (keepalive is handled separately).
+allFieldNames :: [String]
+allFieldNames = baseFieldNames ++ probeFieldNames
+
+-- | Non-infra keys required for 'NixServiceOptions' parsing to succeed.
+requiredKeys :: [Key]
+requiredKeys = map fromString (baseFieldNames ++ requiredProbeNames)
+
+
+-- | Generate a user config JSON with biased field selection:
+--
+-- * 25% base fields only
+-- * 25% probe fields only
+-- * 30% everything
+-- * 20% a random subset (count uniformly chosen from @[0..all]@)
+genUserConfig :: Gen Value
+genUserConfig = do
+  tpsVal       <- choose (1 :: Int, 1000)
+  txCountVal   <- choose (1 :: Int, 10000)
+  socketVal    <- ("/test/socket/" ++) . show <$> choose (1 :: Int, 100)
+  keepaliveVal <- oneof [pure Nothing, Just <$> choose (1 :: Integer, 120)]
+
+  included <- frequency
+    [ (25, pure baseFieldNames)
+    , (25, pure probeFieldNames)
+    , (30, pure allFieldNames)
+    , (20, randomSubset allFieldNames)
+    ]
+
+  let has :: String -> Bool
+      has n = n `elem` included
+
+  let allFields :: [(String, Value)]
+      allFields =
+        [ ("debugMode",           toJSON False)
+        , ("era",                 toJSON (AnyCardanoEra ConwayEra))
+        , ("tps",                 toJSON tpsVal)
+        , ("tx_count",            toJSON txCountVal)
+        , ("inputs_per_tx",       toJSON (2 :: Int))
+        , ("outputs_per_tx",      toJSON (2 :: Int))
+        , ("tx_fee",              toJSON (212345 :: Int))
+        , ("min_utxo_value",      toJSON (1000000 :: Int))
+        , ("add_tx_size",         toJSON (39 :: Int))
+        , ("init_cooldown",       toJSON (50 :: Double))
+        , ("localNodeSocketPath", toJSON socketVal)
+        ]
+
+  pure $ object
+    $  [ fromString k .= v | (k, v) <- allFields, has k ]
+    ++ [ "keepalive" .= v | Just v <- [keepaliveVal] ]
+
+
+-- | Pick a uniformly random number of elements from a list.
+randomSubset :: [a] -> Gen [a]
+randomSubset xs = do
+  n <- choose (0, length xs)
+  take n <$> shuffle xs
+
+
+-- | Predict whether 'discoverTestnetConfig' will fail, by inspecting the
+-- actual JSON content.
+expectFailure :: FillDefaults -> Value -> Bool
+expectFailure NoFillDefaults (Object obj) = not $ all (`KM.member` obj) requiredKeys
+expectFailure NoFillDefaults _            = True
+expectFailure FillDefaults   _            = False
+
+
+-- | Extract a field from a JSON 'Value', returning 'Nothing' if absent.
+jsonField :: FromJSON a => Key -> Value -> Maybe a
+jsonField k = parseMaybe (withObject "config" (.: k))
+
+
+-- | Property: the merge logic in 'discoverTestnetConfig' produces predictable
+-- results depending on 'FillDefaults', 'ForceInfra', and which fields the user
+-- provides.
+--
+-- Three independently generated variables: 'FillDefaults', 'ForceInfra', and
+-- a biased random user config JSON.
+prop_mergeFlags :: Property
+prop_mergeFlags =
+  forAll arbitraryBoundedEnum $ \fd ->
+  forAll arbitraryBoundedEnum $ \fi ->
+  forAll genUserConfig $ \userConfig ->
+  let fails = expectFailure fd userConfig
+  in
+  cover 5 (fd == FillDefaults   && fi == NoForceInfra)                "FillDefaults + NoForceInfra (success)" $
+  cover 5 (fd == FillDefaults   && fi == ForceInfra)                  "FillDefaults + ForceInfra (success)" $
+  cover 1 (fd == NoFillDefaults && fi == NoForceInfra && not fails) "NoFillDefaults + NoForceInfra (success)" $
+  cover 1 (fd == NoFillDefaults && fi == ForceInfra && not fails)   "NoFillDefaults + ForceInfra (success)" $
+  cover 5 (fails && fi == NoForceInfra)                             "NoFillDefaults + NoForceInfra (failure)" $
+  cover 5 (fails && fi == ForceInfra)                               "NoFillDefaults + ForceInfra (failure)" $
+  ioProperty $ withMockTestnet $ \tmpDir -> do
+    let tryDiscover :: IO (Either SomeException NixServiceOptions)
+        tryDiscover = try (evaluate =<< discover tmpDir fd fi userConfig)
+    result <- if fails then withSilentStderr tryDiscover else tryDiscover
+
+    pure $ conjoin
+      [
+        -- Check 1: outcome matches prediction from expectFailure
+        counterexample
+          ("outcome: expected " ++ (if fails then "failure" else "success")
+           ++ ", got " ++ either (\e -> "failure (" ++ show e ++ ")") (const "success") result)
+        $ property (isLeft result == fails)
+
+        -- Check 2: in the success case, verify the merged values
+      , case result of
+          Left _ -> property fails
+          Right opts ->
+            let expectedTps :: Double
+                expectedTps = case (fd, jsonField "tps" userConfig :: Maybe Int) of
+                  (_,              Just v)  -> fromIntegral v
+                  (FillDefaults,   Nothing) -> 10
+                  (NoFillDefaults, Nothing) -> error "unreachable: expectFailure guards this"
+
+                expectedTxCount :: Int
+                expectedTxCount = case (fd, jsonField "tx_count" userConfig :: Maybe Int) of
+                  (_,              Just v)  -> v
+                  (FillDefaults,   Nothing) -> 100
+                  (NoFillDefaults, Nothing) -> error "unreachable: expectFailure guards this"
+
+                sigKeyOk :: Bool
+                sigKeyOk = defaultUtxoSKeyPath 1 `isSuffixOf` unFile (_nix_sigKey opts)
+
+                socketPathAssertion :: Property
+                socketPathAssertion = case (fi, jsonField "localNodeSocketPath" userConfig :: Maybe String) of
+                  (NoForceInfra, Just v) -> counterexample "wrong socket path: " $ _nix_localNodeSocketPath opts === v
+                  (_,            _)      -> assertSuffix "socket path unexpected:" (defaultSocketPath 1) (_nix_localNodeSocketPath opts)
+
+                -- keepalive is optional, non-infra, non-required:
+                -- ForceInfra should never affect it.
+                expectedKeepalive :: Maybe Integer
+                expectedKeepalive = case (fd, jsonField "keepalive" userConfig :: Maybe Integer) of
+                  (_,              Just v)  -> Just v
+                  (FillDefaults,   Nothing) -> Just 30
+                  (NoFillDefaults, Nothing) -> Nothing
+
+            in conjoin
+              [ counterexample ("tps: expected " ++ show expectedTps ++ ", got " ++ show (_nix_tps opts))
+                  $ _nix_tps opts === expectedTps
+              , counterexample ("tx_count: expected " ++ show expectedTxCount ++ ", got " ++ show (_nix_tx_count opts))
+                  $ _nix_tx_count opts === expectedTxCount
+              , counterexample ("sigKey should end with testnet path, got: " ++ unFile (_nix_sigKey opts))
+                  $ property sigKeyOk
+              , socketPathAssertion
+              , counterexample ("keepalive: expected " ++ show expectedKeepalive ++ ", got " ++ show (_nix_keepalive opts))
+                  $ _nix_keepalive opts === expectedKeepalive
+              ]
+      ]
+  where
+    -- Asserts that the specified expected value is a suffix of
+    -- the actual value, providing better error messages for path checks.
+    assertSuffix :: String -> String -> String -> Property
+    assertSuffix preface expectedSuffix actual =
+      if expectedSuffix `isSuffixOf` actual
+        then property True
+        else counterexample ((munless (null preface) preface ++ "\n") ++
+              "expected string with suffix: " ++ show expectedSuffix ++ "\n but got: " ++ show actual) $ property False
+      where
+        munless :: Monoid m => Bool -> m -> m
+        munless b = mwhen (not b)
+
+
+-- Helpers
+
+-- | Run an IO action with stderr silenced. Useful for expected-failure tests
+-- where 'die' prints an error message before throwing.
+withSilentStderr :: IO a -> IO a
+withSilentStderr action = bracket acquire release (const action)
+  where
+    acquire = do
+      saved <- hDuplicate stderr
+      devNull <- openFile "/dev/null" WriteMode
+      hDuplicateTo devNull stderr
+      pure (saved, devNull)
+    release (saved, devNull) = do
+      hDuplicateTo saved stderr
+      hClose saved
+      hClose devNull
+
+withMockTestnet :: (FilePath -> IO a) -> IO a
+withMockTestnet action = withSystemTempDirectory "mock-testnet" $ \dir -> do
+  setupMockTestnetDir dir
+  action dir
+
+discover :: FilePath -> FillDefaults -> ForceInfra -> Value -> IO NixServiceOptions
+discover dir fd fi = discoverTestnetConfig
+    TestnetConfig { tcDir = dir, tcMergeFlags = TestnetMergeFlags fd fi }
 
 
 -- | Set up a minimal mock testnet directory with all files that discoverTestnetConfig expects.

--- a/bench/tx-generator/test/TestnetDiscoveryTest.hs
+++ b/bench/tx-generator/test/TestnetDiscoveryTest.hs
@@ -215,17 +215,19 @@ prop_connectionSettingsOverride =
 
 -- | Run an IO action with stderr silenced.
 withSilentStderr :: IO a -> IO a
-withSilentStderr action = bracket acquire release (const action)
+withSilentStderr action =
+  withSystemTempDirectory "silent-stderr" $ \dir ->
+    bracket (acquire (dir </> "stderr")) release (const action)
   where
-    acquire = do
+    acquire path = do
       saved <- hDuplicate stderr
-      devNull <- openFile "/dev/null" WriteMode
-      hDuplicateTo devNull stderr
-      pure (saved, devNull)
-    release (saved, devNull) = do
+      sink <- openFile path WriteMode
+      hDuplicateTo sink stderr
+      pure (saved, sink)
+    release (saved, sink) = do
       hDuplicateTo saved stderr
       hClose saved
-      hClose devNull
+      hClose sink
 
 withMockTestnet :: (FilePath -> IO a) -> IO a
 withMockTestnet action = withSystemTempDirectory "mock-testnet" $ \dir -> do

--- a/bench/tx-generator/test/TestnetDiscoveryTest.hs
+++ b/bench/tx-generator/test/TestnetDiscoveryTest.hs
@@ -42,11 +42,11 @@ import           Data.Maybe (fromMaybe)
 testnetDiscoveryTests :: TestTree
 testnetDiscoveryTests = testGroup "TestnetDiscovery"
   [ testCase "round-trip: JSON serialization" roundTripTest
-  , testProperty "infra fields always override user config" prop_infraOverride
+  , testProperty "connection settings always override user config" prop_connectionSettingsOverride
   ]
 
 
--- | A complete user config that provides all required non-infra fields.
+-- | A complete user config that provides all required fields besides connection settings.
 completeUserConfig :: Value
 completeUserConfig = object
   [ "debugMode"      .= False
@@ -74,26 +74,26 @@ roundTripTest = withMockTestnet $ \tmpDir -> do
 
 -- Property test --
 
--- | Non-infra required field names.
+-- | Required field names (excluding connection settings).
 requiredFieldNames :: [String]
 requiredFieldNames = [ "debugMode", "era", "inputs_per_tx", "outputs_per_tx"
                      , "tx_fee", "min_utxo_value", "add_tx_size", "init_cooldown"
                      , "tps", "tx_count" ]
 
--- | Required keys for NixServiceOptions parsing to succeed (non-infra only).
+-- | Required keys for NixServiceOptions parsing to succeed (excluding connection settings).
 requiredKeys :: [Key]
 requiredKeys = map fromString requiredFieldNames
 
 
 -- | Generate a user config JSON with a biased random subset of required fields,
--- and optionally with user-provided infra fields that should be overridden.
+-- and optionally with user-provided connection settings that should be overridden.
 genUserConfig :: Gen Value
 genUserConfig = do
   tpsVal       <- choose (1 :: Int, 1000)
   txCountVal   <- choose (1 :: Int, 10000)
   socketVal    <- ("/test/socket/" ++) . show <$> choose (1 :: Int, 100)
   keepaliveVal <- oneof [pure Nothing, Just <$> choose (1 :: Integer, 120)]
-  includeInfra <- arbitrary
+  includeConnectionSettings <- arbitrary
 
   included <- frequency
     [ (70, pure requiredFieldNames)
@@ -120,7 +120,7 @@ genUserConfig = do
   pure $ object
     $  [ fromString k .= v | (k, v) <- allFields, has k ]
     ++ [ "keepalive" .= v | Just v <- [keepaliveVal] ]
-    ++ [ "localNodeSocketPath" .= socketVal | includeInfra ]
+    ++ [ "localNodeSocketPath" .= socketVal | includeConnectionSettings ]
 
 
 -- | Pick a uniformly random number of elements from a list.
@@ -131,7 +131,7 @@ randomSubset xs = do
 
 
 -- | Predict whether 'discoverTestnetConfig' will fail: all required
--- non-infra fields must be present in the user config.
+-- all required fields besides connection settings must be present in the user config.
 expectFailure :: Value -> Bool
 expectFailure (Object obj) = not $ all (`KM.member` obj) requiredKeys
 expectFailure _            = True
@@ -142,11 +142,11 @@ jsonField :: FromJSON a => Key -> Value -> Maybe a
 jsonField k = parseMaybe (withObject "config" (.: k))
 
 
--- | Property: infrastructure fields always come from the testnet directory
--- regardless of what the user supplies; non-infra fields come from the user
--- config; missing required non-infra fields cause failure.
-prop_infraOverride :: Property
-prop_infraOverride =
+-- | Property: connection settings always come from the testnet directory
+-- regardless of what the user supplies; remaining fields come from the user
+-- config; missing required fields cause failure.
+prop_connectionSettingsOverride :: Property
+prop_connectionSettingsOverride =
   forAll genUserConfig $ \userConfig ->
   let fails = expectFailure userConfig
       hasUserSocket = case jsonField "localNodeSocketPath" userConfig :: Maybe String of
@@ -155,7 +155,7 @@ prop_infraOverride =
   in
   cover 30 (not fails)                        "success" $
   cover 5  fails                              "failure (missing required)" $
-  cover 5  (hasUserSocket && not fails)       "user provides infra (should be overridden)" $
+  cover 5  (hasUserSocket && not fails)       "user provides connection settings (should be overridden)" $
   ioProperty $ withMockTestnet $ \tmpDir -> do
     let tryDiscover :: IO (Either SomeException NixServiceOptions)
         tryDiscover = try (evaluate =<< discover tmpDir userConfig)

--- a/bench/tx-generator/test/TestnetDiscoveryTest.hs
+++ b/bench/tx-generator/test/TestnetDiscoveryTest.hs
@@ -1,0 +1,117 @@
+{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
+
+module TestnetDiscoveryTest
+  ( testnetDiscoveryTests
+  ) where
+
+import           Prelude
+
+import           Data.Aeson (Value (..), (.=), encode, fromJSON, object, toJSON)
+import           Data.Aeson.Types (Result (..))
+import           Data.ByteString.Lazy as LBS (writeFile)
+import           System.Directory (createDirectoryIfMissing)
+import           System.FilePath (takeDirectory, (</>))
+import           System.IO.Temp (withSystemTempDirectory)
+import           Test.Tasty
+import           Test.Tasty.HUnit
+
+import           Cardano.Api (AnyCardanoEra (..), CardanoEra (..))
+import           Cardano.Node.Testnet.Paths (defaultConfigFile, defaultPortFile,
+                   defaultSocketPath, defaultUtxoSKeyPath)
+import           Cardano.TxGenerator.Setup.NixService (NixServiceOptions (..))
+import           Cardano.TxGenerator.Setup.TestnetDiscovery (TestnetConfig (..),
+                   discoverTestnetConfig)
+
+
+testnetDiscoveryTests :: TestTree
+testnetDiscoveryTests = testGroup "TestnetDiscovery"
+  [ testCase "round-trip: JSON serialization" roundTripTest
+  ]
+
+
+-- | A complete user config that provides all required non-infra fields.
+completeUserConfig :: Value
+completeUserConfig = object
+  [ "debugMode"      .= False
+  , "era"            .= AnyCardanoEra ConwayEra
+  , "tps"            .= (10 :: Int)
+  , "tx_count"       .= (100 :: Int)
+  , "inputs_per_tx"  .= (2 :: Int)
+  , "outputs_per_tx" .= (2 :: Int)
+  , "tx_fee"         .= (212345 :: Int)
+  , "min_utxo_value" .= (1000000 :: Int)
+  , "add_tx_size"    .= (39 :: Int)
+  , "init_cooldown"  .= (50 :: Double)
+  ]
+
+
+-- | Verify that the discovered NixServiceOptions survives a JSON round-trip.
+roundTripTest :: Assertion
+roundTripTest = withMockTestnet $ \tmpDir -> do
+  opts <- discover tmpDir completeUserConfig
+  let json = toJSON opts
+  case fromJSON json of
+    Error err -> assertFailure $ "JSON round-trip failed: " ++ err ++ "\nJSON: " ++ show json
+    Success opts' -> opts @?= opts'
+
+
+-- Helpers
+
+withMockTestnet :: (FilePath -> IO a) -> IO a
+withMockTestnet action = withSystemTempDirectory "mock-testnet" $ \dir -> do
+  setupMockTestnetDir dir
+  action dir
+
+discover :: FilePath -> Value -> IO NixServiceOptions
+discover dir = discoverTestnetConfig TestnetConfig { tcDir = dir }
+
+
+-- | Set up a minimal mock testnet directory with all files that discoverTestnetConfig expects.
+setupMockTestnetDir :: FilePath -> IO ()
+setupMockTestnetDir dir = do
+  mapM_ (setupNodeDir dir) [1..3]
+
+  let socketPath = dir </> defaultSocketPath 1
+  createDirectoryIfMissing True (takeDirectory socketPath)
+  Prelude.writeFile socketPath ""
+
+  let sigKeyPath = dir </> defaultUtxoSKeyPath 1
+  createDirectoryIfMissing True (takeDirectory sigKeyPath)
+  Prelude.writeFile sigKeyPath "{}"
+
+  let configPath = dir </> defaultConfigFile
+  LBS.writeFile configPath $ encode minimalTestnetConfig
+
+
+-- | Create a node data directory with a port file.
+setupNodeDir :: FilePath -> Int -> IO ()
+setupNodeDir dir idx = do
+  let portPath = dir </> defaultPortFile idx
+  createDirectoryIfMissing True (takeDirectory portPath)
+  Prelude.writeFile portPath (show (30000 + idx))
+
+
+-- | Minimal configuration.yaml that will allow node-config parsing.
+minimalTestnetConfig :: Value
+minimalTestnetConfig = object
+  [ "Protocol"                       .= ("Cardano" :: String)
+  , "LastKnownBlockVersion-Major"    .= (9 :: Int)
+  , "LastKnownBlockVersion-Minor"    .= (0 :: Int)
+  , "LastKnownBlockVersion-Alt"      .= (0 :: Int)
+  , "ByronGenesisFile"               .= ("byron-genesis.json" :: String)
+  , "ShelleyGenesisFile"             .= ("shelley-genesis.json" :: String)
+  , "AlonzoGenesisFile"              .= ("alonzo-genesis.json" :: String)
+  , "ConwayGenesisFile"              .= ("conway-genesis.json" :: String)
+  , "DijkstraGenesisFile"            .= ("dijkstra-genesis.json" :: String)
+  , "RequiresNetworkMagic"           .= ("RequiresMagic" :: String)
+  , "ExperimentalHardForksEnabled"   .= True
+  , "ExperimentalProtocolsEnabled"   .= True
+  , "TestShelleyHardForkAtEpoch"     .= (0 :: Int)
+  , "TestAllegraHardForkAtEpoch"     .= (0 :: Int)
+  , "TestMaryHardForkAtEpoch"        .= (0 :: Int)
+  , "TestAlonzoHardForkAtEpoch"      .= (0 :: Int)
+  , "TestBabbageHardForkAtEpoch"     .= (0 :: Int)
+  , "TestConwayHardForkAtEpoch"      .= (0 :: Int)
+  ]

--- a/bench/tx-generator/test/TestnetDiscoveryTest.hs
+++ b/bench/tx-generator/test/TestnetDiscoveryTest.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
+
+module TestnetDiscoveryTest
+  ( testnetDiscoveryTests
+  ) where
+
+import           Prelude
+
+import           Data.Aeson (Value, (.=), encode, fromJSON, object, toJSON)
+import           Data.Aeson.Types (Result (..))
+import           Data.ByteString.Lazy as LBS (writeFile)
+import           System.Directory (createDirectoryIfMissing)
+import           System.FilePath (takeDirectory, (</>))
+import           System.IO.Temp (withSystemTempDirectory)
+import           Test.Tasty
+import           Test.Tasty.HUnit
+
+import           Cardano.Node.Testnet.Paths (defaultConfigFile, defaultPortFile,
+                   defaultSocketPath, defaultUtxoSKeyPath)
+import           Cardano.TxGenerator.Setup.TestnetDiscovery (FillDefaults (..), ForceInfra (..),
+                   TestnetConfig (..), TestnetMergeFlags (..), discoverTestnetConfig)
+
+
+testnetDiscoveryTests :: TestTree
+testnetDiscoveryTests = testGroup "TestnetDiscovery"
+  [ testCase "round-trip: discoverTestnetConfig result survives JSON serialization" roundTripTest
+  ]
+
+
+-- | Create a mock testnet directory with the minimum files needed by discoverTestnetConfig,
+-- then verify that the discovered NixServiceOptions survives a JSON round-trip.
+roundTripTest :: Assertion
+roundTripTest = withSystemTempDirectory "mock-testnet" $ \tmpDir -> do
+  setupMockTestnetDir tmpDir
+
+  let tc = TestnetConfig
+        { tcDir = tmpDir
+        , tcMergeFlags = TestnetMergeFlags FillDefaults NoForceInfra
+        }
+  opts <- discoverTestnetConfig tc (object mempty)
+
+  case fromJSON (toJSON opts) of
+    Error err ->
+      assertFailure $ "JSON round-trip deserialization failed: " ++ err
+    Success opts' ->
+      opts @?= opts'
+
+
+-- | Set up a minimal mock testnet directory with all files that discoverTestnetConfig expects.
+setupMockTestnetDir :: FilePath -> IO ()
+setupMockTestnetDir dir = do
+  mapM_ (setupNodeDir dir) [1..3]
+
+  let socketPath = dir </> defaultSocketPath 1
+  createDirectoryIfMissing True (takeDirectory socketPath)
+  Prelude.writeFile socketPath ""
+
+  let sigKeyPath = dir </> defaultUtxoSKeyPath 1
+  createDirectoryIfMissing True (takeDirectory sigKeyPath)
+  Prelude.writeFile sigKeyPath "{}"
+
+  let configPath = dir </> defaultConfigFile
+  LBS.writeFile configPath $ encode minimalTestnetConfig
+
+
+-- | Create a node data directory with a port file.
+setupNodeDir :: FilePath -> Int -> IO ()
+setupNodeDir dir idx = do
+  let portPath = dir </> defaultPortFile idx
+  createDirectoryIfMissing True (takeDirectory portPath)
+  Prelude.writeFile portPath (show (30000 + idx))
+
+
+-- | Minimal configuration.yaml that will parse and allow era detection.
+minimalTestnetConfig :: Value
+minimalTestnetConfig = object
+  [ "Protocol"                       .= ("Cardano" :: String)
+  , "LastKnownBlockVersion-Major"    .= (9 :: Int)
+  , "LastKnownBlockVersion-Minor"    .= (0 :: Int)
+  , "LastKnownBlockVersion-Alt"      .= (0 :: Int)
+  , "ByronGenesisFile"               .= ("byron-genesis.json" :: String)
+  , "ShelleyGenesisFile"             .= ("shelley-genesis.json" :: String)
+  , "AlonzoGenesisFile"              .= ("alonzo-genesis.json" :: String)
+  , "ConwayGenesisFile"              .= ("conway-genesis.json" :: String)
+  , "DijkstraGenesisFile"            .= ("dijkstra-genesis.json" :: String)
+  , "RequiresNetworkMagic"           .= ("RequiresMagic" :: String)
+  , "ExperimentalHardForksEnabled"   .= True
+  , "ExperimentalProtocolsEnabled"   .= True
+  , "TestShelleyHardForkAtEpoch"     .= (0 :: Int)
+  , "TestAllegraHardForkAtEpoch"     .= (0 :: Int)
+  , "TestMaryHardForkAtEpoch"        .= (0 :: Int)
+  , "TestAlonzoHardForkAtEpoch"      .= (0 :: Int)
+  , "TestBabbageHardForkAtEpoch"     .= (0 :: Int)
+  , "TestConwayHardForkAtEpoch"      .= (0 :: Int)
+  ]

--- a/bench/tx-generator/test/TestnetDiscoveryTest.hs
+++ b/bench/tx-generator/test/TestnetDiscoveryTest.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
 
@@ -8,14 +9,25 @@ module TestnetDiscoveryTest
 
 import           Prelude
 
-import           Data.Aeson (Value (..), (.=), encode, fromJSON, object, toJSON)
-import           Data.Aeson.Types (Result (..))
+import           Control.Exception (bracket, evaluate, try, SomeException)
+import           Data.Aeson (FromJSON, Value (..), (.=), (.:), encode, fromJSON, object, toJSON,
+                   withObject)
+import           Data.Aeson.KeyMap qualified as KM (member)
+import           Data.Aeson.Key (Key, fromString)
+import           Data.Aeson.Types (Result (..), parseMaybe)
 import           Data.ByteString.Lazy as LBS (writeFile)
+import           Data.Either (isLeft)
+import           Data.List (isSuffixOf)
+import           Data.Monoid.Extra (mwhen)
+import           GHC.IO.Handle (hDuplicate, hDuplicateTo)
 import           System.Directory (createDirectoryIfMissing)
 import           System.FilePath (takeDirectory, (</>))
+import           System.IO (IOMode (..), hClose, openFile, stderr)
 import           System.IO.Temp (withSystemTempDirectory)
 import           Test.Tasty
 import           Test.Tasty.HUnit
+import           Test.Tasty.QuickCheck (testProperty)
+import           Test.QuickCheck hiding (Success, expectFailure)
 
 import           Cardano.Api (AnyCardanoEra (..), CardanoEra (..))
 import           Cardano.Node.Testnet.Paths (defaultConfigFile, defaultPortFile,
@@ -23,11 +35,14 @@ import           Cardano.Node.Testnet.Paths (defaultConfigFile, defaultPortFile,
 import           Cardano.TxGenerator.Setup.NixService (NixServiceOptions (..))
 import           Cardano.TxGenerator.Setup.TestnetDiscovery (TestnetConfig (..),
                    discoverTestnetConfig)
+import           Cardano.Node.Configuration.NodeAddress (unFile)
+import           Data.Maybe (fromMaybe)
 
 
 testnetDiscoveryTests :: TestTree
 testnetDiscoveryTests = testGroup "TestnetDiscovery"
   [ testCase "round-trip: JSON serialization" roundTripTest
+  , testProperty "infra fields always override user config" prop_infraOverride
   ]
 
 
@@ -57,7 +72,160 @@ roundTripTest = withMockTestnet $ \tmpDir -> do
     Success opts' -> opts @?= opts'
 
 
+-- Property test --
+
+-- | Non-infra required field names.
+requiredFieldNames :: [String]
+requiredFieldNames = [ "debugMode", "era", "inputs_per_tx", "outputs_per_tx"
+                     , "tx_fee", "min_utxo_value", "add_tx_size", "init_cooldown"
+                     , "tps", "tx_count" ]
+
+-- | Required keys for NixServiceOptions parsing to succeed (non-infra only).
+requiredKeys :: [Key]
+requiredKeys = map fromString requiredFieldNames
+
+
+-- | Generate a user config JSON with a biased random subset of required fields,
+-- and optionally with user-provided infra fields that should be overridden.
+genUserConfig :: Gen Value
+genUserConfig = do
+  tpsVal       <- choose (1 :: Int, 1000)
+  txCountVal   <- choose (1 :: Int, 10000)
+  socketVal    <- ("/test/socket/" ++) . show <$> choose (1 :: Int, 100)
+  keepaliveVal <- oneof [pure Nothing, Just <$> choose (1 :: Integer, 120)]
+  includeInfra <- arbitrary
+
+  included <- frequency
+    [ (70, pure requiredFieldNames)
+    , (30, randomSubset requiredFieldNames)
+    ]
+
+  let has :: String -> Bool
+      has n = n `elem` included
+
+  let allFields :: [(String, Value)]
+      allFields =
+        [ ("debugMode",           toJSON False)
+        , ("era",                 toJSON (AnyCardanoEra ConwayEra))
+        , ("tps",                 toJSON tpsVal)
+        , ("tx_count",            toJSON txCountVal)
+        , ("inputs_per_tx",       toJSON (2 :: Int))
+        , ("outputs_per_tx",      toJSON (2 :: Int))
+        , ("tx_fee",              toJSON (212345 :: Int))
+        , ("min_utxo_value",      toJSON (1000000 :: Int))
+        , ("add_tx_size",         toJSON (39 :: Int))
+        , ("init_cooldown",       toJSON (50 :: Double))
+        ]
+
+  pure $ object
+    $  [ fromString k .= v | (k, v) <- allFields, has k ]
+    ++ [ "keepalive" .= v | Just v <- [keepaliveVal] ]
+    ++ [ "localNodeSocketPath" .= socketVal | includeInfra ]
+
+
+-- | Pick a uniformly random number of elements from a list.
+randomSubset :: [a] -> Gen [a]
+randomSubset xs = do
+  n <- choose (0, length xs)
+  take n <$> shuffle xs
+
+
+-- | Predict whether 'discoverTestnetConfig' will fail: all required
+-- non-infra fields must be present in the user config.
+expectFailure :: Value -> Bool
+expectFailure (Object obj) = not $ all (`KM.member` obj) requiredKeys
+expectFailure _            = True
+
+
+-- | Extract a field from a JSON 'Value', returning 'Nothing' if absent.
+jsonField :: FromJSON a => Key -> Value -> Maybe a
+jsonField k = parseMaybe (withObject "config" (.: k))
+
+
+-- | Property: infrastructure fields always come from the testnet directory
+-- regardless of what the user supplies; non-infra fields come from the user
+-- config; missing required non-infra fields cause failure.
+prop_infraOverride :: Property
+prop_infraOverride =
+  forAll genUserConfig $ \userConfig ->
+  let fails = expectFailure userConfig
+      hasUserSocket = case jsonField "localNodeSocketPath" userConfig :: Maybe String of
+                        Just _ -> True
+                        Nothing -> False
+  in
+  cover 30 (not fails)                        "success" $
+  cover 5  fails                              "failure (missing required)" $
+  cover 5  (hasUserSocket && not fails)       "user provides infra (should be overridden)" $
+  ioProperty $ withMockTestnet $ \tmpDir -> do
+    let tryDiscover :: IO (Either SomeException NixServiceOptions)
+        tryDiscover = try (evaluate =<< discover tmpDir userConfig)
+    result <- if fails then withSilentStderr tryDiscover else tryDiscover
+
+    pure $ conjoin
+      [
+        counterexample
+          ("outcome: expected " ++ (if fails then "failure" else "success")
+           ++ ", got " ++ either (\e -> "failure (" ++ show e ++ ")") (const "success") result)
+        $ property (isLeft result == fails)
+
+      , case result of
+          Left _ -> property fails
+          Right opts ->
+            let expectedTps :: Double
+                expectedTps = case jsonField "tps" userConfig :: Maybe Int of
+                  Just v  -> fromIntegral v
+                  Nothing -> error "unreachable: expectFailure guards this"
+
+                expectedTxCount :: Int
+                expectedTxCount = case jsonField "tx_count" userConfig :: Maybe Int of
+                  Just v  -> v
+                  Nothing -> error "unreachable: expectFailure guards this"
+
+                expectedKeepalive :: Maybe Integer
+                expectedKeepalive = jsonField "keepalive" userConfig
+
+            in conjoin
+              [ assertSuffix "sigKey from discovery:"
+                  (defaultUtxoSKeyPath 1)
+                  (unFile (_nix_sigKey opts))
+              , assertSuffix "socket path from discovery:"
+                  (defaultSocketPath 1)
+                  (_nix_localNodeSocketPath opts)
+              , assertSuffix "nodeConfigFile from discovery:"
+                  defaultConfigFile
+                  (fromMaybe "" (_nix_nodeConfigFile opts))
+              , _nix_tps opts === expectedTps
+              , _nix_tx_count opts === expectedTxCount
+              , _nix_keepalive opts === expectedKeepalive
+              ]
+      ]
+  where
+    assertSuffix :: String -> String -> String -> Property
+    assertSuffix preface expectedSuffix actual =
+      if expectedSuffix `isSuffixOf` actual
+        then property True
+        else counterexample (munless (null preface) (preface ++ "\n") ++
+              "expected string with suffix: " ++ show expectedSuffix ++ "\n but got: " ++ show actual) $ property False
+      where
+        munless :: Monoid m => Bool -> m -> m
+        munless b = mwhen (not b)
+
+
 -- Helpers
+
+-- | Run an IO action with stderr silenced.
+withSilentStderr :: IO a -> IO a
+withSilentStderr action = bracket acquire release (const action)
+  where
+    acquire = do
+      saved <- hDuplicate stderr
+      devNull <- openFile "/dev/null" WriteMode
+      hDuplicateTo devNull stderr
+      pure (saved, devNull)
+    release (saved, devNull) = do
+      hDuplicateTo saved stderr
+      hClose saved
+      hClose devNull
 
 withMockTestnet :: (FilePath -> IO a) -> IO a
 withMockTestnet action = withSystemTempDirectory "mock-testnet" $ \dir -> do

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   tx-generator
-version:                2.15
+version:                2.16
 synopsis:               A transaction workload generator for Cardano clusters
 description:            A transaction workload generator for Cardano clusters.
 category:               Cardano,

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -257,9 +257,12 @@ test-suite tx-generator-test
                       , cardano-api
                       , cardano-node
                       , directory
+                      , extra
                       , filepath
+                      , QuickCheck
                       , tasty
                       , tasty-hunit
+                      , tasty-quickcheck
                       , temporary
                       , tx-generator
 

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -252,9 +252,17 @@ test-suite tx-generator-test
   type:                 exitcode-stdio-1.0
 
   build-depends:        base
+                      , aeson
+                      , bytestring
+                      , cardano-node
+                      , directory
+                      , filepath
                       , tasty
                       , tasty-hunit
+                      , temporary
                       , tx-generator
+
+  other-modules:        TestnetDiscoveryTest
 
   ghc-options:          -Weverything
                         -fno-warn-missing-import-lists

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -252,9 +252,18 @@ test-suite tx-generator-test
   type:                 exitcode-stdio-1.0
 
   build-depends:        base
+                      , aeson
+                      , bytestring
+                      , cardano-api
+                      , cardano-node
+                      , directory
+                      , filepath
                       , tasty
                       , tasty-hunit
+                      , temporary
                       , tx-generator
+
+  other-modules:        TestnetDiscoveryTest
 
   ghc-options:          -Weverything
                         -fno-warn-missing-import-lists

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -86,6 +86,7 @@ library
                         Cardano.TxGenerator.Script.Types
                         Cardano.TxGenerator.Setup.NixService
                         Cardano.TxGenerator.Setup.NodeConfig
+                        Cardano.TxGenerator.Setup.TestnetDiscovery
                         Cardano.TxGenerator.Setup.Plutus
                         Cardano.TxGenerator.PlutusContext
                         Cardano.TxGenerator.Setup.SigningKey
@@ -127,6 +128,7 @@ library
                       , cborg >= 0.2.2 && < 0.3
                       , containers
                       , constraints-extras
+                      , directory
                       , dlist
                       , extra
                       , filepath

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -254,11 +254,15 @@ test-suite tx-generator-test
   build-depends:        base
                       , aeson
                       , bytestring
+                      , cardano-api
                       , cardano-node
                       , directory
+                      , extra
                       , filepath
+                      , QuickCheck
                       , tasty
                       , tasty-hunit
+                      , tasty-quickcheck
                       , temporary
                       , tx-generator
 


### PR DESCRIPTION
# Description

Adds a `--testnet-config-dir` flag to `tx-generator json_highlevel` that auto-discovers connection settings config (socket path, signing key, node config, target nodes) from a `cardano-testnet` output directory, using the shared path conventions from `Cardano.Node.Testnet.Paths`.

Discovered infrastructure always overrides any user-provided values for those fields.  All other config fields must be supplied by the user.

Closes #6513 (part 2 of #6510). Depends on #6518 (part 1).

**What's new:**

- `Cardano.TxGenerator.Setup.TestnetDiscovery` module — scans testnet dir for infrastructure config, merges with user config at JSON level (infrastructure always wins)
- `json_highlevel` parser now accepts either a full config file (existing behaviour preserved) or `--testnet-config-dir` with an optional partial config overlay
- Property-based test verifying infrastructure fields always override user-provided values, and that missing required non-infra fields cause failure

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - property tests
  - roundtrip tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff
