### PR TITLE
cardano-testnet: Split testnet options into purpose-specific types

### DIFF
--- a/cardano-node-chairman/test/Spec/Chairman/Cardano.hs
+++ b/cardano-node-chairman/test/Spec/Chairman/Cardano.hs
@@ -20,7 +20,7 @@ hprop_chairman :: H.Property
 hprop_chairman = integrationRetryWorkspace 2 "cardano-chairman" $ \tempAbsPath' -> H.runWithDefaultWatchdog_ $ do
   conf <- mkConf tempAbsPath'
 
-  let testnetOptions = def{ cardanoNodes = SpoNodeOptions [] :| [RelayNodeOptions [], RelayNodeOptions []] }
-  allNodes <- testnetNodes <$> createAndRunTestnet testnetOptions def conf
+  let creationOptions = def{ creationNodes = SpoNodeOptions [] :| [RelayNodeOptions [], RelayNodeOptions []] }
+  allNodes <- testnetNodes <$> createAndRunTestnet creationOptions def conf
 
   chairmanOver 120 50 conf allNodes

--- a/cardano-testnet/changelog.d/20260424_213403_palas_split_refactor_testnet_options.md
+++ b/cardano-testnet/changelog.d/20260424_213403_palas_split_refactor_testnet_options.md
@@ -7,7 +7,7 @@
 ### Changed
 
 - Split `CardanoTestnetOptions` into `TestnetCreationOptions` and `TestnetRuntimeOptions` so each function receives only the fields it uses.
-- `CardanoTestnetCliOptions` is now a sum type (`StartFromScratch | StartFromEnv`), making `--node-env` and `--num-pool-nodes` structurally mutually exclusive in the CLI parser.
+- `CardanoTestnetCliOptions` is now a sum type (`NoUserProvidedEnv | StartFromEnv`), making `--node-env` and `--num-pool-nodes` structurally mutually exclusive in the CLI parser.
 - Simplified `CardanoTestnetCreateEnvOptions` and `createTestnetEnv` signatures (fewer arguments, genesis options and on-chain params folded into `TestnetCreationOptions`).
 
 ### Added

--- a/cardano-testnet/changelog.d/20260424_213403_palas_split_refactor_testnet_options.md
+++ b/cardano-testnet/changelog.d/20260424_213403_palas_split_refactor_testnet_options.md
@@ -1,0 +1,16 @@
+
+### Removed
+
+- Removed `CardanoTestnetOptions` type and `CreateEnvOptions` wrapper (replaced by purpose-specific types).
+- Removed dead fields `cardanoNodeLoggingFormat` and `cardanoOutputDir`.
+
+### Changed
+
+- Split `CardanoTestnetOptions` into `TestnetCreationOptions` and `TestnetRuntimeOptions` so each function receives only the fields it uses.
+- `CardanoTestnetCliOptions` is now a sum type (`StartFromScratch | StartFromEnv`), making `--node-env` and `--num-pool-nodes` structurally mutually exclusive in the CLI parser.
+- Simplified `CardanoTestnetCreateEnvOptions` and `createTestnetEnv` signatures (fewer arguments, genesis options and on-chain params folded into `TestnetCreationOptions`).
+
+### Added
+
+- `readNodeOptionsFromEnv`: scans an existing testnet environment directory to classify nodes as SPO or relay.
+

--- a/cardano-testnet/src/Cardano/Testnet.hs
+++ b/cardano-testnet/src/Cardano/Testnet.hs
@@ -10,7 +10,9 @@ module Cardano.Testnet (
   retryOnAddressInUseError,
 
   -- ** Testnet options
-  CardanoTestnetOptions(..),
+  TestnetCreationOptions(..),
+  TestnetRuntimeOptions(..),
+  TestnetEnvOptions(..),
   RpcSupport(..),
   NodeOption(..),
   cardanoDefaultTestnetNodeOptions,

--- a/cardano-testnet/src/Parsers/Cardano.hs
+++ b/cardano-testnet/src/Parsers/Cardano.hs
@@ -33,7 +33,7 @@ optsTestnet = mkCliOptions <$> pModeOptions <*> pRuntimeOptions
           Left <$> pFromEnv
       <|> Right <$> ((,) <$> pCreationOptions <*> pScratchOutputDir)
     mkCliOptions (Left envOpts) rt = StartFromEnv (StartFromEnvOptions envOpts rt)
-    mkCliOptions (Right (creation, outDir)) rt = StartFromScratch (StartFromScratchOptions creation outDir rt)
+    mkCliOptions (Right (creation, outDir)) rt = NoUserProvidedEnv (NoUserProvidedEnvOptions creation outDir rt)
 
 optsCreateTestnet :: Parser CardanoTestnetCreateEnvOptions
 optsCreateTestnet = CardanoTestnetCreateEnvOptions

--- a/cardano-testnet/src/Parsers/Cardano.hs
+++ b/cardano-testnet/src/Parsers/Cardano.hs
@@ -6,7 +6,6 @@ module Parsers.Cardano
   ) where
 
 import           Cardano.Api (AnyShelleyBasedEra (..))
-import           Cardano.Api.Pretty
 
 import           Cardano.CLI.EraBased.Common.Option hiding (pNetworkId)
 import           Cardano.Prelude (readMaybe)
@@ -26,68 +25,81 @@ import           Options.Applicative.Types (readerAsk)
 import           Testnet.Defaults (defaultEra)
 import           Testnet.Start.Cardano
 import           Testnet.Start.Types
-import           Testnet.Types (readNodeLoggingFormat)
 
 optsTestnet :: Parser CardanoTestnetCliOptions
-optsTestnet = CardanoTestnetCliOptions
-  <$> pCardanoTestnetCliOptions
-  <*> pGenesisOptions
-  <*> pNodeEnvironment
-  <*> pUpdateTimestamps
-  <*> pOnChainParams
+optsTestnet = mkCliOptions <$> pModeOptions <*> pRuntimeOptions
+  where
+    pModeOptions =
+          Left <$> pFromEnv
+      <|> Right <$> ((,) <$> pCreationOptions <*> pScratchOutputDir)
+    mkCliOptions (Left envOpts) rt = StartFromEnv (StartFromEnvOptions envOpts rt)
+    mkCliOptions (Right (creation, outDir)) rt = StartFromScratch (StartFromScratchOptions creation outDir rt)
 
 optsCreateTestnet :: Parser CardanoTestnetCreateEnvOptions
 optsCreateTestnet = CardanoTestnetCreateEnvOptions
-  <$> pCardanoTestnetCliOptions
-  <*> pGenesisOptions
+  <$> pCreationOptions
   <*> pEnvOutputDir
-  <*> pCreateEnvOptions
 
--- We can't fill in the optional Genesis files at parse time, because we want to be in a monad
--- to properly parse JSON. We delegate this task to the caller.
-pCreateEnvOptions :: Parser CreateEnvOptions
-pCreateEnvOptions = CreateEnvOptions
-  <$> pOnChainParams
+pFromEnv :: Parser TestnetEnvOptions
+pFromEnv = TestnetEnvOptions
+  <$> OA.strOption
+      (  OA.long "node-env"
+      <> OA.metavar "FILEPATH"
+      <> OA.help "Path to the node's environment (which is generated otherwise). You can generate a default environment with the 'create-env' command, then modify it and pass it with this argument."
+      )
+  <*> pUpdateTimestamps
 
-pCardanoTestnetCliOptions :: Parser CardanoTestnetOptions
-pCardanoTestnetCliOptions = CardanoTestnetOptions
+pCreationOptions :: Parser TestnetCreationOptions
+pCreationOptions = TestnetCreationOptions
   <$> pTestnetNodeOptions
   <*> pure (AnyShelleyBasedEra defaultEra)
   <*> pMaxLovelaceSupply
-  <*> OA.option (OA.eitherReader readNodeLoggingFormat)
-      (   OA.long "node-logging-format"
-      <>  OA.help "Node logging format (json|text)"
-      <>  OA.metavar "LOGGING_FORMAT"
-      <>  OA.showDefaultWith prettyShow
-      <>  OA.value (cardanoNodeLoggingFormat def)
-      )
-  <*> OA.option OA.auto
-      (   OA.long "num-dreps"
-      <>  OA.help "Number of delegate representatives (DReps) to generate. Ignored if a node environment is passed."
-      <>  OA.metavar "NUMBER"
-      <>  OA.showDefault
-      <>  OA.value 3
-      )
-  <*> OA.switch
-      (   OA.long "enable-new-epoch-state-logging"
-      <>  OA.help "Enable new epoch state logging to logs/ledger-epoch-state.log"
-      <>  OA.showDefault
-      )
-  <*> (maybe NoUserProvidedEnv UserProvidedEnv <$> optional (OA.strOption
-      (   OA.long "output-dir"
-      <>  OA.help "Directory where to store files, sockets, and so on. It is created if it doesn't exist. If unset, a temporary directory is used."
-      <>  OA.metavar "DIRECTORY"
-      )))
-  <*> OA.flag RpcDisabled RpcEnabled
-      (   OA.long "enable-grpc"
-      <>  OA.help "[EXPERIMENTAL] Enable gRPC endpoint on all of testnet nodes. The listening socket file will be the same directory as node's N2C socket."
-      <>  OA.showDefault
-      )
-  <*> OA.flag UseKesKeyFile UseKesSocket
-      (   OA.long "use-kes-agent"
-      <>  OA.help "Get Praos block forging credentials from kes-agent via the default socket path"
-      <>  OA.showDefault
-      )
+  <*> pNumDReps
+  <*> pGenesisOptions
+  <*> pOnChainParams
+
+pRuntimeOptions :: Parser TestnetRuntimeOptions
+pRuntimeOptions = TestnetRuntimeOptions
+  <$> pEnableNewEpochStateLogging
+  <*> pEnableRpc
+  <*> pKesSource
+
+pScratchOutputDir :: Parser (Maybe FilePath)
+pScratchOutputDir = optional $ OA.strOption
+  (   OA.long "output-dir"
+  <>  OA.help "Directory where to store files, sockets, and so on. It is created if it doesn't exist. If unset, a temporary directory is used."
+  <>  OA.metavar "DIRECTORY"
+  )
+
+pNumDReps :: Parser NumDReps
+pNumDReps = OA.option OA.auto
+  (   OA.long "num-dreps"
+  <>  OA.help "Number of delegate representatives (DReps) to generate."
+  <>  OA.metavar "NUMBER"
+  <>  OA.showDefault
+  <>  OA.value 3
+  )
+
+pEnableNewEpochStateLogging :: Parser Bool
+pEnableNewEpochStateLogging = OA.switch
+  (   OA.long "enable-new-epoch-state-logging"
+  <>  OA.help "Enable new epoch state logging to logs/ledger-epoch-state.log"
+  <>  OA.showDefault
+  )
+
+pEnableRpc :: Parser RpcSupport
+pEnableRpc = OA.flag RpcDisabled RpcEnabled
+  (   OA.long "enable-grpc"
+  <>  OA.help "[EXPERIMENTAL] Enable gRPC endpoint on all of testnet nodes. The listening socket file will be the same directory as node's N2C socket."
+  <>  OA.showDefault
+  )
+
+pKesSource :: Parser PraosCredentialsSource
+pKesSource = OA.flag UseKesKeyFile UseKesSocket
+  (   OA.long "use-kes-agent"
+  <>  OA.help "Get Praos block forging credentials from kes-agent via the default socket path"
+  <>  OA.showDefault
+  )
 
 pTestnetNodeOptions :: Parser (NonEmpty NodeOption)
 pTestnetNodeOptions =
@@ -107,14 +119,6 @@ pTestnetNodeOptions =
       case readMaybe arg of
         Just n | n >= 1 -> pure n
         _ -> fail "Need at least one SPO node to produce blocks, but got none."
-
-pNodeEnvironment :: Parser UserProvidedEnv
-pNodeEnvironment = fmap (maybe NoUserProvidedEnv UserProvidedEnv) <$>
-  optional $ OA.strOption
-    (  OA.long "node-env"
-    <> OA.metavar "FILEPATH"
-    <> OA.help "Path to the node's environment (which is generated otherwise). You can generate a default environment with the 'create-env' command, then modify it and pass it with this argument."
-    )
 
 pOnChainParams :: Parser TestnetOnChainParams
 pOnChainParams = fmap (fromMaybe DefaultParams) <$> optional $
