### PR TITLE
cardano-testnet: declare supported cli/node versions

### DIFF
--- a/cardano-testnet/README.md
+++ b/cardano-testnet/README.md
@@ -1,1 +1,10 @@
 For information on how to use this package, see [Launching a Testnet](https://developers.cardano.org/docs/get-started/cardano-testnet)
+
+## Supported versions
+
+cardano-testnet is designed to run the cardano-cli and cardano-node that ship
+in the same release. Mixing binaries across releases is unsupported; use cli
+and node from the same release tarball as this cardano-testnet.
+
+The cardano-api and cardano-cli versions this build was compiled against are
+printed by `cardano-testnet version`.

--- a/cardano-testnet/changelog.d/20260424_015940_palas_tag_testnet_compatibility.md
+++ b/cardano-testnet/changelog.d/20260424_015940_palas_tag_testnet_compatibility.md
@@ -1,0 +1,5 @@
+### Added
+
+- Added "Supported versions" section to README declaring the single-release policy for cli/node compatibility.
+- `cardano-testnet version` now reports the cardano-api and cardano-cli versions it was built against.
+

--- a/cardano-testnet/src/Parsers/Version.hs
+++ b/cardano-testnet/src/Parsers/Version.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Parsers.Version
@@ -33,6 +34,8 @@ runVersionOptions VersionOptions = do
     , " - ", os, "-", arch
     , " - ", compilerName, "-", showVersion compilerVersion
     , "\ngit rev ", T.unpack $(gitRev)
+    , "\nbuilt against cardano-api ", VERSION_cardano_api
+    , "\nbuilt against cardano-cli ", VERSION_cardano_cli
     ]
 
 cmdVersion :: Mod CommandFields VersionOptions

--- a/cardano-testnet/test/cardano-testnet-golden/Cardano/Testnet/Test/Golden/Help.hs
+++ b/cardano-testnet/test/cardano-testnet-golden/Cardano/Testnet/Test/Golden/Help.hs
@@ -5,6 +5,7 @@
 module Cardano.Testnet.Test.Golden.Help
   ( golden_HelpAll
   , golden_HelpCmds
+  , golden_VersionCmd
   ) where
 
 import           Cardano.Testnet.Test.Golden.Util
@@ -102,3 +103,24 @@ golden_HelpCmds =
         cmdHelp <- filterAnsi . second <$> execDetailCardanoTestnet (fmap Text.unpack usage <> ["--help"])
 
         H.diffVsGoldenFile cmdHelp expectedCmdHelpFp
+
+-- | Filter out volatile lines from 'cardano-testnet version' output.
+-- Removes the first two lines: The first one contains package version,
+-- OS, arch, compiler and the second one is the git rev line.
+filterVersionOutput :: String -> String
+filterVersionOutput =
+  unlines . drop 2 . map Text.unpack . Text.lines . Text.pack
+
+-- | Execute me with:
+-- @DISABLE_RETRIES=1 cabal test cardano-testnet-golden --test-options '-p "/golden_VersionCmd/"'@
+golden_VersionCmd :: Property
+golden_VersionCmd =
+  H.propertyOnce . H.moduleWorkspace "version-cmd" $ \_ -> do
+    unless isWin32 $ do
+      versionFp <- H.note "test/cardano-testnet-golden/files/golden/version_cmd.cli"
+
+      versionOutput <- filterVersionOutput . filterAnsi <$> execCardanoTestnet
+        [ "version"
+        ]
+
+      H.diffVsGoldenFile versionOutput versionFp

--- a/cardano-testnet/test/cardano-testnet-golden/cardano-testnet-golden.hs
+++ b/cardano-testnet/test/cardano-testnet-golden/cardano-testnet-golden.hs
@@ -24,6 +24,7 @@ tests = pure $ T.testGroup "Golden tests"
   [ H.testPropertyNamed "golden_DefaultConfig" (fromString "golden_DefaultConfig") Cardano.Testnet.Test.Golden.Config.goldenDefaultConfigYaml
   , H.testPropertyNamed "golden_HelpAll" (fromString "golden_HelpAll") Cardano.Testnet.Test.Golden.Help.golden_HelpAll
   , H.testPropertyNamed "golden_HelpCmds" (fromString "golden_HelpCmds") Cardano.Testnet.Test.Golden.Help.golden_HelpCmds
+  , H.testPropertyNamed "golden_VersionCmd" (fromString "golden_VersionCmd") Cardano.Testnet.Test.Golden.Help.golden_VersionCmd
   ]
 
 ingredients :: [T.Ingredient]

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/version_cmd.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/version_cmd.cli
@@ -1,0 +1,2 @@
+built against cardano-api 10.26.0.0
+built against cardano-cli 10.16.0.0


### PR DESCRIPTION
# Description

Declares which `cardano-cli\` and `cardano-node` versions `cardano-testnet` supports,
via two zero-maintenance mechanisms:

1. **README "Supported versions" section** — states the single-release policy:
   use cli and node from the same release tarball as cardano-testnet.

2. **Extended `cardano-testnet version` output** — reports the `cardano-api` and
   `cardano-cli` versions the build was compiled against, using Cabal's
   auto-generated `VERSION_cardano_api` and `VERSION_cardano_cli` CPP macros.
   The cabal file remains the sole source of truth.

Also fixes the version banner which incorrectly said "cardano-node" instead of
"cardano-testnet".

Closes #6548

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff