### PR TITLE
cardano-testnet | Test transaction autobalancing with withdrawal

### DIFF
--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -218,6 +218,7 @@ test-suite cardano-testnet-test
                         Cardano.Testnet.Test.Cli.Transaction
                         Cardano.Testnet.Test.Cli.Transaction.BuildEstimate
                         Cardano.Testnet.Test.Cli.Transaction.RegisterDeregisterStakeAddress
+                        Cardano.Testnet.Test.Cli.Transaction.WithdrawalReward
                         Cardano.Testnet.Test.DumpConfig
                         Cardano.Testnet.Test.FoldEpochState
                         Cardano.Testnet.Test.Gov.CommitteeAddNew

--- a/cardano-testnet/changelog.d/20260424_075510_mgalazyn_test_withdrawal_balancing.md
+++ b/cardano-testnet/changelog.d/20260424_075510_mgalazyn_test_withdrawal_balancing.md
@@ -1,0 +1,4 @@
+
+### Tests
+
+- Added integration tests for `transaction build` with `--withdrawal`, covering both key-witnessed and Plutus V3 script-witnessed withdrawals. The tests verify that the auto-balancer correctly sums withdrawals into consumed value when the output exceeds the input.

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction/WithdrawalReward.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction/WithdrawalReward.hs
@@ -1,0 +1,196 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | Smoke tests for @transaction build@ with a @--withdrawal@ flag,
+-- covering both key-witnessed and Plutus-script-witnessed withdrawals.
+-- Loosely related to https://github.com/IntersectMBO/cardano-cli/issues/965.
+module Cardano.Testnet.Test.Cli.Transaction.WithdrawalReward
+  ( hprop_tx_withdrawal_reward
+  , hprop_tx_withdrawal_reward_plutus_v3
+  ) where
+
+import           Cardano.Api as Api
+import qualified Cardano.Api.Ledger as L
+
+import           Cardano.Testnet
+
+import           Prelude
+
+import           Control.Monad (void)
+import           Data.Default.Class
+import qualified Data.Text as Text
+import           System.Exit (ExitCode (..))
+import           System.FilePath ((</>))
+
+import           Testnet.Components.Configuration
+import           Testnet.Components.Query
+import           Testnet.Defaults (plutusV3Script)
+import           Testnet.Process.Run (execCli, execCliAny, mkExecConfig)
+import           Testnet.Property.Util (integrationRetryWorkspace)
+import           Testnet.Start.Types
+import           Testnet.Types
+
+import           Hedgehog
+import qualified Hedgehog as H
+import qualified Hedgehog.Extras as H
+
+
+-- | Smoke test: @transaction build@ builds a transaction whose output
+-- exceeds the input, with a @--withdrawal@ covering the shortfall
+-- (@output = 2 * input@, @withdrawal = 2 * input@). The auto-balancer
+-- sums the withdrawal into consumed value, producing
+-- @change = inputs + withdrawal - outputs - fee = input - fee@ (positive).
+--
+-- The withdrawal amount is fictional; the CLI does not validate it against
+-- on-chain reward balances at build time, and the test only exercises the
+-- build step.
+--
+-- Execute me with:
+-- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/transaction build with withdrawal/"'@
+hprop_tx_withdrawal_reward :: Property
+hprop_tx_withdrawal_reward = integrationRetryWorkspace 2 "tx-withdrawal-reward" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
+  conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
+  let tempAbsPath' = unTmpAbsPath tempAbsPath
+      tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
+
+  work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
+
+  let ceo = ConwayEraOnwardsConway
+      sbe = convert ceo
+      eraName = eraToString sbe
+      fastTestnetOptions = def { cardanoNodeEra = AnyShelleyBasedEra sbe }
+      shelleyOptions = def { genesisEpochLength = 100 }
+
+  TestnetRuntime
+    { testnetMagic
+    , testnetNodes
+    , wallets = wallet0:_
+    , configurationFile
+    }
+    <- createAndRunTestnet fastTestnetOptions shelleyOptions conf
+
+  node <- H.headM testnetNodes
+  poolSprocket1 <- H.noteShow $ nodeSprocket node
+  execConfig <- mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
+  let socketPath = nodeSocketPath node
+
+  epochStateView <- getEpochStateView configurationFile socketPath
+
+  let delegatorStakeVKeyFp = tempAbsPath' </> "stake-delegators" </> "delegator1" </> "staking.vkey"
+
+  delegatorStakeAddress <- filter (/= '\n') <$>
+    execCli
+      [ "latest", "stake-address", "build"
+      , "--stake-verification-key-file", delegatorStakeVKeyFp
+      , "--testnet-magic", show @Int testnetMagic
+      ]
+  H.note_ $ "Delegator stake address: " <> delegatorStakeAddress
+
+  (txinForWithdrawal, TxOut _ txinValue _ _) <- H.nothingFailM $
+    findLargestUtxoWithAddress epochStateView sbe $ paymentKeyInfoAddr wallet0
+  let L.Coin inputLovelace = txOutValueToLovelace txinValue
+  H.note_ $ "Input UTxO: " <> show txinForWithdrawal <> " = " <> show inputLovelace <> " lovelace"
+
+  let withdrawalLovelace = inputLovelace * 2
+      outputLovelace     = withdrawalLovelace
+
+  let withdrawalTxBodyFp = work </> "withdrawal.txbody"
+
+  (exitCode, _stdout, stderr) <- execCliAny execConfig
+    [ eraName, "transaction", "build"
+    , "--change-address", Text.unpack $ paymentKeyInfoAddr wallet0
+    , "--tx-in", Text.unpack $ renderTxIn txinForWithdrawal
+    , "--tx-out", Text.unpack (paymentKeyInfoAddr wallet0) <> "+" <> show outputLovelace
+    , "--withdrawal", delegatorStakeAddress <> "+" <> show withdrawalLovelace
+    , "--witness-override", show @Int 2
+    , "--out-file", withdrawalTxBodyFp
+    ]
+  H.note_ stderr
+
+  exitCode H.=== ExitSuccess
+
+  -- Verify the transaction body was written and can be read back
+  void $ H.readFile withdrawalTxBodyFp
+
+-- | Plutus-script-witnessed withdrawal variant of 'hprop_tx_withdrawal_reward'.
+-- A Plutus V3 always-succeeds script acts as the stake credential, exercising
+-- the script-witness branch of the auto-balancer. Same balance arithmetic
+-- (output exceeds input, withdrawal covers the difference), and the
+-- withdrawal amount is likewise fictional.
+--
+-- Execute me with:
+-- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/transaction build with plutus withdrawal/"'@
+hprop_tx_withdrawal_reward_plutus_v3 :: Property
+hprop_tx_withdrawal_reward_plutus_v3 = integrationRetryWorkspace 2 "tx-withdrawal-reward-plutus-v3" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
+  conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
+  let tempAbsPath' = unTmpAbsPath tempAbsPath
+      tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
+
+  work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
+
+  let ceo = ConwayEraOnwardsConway
+      sbe = convert ceo
+      eraName = eraToString sbe
+      fastTestnetOptions = def { cardanoNodeEra = AnyShelleyBasedEra sbe }
+      shelleyOptions = def { genesisEpochLength = 100 }
+
+  TestnetRuntime
+    { testnetMagic
+    , testnetNodes
+    , wallets = wallet0:wallet1:_
+    , configurationFile
+    }
+    <- createAndRunTestnet fastTestnetOptions shelleyOptions conf
+
+  node <- H.headM testnetNodes
+  poolSprocket1 <- H.noteShow $ nodeSprocket node
+  execConfig <- mkExecConfig tempBaseAbsPath poolSprocket1 testnetMagic
+  let socketPath = nodeSocketPath node
+
+  epochStateView <- getEpochStateView configurationFile socketPath
+
+  -- Write the always-succeeds Plutus V3 script used as stake credential
+  plutusScriptFp <- H.note $ work </> "always-succeeds.plutusV3"
+  H.writeFile plutusScriptFp $ Text.unpack plutusV3Script
+
+  -- Build the bech32 stake address for the script credential
+  scriptStakeAddr <- filter (/= '\n') <$> execCli
+    [ eraName, "stake-address", "build"
+    , "--stake-script-file", plutusScriptFp
+    , "--testnet-magic", show @Int testnetMagic
+    ]
+  H.note_ $ "Script stake address: " <> scriptStakeAddr
+
+  (txinForWithdrawal, TxOut _ txinValue _ _) <- H.nothingFailM $
+    findLargestUtxoWithAddress epochStateView sbe $ paymentKeyInfoAddr wallet0
+  let L.Coin inputLovelace = txOutValueToLovelace txinValue
+  H.note_ $ "Input UTxO: " <> show txinForWithdrawal <> " = " <> show inputLovelace <> " lovelace"
+
+  -- Plutus scripts require collateral
+  txinCollateral <- findLargestUtxoForPaymentKey epochStateView sbe wallet1
+
+  let withdrawalLovelace = inputLovelace * 2
+      outputLovelace     = withdrawalLovelace
+
+  let withdrawalTxBodyFp = work </> "withdrawal.txbody"
+
+  (exitCode, _stdout, stderr) <- execCliAny execConfig
+    [ eraName, "transaction", "build"
+    , "--change-address", Text.unpack $ paymentKeyInfoAddr wallet0
+    , "--tx-in-collateral", Text.unpack $ renderTxIn txinCollateral
+    , "--tx-in", Text.unpack $ renderTxIn txinForWithdrawal
+    , "--tx-out", Text.unpack (paymentKeyInfoAddr wallet0) <> "+" <> show outputLovelace
+    , "--withdrawal", scriptStakeAddr <> "+" <> show withdrawalLovelace
+    , "--withdrawal-script-file", plutusScriptFp
+    , "--withdrawal-redeemer-value", "0"
+    , "--witness-override", show @Int 2
+    , "--out-file", withdrawalTxBodyFp
+    ]
+  H.note_ stderr
+
+  exitCode H.=== ExitSuccess
+
+  -- Verify the transaction body was written and can be read back
+  void $ H.readFile withdrawalTxBodyFp

--- a/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
+++ b/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
@@ -9,12 +9,17 @@ import qualified Cardano.Testnet.Test.Api.TxReferenceInputDatum
 import qualified Cardano.Testnet.Test.Cli.KesPeriodInfo
 import qualified Cardano.Testnet.Test.Cli.Plutus.BuildRaw
 import qualified Cardano.Testnet.Test.Cli.Plutus.CostCalculation
+import qualified Cardano.Testnet.Test.Cli.Plutus.MultiAssetReturnCollateral
 import qualified Cardano.Testnet.Test.Cli.Plutus.Scripts
 import qualified Cardano.Testnet.Test.Cli.Query
 import qualified Cardano.Testnet.Test.Cli.QuerySlotNumber
+import qualified Cardano.Testnet.Test.Cli.Scripts.Simple.CostCalculation
+import qualified Cardano.Testnet.Test.Cli.Scripts.Simple.Mint
 import qualified Cardano.Testnet.Test.Cli.StakeSnapshot
 import qualified Cardano.Testnet.Test.Cli.Transaction
+import qualified Cardano.Testnet.Test.Cli.Transaction.BuildEstimate
 import qualified Cardano.Testnet.Test.Cli.Transaction.RegisterDeregisterStakeAddress
+import qualified Cardano.Testnet.Test.Cli.Transaction.WithdrawalReward
 import qualified Cardano.Testnet.Test.DumpConfig
 import qualified Cardano.Testnet.Test.FoldEpochState
 import qualified Cardano.Testnet.Test.Gov.CommitteeAddNew as Gov