@@ -161,7 +165,7 @@ pGenesisOptions =
     pEpochLength =
       OA.option OA.auto
         (   OA.long "epoch-length"
-        <>  OA.help "Epoch length, in number of slots. Ignored if a node environment is passed."
+        <>  OA.help "Epoch length, in number of slots."
         <>  OA.metavar "SLOTS"
         <>  OA.showDefault
         <>  OA.value (genesisEpochLength def)
@@ -169,7 +173,7 @@ pGenesisOptions =
     pSlotLength =
       OA.option OA.auto
         (   OA.long "slot-length"
-        <>  OA.help "Slot length. Ignored if a node environment is passed."
+        <>  OA.help "Slot length."
         <>  OA.metavar "SECONDS"
         <>  OA.showDefault
         <>  OA.value (genesisSlotLength def)
@@ -177,7 +181,7 @@ pGenesisOptions =
     pActiveSlotCoeffs =
       OA.option OA.auto
         (   OA.long "active-slots-coeff"
-        <>  OA.help "Active slots coefficient. Ignored if a node environment is passed."
+        <>  OA.help "Active slots coefficient."
         <>  OA.metavar "DOUBLE"
         <>  OA.showDefault
         <>  OA.value (genesisActiveSlotsCoeff def)
@@ -203,8 +207,8 @@ pMaxLovelaceSupply :: Parser Word64
 pMaxLovelaceSupply =
   OA.option OA.auto
       (   OA.long "max-lovelace-supply"
-      <>  OA.help "Max lovelace supply that your testnet starts with. Ignored if a node environment is passed."
+      <>  OA.help "Max lovelace supply that your testnet starts with."
       <>  OA.metavar "WORD64"
       <>  OA.showDefault
-      <>  OA.value (cardanoMaxSupply def)
+      <>  OA.value (creationMaxSupply def)
       )

--- a/cardano-testnet/src/Parsers/Cardano.hs
+++ b/cardano-testnet/src/Parsers/Cardano.hs
@@ -26,14 +26,18 @@ import           Testnet.Defaults (defaultEra)
 import           Testnet.Start.Cardano
 import           Testnet.Start.Types
 
+data ModeOptions
+  = ModeFromEnv TestnetEnvOptions
+  | ModeNewEnv TestnetCreationOptions (Maybe FilePath)
+
 optsTestnet :: Parser CardanoTestnetCliOptions
 optsTestnet = mkCliOptions <$> pModeOptions <*> pRuntimeOptions
   where
     pModeOptions =
-          Left <$> pFromEnv
-      <|> Right <$> ((,) <$> pCreationOptions <*> pScratchOutputDir)
-    mkCliOptions (Left envOpts) rt = StartFromEnv (StartFromEnvOptions envOpts rt)
-    mkCliOptions (Right (creation, outDir)) rt = NoUserProvidedEnv (NoUserProvidedEnvOptions creation outDir rt)
+          ModeFromEnv <$> pFromEnv
+      <|> ModeNewEnv <$> pCreationOptions <*> pScratchOutputDir
+    mkCliOptions (ModeFromEnv envOpts) rt = StartFromEnv (StartFromEnvOptions envOpts rt)
+    mkCliOptions (ModeNewEnv creation outDir) rt = NoUserProvidedEnv (NoUserProvidedEnvOptions creation outDir rt)
 
 optsCreateTestnet :: Parser CardanoTestnetCreateEnvOptions
 optsCreateTestnet = CardanoTestnetCreateEnvOptions

--- a/cardano-testnet/src/Parsers/Run.hs
+++ b/cardano-testnet/src/Parsers/Run.hs
@@ -73,17 +73,17 @@ createEnvOptions CardanoTestnetCreateEnvOptions
 
 runCardanoOptions :: CardanoTestnetCliOptions -> IO ()
 runCardanoOptions = \case
-  StartFromScratch StartFromScratchOptions{scratchCreationOptions, scratchOutputDir, scratchRuntimeOptions} -> do
+  NoUserProvidedEnv NoUserProvidedEnvOptions{noEnvCreationOptions, noEnvOutputDir, noEnvRuntimeOptions} -> do
     -- Create the sandbox, then run cardano-testnet.
     -- It is not necessary to update timestamps here, because
     -- the genesis files will be created with up-to-date stamps already.
-    let dirName = fromMaybe "testnet" scratchOutputDir
+    let dirName = fromMaybe "testnet" noEnvOutputDir
     conf <- mkConfigAbs dirName
     runSimpleApp . runResourceT $ do
       logInfo $ "Creating environment: " <> display (tempAbsPath conf)
-      createTestnetEnv scratchCreationOptions conf
+      createTestnetEnv noEnvCreationOptions conf
       logInfo $ "Starting testnet in environment: " <> display (tempAbsPath conf)
-      void $ cardanoTestnet (creationNodes scratchCreationOptions) scratchRuntimeOptions conf
+      void $ cardanoTestnet (creationNodes noEnvCreationOptions) noEnvRuntimeOptions conf
       logInfo "Testnet started"
       waitForShutdown
   StartFromEnv StartFromEnvOptions{fromEnvOptions, fromEnvRuntimeOptions} -> do

--- a/cardano-testnet/src/Parsers/Run.hs
+++ b/cardano-testnet/src/Parsers/Run.hs
@@ -17,6 +17,7 @@ import           Control.Monad (void)
 import           Data.Maybe (fromMaybe)
 import           Options.Applicative
 import qualified Options.Applicative as Opt
+import           System.Directory (doesDirectoryExist)
 
 import           Testnet.Filepath (unTmpAbsPath)
 import           Testnet.Start.Cardano
@@ -27,6 +28,7 @@ import           Parsers.Help
 import           Parsers.Version
 import           RIO (display, forever, logInfo, runSimpleApp, threadDelay)
 import           UnliftIO.Resource (runResourceT)
+import           Cardano.Prelude (unlessM)
 
 pref :: ParserPrefs
 pref = Opt.prefs $ showHelpOnEmpty <> showHelpOnError
@@ -86,7 +88,9 @@ runCardanoOptions = \case
       waitForShutdown
   StartFromEnv StartFromEnvOptions{fromEnvOptions, fromEnvRuntimeOptions} -> do
     -- Run cardano-testnet in the sandbox provided by the user
-    conf <- mkConfigAbs (envPath fromEnvOptions)
+    let dirName = envPath fromEnvOptions
+    unlessM (doesDirectoryExist dirName) $ error $ "The provided path does not exist or is not a directory: " <> dirName
+    conf <- mkConfigAbs dirName
     nodes <- readNodeOptionsFromEnv (unTmpAbsPath (tempAbsPath conf))
     runSimpleApp . runResourceT $ do
       logInfo $ "Starting testnet in environment: " <> display (tempAbsPath conf)

--- a/cardano-testnet/src/Parsers/Run.hs
+++ b/cardano-testnet/src/Parsers/Run.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -13,9 +14,11 @@ module Parsers.Run
 import           Cardano.CLI.Environment
 
 import           Control.Monad (void)
+import           Data.Maybe (fromMaybe)
 import           Options.Applicative
 import qualified Options.Applicative as Opt
 
+import           Testnet.Filepath (unTmpAbsPath)
 import           Testnet.Start.Cardano
 import           Testnet.Start.Types
 
@@ -56,50 +59,41 @@ runTestnetCmd = \case
 
 createEnvOptions :: CardanoTestnetCreateEnvOptions -> IO ()
 createEnvOptions CardanoTestnetCreateEnvOptions
-  { createEnvTestnetOptions=testnetOptions
-  , createEnvGenesisOptions=genesisOptions
+  { createEnvCreationOptions=creationOptions
   , createEnvOutputDir=outputDir
-  , createEnvCreateEnvOptions=ceOptions
   } = do
       conf <- mkConfigAbs outputDir
       void $ createTestnetEnv
-        testnetOptions genesisOptions ceOptions
+        creationOptions
         -- Do not add hashes to the main config file, so that genesis files
         -- can be modified without having to recompute hashes every time.
         conf{genesisHashesPolicy = WithoutHashes}
 
 runCardanoOptions :: CardanoTestnetCliOptions -> IO ()
-runCardanoOptions CardanoTestnetCliOptions
-  { cliTestnetOptions=testnetOptions
-  , cliGenesisOptions=genesisOptions
-  , cliNodeEnvironment=env
-  , cliUpdateTimestamps=updateTimestamps'
-  , cliOnChainParams=onChainParams
-  } = do
-    case env of
-      NoUserProvidedEnv -> do
-        -- Create the sandbox, then run cardano-testnet.
-        -- It is not necessary to honor `cliUpdateTimestamps` here, because
-        -- the genesis files will be created with up-to-date stamps already.
-        conf <- mkConfigAbs "testnet"
-        runSimpleApp . runResourceT $ do
-          logInfo $ "Creating environment: " <> display (tempAbsPath conf)
-          createTestnetEnv testnetOptions genesisOptions (CreateEnvOptions onChainParams) conf
-          logInfo $ "Starting testnet in environment: " <> display (tempAbsPath conf)
-          void $ cardanoTestnet testnetOptions conf
-          logInfo "Testnet started"
-          waitForShutdown
-      UserProvidedEnv nodeEnvPath -> do
-        -- Run cardano-testnet in the sandbox provided by the user
-        -- In that case, 'cardanoOutputDir' is not used
-        conf <- mkConfigAbs nodeEnvPath
-        runSimpleApp . runResourceT $ do
-          logInfo $ "Starting testnet in environment: " <> display (tempAbsPath conf)
-          void $ cardanoTestnet
-            testnetOptions
-            conf{updateTimestamps=updateTimestamps'}
-          logInfo "Testnet started"
-          waitForShutdown
+runCardanoOptions = \case
+  StartFromScratch StartFromScratchOptions{scratchCreationOptions, scratchOutputDir, scratchRuntimeOptions} -> do
+    -- Create the sandbox, then run cardano-testnet.
+    -- It is not necessary to update timestamps here, because
+    -- the genesis files will be created with up-to-date stamps already.
+    let dirName = fromMaybe "testnet" scratchOutputDir
+    conf <- mkConfigAbs dirName
+    runSimpleApp . runResourceT $ do
+      logInfo $ "Creating environment: " <> display (tempAbsPath conf)
+      createTestnetEnv scratchCreationOptions conf
+      logInfo $ "Starting testnet in environment: " <> display (tempAbsPath conf)
+      void $ cardanoTestnet (creationNodes scratchCreationOptions) scratchRuntimeOptions conf
+      logInfo "Testnet started"
+      waitForShutdown
+  StartFromEnv StartFromEnvOptions{fromEnvOptions, fromEnvRuntimeOptions} -> do
+    -- Run cardano-testnet in the sandbox provided by the user
+    conf <- mkConfigAbs (envPath fromEnvOptions)
+    nodes <- readNodeOptionsFromEnv (unTmpAbsPath (tempAbsPath conf))
+    runSimpleApp . runResourceT $ do
+      logInfo $ "Starting testnet in environment: " <> display (tempAbsPath conf)
+      void $ cardanoTestnet nodes fromEnvRuntimeOptions
+               conf{updateTimestamps = envUpdateTimestamps fromEnvOptions}
+      logInfo "Testnet started"
+      waitForShutdown
   where
     waitForShutdown = do
       logInfo "Waiting for shutdown (Ctrl+C)"

--- a/cardano-testnet/src/Testnet/Components/Configuration.hs
+++ b/cardano-testnet/src/Testnet/Components/Configuration.hs
@@ -153,16 +153,16 @@ createSPOGenesisAndFiles
   :: MonadIO m
   => HasCallStack
   => MonadThrow m
-  => CardanoTestnetOptions -- ^ The options to use
-  -> GenesisOptions
-  -> TestnetOnChainParams
+  => TestnetCreationOptions
   -> TmpAbsolutePath
   -> m FilePath -- ^ Shelley genesis directory
 createSPOGenesisAndFiles
-  testnetOptions genesisOptions@GenesisOptions{genesisTestnetMagic}
-  onChainParams
+  creationOptions@TestnetCreationOptions
+    { creationGenesisOptions=genesisOptions@GenesisOptions{genesisTestnetMagic}
+    , creationOnChainParams=onChainParams
+    }
   (TmpAbsolutePath tempAbsPath) =  do
-  AnyShelleyBasedEra sbe <- pure cardanoNodeEra
+  AnyShelleyBasedEra sbe <- pure creationEra
 
 
   let genesisShelleyDir = takeDirectory inputGenesisShelleyFp
@@ -171,9 +171,9 @@ createSPOGenesisAndFiles
 
   let -- At least there should be a delegator per DRep
       -- otherwise some won't be representing anybody
-      numStakeDelegators = max 3 (fromIntegral cardanoNumDReps) :: Int
+      numStakeDelegators = max 3 (fromIntegral creationNumDReps) :: Int
 
-  shelleyGenesis'' <- getDefaultShelleyGenesis cardanoNodeEra cardanoMaxSupply genesisOptions
+  shelleyGenesis'' <- getDefaultShelleyGenesis creationEra creationMaxSupply genesisOptions
   -- TODO: Remove this rewrite.
   -- 50 second epochs
   -- Epoch length should be "10 * k / f" where "k = securityParam, f = activeSlotsCoeff"
@@ -209,10 +209,10 @@ createSPOGenesisAndFiles
     ++
     [ "--testnet-magic", show genesisTestnetMagic
     , "--pools", show nPoolNodes
-    , "--total-supply",     show cardanoMaxSupply -- Half of this will be delegated, see https://github.com/IntersectMBO/cardano-cli/pull/874
+    , "--total-supply",     show creationMaxSupply -- Half of this will be delegated, see https://github.com/IntersectMBO/cardano-cli/pull/874
     , "--stake-delegators", show numStakeDelegators
     , "--utxo-keys", show numSeededUTxOKeys]
-    <> monoidForEraInEon @ConwayEraOnwards era (const ["--drep-keys", show cardanoNumDReps])
+    <> monoidForEraInEon @ConwayEraOnwards era (const ["--drep-keys", show creationNumDReps])
     <> [ "--start-time", DTC.formatIso8601 startTime
     , "--out-dir", tempAbsPath
     ]
@@ -230,8 +230,8 @@ createSPOGenesisAndFiles
     inputGenesisAlonzoFp  = genesisInputFilepath AlonzoEra
     inputGenesisConwayFp  = genesisInputFilepath ConwayEra
     inputGenesisDijkstraFp  = genesisInputFilepath DijkstraEra
-    nPoolNodes = cardanoNumPools testnetOptions
-    CardanoTestnetOptions{cardanoNodeEra, cardanoMaxSupply, cardanoNumDReps} = testnetOptions
+    nPoolNodes = creationNumPools creationOptions
+    TestnetCreationOptions{creationEra, creationMaxSupply, creationNumDReps} = creationOptions
     genesisInputFilepath :: Pretty (eon era) => eon era -> FilePath
     genesisInputFilepath e = tempAbsPath </> ("genesis-input." <> eraToString e <> ".json")
     createTestnetDataFlag :: Pretty (eon era) => eon era -> [String]

--- a/cardano-testnet/src/Testnet/Property/Run.hs
+++ b/cardano-testnet/src/Testnet/Property/Run.hs
@@ -47,9 +47,14 @@ import qualified Test.Tasty.Hedgehog as H
 import           Test.Tasty.Providers (testPassed)
 import           Test.Tasty.Runners (Result (resultShortDescription), TestTree)
 
+-- | Whether the user has provided the path to an existing testnet environment
+-- through the @--node-env@ flag, or not. This determines whether the testnet
+-- will reuse an existing environment or whether a new one should be created.
 data UserProvidedEnv
   = NoUserProvidedEnv
+    -- ^ No user-provided environment, a new environment will be created for the user.
   | UserProvidedEnv FilePath
+    -- ^ The user provided the path to an existing testnet environment through the @--node-env@ flag.
 
 runTestnet :: UserProvidedEnv -> (Conf -> H.Integration TestnetRuntime) -> IO ()
 runTestnet env tn = do

--- a/cardano-testnet/src/Testnet/Property/Run.hs
+++ b/cardano-testnet/src/Testnet/Property/Run.hs
@@ -2,7 +2,8 @@
 {-# LANGUAGE NamedFieldPuns #-}
 
 module Testnet.Property.Run
-  ( runTestnet
+  ( UserProvidedEnv(..)
+  , runTestnet
   -- Ignore tests on various OSs
   , ignoreOn
   , ignoreOnWindows
@@ -32,7 +33,8 @@ import           Text.Printf (printf)
 
 import           Testnet.Process.RunIO
 import           Testnet.Property.Util (integration, integrationWorkspace)
-import           Testnet.Start.Types (Conf, UserProvidedEnv (..), mkConf)
+import           Testnet.Start.Types (Conf, mkConf)
+
 import           Testnet.Types (TestnetNode (..), TestnetRuntime (..), spoNodes)
 
 import           Hedgehog (Property)
@@ -44,6 +46,10 @@ import           Test.Tasty.ExpectedFailure (wrapTest)
 import qualified Test.Tasty.Hedgehog as H
 import           Test.Tasty.Providers (testPassed)
 import           Test.Tasty.Runners (Result (resultShortDescription), TestTree)
+
+data UserProvidedEnv
+  = NoUserProvidedEnv
+  | UserProvidedEnv FilePath
 
 runTestnet :: UserProvidedEnv -> (Conf -> H.Integration TestnetRuntime) -> IO ()
 runTestnet env tn = do

--- a/cardano-testnet/src/Testnet/Start/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Start/Cardano.hs
@@ -12,7 +12,7 @@
 
 module Testnet.Start.Cardano
   ( CardanoTestnetCliOptions(..)
-  , StartFromScratchOptions(..)
+  , NoUserProvidedEnvOptions(..)
   , StartFromEnvOptions(..)
   , TestnetCreationOptions(..)
   , TestnetRuntimeOptions(..)

--- a/cardano-testnet/src/Testnet/Start/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Start/Cardano.hs
@@ -12,7 +12,11 @@
 
 module Testnet.Start.Cardano
   ( CardanoTestnetCliOptions(..)
-  , CardanoTestnetOptions(..)
+  , StartFromScratchOptions(..)
+  , StartFromEnvOptions(..)
+  , TestnetCreationOptions(..)
+  , TestnetRuntimeOptions(..)
+  , TestnetEnvOptions(..)
   , NodeOption(..)
   , cardanoDefaultTestnetNodeOptions
 
@@ -23,6 +27,7 @@ module Testnet.Start.Cardano
   , createTestnetEnv
   , getDefaultAlonzoGenesis
   , getDefaultShelleyGenesis
+  , readNodeOptionsFromEnv
   , retryOnAddressInUseError
 
   , liftToIntegration
@@ -35,7 +40,7 @@ import qualified Cardano.Api.Byron as Byron
 
 import           Cardano.Network.Diffusion.Topology (CardanoNetworkTopology)
 import           Cardano.Node.Configuration.NodeAddress (PortNumber)
-import           Cardano.Prelude (NonEmpty ((:|)), canonicalEncodePretty)
+import           Cardano.Prelude (NonEmpty ((:|)), canonicalEncodePretty, readMaybe)
 import           Ouroboros.Network.PeerSelection.RelayAccessPoint (RelayAccessPoint (..))
 
 import           Prelude hiding (lines)
@@ -47,10 +52,11 @@ import           Control.Monad.Trans.Resource (MonadResource, getInternalState)
 import           Data.Aeson
 import qualified Data.Aeson.Encode.Pretty as A
 import qualified Data.ByteString.Lazy as LBS
-import           Data.Default.Class (def)
+import           Data.Default.Class ()
 import           Data.Either
+import           Data.Maybe (mapMaybe)
 import           Data.Functor
-import           Data.List (uncons)
+import           Data.List (sort, stripPrefix, uncons)
 import qualified Data.List.NonEmpty as NEL
 import qualified Data.Map as Map
 import           Data.MonoTraversable (Element, MonoFunctor, omap)
@@ -91,9 +97,9 @@ import           UnliftIO.Exception (stringException)
 testMinimumConfigurationRequirements :: ()
   => HasCallStack
   => MonadIO m
-  => CardanoTestnetOptions -> m ()
-testMinimumConfigurationRequirements options = withFrozenCallStack $ do
-  when (cardanoNumPools options < 1) $ do
+  => NonEmpty NodeOption -> m ()
+testMinimumConfigurationRequirements nodes = withFrozenCallStack $ do
+  unless (any isSpoNodeOptions nodes) $ do
     throwString "Need at least one SPO node to produce blocks, but got none."
 
 liftToIntegration :: HasCallStack => RIO ResourceMap a -> H.Integration a
@@ -106,31 +112,25 @@ createTestnetEnv :: ()
   => MonadIO m
   => MonadThrow m
   => MonadFail m
-  => CardanoTestnetOptions
-  -> GenesisOptions
-  -> CreateEnvOptions
+  => TestnetCreationOptions
   -> Conf
   -> m ()
 createTestnetEnv
-  testnetOptions@CardanoTestnetOptions
-    { cardanoNodeEra=asbe
-    , cardanoNodes
-    }
-  genesisOptions
-  CreateEnvOptions
-    { ceoOnChainParams=onChainParams
+  creationOptions@TestnetCreationOptions
+    { creationEra=asbe
+    , creationNodes
     }
   Conf
     { genesisHashesPolicy
     , tempAbsPath=TmpAbsolutePath tmpAbsPath
     } = do
 
-  testMinimumConfigurationRequirements testnetOptions
+  testMinimumConfigurationRequirements creationNodes
 
   AnyShelleyBasedEra sbe <- pure asbe
 
   _ <- createSPOGenesisAndFiles
-    testnetOptions genesisOptions onChainParams
+    creationOptions
     (TmpAbsolutePath tmpAbsPath)
 
   let configurationFile = tmpAbsPath </> defaultConfigFile
@@ -141,13 +141,13 @@ createTestnetEnv
 
   liftIOAnnotated . LBS.writeFile configurationFile $ A.encodePretty $ Object config
 
-  portNumbers <- forM (NEL.zip (1 :| [2..]) cardanoNodes)
+  portNumbers <- forM (NEL.zip (1 :| [2..]) creationNodes)
     (\(i, _nodeOption) -> (i,) <$> H.randomPort testnetDefaultIpv4Address)
 
   let portNumbersMap = Map.fromList (NEL.toList portNumbers)
 
   -- Create network topology and write port files
-  let nodeIds = fst <$> NEL.zip (1 :| [2..]) cardanoNodes
+  let nodeIds = fst <$> NEL.zip (1 :| [2..]) creationNodes
   forM_ nodeIds $ \i -> do
     let nodeDataDir = tmpAbsPath </> Defaults.defaultNodeDataDir i
     liftIOAnnotated $ IO.createDirectoryIfMissing True nodeDataDir
@@ -161,8 +161,7 @@ createTestnetEnv
     let topology = Defaults.defaultP2PTopology producers
     liftIOAnnotated . LBS.writeFile (nodeDataDir </> "topology.json") $ A.encodePretty topology
 
--- | Starts a number of nodes, as configured by the value of the 'cardanoNodes'
--- field in the 'CardanoTestnetOptions' argument. Regarding this field, you can either:
+-- | Starts a number of nodes, as given by the first argument. You can either:
 --
 -- 1. Pass a value 'UserProvidedNodeOptions filepath' to specify your own node configuration file.
 --    In this case, only 1 node will be started (TODO: allow an arbitrary number of nodes to be started)
@@ -233,22 +232,22 @@ cardanoTestnet
   => MonadResource m
   => MonadCatch m
   => MonadFail m
-  => CardanoTestnetOptions -- ^ The options to use
+  => NonEmpty NodeOption -- ^ The nodes to start
+  -> TestnetRuntimeOptions -- ^ Runtime options
   -> Conf -- ^ Path to the test sandbox
   -> m TestnetRuntime
 cardanoTestnet
-  testnetOptions
+  cardanoNodes
+  TestnetRuntimeOptions
+    { runtimeEnableNewEpochStateLogging=enableNewEpochStateLogging
+    , runtimeEnableRpc=cardanoEnableRpc
+    , runtimeKESSource=cardanoKESSource
+    }
   Conf
     { tempAbsPath=TmpAbsolutePath tmpAbsPath
     , updateTimestamps
     } = do
-  let CardanoTestnetOptions
-        { cardanoEnableNewEpochStateLogging=enableNewEpochStateLogging
-        , cardanoNodes
-        , cardanoEnableRpc
-        , cardanoKESSource
-        } = testnetOptions
-      nPools = cardanoNumPools testnetOptions
+  let nPools = NumPools $ length $ NEL.filter isSpoNodeOptions cardanoNodes
       nodeConfigFile = tmpAbsPath </> defaultConfigFile
       byronGenesisFile = tmpAbsPath </> "byron-genesis.json"
       shelleyGenesisFile = tmpAbsPath </> "shelley-genesis.json"
@@ -471,16 +470,14 @@ idToRemoteAddressP2P portNumbersMap (NodeId i) = case Map.lookup i portNumbersMa
 -- | A convenience wrapper around `createTestnetEnv` and `cardanoTestnet`
 createAndRunTestnet :: ()
   => HasCallStack
-  => CardanoTestnetOptions -- ^ The options to use
-  -> GenesisOptions
+  => TestnetCreationOptions
+  -> TestnetRuntimeOptions
   -> Conf -- ^ Path to the test sandbox
   -> H.Integration TestnetRuntime
-createAndRunTestnet testnetOptions genesisOptions conf = do
+createAndRunTestnet creationOptions runtimeOptions conf = do
   liftToIntegration $ do
-     createTestnetEnv
-       testnetOptions genesisOptions def
-       conf
-     cardanoTestnet testnetOptions conf
+     createTestnetEnv creationOptions conf
+     cardanoTestnet (creationNodes creationOptions) runtimeOptions conf
 
 -- | Retry an action when `NodeAddressAlreadyInUseError` gets thrown from an action
 retryOnAddressInUseError
@@ -511,3 +508,21 @@ retryOnAddressInUseError act = withFrozenCallStack $ go maximumTimeout retryTime
     maximumTimeout = 150
     -- Wait for that many seconds before retrying.
     retryTimeout = 5
+
+-- | Read node options from an existing testnet environment directory.
+-- Scans @node-data/@ for node directories and checks @pools-keys/@ to
+-- classify each node as SPO or relay.
+readNodeOptionsFromEnv :: MonadIO m => FilePath -> m (NonEmpty NodeOption)
+readNodeOptionsFromEnv envDir = do
+  entries <- liftIO $ IO.listDirectory (envDir </> "node-data")
+  let nodeNums = sort $ mapMaybe parseNodeNum entries
+  case nodeNums of
+    [] -> throwString "No node directories found in environment"
+    (n:ns) -> mapM classifyNode (n :| ns)
+  where
+    parseNodeNum s = do
+      rest <- stripPrefix "node" s
+      readMaybe rest :: Maybe Int
+    classifyNode i = do
+      hasPools <- liftIO $ IO.doesDirectoryExist (envDir </> Defaults.defaultSpoKeysDir i)
+      pure $ if hasPools then SpoNodeOptions [] else RelayNodeOptions []

--- a/cardano-testnet/src/Testnet/Start/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Start/Cardano.hs
@@ -247,6 +247,7 @@ cardanoTestnet
     { tempAbsPath=TmpAbsolutePath tmpAbsPath
     , updateTimestamps
     } = do
+  testMinimumConfigurationRequirements cardanoNodes
   let nPools = NumPools $ length $ NEL.filter isSpoNodeOptions cardanoNodes
       nodeConfigFile = tmpAbsPath </> defaultConfigFile
       byronGenesisFile = tmpAbsPath </> "byron-genesis.json"

--- a/cardano-testnet/src/Testnet/Start/Types.hs
+++ b/cardano-testnet/src/Testnet/Start/Types.hs
@@ -8,27 +8,31 @@
 
 module Testnet.Start.Types
   ( CardanoTestnetCliOptions(..)
+  , StartFromScratchOptions(..)
+  , StartFromEnvOptions(..)
   , CardanoTestnetCreateEnvOptions (..)
-  , CardanoTestnetOptions(..)
+  , TestnetCreationOptions(..)
+  , TestnetRuntimeOptions(..)
+  , TestnetEnvOptions(..)
   , InputNodeConfigFile(..)
   , NodeId(..)
   , NumDReps(..)
   , NumPools(..)
   , NumRelays(..)
   , RpcSupport(..)
-  , cardanoNumPools
-  , cardanoNumRelays
+  , creationNumPools
+  , creationNumRelays
 
   , anyEraToString
   , anyShelleyBasedEraToString
   , defaultTestnetMagic
   , eraToString
 
-  , CreateEnvOptions(..)
   , UpdateTimestamps(..)
   , TestnetOnChainParams(..)
   , mainnetParamsRequest
   , NodeOption(..)
+  , isSpoNodeOptions
   , isRelayNodeOptions
   , cardanoDefaultTestnetNodeOptions
   , GenesisOptions(..)
@@ -77,47 +81,39 @@ import qualified Hedgehog.Extras as H
 defaultTestnetMagic :: Int
 defaultTestnetMagic = 42
 
--- | Command line options for the @cardano-testnet@ executable. They are used
--- in the parser, and then get split into 'CardanoTestnetOptions' and
--- 'GenesisOptions'. If 'cliNodeEnvironment' is provided, don't create a
--- sandbox environment, use the one at the given path.
-data CardanoTestnetCliOptions = CardanoTestnetCliOptions
-  { cliTestnetOptions :: CardanoTestnetOptions
-  , cliGenesisOptions :: GenesisOptions
-  , cliNodeEnvironment :: UserProvidedEnv
-  , cliUpdateTimestamps :: UpdateTimestamps
-  , cliOnChainParams :: TestnetOnChainParams
+-- | Command line options for the @cardano-testnet cardano@ command.
+-- Either start from scratch (creating a new testnet environment) or
+-- start from a pre-existing environment (created by @create-env@).
+data CardanoTestnetCliOptions
+  = StartFromScratch StartFromScratchOptions
+  | StartFromEnv StartFromEnvOptions
+  deriving (Eq, Show)
+
+-- | Options for @cardano-testnet cardano@ when creating a new environment
+-- and then starting the testnet.
+data StartFromScratchOptions = StartFromScratchOptions
+  { scratchCreationOptions :: TestnetCreationOptions
+  , scratchOutputDir :: Maybe FilePath -- ^ @--output-dir@, uses a temporary directory if absent
+  , scratchRuntimeOptions :: TestnetRuntimeOptions
   } deriving (Eq, Show)
 
-instance Default CardanoTestnetCliOptions where
-  def = CardanoTestnetCliOptions
-    { cliTestnetOptions = def
-    , cliGenesisOptions = def
-    , cliNodeEnvironment = def
-    , cliUpdateTimestamps = def
-    , cliOnChainParams = def
-    }
+-- | Options for @cardano-testnet cardano --node-env@ when starting a testnet
+-- from a pre-existing environment (created by @create-env@).
+data StartFromEnvOptions = StartFromEnvOptions
+  { fromEnvOptions :: TestnetEnvOptions
+  , fromEnvRuntimeOptions :: TestnetRuntimeOptions
+  } deriving (Eq, Show)
 
 data UserProvidedEnv
   = NoUserProvidedEnv
   | UserProvidedEnv FilePath
   deriving (Eq, Show)
 
-instance Default UserProvidedEnv where
-  def = NoUserProvidedEnv
-
 data UpdateTimestamps = UpdateTimestamps | DontUpdateTimestamps
   deriving (Eq, Show)
 
 instance Default UpdateTimestamps where
   def = DontUpdateTimestamps
-
-newtype CreateEnvOptions = CreateEnvOptions
-  { ceoOnChainParams :: TestnetOnChainParams
-  } deriving (Eq, Show)
-
-instance Default CreateEnvOptions where
-  def = CreateEnvOptions { ceoOnChainParams = def }
 
 data TestnetOnChainParams
   = DefaultParams
@@ -170,11 +166,11 @@ instance FromJSON NodeId where
       Left _ -> parseFail $ "Incorrect format for NodeId: " ++ show t
     _ -> parseFail $ "Incorrect format for NodeId: " ++ show t
 
+-- | Command line options for the @cardano-testnet create-env@ subcommand.
+-- Creates a sandbox environment without starting nodes.
 data CardanoTestnetCreateEnvOptions = CardanoTestnetCreateEnvOptions
-  { createEnvTestnetOptions :: CardanoTestnetOptions
-  , createEnvGenesisOptions :: GenesisOptions
-  , createEnvOutputDir :: FilePath
-  , createEnvCreateEnvOptions :: CreateEnvOptions
+  { createEnvCreationOptions :: TestnetCreationOptions
+  , createEnvOutputDir :: FilePath -- ^ Required @--output@ directory
   } deriving (Eq, Show)
 
 data RpcSupport
@@ -182,34 +178,64 @@ data RpcSupport
   | RpcEnabled
   deriving (Eq, Show)
 
--- | Options which, contrary to 'GenesisOptions' are not implemented
--- by tuning the genesis files.
-data CardanoTestnetOptions = CardanoTestnetOptions
+-- | Options for creating a testnet environment (genesis files, topology, ports).
+-- Used by both the @cardano@ and @create-env@ subcommands, and by
+-- 'Testnet.Start.Cardano.createAndRunTestnet' in tests.
+data TestnetCreationOptions = TestnetCreationOptions
   { -- | Options controlling how many nodes to create and of which type.
-    cardanoNodes :: NonEmpty NodeOption
-  , cardanoNodeEra :: AnyShelleyBasedEra -- ^ The era to start at
-  , cardanoMaxSupply :: Word64 -- ^ The amount of Lovelace you are starting your testnet with (forwarded to shelley genesis)
-                               -- TODO move me to GenesisOptions when https://github.com/IntersectMBO/cardano-cli/pull/874 makes it to cardano-node
-  , cardanoNodeLoggingFormat :: NodeLoggingFormat
-  , cardanoNumDReps :: NumDReps -- ^ The number of DReps to generate at creation
-  , cardanoEnableNewEpochStateLogging :: Bool -- ^ if epoch state logging is enabled
-  , cardanoOutputDir :: UserProvidedEnv -- ^ The output directory where to store files, sockets, and so on. If unset, a temporary directory is used.
-  , cardanoEnableRpc :: RpcSupport
-  -- ^ Whether to enable gRPC endpoints in all testnet nodes
-  , cardanoKESSource :: PraosCredentialsSource
+    creationNodes :: NonEmpty NodeOption
+  , creationEra :: AnyShelleyBasedEra -- ^ The era to start at
+  , creationMaxSupply :: Word64 -- ^ The amount of Lovelace you are starting your testnet with (forwarded to shelley genesis)
+                                -- TODO move me to GenesisOptions when https://github.com/IntersectMBO/cardano-cli/pull/874 makes it to cardano-node
+  , creationNumDReps :: NumDReps -- ^ The number of DReps to generate at creation
+  , creationGenesisOptions :: GenesisOptions
+  , creationOnChainParams :: TestnetOnChainParams
+  } deriving (Eq, Show)
+
+instance Default TestnetCreationOptions where
+  def = TestnetCreationOptions
+    { creationNodes = cardanoDefaultTestnetNodeOptions
+    , creationEra = AnyShelleyBasedEra ShelleyBasedEraConway
+    , creationMaxSupply = 100_000_020_000_000
+    , creationNumDReps = 3
+    , creationGenesisOptions = def
+    , creationOnChainParams = def
+    }
+
+-- | Options for running testnet nodes (after the environment is created).
+-- These are independent of how the environment was created (from scratch
+-- or from an existing @--node-env@ path).
+data TestnetRuntimeOptions = TestnetRuntimeOptions
+  { runtimeEnableNewEpochStateLogging :: Bool -- ^ if epoch state logging is enabled
+  , runtimeEnableRpc :: RpcSupport -- ^ Whether to enable gRPC endpoints in all testnet nodes
+  , runtimeKESSource :: PraosCredentialsSource
+  } deriving (Eq, Show)
+
+instance Default TestnetRuntimeOptions where
+  def = TestnetRuntimeOptions
+    { runtimeEnableNewEpochStateLogging = True
+    , runtimeEnableRpc = RpcDisabled
+    , runtimeKESSource = def
+    }
+
+-- | Options specific to the @--node-env@ path: the environment directory
+-- and whether to update genesis timestamps before starting.
+data TestnetEnvOptions = TestnetEnvOptions
+  { envPath :: FilePath -- ^ Path to the pre-existing environment
+  , envUpdateTimestamps :: UpdateTimestamps
   } deriving (Eq, Show)
 
 -- | Path to the configuration file of the node, specified by the user
 newtype InputNodeConfigFile = InputNodeConfigFile FilePath
   deriving (Eq, Show)
 
-cardanoNumPools :: CardanoTestnetOptions -> NumPools
-cardanoNumPools CardanoTestnetOptions{cardanoNodes} =
-  NumPools $ length $ NEL.filter isSpoNodeOptions cardanoNodes
+creationNumPools :: TestnetCreationOptions -> NumPools
+creationNumPools TestnetCreationOptions{creationNodes} =
+  NumPools $ length $ NEL.filter isSpoNodeOptions creationNodes
 
-cardanoNumRelays :: CardanoTestnetOptions -> NumRelays
-cardanoNumRelays CardanoTestnetOptions{cardanoNodes} =
-  NumRelays $ length $ NEL.filter isRelayNodeOptions cardanoNodes
+creationNumRelays :: TestnetCreationOptions -> NumRelays
+creationNumRelays TestnetCreationOptions{creationNodes} =
+  NumRelays $ length $ NEL.filter isRelayNodeOptions creationNodes
 
 -- | Number of stake pool nodes
 newtype NumPools = NumPools Int
@@ -222,19 +248,6 @@ newtype NumRelays = NumRelays Int
 -- | Number of Delegate Represenatives
 newtype NumDReps = NumDReps Int
   deriving (Show, Read, Eq, Enum, Ord, Num, Real, Integral) via Int
-
-instance Default CardanoTestnetOptions where
-  def = CardanoTestnetOptions
-    { cardanoNodes = cardanoDefaultTestnetNodeOptions
-    , cardanoNodeEra = AnyShelleyBasedEra ShelleyBasedEraConway
-    , cardanoMaxSupply = 100_000_020_000_000 -- 100 000 billions Lovelace, so 100 millions ADA. This amount should be bigger than the 'byronTotalBalance' in Testnet.Start.Byron
-    , cardanoNodeLoggingFormat = NodeLoggingFormatAsJson
-    , cardanoNumDReps = 3
-    , cardanoEnableNewEpochStateLogging = True
-    , cardanoOutputDir = def
-    , cardanoEnableRpc = RpcDisabled
-    , cardanoKESSource = def -- TODO(10.7): use default value
-    }
 
 -- | Options that are implemented by writing fields in the Shelley genesis file.
 data GenesisOptions = GenesisOptions

--- a/cardano-testnet/src/Testnet/Start/Types.hs
+++ b/cardano-testnet/src/Testnet/Start/Types.hs
@@ -8,7 +8,7 @@
 
 module Testnet.Start.Types
   ( CardanoTestnetCliOptions(..)
-  , StartFromScratchOptions(..)
+  , NoUserProvidedEnvOptions(..)
   , StartFromEnvOptions(..)
   , CardanoTestnetCreateEnvOptions (..)
   , TestnetCreationOptions(..)
@@ -37,7 +37,6 @@ module Testnet.Start.Types
   , cardanoDefaultTestnetNodeOptions
   , GenesisOptions(..)
   , UserProvidedData(..)
-  , UserProvidedEnv(..)
   , UserProvidedGeneses(..)
   , PraosCredentialsSource(..)
 
@@ -82,19 +81,19 @@ defaultTestnetMagic :: Int
 defaultTestnetMagic = 42
 
 -- | Command line options for the @cardano-testnet cardano@ command.
--- Either start from scratch (creating a new testnet environment) or
--- start from a pre-existing environment (created by @create-env@).
+-- Either create a new testnet environment or use a pre-existing one
+-- (created by @create-env@).
 data CardanoTestnetCliOptions
-  = StartFromScratch StartFromScratchOptions
+  = NoUserProvidedEnv NoUserProvidedEnvOptions
   | StartFromEnv StartFromEnvOptions
   deriving (Eq, Show)
 
--- | Options for @cardano-testnet cardano@ when creating a new environment
--- and then starting the testnet.
-data StartFromScratchOptions = StartFromScratchOptions
-  { scratchCreationOptions :: TestnetCreationOptions
-  , scratchOutputDir :: Maybe FilePath -- ^ @--output-dir@, uses a temporary directory if absent
-  , scratchRuntimeOptions :: TestnetRuntimeOptions
+-- | Options for @cardano-testnet cardano@ when no user-provided environment
+-- is given: create a new environment and then start the testnet.
+data NoUserProvidedEnvOptions = NoUserProvidedEnvOptions
+  { noEnvCreationOptions :: TestnetCreationOptions
+  , noEnvOutputDir :: Maybe FilePath -- ^ @--output-dir@, uses a temporary directory if absent
+  , noEnvRuntimeOptions :: TestnetRuntimeOptions
   } deriving (Eq, Show)
 
 -- | Options for @cardano-testnet cardano --node-env@ when starting a testnet
@@ -103,11 +102,6 @@ data StartFromEnvOptions = StartFromEnvOptions
   { fromEnvOptions :: TestnetEnvOptions
   , fromEnvRuntimeOptions :: TestnetRuntimeOptions
   } deriving (Eq, Show)
-
-data UserProvidedEnv
-  = NoUserProvidedEnv
-  | UserProvidedEnv FilePath
-  deriving (Eq, Show)
 
 data UpdateTimestamps = UpdateTimestamps | DontUpdateTimestamps
   deriving (Eq, Show)

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
@@ -1,37 +1,32 @@
 Usage: cardano-testnet (cardano | create-env | version | help)
 
-Usage: cardano-testnet cardano [--num-pool-nodes COUNT]
-  [--max-lovelace-supply WORD64]
-  [--node-logging-format LOGGING_FORMAT]
-  [--num-dreps NUMBER]
+Usage: cardano-testnet cardano 
+  [ --node-env FILEPATH [--preserve-timestamps]
+  | [--num-pool-nodes COUNT]
+    [--max-lovelace-supply WORD64]
+    [--num-dreps NUMBER]
+    [--testnet-magic INT]
+    [--epoch-length SLOTS]
+    [--slot-length SECONDS]
+    [--active-slots-coeff DOUBLE]
+    [--params-file FILEPATH | --params-mainnet]
+    [--output-dir DIRECTORY]
+  ]
   [--enable-new-epoch-state-logging]
-  [--output-dir DIRECTORY]
   [--enable-grpc]
   [--use-kes-agent]
-  [--testnet-magic INT]
-  [--epoch-length SLOTS]
-  [--slot-length SECONDS]
-  [--active-slots-coeff DOUBLE]
-  [--node-env FILEPATH]
-  [--preserve-timestamps]
-  [--params-file FILEPATH | --params-mainnet]
 
   Start a testnet and keep it running until stopped
 
 Usage: cardano-testnet create-env [--num-pool-nodes COUNT]
   [--max-lovelace-supply WORD64]
-  [--node-logging-format LOGGING_FORMAT]
   [--num-dreps NUMBER]
-  [--enable-new-epoch-state-logging]
-  [--output-dir DIRECTORY]
-  [--enable-grpc]
-  [--use-kes-agent]
   [--testnet-magic INT]
   [--epoch-length SLOTS]
   [--slot-length SECONDS]
   [--active-slots-coeff DOUBLE]
-  --output DIRECTORY
   [--params-file FILEPATH | --params-mainnet]
+  --output DIRECTORY
 
   Create a sandbox for Cardano testnet
 

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/cardano.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/cardano.cli
@@ -1,60 +1,53 @@
-Usage: cardano-testnet cardano [--num-pool-nodes COUNT]
-  [--max-lovelace-supply WORD64]
-  [--node-logging-format LOGGING_FORMAT]
-  [--num-dreps NUMBER]
+Usage: cardano-testnet cardano 
+  [ --node-env FILEPATH [--preserve-timestamps]
+  | [--num-pool-nodes COUNT]
+    [--max-lovelace-supply WORD64]
+    [--num-dreps NUMBER]
+    [--testnet-magic INT]
+    [--epoch-length SLOTS]
+    [--slot-length SECONDS]
+    [--active-slots-coeff DOUBLE]
+    [--params-file FILEPATH | --params-mainnet]
+    [--output-dir DIRECTORY]
+  ]
   [--enable-new-epoch-state-logging]
-  [--output-dir DIRECTORY]
   [--enable-grpc]
   [--use-kes-agent]
-  [--testnet-magic INT]
-  [--epoch-length SLOTS]
-  [--slot-length SECONDS]
-  [--active-slots-coeff DOUBLE]
-  [--node-env FILEPATH]
-  [--preserve-timestamps]
-  [--params-file FILEPATH | --params-mainnet]
 
   Start a testnet and keep it running until stopped
 
 Available options:
-  --num-pool-nodes COUNT   Number of pool nodes. Note this uses a default node
-                           configuration for all nodes.
-  --max-lovelace-supply WORD64
-                           Max lovelace supply that your testnet starts with.
-                           Ignored if a node environment is passed.
-                           (default: 100000020000000)
-  --node-logging-format LOGGING_FORMAT
-                           Node logging format (json|text) (default: json)
-  --num-dreps NUMBER       Number of delegate representatives (DReps) to
-                           generate. Ignored if a node environment is passed.
-                           (default: 3)
-  --enable-new-epoch-state-logging
-                           Enable new epoch state logging to
-                           logs/ledger-epoch-state.log
-  --output-dir DIRECTORY   Directory where to store files, sockets, and so on.
-                           It is created if it doesn't exist. If unset, a
-                           temporary directory is used.
-  --enable-grpc            [EXPERIMENTAL] Enable gRPC endpoint on all of testnet
-                           nodes. The listening socket file will be the same
-                           directory as node's N2C socket.
-  --use-kes-agent          Get Praos block forging credentials from kes-agent
-                           via the default socket path
-  --testnet-magic INT      Specify a testnet magic id. (default: 42)
-  --epoch-length SLOTS     Epoch length, in number of slots. Ignored if a node
-                           environment is passed. (default: 500)
-  --slot-length SECONDS    Slot length. Ignored if a node environment is passed.
-                           (default: 0.1)
-  --active-slots-coeff DOUBLE
-                           Active slots coefficient. Ignored if a node
-                           environment is passed. (default: 5.0e-2)
   --node-env FILEPATH      Path to the node's environment (which is generated
                            otherwise). You can generate a default environment
                            with the 'create-env' command, then modify it and
                            pass it with this argument.
   --preserve-timestamps    Do not update the time stamps in genesis files to
                            current date.
+  --num-pool-nodes COUNT   Number of pool nodes. Note this uses a default node
+                           configuration for all nodes.
+  --max-lovelace-supply WORD64
+                           Max lovelace supply that your testnet starts with.
+                           (default: 100000020000000)
+  --num-dreps NUMBER       Number of delegate representatives (DReps) to
+                           generate. (default: 3)
+  --testnet-magic INT      Specify a testnet magic id. (default: 42)
+  --epoch-length SLOTS     Epoch length, in number of slots. (default: 500)
+  --slot-length SECONDS    Slot length. (default: 0.1)
+  --active-slots-coeff DOUBLE
+                           Active slots coefficient. (default: 5.0e-2)
   --params-file FILEPATH   File containing custom on-chain parameters in
                            Blockfrost format:
                            https://docs.blockfrost.io/#tag/cardano--epochs/GET/epochs/latest/parameters
   --params-mainnet         Use mainnet on-chain parameters
+  --output-dir DIRECTORY   Directory where to store files, sockets, and so on.
+                           It is created if it doesn't exist. If unset, a
+                           temporary directory is used.
+  --enable-new-epoch-state-logging
+                           Enable new epoch state logging to
+                           logs/ledger-epoch-state.log
+  --enable-grpc            [EXPERIMENTAL] Enable gRPC endpoint on all of testnet
+                           nodes. The listening socket file will be the same
+                           directory as node's N2C socket.
+  --use-kes-agent          Get Praos block forging credentials from kes-agent
+                           via the default socket path
   -h,--help                Show this help text

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/create-env.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/create-env.cli
@@ -1,17 +1,12 @@
 Usage: cardano-testnet create-env [--num-pool-nodes COUNT]
   [--max-lovelace-supply WORD64]
-  [--node-logging-format LOGGING_FORMAT]
   [--num-dreps NUMBER]
-  [--enable-new-epoch-state-logging]
-  [--output-dir DIRECTORY]
-  [--enable-grpc]
-  [--use-kes-agent]
   [--testnet-magic INT]
   [--epoch-length SLOTS]
   [--slot-length SECONDS]
   [--active-slots-coeff DOUBLE]
-  --output DIRECTORY
   [--params-file FILEPATH | --params-mainnet]
+  --output DIRECTORY
 
   Create a sandbox for Cardano testnet
 
@@ -20,35 +15,17 @@ Available options:
                            configuration for all nodes.
   --max-lovelace-supply WORD64
                            Max lovelace supply that your testnet starts with.
-                           Ignored if a node environment is passed.
                            (default: 100000020000000)
-  --node-logging-format LOGGING_FORMAT
-                           Node logging format (json|text) (default: json)
   --num-dreps NUMBER       Number of delegate representatives (DReps) to
-                           generate. Ignored if a node environment is passed.
-                           (default: 3)
-  --enable-new-epoch-state-logging
-                           Enable new epoch state logging to
-                           logs/ledger-epoch-state.log
-  --output-dir DIRECTORY   Directory where to store files, sockets, and so on.
-                           It is created if it doesn't exist. If unset, a
-                           temporary directory is used.
-  --enable-grpc            [EXPERIMENTAL] Enable gRPC endpoint on all of testnet
-                           nodes. The listening socket file will be the same
-                           directory as node's N2C socket.
-  --use-kes-agent          Get Praos block forging credentials from kes-agent
-                           via the default socket path
+                           generate. (default: 3)
   --testnet-magic INT      Specify a testnet magic id. (default: 42)
-  --epoch-length SLOTS     Epoch length, in number of slots. Ignored if a node
-                           environment is passed. (default: 500)
-  --slot-length SECONDS    Slot length. Ignored if a node environment is passed.
-                           (default: 0.1)
+  --epoch-length SLOTS     Epoch length, in number of slots. (default: 500)
+  --slot-length SECONDS    Slot length. (default: 0.1)
   --active-slots-coeff DOUBLE
-                           Active slots coefficient. Ignored if a node
-                           environment is passed. (default: 5.0e-2)
-  --output DIRECTORY       Directory where to create the sandbox environment.
+                           Active slots coefficient. (default: 5.0e-2)
   --params-file FILEPATH   File containing custom on-chain parameters in
                            Blockfrost format:
                            https://docs.blockfrost.io/#tag/cardano--epochs/GET/epochs/latest/parameters
   --params-mainnet         Use mainnet on-chain parameters
+  --output DIRECTORY       Directory where to create the sandbox environment.
   -h,--help                Show this help text

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Api/TxReferenceInputDatum.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Api/TxReferenceInputDatum.hs
@@ -57,14 +57,14 @@ hprop_tx_refin_datum = integrationRetryWorkspace 2 "api-tx-refin-dat" $ \tempAbs
       beo = convert ceo
       sbe = convert ceo
       eraProxy = proxyToAsType Proxy
-      options = def{cardanoNodeEra = AnyShelleyBasedEra sbe}
+      creationOptions = def{creationEra = AnyShelleyBasedEra sbe}
 
   tr@TestnetRuntime
     { configurationFile
     , testnetNodes = node0 : _
     , wallets = wallet0@(PaymentKeyInfo _ addrTxt0) : wallet1 : _
     } <-
-    createAndRunTestnet options def conf
+    createAndRunTestnet creationOptions def conf
 
   systemStart <- H.noteShowM $ getStartTime tempAbsPath' tr
   epochStateView <- getEpochStateView configurationFile (nodeSocketPath node0)

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/KesPeriodInfo.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/KesPeriodInfo.hs
@@ -69,7 +69,7 @@ hprop_kes_period_info = integrationRetryWorkspace 2 "kes-period-info" $ \tempAbs
       sbe = convert ceo
       asbe = AnyShelleyBasedEra sbe
       eraString = eraToString sbe
-      cTestnetOptions = def { cardanoNodeEra = asbe }
+      cTestnetOptions = def { creationEra = asbe }
 
   runTime@TestnetRuntime
     { configurationFile
@@ -149,7 +149,7 @@ hprop_kes_period_info = integrationRetryWorkspace 2 "kes-period-info" $ \tempAbs
   -- Test stake address registration cert
   createStakeKeyRegistrationCertificate
     tempAbsPath
-    (cardanoNodeEra cTestnetOptions)
+    (creationEra cTestnetOptions)
     (verificationKey testDelegatorKeys)
     keyDeposit
     testDelegatorRegCertFp

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/LeadershipSchedule.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/LeadershipSchedule.hs
@@ -69,8 +69,8 @@ hprop_leadershipSchedule = integrationRetryWorkspace 2 "leadership-schedule" $ \
       sbe = convert ceo
       asbe = AnyShelleyBasedEra sbe
       cTestnetOptions = def
-        { cardanoNodeEra = asbe
-        , cardanoNodes =
+        { creationEra = asbe
+        , creationNodes =
             SpoNodeOptions [] :|
           [ SpoNodeOptions []
           , SpoNodeOptions []
@@ -154,7 +154,7 @@ hprop_leadershipSchedule = integrationRetryWorkspace 2 "leadership-schedule" $ \
   -- Test stake address registration cert
   createStakeKeyRegistrationCertificate
     tempAbsPath
-    (cardanoNodeEra cTestnetOptions)
+    (creationEra cTestnetOptions)
     (verificationKey testDelegatorKeys)
     keyDeposit
     testDelegatorRegCertFp

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Plutus/BuildRaw.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Plutus/BuildRaw.hs
@@ -53,7 +53,7 @@ hprop_build_raw_ref_script_spend = integrationRetryWorkspace 2 "build-raw-ref-sc
         cEra = AnyCardanoEra era
         eraName = eraToString era
         tempBaseAbsPath = makeTmpBaseAbsPath $ TmpAbsolutePath tempAbsPath'
-        options = def{cardanoNodeEra = AnyShelleyBasedEra sbe}
+        creationOptions = def{creationEra = AnyShelleyBasedEra sbe}
 
     TestnetRuntime
         { configurationFile
@@ -61,7 +61,7 @@ hprop_build_raw_ref_script_spend = integrationRetryWorkspace 2 "build-raw-ref-sc
         , testnetNodes
         , wallets = wallet0 : wallet1 : _
         } <-
-        createAndRunTestnet options def conf
+        createAndRunTestnet creationOptions def conf
 
     poolNode1 <- H.headM testnetNodes
     poolSprocket1 <- H.noteShow $ nodeSprocket poolNode1

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Plutus/CostCalculation.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Plutus/CostCalculation.hs
@@ -66,7 +66,7 @@ hprop_ref_plutus_cost_calculation = integrationRetryWorkspace 2 "ref-plutus-scri
     cEra = AnyCardanoEra era
     eraName = eraToString era
     tempBaseAbsPath = makeTmpBaseAbsPath $ TmpAbsolutePath tempAbsPath'
-    options = def{cardanoNodeEra = AnyShelleyBasedEra sbe}
+    creationOptions = def{creationEra = AnyShelleyBasedEra sbe}
 
   TestnetRuntime
     { configurationFile
@@ -74,7 +74,7 @@ hprop_ref_plutus_cost_calculation = integrationRetryWorkspace 2 "ref-plutus-scri
     , testnetNodes
     , wallets = wallet0 : wallet1 : _
     } <-
-    createAndRunTestnet options def conf
+    createAndRunTestnet creationOptions def conf
 
   poolNode1 <- H.headM testnetNodes
   poolSprocket1 <- H.noteShow $ nodeSprocket poolNode1
@@ -222,7 +222,7 @@ hprop_included_plutus_cost_calculation = integrationRetryWorkspace 2 "included-p
     cEra = AnyCardanoEra era
     eraName = eraToString era
     tempBaseAbsPath = makeTmpBaseAbsPath $ TmpAbsolutePath tempAbsPath'
-    options = def{cardanoNodeEra = AnyShelleyBasedEra sbe}
+    creationOptions = def{creationEra = AnyShelleyBasedEra sbe}
 
   TestnetRuntime
     { configurationFile
@@ -230,7 +230,7 @@ hprop_included_plutus_cost_calculation = integrationRetryWorkspace 2 "included-p
     , testnetNodes
     , wallets = wallet0 : wallet1 : _
     } <-
-    createAndRunTestnet options def conf
+    createAndRunTestnet creationOptions def conf
 
   poolNode1 <- H.headM testnetNodes
   poolSprocket1 <- H.noteShow $ nodeSprocket poolNode1
@@ -334,7 +334,7 @@ hprop_included_simple_script_cost_calculation = integrationRetryWorkspace 2 "inc
     cEra = AnyCardanoEra era
     eraName = eraToString era
     tempBaseAbsPath = makeTmpBaseAbsPath $ TmpAbsolutePath tempAbsPath'
-    options = def{cardanoNodeEra = AnyShelleyBasedEra sbe}
+    creationOptions = def{creationEra = AnyShelleyBasedEra sbe}
 
   TestnetRuntime
     { configurationFile
@@ -342,7 +342,7 @@ hprop_included_simple_script_cost_calculation = integrationRetryWorkspace 2 "inc
     , testnetNodes
     , wallets = wallet0 : wallet1 : _
     } <-
-    createAndRunTestnet options def conf
+    createAndRunTestnet creationOptions def conf
 
   poolNode1 <- H.headM testnetNodes
   poolSprocket1 <- H.noteShow $ nodeSprocket poolNode1

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Plutus/MultiAssetReturnCollateral.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Plutus/MultiAssetReturnCollateral.hs
@@ -45,14 +45,14 @@ hprop_collateral_with_tokens = integrationRetryWorkspace 2 "collateral-with-toke
     sbe = convert ceo
     era = toCardanoEra sbe
     anyEra = AnyCardanoEra era
-    options = def { cardanoNodeEra = AnyShelleyBasedEra sbe }
+    creationOptions = def { creationEra = AnyShelleyBasedEra sbe }
 
   TestnetRuntime
     { configurationFile
     , testnetMagic
     , testnetNodes
     , wallets=wallet0:wallet1:wallet2:_
-    } <- createAndRunTestnet options def conf
+    } <- createAndRunTestnet creationOptions def conf
 
   node <- H.headM testnetNodes
   poolSprocket1 <- H.noteShow $ nodeSprocket node

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Plutus/Scripts.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Plutus/Scripts.hs
@@ -57,14 +57,14 @@ hprop_plutus_purposes_v3 = integrationRetryWorkspace 2 "all-plutus-script-purpos
     sbe = convert ceo
     era = toCardanoEra sbe
     anyEra = AnyCardanoEra era
-    options = def { cardanoNodeEra = AnyShelleyBasedEra sbe }
+    creationOptions = def { creationEra = AnyShelleyBasedEra sbe }
 
   TestnetRuntime
     { configurationFile
     , testnetMagic
     , testnetNodes
     , wallets=wallet0:wallet1:_
-    } <- createAndRunTestnet options def conf
+    } <- createAndRunTestnet creationOptions def conf
 
   node <- H.headM testnetNodes
   poolSprocket1 <- H.noteShow $ nodeSprocket node
@@ -207,14 +207,14 @@ hprop_tx_two_script_certs_v2 = integrationRetryWorkspace 2 "tx-2-script-certs" $
     sbe = convert ceo
     era = toCardanoEra sbe
     anyEra = AnyCardanoEra era
-    options = def { cardanoNodeEra = AnyShelleyBasedEra sbe }
+    creationOptions = def { creationEra = AnyShelleyBasedEra sbe }
 
   TestnetRuntime
     { configurationFile
     , testnetMagic
     , testnetNodes
     , wallets=wallet0:_
-    } <- createAndRunTestnet options def conf
+    } <- createAndRunTestnet creationOptions def conf
 
   node <- H.headM testnetNodes
   SpoNodeKeys{poolNodeKeysCold=KeyPair{verificationKey=spoKeyCold}} <- H.nothingFail $ poolKeys node

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Query.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Query.hs
@@ -59,7 +59,7 @@ import           Testnet.Process.Cli.Transaction (TxOutAddress (..), mkSimpleSpe
 import           Testnet.Process.Run (execCli', execCliStdoutToJson, mkExecConfig)
 import           Testnet.Process.RunIO (liftIOAnnotated)
 import           Testnet.Property.Util (integrationRetryWorkspace)
-import           Testnet.Start.Types (GenesisOptions (..), NumPools (..), cardanoNumPools)
+import           Testnet.Start.Types (GenesisOptions (..), NumPools (..), creationNumPools)
 import           Testnet.TestQueryCmds (TestQueryCmds (..), forallQueryCommands)
 import           Testnet.Types
 
@@ -86,14 +86,16 @@ hprop_cli_queries = integrationRetryWorkspace 2 "cli-queries" $ \tempAbsBasePath
       era = toCardanoEra sbe
       cEra = AnyCardanoEra era
       eraName = eraToString era
-      fastTestnetOptions = def { cardanoNodeEra = asbe }
-      shelleyOptions = def
-        { genesisEpochLength = 100
-        -- We change slotCoeff because epochLength must be equal to:
-        -- securityParam * 10 / slotCoeff
-        , genesisActiveSlotsCoeff = 0.5
+      fastTestnetOptions = def
+        { creationEra = asbe
+        , creationGenesisOptions = def
+            { genesisEpochLength = 100
+            -- We change slotCoeff because epochLength must be equal to:
+            -- securityParam * 10 / slotCoeff
+            , genesisActiveSlotsCoeff = 0.5
+            }
         }
-      nPools = cardanoNumPools fastTestnetOptions
+      nPools = creationNumPools fastTestnetOptions
 
   TestnetRuntime
     { testnetMagic
@@ -101,7 +103,7 @@ hprop_cli_queries = integrationRetryWorkspace 2 "cli-queries" $ \tempAbsBasePath
     , configurationFile
     , wallets=wallet0:wallet1:_
     }
-    <- createAndRunTestnet fastTestnetOptions shelleyOptions conf
+    <- createAndRunTestnet fastTestnetOptions def conf
 
   let shelleyGeneisFile = work </> Defaults.defaultGenesisFilepath ShelleyEra
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Scripts/Simple/CostCalculation.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Scripts/Simple/CostCalculation.hs
@@ -51,7 +51,7 @@ hprop_ref_simple_script_mint = integrationRetryWorkspace 2 "ref-simple-script" $
     cEra = AnyCardanoEra era
     eraName = eraToString era
     tempBaseAbsPath = makeTmpBaseAbsPath $ TmpAbsolutePath tempAbsPath'
-    options = def{cardanoNodeEra = AnyShelleyBasedEra sbe}
+    creationOptions = def{creationEra = AnyShelleyBasedEra sbe}
 
   TestnetRuntime
     { configurationFile
@@ -59,7 +59,7 @@ hprop_ref_simple_script_mint = integrationRetryWorkspace 2 "ref-simple-script" $
     , testnetNodes
     , wallets = wallet0 : wallet1 : _
     } <-
-    createAndRunTestnet options def conf
+    createAndRunTestnet creationOptions def conf
 
   poolNode1 <- H.headM testnetNodes
   poolSprocket1 <- H.noteShow $ nodeSprocket poolNode1

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Scripts/Simple/Mint.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Scripts/Simple/Mint.hs
@@ -48,14 +48,14 @@ hprop_simple_script_mint = integrationRetryWorkspace 2 "simple-script-mint" $ \t
     sbe = convert ceo
     era = toCardanoEra sbe
     anyEra = AnyCardanoEra era
-    options = def { cardanoNodeEra = AnyShelleyBasedEra sbe }
+    creationOptions = def { creationEra = AnyShelleyBasedEra sbe }
 
   TestnetRuntime
     { configurationFile
     , testnetMagic
     , testnetNodes
     , wallets=wallet0:wallet1:_
-    } <- createAndRunTestnet options def conf
+    } <- createAndRunTestnet creationOptions def conf
 
   node <- H.headM testnetNodes
   poolSprocket1 <- H.noteShow $ nodeSprocket node

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction.hs
@@ -54,14 +54,14 @@ hprop_transaction = integrationRetryWorkspace 2 "simple transaction build" $ \te
     era = toCardanoEra sbe
     cEra = AnyCardanoEra era
     tempBaseAbsPath = makeTmpBaseAbsPath $ TmpAbsolutePath tempAbsPath'
-    options = def { cardanoNodeEra = AnyShelleyBasedEra sbe }
+    creationOptions = def { creationEra = AnyShelleyBasedEra sbe }
 
   TestnetRuntime
     { configurationFile
     , testnetMagic
     , testnetNodes
     , wallets=wallet0:_
-    } <- createAndRunTestnet options def conf
+    } <- createAndRunTestnet creationOptions def conf
 
   poolNode1 <- H.headM testnetNodes
   poolSprocket1 <- H.noteShow $ nodeSprocket poolNode1

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction/BuildEstimate.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction/BuildEstimate.hs
@@ -48,8 +48,10 @@ hprop_tx_build_estimate = integrationRetryWorkspace 2 "transaction-build-estimat
   let ceo = ConwayEraOnwardsConway
       sbe = convert ceo
       eraName = eraToString sbe
-      fastTestnetOptions = def { cardanoNodeEra = AnyShelleyBasedEra sbe }
-      shelleyOptions = def { genesisEpochLength = 200 }
+      creationOptions = def
+        { creationEra = AnyShelleyBasedEra sbe
+        , creationGenesisOptions = def { genesisEpochLength = 200 }
+        }
 
   TestnetRuntime
     { testnetMagic
@@ -57,7 +59,7 @@ hprop_tx_build_estimate = integrationRetryWorkspace 2 "transaction-build-estimat
     , wallets=wallet0:wallet1:_
     , configurationFile
     }
-    <- createAndRunTestnet fastTestnetOptions shelleyOptions conf
+    <- createAndRunTestnet creationOptions def conf
 
   node <- H.headM testnetNodes
   poolSprocket1 <- H.noteShow $ nodeSprocket node

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction/RegisterDeregisterStakeAddress.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction/RegisterDeregisterStakeAddress.hs
@@ -51,8 +51,10 @@ hprop_tx_register_deregister_stake_address = integrationRetryWorkspace 2 "regist
   let ceo = ConwayEraOnwardsConway
       sbe = convert ceo
       eraName = eraToString sbe
-      fastTestnetOptions = def { cardanoNodeEra = AnyShelleyBasedEra sbe }
-      shelleyOptions = def { genesisEpochLength = 200 }
+      creationOptions = def
+        { creationEra = AnyShelleyBasedEra sbe
+        , creationGenesisOptions = def { genesisEpochLength = 200 }
+        }
 
   TestnetRuntime
     { testnetMagic
@@ -60,7 +62,7 @@ hprop_tx_register_deregister_stake_address = integrationRetryWorkspace 2 "regist
     , wallets=wallet0:wallet1:_
     , configurationFile
     }
-    <- createAndRunTestnet fastTestnetOptions shelleyOptions conf
+    <- createAndRunTestnet creationOptions def conf
 
   node <- H.headM testnetNodes
   poolSprocket1 <- H.noteShow $ nodeSprocket node

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction/WithdrawalReward.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction/WithdrawalReward.hs
@@ -60,8 +60,10 @@ hprop_tx_withdrawal_reward = integrationRetryWorkspace 2 "tx-withdrawal-reward" 
   let ceo = ConwayEraOnwardsConway
       sbe = convert ceo
       eraName = eraToString sbe
-      fastTestnetOptions = def { cardanoNodeEra = AnyShelleyBasedEra sbe }
-      shelleyOptions = def { genesisEpochLength = 100 }
+      creationOptions = def
+        { creationEra = AnyShelleyBasedEra sbe
+        , creationGenesisOptions = def { genesisEpochLength = 100 }
+        }
 
   TestnetRuntime
     { testnetMagic
@@ -69,7 +71,7 @@ hprop_tx_withdrawal_reward = integrationRetryWorkspace 2 "tx-withdrawal-reward" 
     , wallets = wallet0:_
     , configurationFile
     }
-    <- createAndRunTestnet fastTestnetOptions shelleyOptions conf
+    <- createAndRunTestnet creationOptions def conf
 
   node <- H.headM testnetNodes
   poolSprocket1 <- H.noteShow $ nodeSprocket node
@@ -133,8 +135,10 @@ hprop_tx_withdrawal_reward_plutus_v3 = integrationRetryWorkspace 2 "tx-withdrawa
   let ceo = ConwayEraOnwardsConway
       sbe = convert ceo
       eraName = eraToString sbe
-      fastTestnetOptions = def { cardanoNodeEra = AnyShelleyBasedEra sbe }
-      shelleyOptions = def { genesisEpochLength = 100 }
+      creationOptions = def
+        { creationEra = AnyShelleyBasedEra sbe
+        , creationGenesisOptions = def { genesisEpochLength = 100 }
+        }
 
   TestnetRuntime
     { testnetMagic
@@ -142,7 +146,7 @@ hprop_tx_withdrawal_reward_plutus_v3 = integrationRetryWorkspace 2 "tx-withdrawa
     , wallets = wallet0:wallet1:_
     , configurationFile
     }
-    <- createAndRunTestnet fastTestnetOptions shelleyOptions conf
+    <- createAndRunTestnet creationOptions def conf
 
   node <- H.headM testnetNodes
   poolSprocket1 <- H.noteShow $ nodeSprocket node

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/DumpConfig.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/DumpConfig.hs
@@ -26,8 +26,7 @@ import           System.FilePath ((</>))
 import           Testnet.Components.Configuration (startTimeOffsetSeconds)
 import           Testnet.Property.Util (integrationRetryWorkspace)
 import           Testnet.Start.Cardano (liftToIntegration)
-import           Testnet.Start.Types (GenesisHashesPolicy (..), GenesisOptions (..),
-                   UserProvidedEnv (..))
+import           Testnet.Start.Types (GenesisHashesPolicy (..), GenesisOptions (..))
 
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras as H
@@ -37,8 +36,7 @@ import qualified Hedgehog.Extras as H
 hprop_dump_config :: H.Property
 hprop_dump_config = integrationRetryWorkspace 2 "dump-config-files" $ \tmpDir -> H.runWithDefaultWatchdog_ $ do
 
-  let testnetOptions = def { cardanoOutputDir = UserProvidedEnv tmpDir }
-      genesisOptions = def { genesisEpochLength = 200 }
+  let creationOptions = def { creationGenesisOptions = def { genesisEpochLength = 200 } }
       byronGenesisFile = tmpDir </> "byron-genesis.json"
       shelleyGenesisFile = tmpDir </> "shelley-genesis.json"
 
@@ -46,7 +44,7 @@ hprop_dump_config = integrationRetryWorkspace 2 "dump-config-files" $ \tmpDir ->
   conf <- mkConf tmpDir
 
   liftToIntegration $ createTestnetEnv
-    testnetOptions genesisOptions def
+    creationOptions
     -- Do not add hashes to the main config file, so that genesis files
     -- can be modified without having to recompute hashes every time.
     conf{genesisHashesPolicy = WithoutHashes}
@@ -71,6 +69,6 @@ hprop_dump_config = integrationRetryWorkspace 2 "dump-config-files" $ \tmpDir ->
   H.lbsWriteFile shelleyGenesisFile $ encodePretty shelleyGenesis
 
   -- Run testnet with generated config
-  runtime <- liftToIntegration $ cardanoTestnet testnetOptions conf
+  runtime <- liftToIntegration $ cardanoTestnet (creationNodes creationOptions) def conf
 
   nodesProduceBlocks tmpDir runtime

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/FoldEpochState.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/FoldEpochState.hs
@@ -29,9 +29,9 @@ prop_foldEpochState = integrationRetryWorkspace 2 "foldEpochState" $ \tempAbsBas
 
   let tempAbsPath' = unTmpAbsPath $ tempAbsPath conf
       sbe = ShelleyBasedEraConway
-      options = def { cardanoNodeEra = AnyShelleyBasedEra sbe }
+      creationOptions = def { creationEra = AnyShelleyBasedEra sbe }
 
-  runtime@TestnetRuntime{configurationFile} <- createAndRunTestnet options def conf
+  runtime@TestnetRuntime{configurationFile} <- createAndRunTestnet creationOptions def conf
 
   socketPathAbs <- do
     socketPath' <- H.sprocketArgumentName <$> H.headM (testnetSprockets runtime)

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/CommitteeAddNew.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/CommitteeAddNew.hs
@@ -47,7 +47,7 @@ import           Testnet.Process.Cli.Transaction (retrieveTransactionId, signTx,
 import           Testnet.Process.Run (addEnvVarsToConfig, execCli', mkExecConfig)
 import           Testnet.Process.RunIO (liftIOAnnotated)
 import           Testnet.Property.Util (integrationRetryWorkspace)
-import           Testnet.Start.Types (GenesisOptions (..), cardanoNumPools)
+import           Testnet.Start.Types (GenesisOptions (..), creationNumPools)
 import           Testnet.Types
 
 import           Hedgehog
@@ -73,17 +73,17 @@ hprop_constitutional_committee_add_new = integrationRetryWorkspace 2 "constituti
               -> [(String, Int)] -- ^ [(vote, ordering number)]
       mkVotes votes = zip (concatMap (uncurry replicate) votes) [1..]
       nDrepVotes = length drepVotes
-      nSpos = fromIntegral $ cardanoNumPools fastTestnetOptions
+      nSpos = fromIntegral $ creationNumPools creationOptions
       ceo = ConwayEraOnwardsConway
       sbe = convert ceo
       era = toCardanoEra sbe
       cEra = AnyCardanoEra era
       eraName = eraToString era
-      fastTestnetOptions = def
-        { cardanoNodeEra = AnyShelleyBasedEra sbe
-        , cardanoNumDReps = fromIntegral nDrepVotes
+      creationOptions = def
+        { creationEra = AnyShelleyBasedEra sbe
+        , creationNumDReps = fromIntegral nDrepVotes
+        , creationGenesisOptions = def { genesisEpochLength = 200 }
         }
-      shelleyOptions = def { genesisEpochLength = 200 }
   H.annotateShow drepVotes
   H.noteShow_ nDrepVotes
 
@@ -92,7 +92,7 @@ hprop_constitutional_committee_add_new = integrationRetryWorkspace 2 "constituti
     , wallets=wallet0:wallet1:_
     , configurationFile
     }
-    <- createAndRunTestnet fastTestnetOptions shelleyOptions conf
+    <- createAndRunTestnet creationOptions def conf
 
   node@TestnetNode{poolKeys=Just poolKeys} <- H.headM . filter isTestnetNodeSpo $ testnetNodes runtime
   poolSprocket1 <- H.noteShow $ nodeSprocket node

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepActivity.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepActivity.hs
@@ -61,12 +61,12 @@ hprop_check_drep_activity = integrationRetryWorkspace 2 "test-activity" $ \tempA
   -- Create default testnet with 3 DReps and 3 stake holders delegated, one to each DRep.
   let ceo = ConwayEraOnwardsConway
       sbe = convert ceo
-      fastTestnetOptions = def
-        { cardanoNodeEra = AnyShelleyBasedEra sbe
-        , cardanoNumDReps = 1
+      creationOptions = def
+        { creationEra = AnyShelleyBasedEra sbe
+        , creationNumDReps = 1
+        , creationGenesisOptions = def { genesisEpochLength = 200 }
         }
       eraName = eraToString sbe
-      shelleyOptions = def { genesisEpochLength = 200 }
 
   TestnetRuntime
     { testnetMagic
@@ -74,7 +74,7 @@ hprop_check_drep_activity = integrationRetryWorkspace 2 "test-activity" $ \tempA
     , wallets=wallet0:wallet1:wallet2:_
     , configurationFile
     }
-    <- createAndRunTestnet fastTestnetOptions shelleyOptions conf
+    <- createAndRunTestnet creationOptions def conf
 
   node <- H.headM testnetNodes
   poolSprocket1 <- H.noteShow $ nodeSprocket node

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepDeposit.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepDeposit.hs
@@ -45,11 +45,11 @@ hprop_ledger_events_drep_deposits = integrationRetryWorkspace 2 "drep-deposits" 
       sbe = convert ceo
       era = toCardanoEra sbe
       cEra = AnyCardanoEra era
-      fastTestnetOptions = def
-        { cardanoNodeEra = AnyShelleyBasedEra sbe
-        , cardanoNumDReps = 0
+      creationOptions = def
+        { creationEra = AnyShelleyBasedEra sbe
+        , creationNumDReps = 0
+        , creationGenesisOptions = def { genesisEpochLength = 100 }
         }
-      shelleyOptions = def { genesisEpochLength = 100 }
 
   TestnetRuntime
     { testnetMagic
@@ -57,7 +57,7 @@ hprop_ledger_events_drep_deposits = integrationRetryWorkspace 2 "drep-deposits" 
     , wallets=wallet0:wallet1:_
     , configurationFile
     }
-    <- createAndRunTestnet fastTestnetOptions shelleyOptions conf
+    <- createAndRunTestnet creationOptions def conf
 
   node <- H.headM testnetNodes
   poolSprocket1 <- H.noteShow $ nodeSprocket node

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepRetirement.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepRetirement.hs
@@ -47,9 +47,10 @@ hprop_drep_retirement = integrationRetryWorkspace 2 "drep-retirement" $ \tempAbs
 
   work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
 
-  let cardanoNodeEra = AnyShelleyBasedEra sbe
-      fastTestnetOptions = def { cardanoNodeEra }
-      shelleyOptions = def { genesisEpochLength = 50 } -- 50 * (1/10s) length, i.e. 5 seconds
+  let creationOptions = def
+        { creationEra = AnyShelleyBasedEra sbe
+        , creationGenesisOptions = def { genesisEpochLength = 50 } -- 50 * (1/10s) length, i.e. 5 seconds
+        }
 
   TestnetRuntime
     { testnetMagic
@@ -57,7 +58,7 @@ hprop_drep_retirement = integrationRetryWorkspace 2 "drep-retirement" $ \tempAbs
     , wallets=wallet0:_
     , configurationFile
     }
-    <- createAndRunTestnet fastTestnetOptions shelleyOptions conf
+    <- createAndRunTestnet creationOptions def conf
 
   node <- H.headM testnetNodes
   poolSprocket1 <- H.noteShow $ nodeSprocket node

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/GovActionTimeout.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/GovActionTimeout.hs
@@ -52,8 +52,10 @@ hprop_check_gov_action_timeout = integrationRetryWorkspace 2 "gov-action-timeout
       sbe = convert ceo
       eraName = eraToString sbe
       asbe = AnyShelleyBasedEra sbe
-      fastTestnetOptions = def { cardanoNodeEra = asbe }
-      shelleyOptions = def { genesisEpochLength = 200 }
+      creationOptions = def
+        { creationEra = asbe
+        , creationGenesisOptions = def { genesisEpochLength = 200 }
+        }
 
   TestnetRuntime
     { testnetMagic
@@ -61,7 +63,7 @@ hprop_check_gov_action_timeout = integrationRetryWorkspace 2 "gov-action-timeout
     , wallets=wallet0:wallet1:_
     , configurationFile
     }
-    <- createAndRunTestnet fastTestnetOptions shelleyOptions conf
+    <- createAndRunTestnet creationOptions def conf
 
   node <- H.headM testnetNodes
   poolSprocket1 <- H.noteShow $ nodeSprocket node

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/InfoAction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/InfoAction.hs
@@ -62,8 +62,10 @@ hprop_ledger_events_info_action = integrationRetryWorkspace 2 "info-hash" $ \tem
       sbe = convert ceo
       asbe = AnyShelleyBasedEra sbe
       eraName = eraToString sbe
-      fastTestnetOptions = def { cardanoNodeEra = asbe }
-      shelleyOptions = def { genesisEpochLength = 200 }
+      creationOptions = def
+        { creationEra = asbe
+        , creationGenesisOptions = def { genesisEpochLength = 200 }
+        }
 
   TestnetRuntime
     { testnetMagic
@@ -71,7 +73,7 @@ hprop_ledger_events_info_action = integrationRetryWorkspace 2 "info-hash" $ \tem
     , wallets=wallet0:wallet1:_
     , configurationFile
     }
-    <- createAndRunTestnet fastTestnetOptions shelleyOptions conf
+    <- createAndRunTestnet creationOptions def conf
 
   node <- H.headM testnetNodes
   poolSprocket1 <- H.noteShow $ nodeSprocket node

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs
@@ -67,8 +67,7 @@ hprop_gov_no_confidence = integrationRetryWorkspace 2 "no-confidence" $ \tempAbs
       asbe = AnyShelleyBasedEra sbe
       era = toCardanoEra sbe
       cEra = AnyCardanoEra era
-      fastTestnetOptions = def { cardanoNodeEra = asbe  }
-      genesisOptions = def { genesisEpochLength = 200 }
+      creationOptions = def { creationEra = asbe, creationGenesisOptions = def { genesisEpochLength = 200 } }
 
   execConfigOffline <- H.mkExecConfigOffline tempBaseAbsPath
 
@@ -103,7 +102,7 @@ hprop_gov_no_confidence = integrationRetryWorkspace 2 "no-confidence" $ \tempAbs
       committeeThreshold = unsafeBoundedRational 0.5
       committee = L.Committee (Map.fromList [(comKeyCred1, EpochNo 100)]) committeeThreshold
 
-  liftToIntegration $ createTestnetEnv fastTestnetOptions genesisOptions def conf
+  liftToIntegration $ createTestnetEnv creationOptions conf
 
   H.rewriteJsonFile (tempAbsBasePath' </> "conway-genesis.json") $
     \conwayGenesis -> conwayGenesis { L.cgCommittee = committee }
@@ -113,7 +112,7 @@ hprop_gov_no_confidence = integrationRetryWorkspace 2 "no-confidence" $ \tempAbs
     , testnetNodes
     , wallets=wallet0:_wallet1:_
     , configurationFile
-    } <- liftToIntegration $ cardanoTestnet fastTestnetOptions conf
+    } <- liftToIntegration $ cardanoTestnet (creationNodes creationOptions) def conf
 
   poolNode1 <- H.headM testnetNodes
   poolSprocket1 <- H.noteShow $ nodeSprocket poolNode1

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PParamChangeFailsSPO.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PParamChangeFailsSPO.hs
@@ -61,8 +61,10 @@ hprop_check_pparam_fails_spo = integrationRetryWorkspace 2 "test-pparam-spo" $ \
       sbe = convert ceo
       asbe = AnyShelleyBasedEra sbe
       eraName = eraToString sbe
-      fastTestnetOptions = def { cardanoNodeEra = asbe }
-      shelleyOptions = def { genesisEpochLength = 200 }
+      creationOptions = def
+        { creationEra = asbe
+        , creationGenesisOptions = def { genesisEpochLength = 200 }
+        }
 
   TestnetRuntime
     { testnetMagic
@@ -70,7 +72,7 @@ hprop_check_pparam_fails_spo = integrationRetryWorkspace 2 "test-pparam-spo" $ \
     , wallets=wallet0:wallet1:_wallet2:_
     , configurationFile
     }
-    <- createAndRunTestnet fastTestnetOptions shelleyOptions conf
+    <- createAndRunTestnet creationOptions def conf
 
   node <- H.headM testnetNodes
   poolSprocket1 <- H.noteShow $ nodeSprocket node

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
@@ -73,11 +73,11 @@ hprop_check_predefined_abstain_drep = H.integrationRetryWorkspace 2 "test-activi
   -- Create default testnet with 3 DReps and 3 stake holders delegated, one to each DRep.
   let ceo = ConwayEraOnwardsConway
       sbe = convert ceo
-      fastTestnetOptions = def
-        { cardanoNodeEra = AnyShelleyBasedEra sbe
-        , cardanoNumDReps = 3
+      creationOptions = def
+        { creationEra = AnyShelleyBasedEra sbe
+        , creationNumDReps = 3
+        , creationGenesisOptions = def { genesisEpochLength = 200 }
         }
-      shelleyOptions = def { genesisEpochLength = 200 }
 
   TestnetRuntime
     { testnetMagic
@@ -85,7 +85,7 @@ hprop_check_predefined_abstain_drep = H.integrationRetryWorkspace 2 "test-activi
     , wallets=wallet0:wallet1:wallet2:_
     , configurationFile
     }
-    <- createAndRunTestnet fastTestnetOptions shelleyOptions conf
+    <- createAndRunTestnet creationOptions def conf
 
   node <- H.headM testnetNodes
   poolSprocket1 <- H.noteShow $ nodeSprocket node

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitution.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitution.hs
@@ -80,11 +80,11 @@ hprop_ledger_events_propose_new_constitution = integrationRetryWorkspace 2 "prop
       era = toCardanoEra sbe
       cEra = AnyCardanoEra era
       eraName = eraToString sbe
-      fastTestnetOptions = def
-        { cardanoNodeEra = AnyShelleyBasedEra sbe
-        , cardanoNumDReps = fromIntegral numVotes
+      creationOptions = def
+        { creationEra = AnyShelleyBasedEra sbe
+        , creationNumDReps = fromIntegral numVotes
+        , creationGenesisOptions = def { genesisEpochLength = 200 }
         }
-      shelleyOptions = def { genesisEpochLength = 200 }
 
   TestnetRuntime
     { testnetMagic
@@ -92,7 +92,7 @@ hprop_ledger_events_propose_new_constitution = integrationRetryWorkspace 2 "prop
     , wallets=wallet0:wallet1:_
     , configurationFile
     }
-    <- createAndRunTestnet fastTestnetOptions shelleyOptions conf
+    <- createAndRunTestnet creationOptions def conf
 
   node <- H.headM testnetNodes
   poolSprocket1 <- H.noteShow $ nodeSprocket node

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitutionSPO.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitutionSPO.hs
@@ -55,15 +55,15 @@ hprop_ledger_events_propose_new_constitution_spo = integrationRetryWorkspace 2 "
       sbe = convert ceo
       era = toCardanoEra sbe
       cEra = AnyCardanoEra era
-      fastTestnetOptions = def
-        { cardanoNodeEra = AnyShelleyBasedEra sbe
-        , cardanoNodes =
+      creationOptions = def
+        { creationEra = AnyShelleyBasedEra sbe
+        , creationNodes =
             SpoNodeOptions [] :|
           [ SpoNodeOptions []
           , SpoNodeOptions []
           ]
+        , creationGenesisOptions = def { genesisEpochLength = 100 }
         }
-      shelleyOptions = def { genesisEpochLength = 100 }
 
   TestnetRuntime
     { testnetMagic
@@ -71,7 +71,7 @@ hprop_ledger_events_propose_new_constitution_spo = integrationRetryWorkspace 2 "
     , wallets=wallet0:_
     , configurationFile
     }
-    <- createAndRunTestnet fastTestnetOptions shelleyOptions conf
+    <- createAndRunTestnet creationOptions def conf
 
   node <- H.headM testnetNodes
   poolSprocket1 <- H.noteShow $ nodeSprocket node

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/Transaction/HashMismatch.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/Transaction/HashMismatch.hs
@@ -50,8 +50,10 @@ hprop_transaction_build_wrong_hash = integrationRetryWorkspace 2 "wrong-hash" $ 
       sbe = convert ceo
       asbe = AnyShelleyBasedEra sbe
       eraName = eraToString sbe
-      fastTestnetOptions = def { cardanoNodeEra = asbe }
-      shelleyOptions = def { genesisEpochLength = 200 }
+      creationOptions = def
+        { creationEra = asbe
+        , creationGenesisOptions = def { genesisEpochLength = 200 }
+        }
 
   TestnetRuntime
     { testnetMagic
@@ -59,7 +61,7 @@ hprop_transaction_build_wrong_hash = integrationRetryWorkspace 2 "wrong-hash" $ 
     , wallets=wallet0:wallet1:_
     , configurationFile
     }
-    <- createAndRunTestnet fastTestnetOptions shelleyOptions conf
+    <- createAndRunTestnet creationOptions def conf
 
   node <- H.headM testnetNodes
   poolSprocket1 <- H.noteShow $ nodeSprocket node

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryDonation.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryDonation.hs
@@ -46,8 +46,10 @@ hprop_ledger_events_treasury_donation = integrationRetryWorkspace 2 "treasury-do
 
   let ceo = ConwayEraOnwardsConway
       sbe = convert ceo
-      fastTestnetOptions = def { cardanoNodeEra = AnyShelleyBasedEra sbe }
-      shelleyOptions = def { genesisEpochLength = 100 }
+      creationOptions = def
+        { creationEra = AnyShelleyBasedEra sbe
+        , creationGenesisOptions = def { genesisEpochLength = 100 }
+        }
 
   TestnetRuntime
     { testnetMagic
@@ -55,7 +57,7 @@ hprop_ledger_events_treasury_donation = integrationRetryWorkspace 2 "treasury-do
     , wallets=wallet0:_
     , configurationFile
     }
-    <- createAndRunTestnet fastTestnetOptions shelleyOptions conf
+    <- createAndRunTestnet creationOptions def conf
 
   node <- H.headM testnetNodes
   poolSprocket1 <- H.noteShow $ nodeSprocket node

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryGrowth.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryGrowth.hs
@@ -41,12 +41,14 @@ prop_check_if_treasury_is_growing = integrationRetryWorkspace 2 "growing-treasur
 
   let era = ConwayEra
       sbe = ShelleyBasedEraConway
-      options = def { cardanoNodeEra = AnyShelleyBasedEra sbe } -- TODO: We should only support the latest era and the upcoming era
-      shelleyOptions = def { genesisEpochLength = 100
-                           , genesisActiveSlotsCoeff = 0.3
-                           }
+      creationOptions = def
+        { creationEra = AnyShelleyBasedEra sbe -- TODO: We should only support the latest era and the upcoming era
+        , creationGenesisOptions = def { genesisEpochLength = 100
+                                       , genesisActiveSlotsCoeff = 0.3
+                                       }
+        }
 
-  TestnetRuntime{testnetMagic, configurationFile, testnetNodes} <- createAndRunTestnet options shelleyOptions conf
+  TestnetRuntime{testnetMagic, configurationFile, testnetNodes} <- createAndRunTestnet creationOptions def conf
 
   (execConfig, socketPathAbs) <- do
     TestnetNode{nodeSprocket} <- H.headM testnetNodes

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryWithdrawal.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryWithdrawal.hs
@@ -64,10 +64,12 @@ hprop_ledger_events_treasury_withdrawal = integrationRetryWorkspace 2  "treasury
       era = toCardanoEra sbe
       eraName = eraToString era
 
-      fastTestnetOptions = def { cardanoNodeEra = AnyShelleyBasedEra sbe }
-      shelleyOptions = def { genesisEpochLength = 200
-                           , genesisActiveSlotsCoeff = 0.3
-                           }
+      creationOptions = def
+        { creationEra = AnyShelleyBasedEra sbe
+        , creationGenesisOptions = def { genesisEpochLength = 200
+                                       , genesisActiveSlotsCoeff = 0.3
+                                       }
+        }
 
   TestnetRuntime
     { testnetMagic
@@ -75,7 +77,7 @@ hprop_ledger_events_treasury_withdrawal = integrationRetryWorkspace 2  "treasury
     , wallets=wallet0:wallet1:_
     , configurationFile
     }
-    <- createAndRunTestnet fastTestnetOptions shelleyOptions conf
+    <- createAndRunTestnet creationOptions def conf
 
   node@TestnetNode{nodeSprocket} <- H.headM testnetNodes
   poolSprocket1 <- H.noteShow nodeSprocket

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/MainnetParams.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/MainnetParams.hs
@@ -18,8 +18,7 @@ import           Lens.Micro ((^?))
 import           Testnet.Process.Run (execCli', mkExecConfig)
 import           Testnet.Property.Util (integrationRetryWorkspace)
 import           Testnet.Start.Cardano (liftToIntegration)
-import           Testnet.Start.Types (CreateEnvOptions (..), GenesisOptions (..),
-                   TestnetOnChainParams (..), UserProvidedEnv (..))
+import           Testnet.Start.Types (GenesisOptions (..), TestnetOnChainParams (..))
 
 import           Hedgehog ((/==))
 import qualified Hedgehog as H
@@ -30,23 +29,21 @@ import qualified Hedgehog.Extras as H
 hprop_mainnet_params :: H.Property
 hprop_mainnet_params = integrationRetryWorkspace 2 "mainnet-params" $ \tmpDir -> H.runWithDefaultWatchdog_ $ do
 
-  let testnetOptions = def { cardanoOutputDir = UserProvidedEnv tmpDir }
-      genesisOptions = def { genesisEpochLength = 200 }
-      createEnvOptions = def
-        { ceoOnChainParams = OnChainParamsFile
+  let creationOptions = def
+        { creationGenesisOptions = def { genesisEpochLength = 200 }
+        , creationOnChainParams = OnChainParamsFile
             "test/cardano-testnet-test/files/input/blockfrost-params.json"
         }
 
   -- Generate the sandbox
   conf <- mkConf tmpDir
-  liftToIntegration $ createTestnetEnv
-    testnetOptions genesisOptions createEnvOptions conf
+  liftToIntegration $ createTestnetEnv creationOptions conf
 
   -- Run testnet with mainnet on-chain params
   TestnetRuntime
     { testnetNodes
     , testnetMagic
-    } <- liftToIntegration $ cardanoTestnet testnetOptions conf
+    } <- liftToIntegration $ cardanoTestnet (creationNodes creationOptions) def conf
 
   -- Get a running node
   TestnetNode{nodeSprocket} <- H.headM testnetNodes

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Node/Shutdown.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Node/Shutdown.hs
@@ -206,16 +206,16 @@ hprop_shutdownOnSlotSynced = integrationRetryWorkspace 2 "shutdown-on-slot-synce
   let maxSlot = 150
       epochLength = 300
       slotLen = 0.1
-  let fastTestnetOptions = def
-        { cardanoNodes =
+  let creationOptions = def
+        { creationNodes =
             SpoNodeOptions ["--shutdown-on-slot-synced", show maxSlot] :| []
+        , creationGenesisOptions = def
+            { genesisEpochLength = epochLength
+            , genesisSlotLength = slotLen
+            , genesisActiveSlotsCoeff = 50.0 / fromIntegral epochLength
+            }
         }
-      shelleyOptions = def
-        { genesisEpochLength = epochLength
-        , genesisSlotLength = slotLen
-        , genesisActiveSlotsCoeff = 50.0 / fromIntegral epochLength
-        }
-  testnetRuntime <- createAndRunTestnet fastTestnetOptions shelleyOptions conf
+  testnetRuntime <- createAndRunTestnet creationOptions def conf
   let allNodes = testnetNodes testnetRuntime
   H.note_ $ "All nodes: " <>  show (map nodeName allNodes)
 
@@ -252,10 +252,11 @@ hprop_shutdownOnSigint = integrationRetryWorkspace 2 "shutdown-on-sigint" $ \tem
   -- TODO: Move yaml filepath specification into individual node options
   conf <- mkConf tempAbsBasePath'
 
-  let fastTestnetOptions = def
-      shelleyOptions = def { genesisEpochLength = 300 }
+  let creationOptions = def
+        { creationGenesisOptions = def { genesisEpochLength = 300 }
+        }
   testnetRuntime
-    <- createAndRunTestnet fastTestnetOptions shelleyOptions conf
+    <- createAndRunTestnet creationOptions def conf
   TestnetNode{nodeProcessHandle, nodeStdout, nodeStderr} <- H.headM $ testnetNodes testnetRuntime
 
   -- send SIGINT

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/P2PTopology.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/P2PTopology.hs
@@ -7,7 +7,7 @@ module Cardano.Testnet.Test.P2PTopology
   ) where
 
 import qualified Cardano.Node.Configuration.TopologyP2P as P2P
-import           Cardano.Testnet (CardanoTestnetOptions (..), cardanoTestnet, createTestnetEnv,
+import           Cardano.Testnet (TestnetCreationOptions (..), cardanoTestnet, createTestnetEnv,
                    mkConf)
 import           Cardano.Testnet.Test.Utils (nodesProduceBlocks)
 
@@ -18,8 +18,8 @@ import           System.FilePath ((</>))
 
 import           Testnet.Property.Util (integrationRetryWorkspace)
 import           Testnet.Start.Cardano (liftToIntegration)
-import           Testnet.Start.Types (CreateEnvOptions (..), GenesisOptions (..), NodeId,
-                   TopologyType (..), UserProvidedEnv (..))
+import           Testnet.Start.Types (GenesisOptions (..), NodeId,
+                   TopologyType (..))
 
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras as H
@@ -30,20 +30,18 @@ import qualified Hedgehog.Extras as H
 hprop_p2p_topology :: H.Property
 hprop_p2p_topology = integrationRetryWorkspace 2 "p2p-topology" $ \tmpDir -> H.runWithDefaultWatchdog_ $ do
 
-  let testnetOptions = def { cardanoOutputDir = UserProvidedEnv tmpDir }
-      genesisOptions = def { genesisEpochLength = 200 }
-      createEnvOptions = def { ceoTopologyType = P2PTopology }
+  let creationOptions = def { creationGenesisOptions = def { genesisEpochLength = 200 } }
       someTopologyFile = tmpDir </> "node-data" </> "node1" </> "topology.json"
 
   -- Generate the sandbox
   conf <- mkConf tmpDir
-  liftToIntegration $ createTestnetEnv testnetOptions genesisOptions createEnvOptions conf
+  liftToIntegration $ createTestnetEnv creationOptions conf
 
   -- Check that the topology is indeed P2P
   eTopology <- H.readJsonFile someTopologyFile
   (_topology :: P2P.NetworkTopology NodeId) <- H.leftFail eTopology
 
   -- Run testnet with generated config
-  runtime <- liftToIntegration $ cardanoTestnet testnetOptions conf
+  runtime <- liftToIntegration $ cardanoTestnet (creationNodes creationOptions) def conf
 
   nodesProduceBlocks tmpDir runtime

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/Query.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/Query.hs
@@ -53,14 +53,15 @@ hprop_rpc_query_pparams = integrationRetryWorkspace 2 "rpc-query-pparams" $ \tem
   let ceo = ConwayEraOnwardsConway
       sbe = convert ceo
       eraName = eraToString sbe
-      options = def{cardanoNodeEra = AnyShelleyBasedEra sbe, cardanoEnableRpc = RpcEnabled}
+      creationOptions = def{creationEra = AnyShelleyBasedEra sbe}
+      runtimeOptions = def{runtimeEnableRpc = RpcEnabled}
 
   TestnetRuntime
     { testnetMagic
     , configurationFile
     , testnetNodes = node0@TestnetNode{nodeSprocket} : _
     } <-
-    createAndRunTestnet options def conf
+    createAndRunTestnet creationOptions runtimeOptions conf
 
   execConfig <- mkExecConfig tempAbsPath' nodeSprocket testnetMagic
   epochStateView <- getEpochStateView configurationFile (nodeSocketPath node0)

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/Transaction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/Transaction.hs
@@ -52,7 +52,8 @@ hprop_rpc_transaction = integrationRetryWorkspace 2 "rpc-tx" $ \tempAbsBasePath'
   let (ceo, eraProxy) =
         (conwayBasedEra, asType) :: era ~ ConwayEra => (ConwayEraOnwards era, AsType era)
       sbe = convert ceo
-      options = def{cardanoNodeEra = AnyShelleyBasedEra sbe, cardanoEnableRpc = RpcEnabled}
+      creationOptions = def{creationEra = AnyShelleyBasedEra sbe}
+      runtimeOptions = def{runtimeEnableRpc = RpcEnabled}
       addrInEra = AsAddressInEra eraProxy
 
   TestnetRuntime
@@ -60,7 +61,7 @@ hprop_rpc_transaction = integrationRetryWorkspace 2 "rpc-tx" $ \tempAbsBasePath'
     , testnetNodes = node0 : _
     , wallets = wallet0@(PaymentKeyInfo _ addrTxt0) : (PaymentKeyInfo _ addrTxt1) : _
     } <-
-    createAndRunTestnet options def conf
+    createAndRunTestnet creationOptions runtimeOptions conf
 
   epochStateView <- getEpochStateView configurationFile $ nodeSocketPath node0
   rpcSocket <- H.note . unFile $ nodeRpcSocketPath node0

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/RunTestnet.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/RunTestnet.hs
@@ -6,7 +6,7 @@ module Cardano.Testnet.Test.RunTestnet
   ( hprop_run_testnet
   ) where
 
-import           Cardano.Testnet (createAndRunTestnet, mkConf)
+import           Cardano.Testnet (TestnetCreationOptions (..), createAndRunTestnet, mkConf)
 import           Cardano.Testnet.Test.Utils (nodesProduceBlocks)
 
 import           Prelude
@@ -24,10 +24,11 @@ import qualified Hedgehog.Extras as H
 hprop_run_testnet :: H.Property
 hprop_run_testnet = integrationRetryWorkspace 2 "run-testnet" $ \tmpDir -> H.runWithDefaultWatchdog_ $ do
 
-  let shelleyOptions = def { genesisEpochLength = 200 }
-      testnetOptions = def
+  let creationOptions = def
+        { creationGenesisOptions = def { genesisEpochLength = 200 }
+        }
 
   conf <- mkConf tmpDir
-  runtime <- createAndRunTestnet testnetOptions shelleyOptions conf
+  runtime <- createAndRunTestnet creationOptions def conf
 
   nodesProduceBlocks tmpDir runtime

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SanityCheck.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SanityCheck.hs
@@ -50,14 +50,15 @@ hprop_ledger_events_sanity_check = integrationRetryWorkspace 2 "ledger-events-sa
   -- Start a local test net
   conf <- mkConf tempAbsBasePath'
 
-  let fastTestnetOptions = def
-      shelleyOptions = def
-        { genesisEpochLength = 100
-        , genesisSlotLength = 0.1
+  let creationOptions = def
+        { creationGenesisOptions = def
+            { genesisEpochLength = 100
+            , genesisSlotLength = 0.1
+            }
         }
 
   TestnetRuntime{configurationFile, testnetNodes}
-    <- createAndRunTestnet fastTestnetOptions shelleyOptions conf
+    <- createAndRunTestnet creationOptions def conf
 
   nr@TestnetNode{nodeSprocket} <- H.headM testnetNodes
   let socketPath = nodeSocketPath nr

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SubmitApi/Transaction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SubmitApi/Transaction.hs
@@ -59,8 +59,8 @@ hprop_transaction = integrationRetryWorkspace 2 "submit-api-transaction" $ \temp
       sbe = ShelleyBasedEraConway
       eraString = eraToString sbe
       tempBaseAbsPath = makeTmpBaseAbsPath $ TmpAbsolutePath tempAbsPath'
-      options = def
-        { cardanoNodeEra = AnyShelleyBasedEra sbe -- TODO: We should only support the latest era and the upcoming era
+      creationOptions = def
+        { creationEra = AnyShelleyBasedEra sbe -- TODO: We should only support the latest era and the upcoming era
         }
 
   work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
@@ -70,7 +70,7 @@ hprop_transaction = integrationRetryWorkspace 2 "submit-api-transaction" $ \temp
     , testnetMagic
     , testnetNodes
     , wallets=wallet0:_
-    } <- createAndRunTestnet options def conf
+    } <- createAndRunTestnet creationOptions def conf
 
   poolNode1 <- H.headM testnetNodes
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/UpdateTimeStamps.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/UpdateTimeStamps.hs
@@ -19,7 +19,7 @@ import           Testnet.Components.Configuration (startTimeOffsetSeconds)
 import           Testnet.Property.Util (integrationRetryWorkspace)
 import           Testnet.Start.Cardano (liftToIntegration)
 import           Testnet.Start.Types (GenesisHashesPolicy (..), GenesisOptions (..),
-                   UpdateTimestamps (..), UserProvidedEnv (..))
+                   UpdateTimestamps (..))
 
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras as H
@@ -29,13 +29,12 @@ import qualified Hedgehog.Extras as H
 hprop_update_time_stamps :: H.Property
 hprop_update_time_stamps = integrationRetryWorkspace 2 "update-time-stamps" $ \tmpDir -> H.runWithDefaultWatchdog_ $ do
 
-  let testnetOptions = def { cardanoOutputDir = UserProvidedEnv tmpDir }
-      genesisOptions = def { genesisEpochLength = 200 }
+  let creationOptions = def { creationGenesisOptions = def { genesisEpochLength = 200 } }
 
   -- Generate the sandbox
   conf <- mkConf tmpDir
   liftToIntegration $ createTestnetEnv
-    testnetOptions genesisOptions def
+    creationOptions
     -- Do not add hashes to the main config file, so that genesis files
     -- can be modified without having to recompute hashes every time.
     conf{genesisHashesPolicy = WithoutHashes}
@@ -45,6 +44,6 @@ hprop_update_time_stamps = integrationRetryWorkspace 2 "update-time-stamps" $ \t
   H.threadDelay $ double2Int $ realToFrac startTimeOffsetSeconds * 1_000_000 * 1.2
 
   -- Run testnet and specify to update time stamps before starting
-  runtime <- liftToIntegration $ cardanoTestnet testnetOptions conf{updateTimestamps = UpdateTimestamps}
+  runtime <- liftToIntegration $ cardanoTestnet (creationNodes creationOptions) def conf{updateTimestamps = UpdateTimestamps}
 
   nodesProduceBlocks tmpDir runtime


### PR DESCRIPTION
# Description

Split the monolithic `CardanoTestnetOptions` record into purpose-specific types so that:

1. **`--node-env` and `--num-pool-nodes` are structurally mutually exclusive** in the CLI parser (via `<|>`, not optional fields that silently coexist).
2. **No dummy/unused values are passed between call sites** — each function receives only the fields it actually uses.
3. **The type structure matches the three real execution modes**: create-only (`create-env`), create-and-run (`cardano`), and run-from-existing-env (`cardano --node-env`).

## New type structure

- **`TestnetCreationOptions`** — everything needed to create a testnet environment: nodes, era, max supply, num DReps, genesis options, on-chain params. Has a `Default` instance for tests.
- **`TestnetRuntimeOptions`** — everything needed to *run* nodes: epoch state logging, gRPC, KES source. Has a `Default` instance for tests.
- **`TestnetEnvOptions`** — `--node-env` path + timestamp update policy.
- **`CardanoTestnetCliOptions`** — sum type: `StartFromScratch StartFromScratchOptions | StartFromEnv StartFromEnvOptions`, making the two modes exclusive at the type level.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [x] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff