### PR TITLE
cardano-testnet | Fix flaky height check in rpc test

### DIFF
--- a/cardano-testnet/changelog.d/20260424_081135_mgalazyn_fix_rpc_transaction_test.md
+++ b/cardano-testnet/changelog.d/20260424_081135_mgalazyn_fix_rpc_transaction_test.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed flaky RPC transaction test that used a stale block height from a prior RPC connection to determine when to query UTxOs after submitting a transaction. Replaced the brittle block-counting wait with `retryUntilM`, which polls the RPC endpoint until the expected UTxOs appear at the destination address.

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/Transaction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/Transaction.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -26,12 +27,13 @@ import           Cardano.Testnet
 import           Prelude
 
 import           Control.Monad
-import           Control.Monad.Fix
+import           Control.Monad.Trans.Control (liftBaseOp)
 import           Data.Default.Class
 import qualified Data.Text.Encoding as T
 import           GHC.Stack
 import           Lens.Micro
 
+import           Testnet.Components.Query (TestnetWaitPeriod (..), getEpochStateView, retryUntilM)
 import           Testnet.Property.Util (integrationRetryWorkspace)
 import           Testnet.Types
 
@@ -40,7 +42,7 @@ import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.TestWatchdog as H
 
-import           RIO (ByteString, threadDelay)
+import           RIO (ByteString)
 
 -- | Run with:
 -- @TASTY_PATTERN='/RPC Transaction Submit/' cabal test cardano-testnet-test@
@@ -54,11 +56,13 @@ hprop_rpc_transaction = integrationRetryWorkspace 2 "rpc-tx" $ \tempAbsBasePath'
       addrInEra = AsAddressInEra eraProxy
 
   TestnetRuntime
-    { testnetNodes = node0 : _
+    { configurationFile
+    , testnetNodes = node0 : _
     , wallets = wallet0@(PaymentKeyInfo _ addrTxt0) : (PaymentKeyInfo _ addrTxt1) : _
     } <-
     createAndRunTestnet options def conf
 
+  epochStateView <- getEpochStateView configurationFile $ nodeSocketPath node0
   rpcSocket <- H.note . unFile $ nodeRpcSocketPath node0
 
   -- prepare tx inputs and output address
@@ -116,40 +120,30 @@ hprop_rpc_transaction = integrationRetryWorkspace 2 "rpc-tx" $ \tempAbsBasePath'
 
   H.noteShowPretty_ utxosResponse
 
-  (utxos, submitResponse) <- H.noteShowM . H.evalIO . Rpc.withConnection def rpcServer $ \conn -> do
-    submitResponse <-
+  liftBaseOp (Rpc.withConnection def rpcServer) $ \conn -> do
+    submitResponse <- H.noteShowM . H.evalIO $
       Rpc.nonStreaming conn (Rpc.rpc @(Rpc.Protobuf UtxoRpc.SubmitService "submitTx")) $
         def & U5c.tx .~ (def & U5c.raw .~ serialiseToCBOR signedTx)
 
-    fix $ \loop -> do
-      resp <- Rpc.nonStreaming conn (Rpc.rpc @(Rpc.Protobuf UtxoRpc.QueryService "readParams")) def
+    submittedTxId <- H.leftFail . deserialiseFromRawBytes AsTxId $ submitResponse ^. U5c.ref
 
-      let previousBlockNo = pparamsResponse ^. U5c.ledgerTip . U5c.height
-          currentBlockNo = resp ^. U5c.ledgerTip . U5c.height
-      -- wait for 2 blocks
-      when (previousBlockNo + 1 >= currentBlockNo) $ do
-        threadDelay 500_000
-        loop
+    H.note_ "Ensure that submitTx returns the same transaction ID as the locally computed signed transaction ID"
+    txId' === submittedTxId
 
     -- TODO use searchUtxos when available
-    utxos <-
-      Rpc.nonStreaming conn (Rpc.rpc @(Rpc.Protobuf UtxoRpc.QueryService "readUtxos")) def
-    pure (utxos, submitResponse)
+    H.note_ $ "Ensure that there are 2 UTXOs in the address " <> show addrTxt1
+    utxosForAddress <- retryUntilM epochStateView (WaitForBlocks 10)
+      (do utxos <- H.evalIO $
+            Rpc.nonStreaming conn (Rpc.rpc @(Rpc.Protobuf UtxoRpc.QueryService "readUtxos")) def
+          flip filterM (utxos ^. U5c.items) $ \utxo -> do
+            utxoAddress <- deserialiseAddressBs addrInEra $ utxo ^. U5c.cardano . U5c.address
+            pure $ addr1 == utxoAddress
+      )
+      (\xs -> length xs == 2)
 
-  submittedTxId <- H.leftFail . deserialiseFromRawBytes AsTxId $ submitResponse ^. U5c.ref
-
-  H.note_ "Ensure that submitted transaction ID is in the submitted transactions list"
-  txId' === submittedTxId
-
-  H.note_ $ "Ensure that there are 2 UTXOs in the address " <> show addrTxt1
-  utxosForAddress <- H.noteShowM . flip filterM (utxos ^. U5c.items) $ \utxo -> do
-    utxoAddress <- deserialiseAddressBs addrInEra $ utxo ^. U5c.cardano . U5c.address
-    pure $ addr1 == utxoAddress
-  2 === length utxosForAddress
-
-  let outputsAmounts = map (^. U5c.cardano . U5c.coin) utxosForAddress
-  H.note_ $ "Ensure that the output sent is one of the utxos for the address " <> show addrTxt1
-  H.assertWith outputsAmounts $ elem (inject amount)
+    let outputsAmounts = map (^. U5c.cardano . U5c.coin) utxosForAddress
+    H.note_ $ "Ensure that the output sent is one of the utxos for the address " <> show addrTxt1
+    H.assertWith outputsAmounts $ elem (inject amount)
 
 txoRefToTxIn :: (HasCallStack, MonadTest m) => Proto UtxoRpc.TxoRef -> m TxIn
 txoRefToTxIn r = withFrozenCallStack $ do


### PR DESCRIPTION
# Description

The chain height check was relying on an assumption that transaction goes into the next block, and sometimes the block nr check was returning stale info. 

This changes the implementation to use retry untilM, to reliably check for the height.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
