### PR TITLE
cardano-testnet: Add backwards-compatibility with some old cli/node versions

### DIFF
--- a/cardano-testnet/changelog.d/20260420_204409_palas_make_testnet_backwards_compatible.md
+++ b/cardano-testnet/changelog.d/20260420_204409_palas_make_testnet_backwards_compatible.md
@@ -1,0 +1,4 @@
+### Added
+
+- Support for running `cardano-testnet` with older `cardano-cli` and `cardano-node` versions.
+

--- a/cardano-testnet/src/Testnet/Components/Configuration.hs
+++ b/cardano-testnet/src/Testnet/Components/Configuration.hs
@@ -262,7 +262,7 @@ createSPOGenesisAndFiles
      , inputGenesisDijkstraFp
      , tempAbsPath </> "byron.genesis.spec.json" -- Created by create-testnet-data
     ]
-    (\fp -> liftIOAnnotated $ whenM (System.doesFileExist fp) (System.removeFile fp))
+    $ \fp -> liftIOAnnotated $ whenM (System.doesFileExist fp) (System.removeFile fp)
 
   return genesisShelleyDir
   where

--- a/cardano-testnet/src/Testnet/Components/Configuration.hs
+++ b/cardano-testnet/src/Testnet/Components/Configuration.hs
@@ -53,13 +53,19 @@ import           System.FilePath.Posix (takeDirectory, (</>))
 import           Testnet.Blockfrost (blockfrostToGenesis)
 import qualified Testnet.Defaults as Defaults
 import           Testnet.Filepath
-import           Testnet.Process.RunIO (execCli_, liftIOAnnotated)
+import           Testnet.Process.RunIO (execCli_, getCliHelpText, liftIOAnnotated)
+import           Testnet.Start.Byron (ByronGenesisOptions (..), byronDefaultGenesisOptions,
+                   createByronGenesis)
 import           Testnet.Start.Types
 
 import qualified Hedgehog.Extras.Stock.OS as OS
 import qualified Hedgehog.Extras.Stock.Time as DTC
 
+import           Data.List (isInfixOf)
+import           Data.Maybe (fromMaybe)
+import           Data.Monoid.Extra (mwhen)
 import           RIO (MonadThrow, throwM)
+
 
 -- | Returns JSON encoded hashes of the era, as well as the hard fork configuration toggle.
 createConfigJson :: ()
@@ -72,9 +78,9 @@ createConfigJson :: ()
 createConfigJson (TmpAbsolutePath tempAbsPath) sbe = GHC.withFrozenCallStack $ do
   byronGenesisHash <- getByronGenesisHash $ tempAbsPath </> "byron-genesis.json"
   shelleyGenesisHash <- getHash ShelleyEra "ShelleyGenesisHash"
-  alonzoGenesisHash  <- getHash AlonzoEra  "AlonzoGenesisHash"
-  conwayGenesisHash  <- getHash ConwayEra  "ConwayGenesisHash"
-  dijkstraGenesisHash  <- getHash DijkstraEra  "DijkstraGenesisHash"
+  alonzoGenesisHash <- getHash AlonzoEra "AlonzoGenesisHash"
+  conwayGenesisHash <- getHash ConwayEra "ConwayGenesisHash"
+  dijkstraGenesisHash <- getHash DijkstraEra "DijkstraGenesisHash"
 
   pure $ mconcat
     [ byronGenesisHash
@@ -85,7 +91,7 @@ createConfigJson (TmpAbsolutePath tempAbsPath) sbe = GHC.withFrozenCallStack $ d
     , Defaults.defaultYamlHardforkViaConfig sbe
     ]
    where
-    getHash ::  MonadIO m => CardanoEra a -> Text.Text -> m (KeyMap Value)
+    getHash :: MonadIO m => CardanoEra a -> Text.Text -> m (KeyMap Value)
     getHash e = getShelleyGenesisHash (tempAbsPath </> Defaults.defaultGenesisFilepath e)
 
 createConfigJsonNoHash :: ()
@@ -119,7 +125,7 @@ getShelleyGenesisHash path key = do
   pure . singleton (fromText key) $ toJSON genesisHash
 
 -- | For an unknown reason, CLI commands are a lot slower on Windows than on Linux and
--- MacOS.  We need to allow a lot more time to set up a testnet.
+-- MacOS. We need to allow a lot more time to set up a testnet.
 startTimeOffsetSeconds :: Int
 startTimeOffsetSeconds = if OS.isWin32 then 90 else 15
 
@@ -161,7 +167,7 @@ createSPOGenesisAndFiles
 createSPOGenesisAndFiles
   testnetOptions genesisOptions@GenesisOptions{genesisTestnetMagic}
   onChainParams
-  (TmpAbsolutePath tempAbsPath) =  do
+  (TmpAbsolutePath tempAbsPath) = do
   AnyShelleyBasedEra sbe <- pure cardanoNodeEra
 
 
@@ -200,16 +206,23 @@ createSPOGenesisAndFiles
   currentTime <- liftIOAnnotated DTC.getCurrentTime
   let startTime = DTC.addUTCTime (fromIntegral startTimeOffsetSeconds) currentTime
 
+  -- Probe which --spec-* flags the installed cardano-cli supports so that
+  -- we only pass flags it understands. To add a new era, just append a
+  -- line below — the rest adapts automatically.
+  let cliHelp = fromMaybe "" <$>
+        getCliHelpText [eraToString sbe, "genesis", "create-testnet-data"]
+  cliHas <- flip isInfixOf <$> cliHelp
+
   execCli_ $
     [ eraToString sbe, "genesis", "create-testnet-data" ]
-    ++ createTestnetDataFlag ShelleyEra
-    ++ createTestnetDataFlag AlonzoEra
-    ++ createTestnetDataFlag ConwayEra
-    ++ createTestnetDataFlag DijkstraEra
+    ++ specFlag cliHas ShelleyEra
+    ++ specFlag cliHas AlonzoEra
+    ++ specFlag cliHas ConwayEra
+    ++ specFlag cliHas DijkstraEra
     ++
     [ "--testnet-magic", show genesisTestnetMagic
     , "--pools", show nPoolNodes
-    , "--total-supply",     show cardanoMaxSupply -- Half of this will be delegated, see https://github.com/IntersectMBO/cardano-cli/pull/874
+    , "--total-supply", show cardanoMaxSupply -- Half of this will be delegated, see https://github.com/IntersectMBO/cardano-cli/pull/874
     , "--stake-delegators", show numStakeDelegators
     , "--utxo-keys", show numSeededUTxOKeys]
     <> monoidForEraInEon @ConwayEraOnwards era (const ["--drep-keys", show cardanoNumDReps])
@@ -217,9 +230,36 @@ createSPOGenesisAndFiles
     , "--out-dir", tempAbsPath
     ]
 
