### PR TITLE
Fix flaky tests by using retryUntilJustM which should provide more reliable wait

### DIFF
--- a/cardano-testnet/changelog.d/20260414_154349_mgalazyn_fix_flaky_tests.md
+++ b/cardano-testnet/changelog.d/20260414_154349_mgalazyn_fix_flaky_tests.md
@@ -1,0 +1,10 @@
+### Tests
+
+- Replaced `waitForBlocks 1` followed by immediate assertions with `retryUntilM`/`retryUntilJustM` polling.
+  The old pattern was flaky on aarch64-linux because `waitForBlocks` only guarantees the block number advanced, not that a submitted transaction was included in that block.
+  Affected tests: Simple Script Mint, Simple Script CostCalculation, TxReferenceInputDatum (two sites), RegisterDeregisterStakeAddress (two sites), and MultiAssetReturnCollateral.
+- Added `retryUntilM` to `Testnet.Components.Query` -- a variant of `retryUntilJustM` that takes a plain action and a predicate, and annotates the failing value on timeout for better observability.
+- Switched all remaining `integrationWorkspace` tests to `integrationRetryWorkspace 2` so that transient failures are retried automatically.
+  Affected tests: FoldEpochState, Simple Script Mint, DRep Deposits, DRep Activity, Predefined Abstain DRep, PlutusV3 purposes, PlutusV2 two script certs, Collateral With Multiassets, Committee Add New, No Confidence, and Transaction Build Estimate.
+- Replaced `waitForEpochs 3` with `watchEpochStateUpdate` polling for the expected treasury value in `TreasuryDonation`.
+  The old pattern assumed the donation would be reflected within 3 epochs, which is not guaranteed.

--- a/cardano-testnet/src/Testnet/Components/Query.hs
+++ b/cardano-testnet/src/Testnet/Components/Query.hs
@@ -27,6 +27,7 @@ module Testnet.Components.Query
   , waitUntilEpoch
   , waitForBlocks
   , retryUntilJustM
+  , retryUntilM
 
   , findAllUtxos
   , findUtxosWithAddress
@@ -182,6 +183,49 @@ retryUntilJustM esv timeout act = withFrozenCallStack $ do
         Nothing -> do
           H.threadDelay 300_000
           go startingValue
+
+    getCurrentValue = withFrozenCallStack $
+      case timeout of
+        WaitForEpochs _ -> unEpochNo <$> getCurrentEpochNo esv
+        WaitForSlots _ -> unSlotNo <$> getSlotNumber esv
+        WaitForBlocks _ -> unBlockNo <$> getBlockNumber esv
+
+    timeoutW64 =
+      case timeout of
+        WaitForEpochs (EpochInterval n) -> fromIntegral n
+        WaitForSlots n -> n
+        WaitForBlocks n -> n
+
+-- | Like 'retryUntilJustM' but takes a plain action and a predicate instead of
+-- an action returning 'Maybe'. On timeout, annotates the last value that failed
+-- the predicate. Intermediate attempts produce no annotations.
+retryUntilM
+  :: HasCallStack
+  => MonadIO m
+  => MonadTest m
+  => MonadAssertion m
+  => Show a
+  => EpochStateView
+  -> TestnetWaitPeriod -- ^ timeout
+  -> m a              -- ^ action to retry
+  -> (a -> Bool)      -- ^ predicate that must hold
+  -> m a
+retryUntilM esv timeout act predicate = withFrozenCallStack $ do
+  startingValue <- getCurrentValue
+  go startingValue
+  where
+    go startingValue = withFrozenCallStack $ do
+      result <- act
+      if predicate result
+        then pure result
+        else do
+          cv <- getCurrentValue
+          if timeoutW64 + startingValue < cv
+            then do
+              H.noteShow_ result
+              H.note_ $ "Predicate not satisfied after: " <> show timeout
+              H.failure
+            else H.threadDelay 300_000 >> go startingValue
 
     getCurrentValue = withFrozenCallStack $
       case timeout of

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Api/TxReferenceInputDatum.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Api/TxReferenceInputDatum.hs
@@ -164,11 +164,9 @@ hprop_tx_refin_datum = integrationRetryWorkspace 2 "api-tx-refin-dat" $ \tempAbs
     expectTxSubmissionSuccess =<< submitTx sbe connectionInfo tx
 
     -- wait till transaction gets included in the block
