### PR TITLE
bench: cardano-recon-framework 1.1.1

### DIFF
--- a/bench/cardano-recon-framework/CHANGELOG.md
+++ b/bench/cardano-recon-framework/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for cardano-trace-ltl
 
+## 1.1.1 -- April 2026
+* Support atoms that refer to property keys at arbitrary depth
+* Set build flag `crash-on-missing-key` to true by default
+
 ## 1.1.0 -- April 2026
 
 * Support configurable timeunits in formulas via a CLI option.

--- a/bench/cardano-recon-framework/CHANGELOG.md
+++ b/bench/cardano-recon-framework/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.1 -- April 2026
 * Support atoms that refer to property keys at arbitrary depth
-* Set build flag `crash-on-missing-key` to true by default
+* Replace the `crash-on-missing-key` build flag with a runtime CLI option `--on-missing-key <crash|bottom>` (default: `bottom`)
 
 ## 1.1.0 -- April 2026
 

--- a/bench/cardano-recon-framework/README.md
+++ b/bench/cardano-recon-framework/README.md
@@ -17,8 +17,8 @@ If negative, reports as such and lists the events that have been relevant to the
 ## CLI Syntax
 
 ```
-Usage: cardano-recon FILE --mode <offline|online> --duration INT FILES 
-                     [--retention INT] [--trace-dispatcher-cfg FILE] 
+Usage: cardano-recon FILE --mode <offline|online> --duration INT FILES
+                     [--retention INT] [--trace-dispatcher-cfg FILE]
                      [--context FILE] [--dump-metrics BOOL] [--seek-to-end BOOL]
 
   Check formula satisfiability against a log of trace messages
@@ -39,5 +39,5 @@ Available options:
 
 ## Build flags
   - _debug_ for enabling verbose tracing of formulas as they evolve (multiple traces per each temporal event).
-  - _crash_on_missing_key_ for making the application crash if a formula atom is evaluated on an event which is missing
+  - _crash-on-missing-key_ for making the application crash if a formula atom is evaluated on an event which is missing
     a key the atom is referencing.

--- a/bench/cardano-recon-framework/README.md
+++ b/bench/cardano-recon-framework/README.md
@@ -20,6 +20,8 @@ If negative, reports as such and lists the events that have been relevant to the
 Usage: cardano-recon FILE --mode <offline|online> --duration INT FILES
                      [--retention INT] [--trace-dispatcher-cfg FILE]
                      [--context FILE] [--dump-metrics BOOL] [--seek-to-end BOOL]
+                     [--timeunit <hour|minute|second|millisecond|microsecond>]
+                     [--on-missing-key <crash|bottom>]
 
   Check formula satisfiability against a log of trace messages
 
@@ -34,10 +36,13 @@ Available options:
                            (default: False)
   --seek-to-end BOOL       seek to the end of the trace file before ingesting it
                            (default: True)
+  --timeunit <hour|minute|second|millisecond|microsecond>
+                           timeunit (default: second)
+  --on-missing-key <crash|bottom>
+                           behaviour when a formula atom references a missing
+                           event property key (default: bottom)
   -h,--help                Show this help text
 ```
 
 ## Build flags
   - _debug_ for enabling verbose tracing of formulas as they evolve (multiple traces per each temporal event).
-  - _crash-on-missing-key_ for making the application crash if a formula atom is evaluated on an event which is missing
-    a key the atom is referencing.

--- a/bench/cardano-recon-framework/app/Cardano/ReCon.hs
+++ b/bench/cardano-recon-framework/app/Cardano/ReCon.hs
@@ -45,17 +45,17 @@ import qualified System.Metrics as EKG
 import           Streaming
 
 
-check :: Word -> Trace IO App.TraceMessage -> Formula TemporalEvent Text -> [TemporalEvent] -> IO ()
-check idx {- Formula index -} tr phi events =
-  let result = satisfies phi events in
+check :: OnMissingKey -> Word -> Trace IO App.TraceMessage -> Formula TemporalEvent Text -> [TemporalEvent] -> IO ()
+check omk idx {- Formula index -} tr phi events =
+  let result = satisfies omk phi events in
   traceWith tr $ formulaOutcome phi result idx
 
-checkS' :: Bool -> Word -> Trace IO App.TraceMessage -> Formula TemporalEvent Text -> Stream (Of TemporalEvent) IO () -> IO ()
-checkS' enableProgressDumps idx {- Formula index -} tr phi events = do
+checkS' :: OnMissingKey -> Bool -> Word -> Trace IO App.TraceMessage -> Formula TemporalEvent Text -> Stream (Of TemporalEvent) IO () -> IO ()
+checkS' omk enableProgressDumps idx {- Formula index -} tr phi events = do
   let initial = SatisfyMetrics 0 phi 0
   metrics <- newIORef initial
   withAsync (when enableProgressDumps $ runDisplayProgressDump initial metrics) $ \counterDisplayThread -> do
-    r <- satisfiesS phi events metrics
+    r <- satisfiesS omk phi events metrics
     traceWith tr $ formulaOutcome phi r idx
     cancel counterDisplayThread
   where
@@ -68,7 +68,8 @@ checkS' enableProgressDumps idx {- Formula index -} tr phi events = do
       threadDelay 1_000_000 -- 1s
       runDisplayProgressDump next counter
 
-checkOnline :: Bool
+checkOnline :: OnMissingKey
+            -> Bool
             -> Trace IO App.TraceMessage
             -> TemporalEventDurationMicrosec
             -> Word
@@ -77,22 +78,23 @@ checkOnline :: Bool
             -> [FilePath]
             -> [Formula TemporalEvent Text]
             -> IO ()
-checkOnline enableProgressDumps tr eventDuration retentionMs failureMode ingestMode files phis = do
+checkOnline omk enableProgressDumps tr eventDuration retentionMs failureMode ingestMode files phis = do
   ing <- mkIngestor (fromIntegral retentionMs)
   for_ files (ingestFileThreaded ing failureMode ingestMode)
   forConcurrently_ (zip [0..] phis) $ \(idx, phi) -> mkIngestorReader ing >>= \reader -> forever $ do
     traceWith tr $ FormulaStartCheck phi idx
-    checkS' enableProgressDumps idx tr phi (readS reader eventDuration)
+    checkS' omk enableProgressDumps idx tr phi (readS reader eventDuration)
 
-checkOffline :: Trace IO App.TraceMessage
+checkOffline :: OnMissingKey
+             -> Trace IO App.TraceMessage
              -> TemporalEventDurationMicrosec
              -> FilePath
              -> [Formula TemporalEvent Text]
              -> IO ()
-checkOffline tr eventDuration file phis = do
+checkOffline omk tr eventDuration file phis = do
   events <- read file eventDuration
   forConcurrently_ (zip [0..] phis) $ \(idx, phi) ->
-    check idx tr phi events
+    check omk idx tr phi events
   threadDelay 200_000 -- Give the tracer a grace period to output the logs to whatever backend
 
 setupTraceDispatcher :: Maybe FilePath -> IO (Trace IO App.TraceMessage)
@@ -155,9 +157,10 @@ main = do
       file <- case options.traces of
         [x] -> pure x
         _   -> die "Only exactly one trace file is supported in 'offline' mode"
-      checkOffline tr options.duration file formulas'
+      checkOffline options.onMissingKey tr options.duration file formulas'
     Online -> do
       checkOnline
+        options.onMissingKey
         options.enableProgressDumps
         tr
         options.duration

--- a/bench/cardano-recon-framework/app/Cardano/ReCon/Cli.hs
+++ b/bench/cardano-recon-framework/app/Cardano/ReCon/Cli.hs
@@ -1,6 +1,8 @@
 module Cardano.ReCon.Cli(Timeunit(..), timeunitToMicrosecond, Mode(..), CliOptions(..), opts) where
 
 
+import           Cardano.ReCon.LTL.Formula (OnMissingKey (..))
+
 import           Control.Arrow ((>>>))
 import           Data.Char (toLower)
 import           Options.Applicative
@@ -118,6 +120,20 @@ parseSeekToEnd = option readBool $
   <> value True
   <> help "seek to the end of the trace file before ingesting it"
 