+  -- Older cardano-cli versions do not generate byron-genesis.json from
+  -- create-testnet-data.  Create it via the legacy byron command when missing.
+  let byronGenesisPath = tempAbsPath </> Defaults.defaultGenesisFilepath ByronEra
+  unlessFileExists byronGenesisPath $ do
+    let byronGenDir = tempAbsPath </> "byron-gen-command"
+        byronParamsFp = tempAbsPath </> "byron-params.json"
+        byronOpts = byronDefaultGenesisOptions
+          { byronNumBftNodes = fromIntegral nPoolNodes }
+    liftIOAnnotated $ LBS.writeFile byronParamsFp $ Aeson.encode Defaults.defaultByronProtocolParamsJsonValue
+    createByronGenesis genesisTestnetMagic startTime byronOpts byronParamsFp byronGenDir
+    liftIOAnnotated $ do
+      System.renameFile (byronGenDir </> "genesis.json") byronGenesisPath
+      forM_ [1..nPoolNodes] $ \i -> do
+        let ii = fromIntegral i :: Int
+            poolKeysDir = tempAbsPath </> Defaults.defaultSpoKeysDir ii
+            padIdx = let s = show (ii - 1) in replicate (3 - length s) '0' ++ s
+        System.copyFile (byronGenDir </> ("delegate-keys." ++ padIdx ++ ".key")) (poolKeysDir </> "byron-delegate.key")
+        System.copyFile (byronGenDir </> ("delegation-cert." ++ padIdx ++ ".json")) (poolKeysDir </> "byron-delegation.cert")
+      System.removeFile byronParamsFp
+
+  -- For eras whose --spec-* flag was not supported, write a default genesis
+  -- file so that the node configuration and hash computation stay uniform.
+  let dijkstraGenesisPath = tempAbsPath </> Defaults.defaultGenesisFilepath DijkstraEra
+  unlessFileExists dijkstraGenesisPath $
+    liftIOAnnotated $ LBS.writeFile dijkstraGenesisPath $ A.encodePretty dijkstraGenesis
+
   -- Remove the input files. We don't need them anymore, since create-testnet-data wrote new versions.
   forM_
     [  inputGenesisShelleyFp, inputGenesisAlonzoFp, inputGenesisConwayFp
+     , inputGenesisDijkstraFp
      , tempAbsPath </> "byron.genesis.spec.json" -- Created by create-testnet-data
     ]
     (\fp -> liftIOAnnotated $ whenM (System.doesFileExist fp) (System.removeFile fp))
@@ -227,16 +267,25 @@ createSPOGenesisAndFiles
   return genesisShelleyDir
   where
     inputGenesisShelleyFp = genesisInputFilepath ShelleyEra
-    inputGenesisAlonzoFp  = genesisInputFilepath AlonzoEra
-    inputGenesisConwayFp  = genesisInputFilepath ConwayEra
-    inputGenesisDijkstraFp  = genesisInputFilepath DijkstraEra
+    inputGenesisAlonzoFp = genesisInputFilepath AlonzoEra
+    inputGenesisConwayFp = genesisInputFilepath ConwayEra
+    inputGenesisDijkstraFp = genesisInputFilepath DijkstraEra
+
     nPoolNodes = cardanoNumPools testnetOptions
+
     CardanoTestnetOptions{cardanoNodeEra, cardanoMaxSupply, cardanoNumDReps} = testnetOptions
+
     genesisInputFilepath :: Pretty (eon era) => eon era -> FilePath
     genesisInputFilepath e = tempAbsPath </> ("genesis-input." <> eraToString e <> ".json")
-    createTestnetDataFlag :: Pretty (eon era) => eon era -> [String]
-    createTestnetDataFlag sbe =
-        ["--spec-" ++ eraToString sbe, genesisInputFilepath sbe]
+
+    specFlag :: Pretty (eon era) => (String -> Bool) -> eon era -> [String]
+    specFlag supported e =
+        let flag = "--spec-" ++ eraToString e
+        in mwhen (supported flag) [flag, genesisInputFilepath e]
+
+    unlessFileExists fp act = do
+      exists <- liftIOAnnotated $ System.doesFileExist fp
+      unless exists act
 
 
 

--- a/cardano-testnet/src/Testnet/Components/Configuration.hs
+++ b/cardano-testnet/src/Testnet/Components/Configuration.hs
@@ -232,23 +232,7 @@ createSPOGenesisAndFiles
 
   -- Older cardano-cli versions do not generate byron-genesis.json from
   -- create-testnet-data.  Create it via the legacy byron command when missing.