-    _ <- waitForBlocks epochStateView 1
-
-    -- test if it's in UTxO set
-    utxo1 <- findAllUtxos epochStateView sbe
-    let txUtxo = Utxo.filterWithKey (\(TxIn txId' _) _ -> txId == txId') utxo1
+    txUtxo <- retryUntilM epochStateView (WaitForBlocks 5)
+      (Utxo.filterWithKey (\(TxIn txId' _) _ -> txId == txId') <$> findAllUtxos epochStateView sbe)
+      (not . Utxo.null)
     (length txOuts + 1) === length (toList txUtxo)
 
     let chainTxOuts =
@@ -177,7 +175,7 @@ hprop_tx_refin_datum = integrationRetryWorkspace 2 "api-tx-refin-dat" $ \tempAbs
             . reverse
             . map snd
             . toList
-            $ Utxo.filterWithKey (\(TxIn txId' _) _ -> txId == txId') utxo1
+            $ txUtxo
 
     -- check that the transaction's outputs are the same as we've submitted them
     -- i.e. check the datums
@@ -227,11 +225,11 @@ hprop_tx_refin_datum = integrationRetryWorkspace 2 "api-tx-refin-dat" $ \tempAbs
     expectTxSubmissionSuccess =<< submitTx sbe connectionInfo tx
 
     -- wait till transaction gets included in the block
-    _ <- waitForBlocks epochStateView 1
+    txUtxo <- retryUntilM epochStateView (WaitForBlocks 5)
+      (Utxo.filterWithKey (\(TxIn txId' _) _ -> txId == txId') <$> findAllUtxos epochStateView sbe)
+      (not . Utxo.null)
 
     -- test if the transaction is visible in UTxO set
-    utxo1 <- findAllUtxos epochStateView sbe
-    let txUtxo = Utxo.filterWithKey (\(TxIn txId' _) _ -> txId == txId') utxo1
     [toCtxUTxOTxOut txOut] === (snd <$> toList txUtxo)
     pure txUtxo
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Plutus/MultiAssetReturnCollateral.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Plutus/MultiAssetReturnCollateral.hs
@@ -4,16 +4,18 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Cardano.Testnet.Test.Cli.Plutus.MultiAssetReturnCollateral 
+module Cardano.Testnet.Test.Cli.Plutus.MultiAssetReturnCollateral
   ( hprop_collateral_with_tokens
-  ) where 
+  ) where
 
 import           Cardano.Api
+
 import           Cardano.Testnet
 
 import           Prelude
+
+import           Control.Monad (mfilter, void)
 import qualified Data.Aeson as Aeson
-import           Control.Monad (void)
 import           Data.Default.Class
 import qualified Data.Text as T
 import           System.FilePath ((</>))
@@ -21,8 +23,9 @@ import           System.FilePath ((</>))
 import           Testnet.Components.Configuration
 import           Testnet.Components.Query
 import           Testnet.Defaults
+import           Testnet.Process.Cli.Transaction (retrieveTransactionId)
 import           Testnet.Process.Run (execCli', mkExecConfig)
-import           Testnet.Property.Util (integrationWorkspace)
+import           Testnet.Property.Util (integrationRetryWorkspace)
 import           Testnet.Types
 
 import           Hedgehog (Property)
@@ -31,7 +34,7 @@ import qualified Hedgehog.Extras as H
 
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/Collateral With Multiassets/"'@
 hprop_collateral_with_tokens :: Property
-hprop_collateral_with_tokens = integrationWorkspace "collateral-with-tokens" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
+hprop_collateral_with_tokens = integrationRetryWorkspace 2 "collateral-with-tokens" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
   work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
@@ -71,12 +74,12 @@ hprop_collateral_with_tokens = integrationWorkspace "collateral-with-tokens" $ \
     ]
   utxo1 <- findUtxosWithAddress epochStateView sbe $ paymentKeyInfoAddr wallet0
 
-  H.noteShow_ utxo1 
+  H.noteShow_ utxo1
     -- Create a simple always-succeeds Plutus V3 script
   plutusScript <- H.note $ work </> "always-succeeds-script.plutusV3"
   H.writeFile plutusScript $ T.unpack plutusV3Script
 
-  
+
   -- Get the policy ID
   mintingPolicyId <- filter (/= '\n') <$>
     execCli' execConfig
@@ -84,9 +87,9 @@ hprop_collateral_with_tokens = integrationWorkspace "collateral-with-tokens" $ \
       , "policyid"
       , "--script-file", plutusScript
       ]
-      
+
   let assetName = "7161636f696e" -- "qacoin" in hex
-  
+
   -- Create a Plutus script address
   plutusSpendingScriptAddr <-
     execCli' execConfig
@@ -113,7 +116,7 @@ hprop_collateral_with_tokens = integrationWorkspace "collateral-with-tokens" $ \
     , "--tx-in-collateral", T.unpack $ renderTxIn txinCollateral
     , "--tx-out-return-collateral", adaOnlyCollateralValue
     , "--witness-override", show @Int 2
-    , "--tx-out", collateralToBeValue 
+    , "--tx-out", collateralToBeValue
     , "--tx-out", fundPlutusScriptAddrVal
     , "--tx-out-datum-hash-value", "0"
     , "--mint", mintValue
@@ -129,6 +132,7 @@ hprop_collateral_with_tokens = integrationWorkspace "collateral-with-tokens" $ \
     , "--signing-key-file", signingKeyFp $ paymentKeyInfoPair wallet1
     , "--out-file", mintTokensTx
     ]
+  mintTxId <- retrieveTransactionId execConfig $ File mintTokensTx
   let mintTxDebugFile = work </> "mint-tokens-tx-view.json"
   void $ execCli' execConfig ["debug", "transaction", "view", "--tx-file", mintTokensTx, "--out-file", mintTxDebugFile]
 
@@ -144,14 +148,14 @@ hprop_collateral_with_tokens = integrationWorkspace "collateral-with-tokens" $ \
 
   -- STEP 2: Attempt to spend from script with collateral containing tokens
   -- This will fail because collateral cannot contain non-ADA tokens
-  
-  -- Wait for transactions to be processed and find UTxOs
-  _ <- waitForBlocks epochStateView 1
-  
-  -- Find the UTxO with tokens at wallet1 (for collateral)
-  txinCollateralWithTokensM <- 
-    findLargestMultiAssetUtxoWithAddress epochStateView sbe $ T.pack maCollateralAddress
-  (txinCollateralWithTokens, collateralTxOut) <- H.evalMaybe txinCollateralWithTokensM
+
+  -- Wait for the mint transaction to appear on chain, then find the specific
+  -- multi-asset UTxO it created at wallet2 (for use as collateral with tokens)
+  (txinCollateralWithTokens, collateralTxOut) <-
+    retryUntilJustM epochStateView (WaitForBlocks 5) $
+      mfilter (\(TxIn txId' _, _) -> txId' == mintTxId)
+        <$> findLargestMultiAssetUtxoWithAddress epochStateView sbe (T.pack maCollateralAddress)
+
   H.note_ "Collateral TxOut"
   H.noteShow_  collateralTxOut
   -- Find the UTxO at the script address
@@ -173,8 +177,8 @@ hprop_collateral_with_tokens = integrationWorkspace "collateral-with-tokens" $ \
     , "--out-file", spendScriptUTxOTxBody
     ]
   let prettyTxBodyFile = work </> "spend-script-utxo-tx-body-view.json"
-  void $ execCli' execConfig ["debug", "transaction", "view", "--tx-body-file", spendScriptUTxOTxBody, "--out-file", prettyTxBodyFile] 
-  
+  void $ execCli' execConfig ["debug", "transaction", "view", "--tx-body-file", spendScriptUTxOTxBody, "--out-file", prettyTxBodyFile]
+
   txBodyPrettyJson :: Aeson.Value <- H.leftFailM . H.readJsonFile $ prettyTxBodyFile
   H.note_ "Tx body"
   H.noteShowPretty_ txBodyPrettyJson
@@ -186,10 +190,10 @@ hprop_collateral_with_tokens = integrationWorkspace "collateral-with-tokens" $ \
     , "--signing-key-file", signingKeyFp $ paymentKeyInfoPair wallet2
     , "--out-file", spendScriptUTxOTx
     ]
-  
+
   let prettyTxFile = work </> "spend-script-utxo-tx-view.json"
-  void $ execCli' execConfig ["debug", "transaction", "view", "--tx-file", spendScriptUTxOTx, "--out-file", prettyTxFile] 
-  
+  void $ execCli' execConfig ["debug", "transaction", "view", "--tx-file", spendScriptUTxOTx, "--out-file", prettyTxFile]
+
   txPrettyJson :: Aeson.Value <- H.leftFailM . H.readJsonFile $ prettyTxFile
   H.noteShowPretty_ txPrettyJson
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Plutus/Scripts.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Plutus/Scripts.hs
@@ -28,7 +28,7 @@ import           Testnet.Components.Query
 import           Testnet.Defaults
 import           Testnet.Process.Cli.SPO
 import           Testnet.Process.Run (execCli', execCliAny, mkExecConfig)
-import           Testnet.Property.Util (integrationWorkspace)
+import           Testnet.Property.Util (integrationRetryWorkspace)
 import           Testnet.Types
 
 import           Hedgehog (Property)
@@ -46,7 +46,7 @@ import qualified Hedgehog.Extras as H
 -- Execute me with:
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/PlutusV3 purposes/"'@
 hprop_plutus_purposes_v3 :: Property
-hprop_plutus_purposes_v3 = integrationWorkspace "all-plutus-script-purposes" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
+hprop_plutus_purposes_v3 = integrationRetryWorkspace 2 "all-plutus-script-purposes" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
   work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
@@ -196,7 +196,7 @@ hprop_plutus_purposes_v3 = integrationWorkspace "all-plutus-script-purposes" $ \
 -- Execute me with:
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/PlutusV2 transaction with two script certs/"'@
 hprop_tx_two_script_certs_v2 :: Property
-hprop_tx_two_script_certs_v2 = integrationWorkspace "tx-2-script-certs" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
+hprop_tx_two_script_certs_v2 = integrationRetryWorkspace 2 "tx-2-script-certs" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
   work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
@@ -257,8 +257,8 @@ hprop_tx_two_script_certs_v2 = integrationWorkspace "tx-2-script-certs" $ \tempA
   let txbody = work </> "two-certs-tx-body"
       tx = work </> "two-certs-tx"
       txout = mconcat [ utxoAddr, "+", show @Int 2_000_000 ]
-  
-  s <- execCli' execConfig [anyEraToString anyEra, "transaction", "policyid", "--script-file", plutusScript] 
+
+  s <- execCli' execConfig [anyEraToString anyEra, "transaction", "policyid", "--script-file", plutusScript]
   H.note_ $ "Script hash: " <> s
   let txBuildArgs =
         [ anyEraToString anyEra, "transaction", "build"

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Scripts/Simple/CostCalculation.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Scripts/Simple/CostCalculation.hs
@@ -11,26 +11,27 @@ import           Cardano.Api hiding (Value)
 import           Cardano.Api.Experimental (Some (Some))
 import           Cardano.Api.Ledger (EpochInterval (..))
 import           Cardano.Api.UTxO (difference, size)
+
 import           Cardano.Testnet
 
 import           Prelude
-import           Testnet.Types
 
 import           Control.Monad (void)
-
 import           Data.Default.Class (Default (def))
 import qualified Data.Text as Text
 import           System.FilePath ((</>))
 import qualified System.Info as SYS
 
-import           Testnet.Components.Query (getEpochStateView, getTxIx, waitForBlocks,
-                   watchEpochStateUpdate, findAllUtxos)
-import qualified Testnet.Defaults  as Defaults
+import           Testnet.Components.Query (TestnetWaitPeriod (..), findAllUtxos, getEpochStateView,
+                   getTxIx, retryUntilM, watchEpochStateUpdate)
+import qualified Testnet.Defaults as Defaults
 import           Testnet.Process.Cli.Transaction (TxOutAddress (..), mkSpendOutputsOnlyTx,
                    retrieveTransactionId, signTx, submitTx)
 import           Testnet.Process.Run (execCli', mkExecConfig)
 import           Testnet.Property.Util (integrationRetryWorkspace)
 import           Testnet.Start.Types (eraToString)
+import           Testnet.Types
+
 import           Hedgehog (Property)
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
@@ -60,7 +61,7 @@ hprop_ref_simple_script_mint = integrationRetryWorkspace 2 "ref-simple-script" $
     , wallets = wallet0 : wallet1 : _
     } <-
     createAndRunTestnet options def conf
-  
+
   poolNode1 <- H.headM testnetNodes
   poolSprocket1 <- H.noteShow $ nodeSprocket poolNode1
   execConfig <- mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
@@ -69,7 +70,7 @@ hprop_ref_simple_script_mint = integrationRetryWorkspace 2 "ref-simple-script" $
   refScriptSizeWork <- H.createDirectoryIfMissing $ work </> "ref-script-publish"
 
   let utxoVKeyFile2 = verificationKeyFp $ paymentKeyInfoPair wallet1
-      
+
   reqSignerHash <- filter (/= '\n') <$>
     execCli' execConfig
       [ eraName, "address", "key-hash"
@@ -148,7 +149,7 @@ hprop_ref_simple_script_mint = integrationRetryWorkspace 2 "ref-simple-script" $
   -- Attempt to mint from a refernce script
   let assetName = "4D696C6C6172436F696E"
 
- 
+
   simpleMintingPolicyId <- filter (/= '\n') <$>
      execCli' execConfig
        [ eraName, "transaction"
@@ -186,14 +187,11 @@ hprop_ref_simple_script_mint = integrationRetryWorkspace 2 "ref-simple-script" $
       "signed-tx"
       unsignedUnlockTx
       [Some $ paymentKeyInfoPair wallet1]
-  
+
   utxoPre <- findAllUtxos epochStateView sbe
 
 
   submitTx execConfig cEra signedUnlockTx
-  void $ waitForBlocks epochStateView 1 
-  utxoPost <- findAllUtxos epochStateView sbe
-
-  let diff = difference utxoPost utxoPre
-      
-  size diff H.=== 2
+  void $ retryUntilM epochStateView (WaitForBlocks 5)
+    (size . (`difference` utxoPre) <$> findAllUtxos epochStateView sbe)
+    (== 2)

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Scripts/Simple/Mint.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Scripts/Simple/Mint.hs
@@ -29,16 +29,15 @@ import           Testnet.Components.Query
 import           Testnet.Defaults
 import           Testnet.Process.Cli.SPO
 import           Testnet.Process.Run (execCli', mkExecConfig)
-import           Testnet.Property.Util (integrationWorkspace)
+import           Testnet.Property.Util (integrationRetryWorkspace)
 import           Testnet.Types
 
 import           Hedgehog (Property)
-import qualified Hedgehog as H
 import qualified Hedgehog.Extras as H
 
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/Simple Script.Simple Script Mint/"'@
 hprop_simple_script_mint :: Property
-hprop_simple_script_mint = integrationWorkspace "simple-script-mint" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
+hprop_simple_script_mint = integrationRetryWorkspace 2 "simple-script-mint" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
   work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
@@ -138,10 +137,10 @@ hprop_simple_script_mint = integrationWorkspace "simple-script-mint" $ \tempAbsB
 
   let spendScriptUTxOTxBody = work </> "spend-script-utxo-tx-body"
       spendScriptUTxOTx = work </> "spend-script-utxo-tx"
- 
+
       txoutWithSupplementalDatum = mconcat [utxoAddr, "+", show @Int 1_000_000]
 
-  -- Mint with a simple script 
+  -- Mint with a simple script
   reqSignerHash <- filter (/= '\n') <$>
     execCli' execConfig
       [ anyEraToString anyEra, "address", "key-hash"
@@ -168,7 +167,7 @@ hprop_simple_script_mint = integrationWorkspace "simple-script-mint" $ \tempAbsB
        ]
 
   H.note_ plutusScriptTestPolId
-  
+
   let mintValue = mconcat ["5 ", simpleMintingPolicyId, ".", assetName]
       txout = mconcat [ utxoAddr, "+", show @Int 2_000_000
                        , "+", mintValue
@@ -203,9 +202,6 @@ hprop_simple_script_mint = integrationWorkspace "simple-script-mint" $ \tempAbsB
     [ "latest", "transaction", "submit"
     , "--tx-file", spendScriptUTxOTx
     ]
-  void $ waitForBlocks epochStateView 1 
-  utxoPost <- findAllUtxos epochStateView sbe
-
-  let diff = difference  utxoPost utxoPre
-
-  size diff H.=== 3
+  void $ retryUntilM epochStateView (WaitForBlocks 5)
+    (size . (`difference` utxoPre) <$> findAllUtxos epochStateView sbe)
+    (== 3)

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction/BuildEstimate.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction/BuildEstimate.hs
@@ -24,10 +24,9 @@ import           System.FilePath ((</>))
 import           Testnet.Components.Configuration
 import           Testnet.Components.Query
 import           Testnet.Process.Cli.Keys
-import           Testnet.Process.Cli.SPO (
-                   createStakeKeyRegistrationCertificate)
+import           Testnet.Process.Cli.SPO (createStakeKeyRegistrationCertificate)
 import           Testnet.Process.Run (execCli', mkExecConfig)
-import           Testnet.Property.Util (aesonObjectLookUp,integrationWorkspace)
+import           Testnet.Property.Util (aesonObjectLookUp, integrationRetryWorkspace)
 import           Testnet.Start.Types
 import           Testnet.Types
 
@@ -38,7 +37,7 @@ import qualified Hedgehog.Extras as H
 -- | Execute me with:
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/Transaction Build Estimate/"'@
 hprop_tx_build_estimate :: Property
-hprop_tx_build_estimate = integrationWorkspace "transaction-build-estimate" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
+hprop_tx_build_estimate = integrationRetryWorkspace 2 "transaction-build-estimate" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   -- Start a local test net
   conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
@@ -92,7 +91,7 @@ hprop_tx_build_estimate = integrationWorkspace "transaction-build-estimate" $ \t
     , "--out-file", work </> "pparams.json"
     ]
   let txBodyEstimateFile = work </> "tx-body-estimate.body"
-  void $ execCli' execConfig 
+  void $ execCli' execConfig
     [ eraName, "transaction", "build-estimate"
     , "--shelley-key-witnesses", "2"
     , "--byron-key-witnesses", "0"
@@ -109,17 +108,17 @@ hprop_tx_build_estimate = integrationWorkspace "transaction-build-estimate" $ \t
     , "--protocol-params-file", work </> "pparams.json"
     , "--out-file", txBodyEstimateFile
     ]
-  let debugOutputFile = work </> "debug-output.txt" 
+  let debugOutputFile = work </> "debug-output.txt"
   void $ execCli' execConfig ["debug", "transaction", "view", "--tx-file", txBodyEstimateFile, "--out-file", debugOutputFile]
 
   generated :: Aeson.Value <- H.leftFailM . H.readJsonFile $ debugOutputFile
   mFee <- aesonObjectLookUp generated "fee"
-  case mFee of 
+  case mFee of
     Just (Aeson.String feeText) ->  feeText === "380 Lovelace"
     Just v -> H.failMessage  callStack $ "Expected a String but got: " <> show v
     Nothing -> H.failMessage callStack "Expected a JSON object"
-  
- 
+
+
 
 
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction/RegisterDeregisterStakeAddress.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction/RegisterDeregisterStakeAddress.hs
@@ -130,15 +130,10 @@ hprop_tx_register_deregister_stake_address = integrationRetryWorkspace 2 "regist
     ]
 
 
-  _ <- waitForBlocks epochStateView 1
-
   H.note_ "Check that stake address is registered"
-  getAccountsStates epochStateView sbe >>=
-    flip H.assertWith
-      (\accountsStates -> isJust $ do
-        _state <- M.lookup stakeKeyHash accountsStates
-        pure () -- TODO: should we check for balance?
-        )
+  void $ retryUntilM epochStateView (WaitForBlocks 5)
+    (getAccountsStates epochStateView sbe)
+    (M.member stakeKeyHash)
 
   -- deregister stake address
   createStakeKeyDeregistrationCertificate
@@ -174,10 +169,8 @@ hprop_tx_register_deregister_stake_address = integrationRetryWorkspace 2 "regist
     , "--tx-file", stakeCertDeregTxSignedFp
     ]
 
-  _ <- waitForBlocks epochStateView 1
-
   H.note_ "Check that stake address is deregistered"
-  getAccountsStates epochStateView sbe >>=
-    flip H.assertWith
-      (isNothing . M.lookup stakeKeyHash)
+  void $ retryUntilM epochStateView (WaitForBlocks 5)
+    (getAccountsStates epochStateView sbe)
+    (M.notMember stakeKeyHash)
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/FoldEpochState.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/FoldEpochState.hs
@@ -16,7 +16,7 @@ import           Data.Default.Class
 import qualified System.Directory as IO
 import           System.FilePath ((</>))
 
-import           Testnet.Property.Util (integrationWorkspace)
+import           Testnet.Property.Util (integrationRetryWorkspace)
 
 import           Hedgehog ((===))
 import qualified Hedgehog as H
@@ -24,7 +24,7 @@ import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as H
 import qualified Hedgehog.Extras.Test as H
 
 prop_foldEpochState :: H.Property
-prop_foldEpochState = integrationWorkspace "foldEpochState" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
+prop_foldEpochState = integrationRetryWorkspace 2 "foldEpochState" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   conf <- TN.mkConf tempAbsBasePath'
 
   let tempAbsPath' = unTmpAbsPath $ tempAbsPath conf

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/CommitteeAddNew.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/CommitteeAddNew.hs
@@ -46,7 +46,7 @@ import           Testnet.Process.Cli.SPO (createStakeKeyRegistrationCertificate)
 import           Testnet.Process.Cli.Transaction (retrieveTransactionId, signTx, submitTx)
 import           Testnet.Process.Run (addEnvVarsToConfig, execCli', mkExecConfig)
 import           Testnet.Process.RunIO (liftIOAnnotated)
-import           Testnet.Property.Util (integrationWorkspace)
+import           Testnet.Property.Util (integrationRetryWorkspace)
 import           Testnet.Start.Types (GenesisOptions (..), cardanoNumPools)
 import           Testnet.Types
 
@@ -57,7 +57,7 @@ import qualified Hedgehog.Extras as H
 -- | Execute me with:
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/Committee Add New/"'@
 hprop_constitutional_committee_add_new :: Property
-hprop_constitutional_committee_add_new = integrationWorkspace "constitutional-committee-add-new" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
+hprop_constitutional_committee_add_new = integrationRetryWorkspace 2 "constitutional-committee-add-new" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
       tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
@@ -202,11 +202,11 @@ hprop_constitutional_committee_add_new = integrationWorkspace "constitutional-co
     , "--out-file", gov </> "stake-hash.addr"
     ]
 
-  stakeKeyHash <- H.readFile $ gov </> "stake-hash.addr" 
+  stakeKeyHash <- H.readFile $ gov </> "stake-hash.addr"
 
   H.note_ $ "Stake key hash:"  <> stakeKeyHash
 
-  
+
 
   -- Create temporary HTTP server with files required by the call to `cardano-cli`
   -- In this case, the server emulates an IPFS gateway

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepActivity.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepActivity.hs
@@ -39,7 +39,7 @@ import           Testnet.Process.Cli.Keys (cliStakeAddressKeyGen)
 import           Testnet.Process.Cli.SPO (createStakeKeyRegistrationCertificate)
 import           Testnet.Process.Cli.Transaction
 import           Testnet.Process.Run (execCli', mkExecConfig)
-import           Testnet.Property.Util (integrationWorkspace)
+import           Testnet.Property.Util (integrationRetryWorkspace)
 import           Testnet.Start.Types
 import           Testnet.Types
 
@@ -50,7 +50,7 @@ import qualified Hedgehog.Extras as H
 -- | Execute me with:
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/DRep Activity/"'@
 hprop_check_drep_activity :: Property
-hprop_check_drep_activity = integrationWorkspace "test-activity" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog $ \watchdog -> do
+hprop_check_drep_activity = integrationRetryWorkspace 2 "test-activity" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog $ \watchdog -> do
   -- Start a local test net
   conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepDeposit.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepDeposit.hs
@@ -21,7 +21,7 @@ import           Testnet.Components.Query
 import           Testnet.Process.Cli.DRep
 import           Testnet.Process.Cli.Transaction
 import           Testnet.Process.Run (mkExecConfig)
-import           Testnet.Property.Util (integrationWorkspace)
+import           Testnet.Property.Util (integrationRetryWorkspace)
 import           Testnet.Start.Types
 import           Testnet.Types
 
@@ -32,7 +32,7 @@ import qualified Hedgehog.Extras as H
 -- | Execute me with:
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/DRep Deposits/"'@
 hprop_ledger_events_drep_deposits :: Property
-hprop_ledger_events_drep_deposits = integrationWorkspace "drep-deposits" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
+hprop_ledger_events_drep_deposits = integrationRetryWorkspace 2 "drep-deposits" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
 
 
   conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs
@@ -39,7 +39,7 @@ import           Testnet.Process.Cli.Keys
 import qualified Testnet.Process.Cli.SPO as SPO
 import           Testnet.Process.Cli.Transaction
 import qualified Testnet.Process.Run as H
-import           Testnet.Property.Util (integrationWorkspace)
+import           Testnet.Property.Util (integrationRetryWorkspace)
 import           Testnet.Start.Cardano (liftToIntegration)
 import           Testnet.Start.Types
 import           Testnet.Types
@@ -54,7 +54,7 @@ import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
 -- Generate a testnet with a committee defined in the Conway genesis. Submit a motion of no confidence
 -- and have the required threshold of SPOs and DReps vote yes on it.
 hprop_gov_no_confidence :: Property
-hprop_gov_no_confidence = integrationWorkspace "no-confidence" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
+hprop_gov_no_confidence = integrationRetryWorkspace 2 "no-confidence" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
 
   conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
@@ -63,7 +63,7 @@ import qualified Hedgehog.Extras as H
 -- Execute me with:
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/Predefined Abstain DRep/"'@
 hprop_check_predefined_abstain_drep :: Property
-hprop_check_predefined_abstain_drep = H.integrationWorkspace "test-activity" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
+hprop_check_predefined_abstain_drep = H.integrationRetryWorkspace 2 "test-activity" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   -- Start a local test net
   conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryDonation.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryDonation.hs
@@ -146,8 +146,7 @@ doTreasuryDonation sbe execConfig work epochStateView wallet0 idx currentTreasur
       H.noteM_ $ execCli' execConfig
         [ "conway", "transaction", "submit" , "--tx-file", signedTxFp ]
 
-      void $ waitForEpochs epochStateView (EpochInterval 3)
-
-      L.Coin finalTreasury <- getTreasuryValue epochStateView
-      H.note_ $ "finalTreasury: " <> show finalTreasury
-      finalTreasury H.=== (currentTreasury + toInteger treasuryDonation)
+      let expectedTreasury = L.Coin $ currentTreasury + toInteger treasuryDonation
+      void $ retryUntilM epochStateView (WaitForEpochs $ EpochInterval 10)
+        (getTreasuryValue epochStateView)
+        (== expectedTreasury)


### PR DESCRIPTION
- Replaced `waitForBlocks 1` followed by immediate assertions with `retryUntilJustM` polling in seven test sites.
  The old pattern was flaky on aarch64-linux because `waitForBlocks` only guarantees the block number advanced, not that a submitted transaction was included in that block.
  Affected tests: Simple Script Mint, Simple Script CostCalculation, TxReferenceInputDatum (two sites), RegisterDeregisterStakeAddress (two sites), and MultiAssetReturnCollateral.

- Switched all remaining `integrationWorkspace` tests to `integrationRetryWorkspace 2` so that transient failures are retried automatically.
  Affected tests: FoldEpochState, Simple Script Mint, DRep Deposits, DRep Activity, Predefined Abstain DRep, PlutusV3 purposes, PlutusV2 two script certs, Collateral With Multiassets, Committee Add New, No Confidence, and Transaction Build Estimate.


# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