+readOnMissingKey :: ReadM OnMissingKey
+readOnMissingKey = eitherReader $ fmap toLower >>> \case
+  "crash"  -> Right CrashOnMissingKey
+  "bottom" -> Right BottomOnMissingKey
+  _        -> Left "Expected either of: 'crash' or 'bottom'"
+
+parseOnMissingKey :: Parser OnMissingKey
+parseOnMissingKey = option readOnMissingKey $
+     long "on-missing-key"
+  <> metavar "<crash|bottom>"
+  <> showDefaultWith (\case BottomOnMissingKey -> "bottom"; CrashOnMissingKey -> "crash")
+  <> value BottomOnMissingKey
+  <> help "behaviour when a formula atom references a missing event property key"
+
 data CliOptions = CliOptions
   { formulas            :: FilePath
   , mode                :: Mode
@@ -129,6 +145,7 @@ data CliOptions = CliOptions
   , enableProgressDumps :: Bool
   , enableSeekToEnd     :: Bool
   , timeunit            :: Timeunit
+  , onMissingKey        :: OnMissingKey
   }
 
 parseCliOptions :: Parser CliOptions
@@ -143,6 +160,7 @@ parseCliOptions = CliOptions
               <*> parseDumpMetrics
               <*> parseSeekToEnd
               <*> parseTimeunit
+              <*> parseOnMissingKey
 
 opts :: ParserInfo CliOptions
 opts = info (parseCliOptions <**> helper)

--- a/bench/cardano-recon-framework/cardano-recon-framework.cabal
+++ b/bench/cardano-recon-framework/cardano-recon-framework.cabal
@@ -36,12 +36,6 @@ flag debug
   default:              False
   manual:               True
 
-flag crash-on-missing-key
-  description:          If enabled throw an exception when a formula atom expects a missing key, otherwise evaluate the atom to ⊥.
-  default:              True
-  manual:               True
-
-
 common common
     ghc-options:      -Wall
 
@@ -53,6 +47,7 @@ common common
 
     default-extensions:
       BangPatterns
+      FlexibleContexts
       FunctionalDependencies
       LambdaCase
       MultiParamTypeClasses
@@ -69,9 +64,6 @@ common common
 
     if flag(debug)
       CPP-Options:        -DTRACE
-
-    if flag(crash-on-missing-key)
-      CPP-Options:        -DCRASH_ON_MISSING_KEY
 
 library
     import:           common
@@ -119,6 +111,7 @@ library
 
     build-depends:    base
                     , containers
+                    , mtl
                     , text
                     , directory
                     , trace-dispatcher ^>= 2.12

--- a/bench/cardano-recon-framework/cardano-recon-framework.cabal
+++ b/bench/cardano-recon-framework/cardano-recon-framework.cabal
@@ -4,7 +4,7 @@ description:        Cardano Re(altime) Con(formance) Framework based on Linear T
 category:           Cardano
                     Testing
 copyright:          2026 Intersect.
-version:            1.1.0
+version:            1.1.1
 license:            Apache-2.0
 license-files:      LICENSE
                     NOTICE
@@ -38,7 +38,7 @@ flag debug
 
 flag crash-on-missing-key
   description:          If enabled throw an exception when a formula atom expects a missing key, otherwise evaluate the atom to ⊥.
-  default:              False
+  default:              True
   manual:               True
 
 

--- a/bench/cardano-recon-framework/src/Cardano/ReCon/LTL/Formula.hs
+++ b/bench/cardano-recon-framework/src/Cardano/ReCon/LTL/Formula.hs
@@ -17,6 +17,7 @@ module Cardano.ReCon.LTL.Formula (
   , Relevance
   , and
   , interpTimeunit
+  , OnMissingKey(..)
   , Event(..)) where
 
 import           Prelude hiding (and)
@@ -243,6 +244,15 @@ interpTimeunit f (PropIntExists x phi)    = PropIntExists x (interpTimeunit f ph
 interpTimeunit f (PropTextExists x phi)   = PropTextExists x (interpTimeunit f phi)
 interpTimeunit f (PropIntExistsN x dom phi)  = PropIntExistsN x dom (interpTimeunit f phi)
 interpTimeunit f (PropTextExistsN x dom phi) = PropTextExistsN x dom (interpTimeunit f phi)
+
+-- | Controls evaluator behaviour when a formula atom references a property
+--   key that is absent from the event being evaluated.
+--
+--   * 'BottomOnMissingKey' — treat the atom as unsatisfied (@⊥@); evaluation
+--     continues silently.  Useful when events may legally omit optional fields.
+--   * 'CrashOnMissingKey' — throw an exception.  Useful during development to
+--     catch formula/event-schema mismatches early.
+data OnMissingKey = BottomOnMissingKey | CrashOnMissingKey
 
 -- | Default name: e.
 --

--- a/bench/cardano-recon-framework/src/Cardano/ReCon/LTL/Internal/Progress.hs
+++ b/bench/cardano-recon-framework/src/Cardano/ReCon/LTL/Internal/Progress.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 module Cardano.ReCon.LTL.Internal.Progress(next, terminate) where
 
 import           Cardano.ReCon.LTL.Formula
@@ -8,12 +7,10 @@ import qualified Cardano.ReCon.LTL.Internal.IR.HomogeneousFormula as H
 
 import           Prelude hiding (lookup)
 
+import           Control.Monad.Reader (Reader, asks)
 import           Data.Map.Strict (lookup)
 import qualified Data.Set as Set
-
-#ifdef CRASH_ON_MISSING_KEY
-import qualified Data.Text                           as Text
-#endif
+import qualified Data.Text as Text
 
 -- This file concerns algorithmically checking formula satisfiability.
 --  There are two parts:
@@ -23,50 +20,44 @@ import qualified Data.Text                           as Text
 
 -- | This is an algorithm for representing
 --   (t t̄ ⊧ φ) in terms of ∃φ'. (t̄ ⊧ φ')
-next :: (Event event ty, Eq ty) => Formula event ty -> event -> Formula event ty
+next :: (Event event ty, Eq ty) => Formula event ty -> event -> Reader OnMissingKey (Formula event ty)
 next (Forall k phi) s = next (unfoldForall k phi) s
 next (ForallN k phi) s = next (unfoldForallN k phi) s
 next (ExistsN k phi) s = next (unfoldExistsN k phi) s
 next (NextN k phi) s = next (unfoldNextN k phi) s
 next (UntilN k phi psi) s = next (unfoldUntilN k phi psi) s
-next (Next phi) _ = phi
-next (And phi psi) s = And (next phi s) (next psi s)
-next (Or phi psi) s = Or (next phi s) (next psi s)
-next (Implies phi psi) s = Implies (next phi s) (next psi s)
-next (Not phi) s = Not (next phi s)
-next Bottom _ = Bottom
-next Top _ = Top
+next (Next phi) _ = pure phi
+next (And phi psi) s = And <$> next phi s <*> next psi s
+next (Or phi psi) s = Or <$> next phi s <*> next psi s
+next (Implies phi psi) s = Implies <$> next phi s <*> next psi s
+next (Not phi) s = Not <$> next phi s
+next Bottom _ = pure Bottom
+next Top _ = pure Top
 next (Atom c is) s | ofTy s c =
-  F.and $ flip fmap (Set.toList is) $ \case
-    IntPropConstraint key t ->
+  F.and <$> traverse missingKey' (Set.toList is)
+  where
+    missingKey' (IntPropConstraint key t) =
       case lookup key (intProps s c) of
-        Just v  -> PropIntBinRel Eq (Set.singleton (s, c)) t (IntConst v)
-        Nothing ->
-#ifdef CRASH_ON_MISSING_KEY
-          error $ "Missing key: " <> Text.unpack key
-#else
-          Bottom
-#endif
-    TextPropConstraint key t ->
+        Just v  -> pure $ PropIntBinRel Eq (Set.singleton (s, c)) t (IntConst v)
+        Nothing -> missingKey key
+    missingKey' (TextPropConstraint key t) =
       case lookup key (textProps s c) of