-  let byronGenesisPath = tempAbsPath </> Defaults.defaultGenesisFilepath ByronEra
-  unlessFileExists byronGenesisPath $ do
-    let byronGenDir = tempAbsPath </> "byron-gen-command"
-        byronParamsFp = tempAbsPath </> "byron-params.json"
-        byronOpts = byronDefaultGenesisOptions
-          { byronNumBftNodes = fromIntegral nPoolNodes }
-    liftIOAnnotated $ LBS.writeFile byronParamsFp $ Aeson.encode Defaults.defaultByronProtocolParamsJsonValue
-    createByronGenesis genesisTestnetMagic startTime byronOpts byronParamsFp byronGenDir
-    liftIOAnnotated $ do
-      System.renameFile (byronGenDir </> "genesis.json") byronGenesisPath
-      forM_ [1..nPoolNodes] $ \i -> do
-        let ii = fromIntegral i :: Int
-            poolKeysDir = tempAbsPath </> Defaults.defaultSpoKeysDir ii
-            padIdx = let s = show (ii - 1) in replicate (3 - length s) '0' ++ s
-        System.copyFile (byronGenDir </> ("delegate-keys." ++ padIdx ++ ".key")) (poolKeysDir </> "byron-delegate.key")
-        System.copyFile (byronGenDir </> ("delegation-cert." ++ padIdx ++ ".json")) (poolKeysDir </> "byron-delegation.cert")
-      System.removeFile byronParamsFp
+  createByronGenesisIfMissing startTime
 
   -- For eras whose --spec-* flag was not supported, write a default genesis
   -- file so that the node configuration and hash computation stay uniform.
@@ -282,6 +266,25 @@ createSPOGenesisAndFiles
     specFlag supported e =
         let flag = "--spec-" ++ eraToString e
         in mwhen (supported flag) [flag, genesisInputFilepath e]
+
+    createByronGenesisIfMissing startTime = do
+      let byronGenesisPath = tempAbsPath </> Defaults.defaultGenesisFilepath ByronEra
+      unlessFileExists byronGenesisPath $ do
+        let byronGenDir = tempAbsPath </> "byron-gen-command"
+            byronParamsFp = tempAbsPath </> "byron-params.json"
+            byronOpts = byronDefaultGenesisOptions
+              { byronNumBftNodes = fromIntegral nPoolNodes }
+        liftIOAnnotated $ LBS.writeFile byronParamsFp $ Aeson.encode Defaults.defaultByronProtocolParamsJsonValue
+        createByronGenesis genesisTestnetMagic startTime byronOpts byronParamsFp byronGenDir
+        liftIOAnnotated $ do
+          System.renameFile (byronGenDir </> "genesis.json") byronGenesisPath
+          forM_ [1..nPoolNodes] $ \i -> do
+            let ii = fromIntegral i :: Int
+                poolKeysDir = tempAbsPath </> Defaults.defaultSpoKeysDir ii
+                padIdx = let s = show (ii - 1) in replicate (3 - length s) '0' ++ s
+            System.copyFile (byronGenDir </> ("delegate-keys." ++ padIdx ++ ".key")) (poolKeysDir </> "byron-delegate.key")
+            System.copyFile (byronGenDir </> ("delegation-cert." ++ padIdx ++ ".json")) (poolKeysDir </> "byron-delegation.cert")
+          System.removeFile byronParamsFp
 
     unlessFileExists fp act = do
       exists <- liftIOAnnotated $ System.doesFileExist fp

--- a/cardano-testnet/src/Testnet/Defaults.hs
+++ b/cardano-testnet/src/Testnet/Defaults.hs
@@ -366,6 +366,7 @@ defaultYamlConfig =
     -- See: https://github.com/input-output-hk/cardano-ledger/blob/master/eras/byron/ledger/impl/doc/network-magic.md
     , ("RequiresNetworkMagic", "RequiresMagic")
 
+    , ("EnableP2P", Aeson.Bool True)
     , ("PeerSharing", Aeson.Bool False)
 
     -- Logging related