@@ -23,7 +28,6 @@ import qualified Cardano.Testnet.Test.Gov.DRepRetirement as Gov
 import qualified Cardano.Testnet.Test.Gov.GovActionTimeout as Gov
 import qualified Cardano.Testnet.Test.Gov.InfoAction as LedgerEvents
 import qualified Cardano.Testnet.Test.Gov.PParamChangeFailsSPO as Gov
-import  qualified Cardano.Testnet.Test.Cli.Scripts.Simple.Mint
 import qualified Cardano.Testnet.Test.Gov.ProposeNewConstitution as Gov
 import qualified Cardano.Testnet.Test.Gov.Transaction.HashMismatch as WrongHash
 import qualified Cardano.Testnet.Test.Gov.TreasuryDonation as Gov
@@ -37,9 +41,6 @@ import qualified Cardano.Testnet.Test.SanityCheck
 import qualified Cardano.Testnet.Test.SanityCheck as LedgerEvents
 import qualified Cardano.Testnet.Test.SubmitApi.Transaction
 import qualified Cardano.Testnet.Test.UpdateTimeStamps
-import qualified Cardano.Testnet.Test.Cli.Scripts.Simple.CostCalculation
-import qualified Cardano.Testnet.Test.Cli.Transaction.BuildEstimate
-import qualified Cardano.Testnet.Test.Cli.Plutus.MultiAssetReturnCollateral 
 
 import           Prelude
 
@@ -89,7 +90,7 @@ tests = do
             , T.testGroup "Simple Script"
                 [ ignoreOnWindows "Simple Script Mint" Cardano.Testnet.Test.Cli.Scripts.Simple.Mint.hprop_simple_script_mint
                 , ignoreOnWindows "Simple Reference Script Mint" Cardano.Testnet.Test.Cli.Scripts.Simple.CostCalculation.hprop_ref_simple_script_mint
-                
+
                 ]
             , T.testGroup "Plutus"
                 [ ignoreOnWindows "PlutusV3 purposes" Cardano.Testnet.Test.Cli.Plutus.Scripts.hprop_plutus_purposes_v3
@@ -115,6 +116,8 @@ tests = do
           , ignoreOnWindows "simple transaction build" Cardano.Testnet.Test.Cli.Transaction.hprop_transaction
           , ignoreOnWindows "Transaction Build Estimate" Cardano.Testnet.Test.Cli.Transaction.BuildEstimate.hprop_tx_build_estimate
           , ignoreOnWindows "register deregister stake address in transaction build"  Cardano.Testnet.Test.Cli.Transaction.RegisterDeregisterStakeAddress.hprop_tx_register_deregister_stake_address
+          , ignoreOnWindows "transaction build with withdrawal" Cardano.Testnet.Test.Cli.Transaction.WithdrawalReward.hprop_tx_withdrawal_reward
+          , ignoreOnWindows "transaction build with plutus withdrawal" Cardano.Testnet.Test.Cli.Transaction.WithdrawalReward.hprop_tx_withdrawal_reward_plutus_v3
           -- FIXME
           -- , ignoreOnMacAndWindows "leadership-schedule" Cardano.Testnet.Test.Cli.LeadershipSchedule.hprop_leadershipSchedule
 


### PR DESCRIPTION
# Description

This test tries to reproduce https://github.com/IntersectMBO/cardano-cli/issues/965

The bug is not present anymore, so the test succeeds.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