-        Just v  -> PropTextEq (Set.singleton (s, c)) t v
-        Nothing ->
-#ifdef CRASH_ON_MISSING_KEY
-          error $ "Missing key: " <> Text.unpack key
-#else
-          Bottom
-#endif
-next (Atom {}) _ = Bottom
-next (PropIntForall  x phi) s = PropIntForall  x (next phi s)
-next (PropTextForall x phi) s = PropTextForall x (next phi s)
-next (PropIntForallN  x dom phi) s = PropIntForallN  x dom (next phi s)
-next (PropTextForallN x dom phi) s = PropTextForallN x dom (next phi s)
-next (PropIntExists  x phi) s = PropIntExists  x (next phi s)
-next (PropTextExists x phi) s = PropTextExists x (next phi s)
-next (PropIntExistsN  x dom phi) s = PropIntExistsN  x dom (next phi s)
-next (PropTextExistsN x dom phi) s = PropTextExistsN x dom (next phi s)
-next (PropIntBinRel rel r a b) _ = PropIntBinRel rel r a b
-next (PropTextEq rel a b)      _ = PropTextEq rel a b
+        Just v  -> pure $ PropTextEq (Set.singleton (s, c)) t v
+        Nothing -> missingKey key
+    missingKey key = asks $ \case
+      BottomOnMissingKey -> Bottom
+      CrashOnMissingKey  -> error $ "Missing key: " <> Text.unpack key
+next (Atom {}) _ = pure Bottom
+next (PropIntForall  x phi) s = PropIntForall  x <$> next phi s
+next (PropTextForall x phi) s = PropTextForall x <$> next phi s
+next (PropIntForallN  x dom phi) s = PropIntForallN  x dom <$> next phi s
+next (PropTextForallN x dom phi) s = PropTextForallN x dom <$> next phi s
+next (PropIntExists  x phi) s = PropIntExists  x <$> next phi s
+next (PropTextExists x phi) s = PropTextExists x <$> next phi s
+next (PropIntExistsN  x dom phi) s = PropIntExistsN  x dom <$> next phi s
+next (PropTextExistsN x dom phi) s = PropTextExistsN x dom <$> next phi s
+next (PropIntBinRel rel r a b) _ = pure $ PropIntBinRel rel r a b
+next (PropTextEq rel a b)      _ = pure $ PropTextEq rel a b
 
 -- | This is an algorithm for (∅ ⊧ ◯ φ)
 terminateNext :: Formula event a -> HomogeneousFormula

--- a/bench/cardano-recon-framework/src/Cardano/ReCon/LTL/Satisfy.hs
+++ b/bench/cardano-recon-framework/src/Cardano/ReCon/LTL/Satisfy.hs
@@ -14,6 +14,8 @@ import           Cardano.ReCon.LTL.Internal.IR.HomogeneousFormula (eval)
 import           Cardano.ReCon.LTL.Internal.Progress
 import           Cardano.ReCon.LTL.Internal.Rewrite
 
+import           Control.Monad.Reader (runReader)
+
 import           Prelude hiding (Foldable (..), lookup)
 
 import           Data.Foldable (Foldable(..))
@@ -41,18 +43,20 @@ data SatisfactionResult event ty = Satisfied | Unsatisfied (Relevance event ty) 
 traceFormula :: Show ty => String -> Formula event ty -> Formula event ty
 traceFormula ~str x =
 #ifdef TRACE
+
   trace (str <> " " <> Text.unpack (prettyFormula x Prec.Universe)) x
 #else
   x
 #endif
 
 handleNext :: (Event event ty, Ord event, Ord ty, Show ty)
-           => (Int, Formula event ty)
+           => OnMissingKey
+           -> (Int, Formula event ty)
            -> event
            -> Either (SatisfactionResult event ty) (Int, Formula event ty)
-handleNext (!n, !formula0) m =
+handleNext omk (!n, !formula0) m =
   let formula1 = traceFormula ("(" <> show (1 + n) <> ")\ninitial:") formula0
-      formula2 = traceFormula "next:" $ next formula1 m
+      formula2 = traceFormula "next:" $ runReader (next formula1 m) omk
       formula3 = traceFormula "rewrite-hom:" (rewriteHomogeneous formula2)
       formula5 = traceFormula "rewrite-id:" (rewriteIdentity formula3) in
   case formula5 of
@@ -68,10 +72,11 @@ handleEnd (!n, !formula) =
 
 -- | Check if the formula is satisfied in the given event timeline.
 satisfies :: (Event event ty, Ord event, Ord ty, Show ty, Foldable f)
-          => Formula event ty
+          => OnMissingKey
+          -> Formula event ty
           -> f event
           -> SatisfactionResult event ty
-satisfies formula xs = fromEither $ handleEnd <$> foldl' (\acc e -> acc >>= flip handleNext e) (Right (0, formula)) xs
+satisfies omk formula xs = fromEither $ handleEnd <$> foldl' (\acc e -> acc >>= flip (handleNext omk) e) (Right (0, formula)) xs
   where
     fromEither :: Either a a -> a
     fromEither = either id id
@@ -87,11 +92,12 @@ data SatisfyMetrics event ty = SatisfyMetrics {
 --    the formula is equivalent to ⊤ or ⊥. This may happen either once the stream terminates or if
 --    the formula is falsified early by some prefix of the stream.
 satisfiesS :: (Event event ty, Ord event, Ord ty, Show ty)
-           => Formula event ty
+           => OnMissingKey
+           -> Formula event ty
            -> Stream (Of event) IO ()
            -> IORef (SatisfyMetrics event ty)
            -> IO (SatisfactionResult event ty)
-satisfiesS formula_ input_ metrics_ = run $ mapped (pure. pure . runIdentity) $ unfold (go metrics_) (0, formula_,  input_) where
+satisfiesS omk formula_ input_ metrics_ = run $ mapped (pure. pure . runIdentity) $ unfold (go metrics_) (0, formula_,  input_) where
   go :: (Event event ty, Ord event, Ord ty, Show ty)
      => IORef (SatisfyMetrics event ty)
      -> (Int, Formula event ty, Stream (Of event) IO ())
@@ -104,4 +110,4 @@ satisfiesS formula_ input_ metrics_ = run $ mapped (pure. pure . runIdentity) $ 
       pure $
         fmap
           (\(!n', !formula') -> Identity (n', formula', more))
-          (handleNext (n, formula) event)
+          (handleNext omk (n, formula) event)

--- a/bench/cardano-recon-framework/src/Cardano/ReCon/Trace/Event.hs
+++ b/bench/cardano-recon-framework/src/Cardano/ReCon/Trace/Event.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
+{-# LANGUAGE TypeSynonymInstances #-}
 module Cardano.ReCon.Trace.Event where
 
 import           Cardano.Logging.Types.TraceMessage (TraceMessage (..))
@@ -14,28 +15,37 @@ import           Data.Map.Strict (Map)
 import           Data.Maybe (isJust)
 import           Data.Text (Text, unpack)
 
-extractIntProps :: Object -> Map VariableIdentifier IntValue
-extractIntProps = Map.delete "kind" . Map.mapMaybe f . Map.mapKeysMonotonic toText . KeyMap.toMap
-  where
-    f (Number v) = Just (truncate v)
-    f _          = Nothing
+class Extractable a where
+  extract :: Value -> Maybe a
 
-extractTextProps :: Object -> Map VariableIdentifier Text
-extractTextProps = Map.delete "kind" . Map.mapMaybe f . Map.mapKeysMonotonic toText . KeyMap.toMap
+instance Extractable IntValue where
+  extract (Number n) = Just (truncate n)
+  extract _          = Nothing
+
+instance Extractable Text where
+  extract (String s) = Just s
+  extract _          = Nothing
+
+extractProps :: Extractable a => Object -> Map VariableIdentifier a
+extractProps = Map.delete "kind" . go ""
   where
-    f (String v) = Just v
-    f _          = Nothing
+    go prefix = Map.foldlWithKey' (\acc k v ->
+        let key = prefix <> k
+        in case v of
+          Object nested -> Map.union acc (go (key <> ".") nested)
+          _             -> maybe acc (\val -> Map.insert key val acc) (extract v)
+      ) Map.empty . Map.mapKeysMonotonic toText . KeyMap.toMap
 
 instance Event TemporalEvent Text where
   ofTy (TemporalEvent _ msgs) c = isJust $ find (\msg -> msg.tmsgNS == c) msgs
   intProps (TemporalEvent _ msgs) c =
     case find (\msg -> msg.tmsgNS == c) msgs of
-      Just x  -> extractIntProps x.tmsgData
+      Just x  -> extractProps x.tmsgData
       Nothing -> error ("Not an event of type " <> unpack c)
   textProps (TemporalEvent _ msgs) c =
     case find (\msg -> msg.tmsgNS == c) msgs of
       Just x  -> Map.insert "host"   x.tmsgHost   $
                    Map.insert "thread" x.tmsgThread $
-                     extractTextProps x.tmsgData
+                     extractProps x.tmsgData
       Nothing -> error ("Not an event of type " <> unpack c)
   beg (TemporalEvent t _) = t

--- a/bench/cardano-recon-framework/test/Cardano/ReCon/Integration/Suite.hs
+++ b/bench/cardano-recon-framework/test/Cardano/ReCon/Integration/Suite.hs
@@ -1,7 +1,7 @@
 {- HLINT ignore "Redundant map" -}
 module Cardano.ReCon.Integration.Suite (integrationTests) where
 
-import           Cardano.ReCon.LTL.Formula (Formula, interpTimeunit)
+import           Cardano.ReCon.LTL.Formula (Formula, OnMissingKey (..), interpTimeunit)
 import           Cardano.ReCon.LTL.Formula.Parser (Context (..))
 import qualified Cardano.ReCon.LTL.Formula.Parser as Parser
 import           Cardano.ReCon.LTL.Formula.Yaml (readFormulas, readPropValues)
@@ -60,13 +60,13 @@ mkPositive :: [Formula TemporalEvent Text] -> FilePath -> String -> TestTree
 mkPositive fs tracesDir name = testCase name $ do
   events <- Feed.read (tracesDir </> name) eventDuration
   forM_ fs $ \phi ->
-    satisfies phi events @?= Satisfied
+    satisfies CrashOnMissingKey phi events @?= Satisfied
 
 mkNegative :: [Formula TemporalEvent Text] -> FilePath -> String -> TestTree
 mkNegative fs tracesDir name = testCase name $ do
   events <- Feed.read (tracesDir </> name) eventDuration
   assertBool "expected at least one Unsatisfied" $
-    any isUnsatisfied (map (`satisfies` events) fs)
+    any isUnsatisfied (map (\f -> satisfies CrashOnMissingKey f events) fs)
 
 isUnsatisfied :: SatisfactionResult event ty -> Bool
 isUnsatisfied (Unsatisfied _) = True

--- a/bench/cardano-recon-framework/test/Cardano/ReCon/LTL/Semantics/Suite.hs
+++ b/bench/cardano-recon-framework/test/Cardano/ReCon/LTL/Semantics/Suite.hs
@@ -232,21 +232,21 @@ semanticsTests = testGroup "Semantics"
 prop1SatisfiabilityTests :: TestTree
 prop1SatisfiabilityTests = testGroup ("Satisfiability of: " <> unpack (prettyFormula prop1 Prec.Universe))
   [ testCase (show log1 <> " satisfies the formula") $
-      satisfies prop1 log1 @?= Satisfied
+      satisfies CrashOnMissingKey prop1 log1 @?= Satisfied
   , testCase (show log2 <> " satisfies the formula") $
-      satisfies prop1 log2 @?= Satisfied
+      satisfies CrashOnMissingKey prop1 log2 @?= Satisfied
   , testCase (show log3 <> " satisfies the formula") $
-      satisfies prop1 log3 @?= Satisfied
+      satisfies CrashOnMissingKey prop1 log3 @?= Satisfied
   , testCase (show log4 <> " does not satisfy the formula") $
-      satisfies prop1 log4 @?= Unsatisfied
+      satisfies CrashOnMissingKey prop1 log4 @?= Unsatisfied
         (fromList [(Msg Start 2, Start)])
   , testCase (show log5 <> " satisfies the formula") $
-      satisfies prop1 log5 @?= Satisfied
+      satisfies CrashOnMissingKey prop1 log5 @?= Satisfied
   , testCase (show log6 <> " satisfies the formula") $
-      satisfies prop1 log6 @?= Unsatisfied
+      satisfies CrashOnMissingKey prop1 log6 @?= Unsatisfied
         (fromList [(Msg Start 1,Start),(Msg Start 4,Start),(Msg Success 7,Success),(Msg Failure 1,Failure)])
   , testCase (show log7 <> " does not satisfy the formula") $
-      satisfies prop1 log7 @?= Unsatisfied
+      satisfies CrashOnMissingKey prop1 log7 @?= Unsatisfied
         (fromList [(Msg Start 2, Start)])
   ]
 
@@ -254,21 +254,21 @@ prop2SatisfiabilityTests :: TestTree
 prop2SatisfiabilityTests = testGroup ("Satisfiability of: " <> unpack (prettyFormula prop2 Prec.Universe))
   [
     testCase (show log1 <> " satisfies the formula") $
-      satisfies prop2 log1 @?= Satisfied
+      satisfies CrashOnMissingKey prop2 log1 @?= Satisfied
   , testCase (show log5 <> " satisfies the formula") $
-      satisfies prop2 log5 @?= Satisfied
+      satisfies CrashOnMissingKey prop2 log5 @?= Satisfied
   , testCase (show logEmpty <> " satisfies the formula") $
-      satisfies prop2 logEmpty @?= Satisfied
+      satisfies CrashOnMissingKey prop2 logEmpty @?= Satisfied
   , testCase (show log8 <> "does not satisfy the formula") $
-      satisfies prop2 log8 @?= Unsatisfied
+      satisfies CrashOnMissingKey prop2 log8 @?= Unsatisfied
         (fromList [(Msg Start 1,Start),(Msg Success 1,Success)])
   , testCase (show log9 <> " does not satisfy the formula") $
-      satisfies prop2 log9 @?= Unsatisfied
+      satisfies CrashOnMissingKey prop2 log9 @?= Unsatisfied
         (fromList [(Msg Success 1,Success)])
   , testCase (show log10 <> " satisfies the formula") $
-      satisfies prop2 log10 @?= Satisfied
+      satisfies CrashOnMissingKey prop2 log10 @?= Satisfied
   , testCase (show log11 <> " does not satisfy the formula") $
-      satisfies prop2 log11 @?=
+      satisfies CrashOnMissingKey prop2 log11 @?=
       Unsatisfied
         (fromList [(Msg Start 1,Start),(Msg Success 1,Success),(Msg Success 2,Success)])
 
@@ -278,39 +278,39 @@ prop3SatisfiabilityTests :: TestTree
 prop3SatisfiabilityTests = testGroup ("Satisfiability of: " <> unpack (prettyFormula prop3 Prec.Universe))
   [
     testCase (show log12 <> " satisfies the formula") $
-      satisfies prop3 log12 @?= Satisfied
+      satisfies CrashOnMissingKey prop3 log12 @?= Satisfied
   , testCase (show log13 <> " does not satisfy the formula") $
-      satisfies prop3 log13 @?= Unsatisfied (fromList [(Msg Start 1,Start),(Msg Success 0,Success)])
+      satisfies CrashOnMissingKey prop3 log13 @?= Unsatisfied (fromList [(Msg Start 1,Start),(Msg Success 0,Success)])
   ]
 
 prop4SatisfiabilityTests :: TestTree
 prop4SatisfiabilityTests = testGroup ("Satisfiability of: " <> unpack (prettyFormula prop4 Prec.Universe))
   [ testCase "[] satisfies the formula" $
-      satisfies prop4 ([] :: [Evt]) @?= Satisfied
+      satisfies CrashOnMissingKey prop4 ([] :: [Evt]) @?= Satisfied
   , testCase (show log14 <> " satisfies the formula") $
-      satisfies prop4 log14 @?= Satisfied
+      satisfies CrashOnMissingKey prop4 log14 @?= Satisfied
   , testCase (show log16 <> " satisfies the formula") $
-      satisfies prop4 log16 @?= Satisfied
+      satisfies CrashOnMissingKey prop4 log16 @?= Satisfied
   , testCase (show log15 <> " does not satisfy the formula") $
-      satisfies prop4 log15 @?=
+      satisfies CrashOnMissingKey prop4 log15 @?=
         Unsatisfied (fromList [(Evt P 1, P), (Evt Q 1, Q)])
   ]
 
 prop5SatisfiabilityTests :: TestTree
 prop5SatisfiabilityTests = testGroup ("Satisfiability of: " <> unpack (prettyFormula prop5 Prec.Universe))
   [ testCase "[] satisfies the formula" $
-      satisfies prop5 ([] :: [Evt]) @?= Satisfied
+      satisfies CrashOnMissingKey prop5 ([] :: [Evt]) @?= Satisfied
   , testCase (show log17 <> " satisfies the formula") $
-      satisfies prop5 log17 @?= Satisfied
+      satisfies CrashOnMissingKey prop5 log17 @?= Satisfied
   , testCase (show log18 <> " does not satisfy the formula") $
-      satisfies prop5 log18 @?=
+      satisfies CrashOnMissingKey prop5 log18 @?=
         Unsatisfied (fromList [(Evt P 2, P), (Evt Q 2, Q)])
   ]
 
 prop6SatisfiabilityTests :: TestTree
 prop6SatisfiabilityTests = testGroup ("Satisfiability of: " <> unpack (prettyFormula prop6 Prec.Universe))
   [ testCase "[] satisfies the formula" $
-      satisfies prop6 ([] :: [Evt]) @?= Satisfied
+      satisfies CrashOnMissingKey prop6 ([] :: [Evt]) @?= Satisfied
   , testCase (show [Noop] <> " satisfies the formula") $
-      satisfies prop6 [Noop] @?= Satisfied
+      satisfies CrashOnMissingKey prop6 [Noop] @?= Satisfied
   ]


### PR DESCRIPTION
* Support atoms that refer to property keys at arbitrary depth
* Replace crash-on-missing-key build flag with `--on-missing-key` CLI option