--- a/cardano-testnet/src/Testnet/Process/RunIO.hs
+++ b/cardano-testnet/src/Testnet/Process/RunIO.hs
@@ -98,9 +98,8 @@ execCli = GHC.withFrozenCallStack $ execFlex "cardano-cli" "CARDANO_CLI"
 -- Returns 'Nothing' if the binary can't be found or the command fails.
 getCliHelpText :: MonadIO m => [String] -> m (Maybe String)
 getCliHelpText args = liftIO $ do
-  result <- try $ runRIO () $
+  result <- tryAny $ runRIO () $
     execFlexAny' defaultExecConfig "cardano-cli" "CARDANO_CLI" (args ++ ["--help"])
-  let _ = result :: Either SomeException (ExitCode, String, String)
   pure $ case result of
     Right (_, stdout', _) -> Just stdout'
     Left _ -> Nothing

--- a/cardano-testnet/src/Testnet/Process/RunIO.hs
+++ b/cardano-testnet/src/Testnet/Process/RunIO.hs
@@ -8,6 +8,7 @@
 module Testnet.Process.RunIO
   ( execCli'
   , execCli_
+  , getCliHelpText
   , mkExecConfig
   , procNode
   , procKesAgent
@@ -92,6 +93,17 @@ execCli
   => [String]
   -> RIO env String
 execCli = GHC.withFrozenCallStack $ execFlex "cardano-cli" "CARDANO_CLI"
+
+-- | Best-effort query of the @cardano-cli@ help text for a subcommand.
+-- Returns 'Nothing' if the binary can't be found or the command fails.
+getCliHelpText :: MonadIO m => [String] -> m (Maybe String)
+getCliHelpText args = liftIO $ do
+  result <- try $ runRIO () $
+    execFlexAny' defaultExecConfig "cardano-cli" "CARDANO_CLI" (args ++ ["--help"])
+  let _ = result :: Either SomeException (ExitCode, String, String)
+  pure $ case result of
+    Right (_, stdout', _) -> Just stdout'
+    Left _ -> Nothing
 
 -- | Create a process returning its stdout.
 --

--- a/cardano-testnet/src/Testnet/Start/Byron.hs
+++ b/cardano-testnet/src/Testnet/Start/Byron.hs
@@ -6,19 +6,18 @@
 {-# LANGUAGE NumericUnderscores #-}
 
 module Testnet.Start.Byron
-  ( createByronGenesis
+  ( ByronGenesisOptions(..)
+  , createByronGenesis
   , byronDefaultGenesisOptions
   ) where
 
-import           Control.Monad.Catch (MonadCatch)
 import           Control.Monad.IO.Class (MonadIO)
 import           Data.Time.Clock (UTCTime)
 import           GHC.Stack
 
-import           Testnet.Process.Run
+import           Testnet.Process.RunIO (execCli_)
 
 import           Hedgehog.Extras.Stock.Time (showUTCTimeSeconds)
-import           Hedgehog.Internal.Property (MonadTest)
 
 data ByronGenesisOptions = ByronGenesisOptions
   { byronNumBftNodes :: Int
@@ -41,7 +40,7 @@ byronDefaultGenesisOptions = ByronGenesisOptions
 -- | Creates a default Byron genesis. This is required for any testnet, predominantly because
 -- we inject our ADA supply into our testnet via the Byron genesis.
 createByronGenesis
-  :: (MonadTest m, MonadCatch m, MonadIO m, HasCallStack)
+  :: (MonadIO m, HasCallStack)
   => Int
   -> UTCTime
   -> ByronGenesisOptions

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/node_default_config.json
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/node_default_config.json
@@ -5,6 +5,7 @@
     "DijkstraGenesisFile": "dijkstra-genesis.json",
     "EnableLogMetrics": false,
     "EnableLogging": true,
+    "EnableP2P": true,
     "ExperimentalHardForksEnabled": true,
     "ExperimentalProtocolsEnabled": true,
     "LastKnownBlockVersion-Alt": 0,


### PR DESCRIPTION
# Description

Makes `cardano-testnet` work seamlessly with older versions of `cardano-cli` and `cardano-node` (not all versions, just to some extent), without hard-coded version checks. The code probes the installed CLI's capabilities at runtime and adapts automatically — genesis files that the CLI doesn't produce are created via fallback, and the node configuration includes settings needed by older nodes.

**Motivation:** We aim to allow for `cardano-testnet` to run testnet with different versions of the `cardano-node`. This PR makes that easier, since we will only have to worry about running the correct node, and not about having the right configuration files generated.

**What changed:**

- **CLI capability detection** (`RunIO.hs`): `getCliHelpText` probes `cardano-cli <era> genesis create-testnet-data --help` to discover which `--spec-*` flags are supported.
- **Conditional spec flags** (`Configuration.hs`): `specFlag` takes a `(String -> Bool)` predicate and only passes flags the CLI advertises. Adding a future era is one extra `++ specFlag cliHas NewEra` line.
- **Byron genesis fallback** (`Configuration.hs`): When the CLI doesn't produce `byron-genesis.json` (older CLIs don't), it is created via the existing `createByronGenesis` from `Byron.hs`, with delegate keys copied into the expected pool-key directories.
- **Dijkstra genesis fallback** (`Configuration.hs`): When `dijkstra-genesis.json` is missing, the default is written directly so that the node configuration and hash computation stay uniform.
- **`Byron.hs` constraint relaxation**: `createByronGenesis` now requires only `MonadIO` (was `MonadTest, MonadCatch, MonadIO`) and uses `Testnet.Process.RunIO.execCli_`, so it can be called from both production code and tests.
- **`EnableP2P` in config** (`Defaults.hs`): Older nodes (≤ 9.x) require `EnableP2P: True` explicitly to parse P2P topology files; newer nodes already default to P2P so the flag is harmless.

**Tests with old versions of `cardano-node` and `cardano-cli` before this PR and after this PR:**

| Release | node   | cli       | Before | After |
|---------|--------|-----------|--------|-------|
| 9.0.0   | 9.0.0  | 9.0.0.0   | FAIL   | OK    |
| 9.1.0   | 9.1.0  | 9.2.1.0   | FAIL   | OK    |
| 9.1.1   | 9.1.1  | 9.2.1.0   | FAIL   | OK    |
| 9.2.0   | 9.2.0  | 9.4.1.0   | FAIL   | OK    |
| 9.2.1   | 9.2.1  | 9.4.1.0   | FAIL   | OK    |
| 10.1.1  | 10.1.1 | 10.1.0.0  | FAIL   | OK    |
| 10.1.2  | 10.1.2 | 10.1.1.0  | FAIL   | OK    |
| 10.1.3  | 10.1.3 | 10.1.1.0  | FAIL   | OK    |
| 10.1.4  | 10.1.4 | 10.1.1.0  | FAIL   | OK    |
| 10.2.1  | 10.2.1 | 10.4.0.0  | FAIL   | OK    |
| 10.3.1  | 10.3.1 | 10.7.0.0  | FAIL   | OK    |
| 10.4.1  | 10.4.1 | 10.8.0.0  | FAIL   | OK    |
| 10.5.1  | 10.5.1 | 10.11.0.0 | FAIL   | OK    |
| 10.5.2  | 10.5.2 | 10.11.0.0 | FAIL   | OK    |
| 10.5.3  | 10.5.3 | 10.11.0.0 | FAIL   | OK    |
| 10.5.4  | 10.5.4 | 10.11.0.0 | FAIL   | OK    |
| 10.6.2  | 10.6.2 | 10.15.0.0 | OK     | OK    |
| 10.6.3  | 10.6.3 | 10.15.0.0 | OK     | OK    |
| 10.6.4  | 10.6.4 | 10.15.0.0 | OK     | OK    |
| 10.7.1  | 10.7.1 | 10.16.0.0 | OK     | OK    |

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff