### PR TITLE
cardano-testnet | Add searchUtxos gRPC test

### DIFF
--- a/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
+++ b/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
@@ -82,7 +82,7 @@ library
   -- IOG dependencies
   --------------------------
   build-depends:
-    , cardano-api             ^>=11.0
+    , cardano-api             ^>=11.2
     , plutus-ledger-api       ^>=1.63
     , plutus-tx               ^>=1.63
     , plutus-tx-plugin        ^>=1.63

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -109,7 +109,7 @@ library
                       , attoparsec-aeson
                       , base16-bytestring
                       , bytestring
-                      , cardano-api ^>= 11.0
+                      , cardano-api ^>= 11.2
                       , cardano-binary
                       , cardano-cli ^>= 11.0
                       , cardano-crypto-class

--- a/cabal.project
+++ b/cabal.project
@@ -91,3 +91,20 @@ allow-newer:
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
 
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-api
+  tag: fb5e86c8f12f8fe94c0ab46fbaf40b9ceec0306c
+  --sha256: sha256-PLACEHOLDER
+  subdir:
+    cardano-api
+    cardano-rpc
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-cli
+  tag: db5a030114ea7de8db9b8c7b322b242a75678008
+  --sha256: sha256-PLACEHOLDER
+  subdir:
+    cardano-cli
+

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -138,7 +138,7 @@ library
                       , async
                       , base16-bytestring
                       , bytestring
-                      , cardano-api ^>= 11.0
+                      , cardano-api ^>= 11.2
                       , cardano-data
                       , cardano-crypto-class ^>=2.3
                       , cardano-crypto-wrapper

--- a/cardano-node/src/Cardano/Node/Protocol/Shelley.hs
+++ b/cardano-node/src/Cardano/Node/Protocol/Shelley.hs
@@ -26,6 +26,7 @@ module Cardano.Node.Protocol.Shelley
 
 import           Cardano.Api hiding (FileError)
 import qualified Cardano.Api as Api
+import           Cardano.Api.Experimental.Certificate (OperationalCertificate (..), getHotKey)
 
 import qualified Cardano.Crypto.Hash.Class as Crypto
 import           Cardano.Ledger.BaseTypes (ProtVer (..), natVersion)

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Rpc.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Rpc.hs
@@ -35,6 +35,10 @@ instance LogFormatting TraceRpc where
                   [ "queryName" .= String "ReadUtxos"
                   , spanToObject s
                   ]
+                TraceRpcQuerySearchUtxosSpan s ->
+                  [ "queryName" .= String "SearchUtxos"
+                  , spanToObject s
+                  ]
           TraceRpcSubmit submitTrace ->
             ["kind" .= String "SubmitService"]
               <> case submitTrace of
@@ -50,6 +54,7 @@ instance LogFormatting TraceRpc where
     -- query names here are taken from UTXORPC spec: https://utxorpc.org/query/intro/#operations
     TraceRpcQuery (TraceRpcQueryParamsSpan (SpanBegin _)) -> [CounterM "rpc.request.QueryService.ReadParams" Nothing]
     TraceRpcQuery (TraceRpcQueryReadUtxosSpan (SpanBegin _)) -> [CounterM "rpc.request.QueryService.ReadUtxos" Nothing]
+    TraceRpcQuery (TraceRpcQuerySearchUtxosSpan (SpanBegin _)) -> [CounterM "rpc.request.QueryService.SearchUtxos" Nothing]
     TraceRpcSubmit (TraceRpcSubmitSpan (SpanBegin _)) -> [CounterM "rpc.request.SubmitService.SubmitTx" Nothing]
     _ -> []
 
@@ -63,6 +68,7 @@ instance MetaTrace TraceRpc where
           : case queryTrace of
             TraceRpcQueryParamsSpan _ -> ["ReadParams", "Span"]
             TraceRpcQueryReadUtxosSpan _ -> ["ReadUtxos", "Span"]
+            TraceRpcQuerySearchUtxosSpan _ -> ["SearchUtxos", "Span"]
       TraceRpcSubmit submitTrace ->
         "SubmitService"
           : case submitTrace of
@@ -76,6 +82,7 @@ instance MetaTrace TraceRpc where
     ["Error"] -> Just Debug -- those are normal operation errors, like request errors, hide them by default
     ["QueryService", "ReadParams", "Span"] -> Just Debug
     ["QueryService", "ReadUtxos", "Span"] -> Just Debug
+    ["QueryService", "SearchUtxos", "Span"] -> Just Debug
     ["SubmitService", "SubmitTx", "Span"] -> Just Debug
     ["SubmitService", "N2cConnectionError"] -> Just Warning -- this is a more serious error, this shouldn't happen
     ["SubmitService", "TxDecodingError"] -> Just Debug -- request error
@@ -87,6 +94,7 @@ instance MetaTrace TraceRpc where
     ["Error"] -> Just "Normal operation errors such as request errors. Those are not harmful to the RPC server itself."
     ["QueryService", "ReadParams", "Span"] -> Just "Span for the ReadParams UTXORPC method."
     ["QueryService", "ReadUtxos", "Span"] -> Just "Span for the ReadUtxos UTXORPC method."
+    ["QueryService", "SearchUtxos", "Span"] -> Just "Span for the SearchUtxos UTXORPC method."
     ["SubmitService", "SubmitTx", "Span"] -> Just "Span for the SubmitTx UTXORPC method."
     ["SubmitService", "N2cConnectionError"] ->
       Just
@@ -100,6 +108,8 @@ instance MetaTrace TraceRpc where
       [("rpc.request.QueryService.ReadParams", "Span for the ReadParams UTXORPC method.")]
     ["QueryService", "ReadUtxos", "Span"] ->
       [("rpc.request.QueryService.ReadUtxos", "Span for the ReadUtxos UTXORPC method.")]
+    ["QueryService", "SearchUtxos", "Span"] ->
+      [("rpc.request.QueryService.SearchUtxos", "Span for the SearchUtxos UTXORPC method.")]
     ["SubmitService", "SubmitTx", "Span"] ->
       [("rpc.request.SubmitService.SubmitTx", "Span for the SubmitTx UTXORPC method.")]
     _ -> []
@@ -110,6 +120,7 @@ instance MetaTrace TraceRpc where
           , ["Error"]
           , ["QueryService", "ReadParams", "Span"]
           , ["QueryService", "ReadUtxos", "Span"]
+          , ["QueryService", "SearchUtxos", "Span"]
           , ["SubmitService", "SubmitTx", "Span"]
           , ["SubmitService", "N2cConnectionError"]
           , ["SubmitService", "TxDecodingError"]

--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -39,7 +39,7 @@ library
                       , aeson
                       , async
                       , bytestring
-                      , cardano-api ^>= 11.0
+                      , cardano-api ^>= 11.2
                       , cardano-binary
                       , cardano-cli ^>= 11.0
                       , cardano-crypto-class ^>=2.3

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -41,7 +41,7 @@ library
                       , annotated-exception
                       , ansi-terminal
                       , bytestring
-                      , cardano-api ^>= 11.0
+                      , cardano-api ^>= 11.2
                       , cardano-cli:{cardano-cli, cardano-cli-test-lib} ^>= 11.0
                       , cardano-crypto-class ^>=2.3
                       , cardano-crypto-wrapper

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -239,6 +239,7 @@ test-suite cardano-testnet-test
                         Cardano.Testnet.Test.Gov.TreasuryGrowth
                         Cardano.Testnet.Test.Gov.TreasuryWithdrawal
                         Cardano.Testnet.Test.Rpc.Query
+                        Cardano.Testnet.Test.Rpc.SearchUtxos
                         Cardano.Testnet.Test.Rpc.Transaction
                         Cardano.Testnet.Test.Misc
                         Cardano.Testnet.Test.Node.Shutdown

--- a/cardano-testnet/src/Testnet/Process/Cli/SPO.hs
+++ b/cardano-testnet/src/Testnet/Process/Cli/SPO.hs
@@ -16,6 +16,7 @@ module Testnet.Process.Cli.SPO
   ) where
 
 import           Cardano.Api hiding (cardanoEra)
+import           Cardano.Api.Experimental.Certificate (PoolId)
 import qualified Cardano.Api.Ledger as L
 
 import qualified Cardano.Ledger.Shelley.LedgerState as L

--- a/cardano-testnet/src/Testnet/Property/Assert.hs
+++ b/cardano-testnet/src/Testnet/Property/Assert.hs
@@ -16,6 +16,7 @@ module Testnet.Property.Assert
 
 
 import           Cardano.Api hiding (Value)
+import           Cardano.Api.Experimental.Certificate (PoolId)
 
 import           Prelude hiding (lines)
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitution.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitution.hs
@@ -261,16 +261,7 @@ hprop_ledger_events_propose_new_constitution = integrationRetryWorkspace 2 "prop
   length (filter ((== L.Abstain) . snd) votes) === 2
   length votes === fromIntegral numVotes
 
-  -- We check that constitution was successfully ratified
-  void . H.leftFailM . H.evalIO . runExceptT $
-    foldEpochState
-      configurationFile
-      socketPath
-      FullValidation
-      (EpochNo 10)
-      ()
-      (\epochState _ _ -> foldBlocksCheckConstitutionWasRatified constitutionHash constitutionScriptHash epochState)
-
+  -- Query proposals via CLI before ratification - the proposal may be removed after ratification
   proposalsJSON :: Aeson.Value <- execCliStdoutToJson execConfig
                                     [ eraName, "query", "proposals", "--governance-action-tx-id", prettyShow txId
                                     , "--governance-action-index", "0"
@@ -337,6 +328,16 @@ hprop_ledger_events_propose_new_constitution = integrationRetryWorkspace 2 "prop
   -- Check the stake pool votes are empty
   proposalsStakePoolVotes <- H.evalMaybe $ proposal ^? Aeson.key "stakePoolVotes" . Aeson._Object
   proposalsStakePoolVotes === mempty
+
+  -- We check that constitution was successfully ratified
+  void . H.leftFailM . H.evalIO . runExceptT $
+    foldEpochState
+      configurationFile
+      socketPath
+      FullValidation
+      (EpochNo 10)
+      ()
+      (\epochState _ _ -> foldBlocksCheckConstitutionWasRatified constitutionHash constitutionScriptHash epochState)
 
 foldBlocksCheckConstitutionWasRatified
   :: String -- submitted constitution hash

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/Query.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/Query.hs
@@ -28,15 +28,20 @@ import           Cardano.Testnet
 import           Prelude
 
 import           Control.Exception
+import           Control.Monad
 import qualified Data.ByteString.Short as SBS
 import           Data.Default.Class
 import qualified Data.Map.Strict as M
+import           Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
+import           Data.Word (Word64)
+import           GHC.Exts (toList)
 import           Lens.Micro
 
 import           Testnet.Components.Query
 import           Testnet.Process.Run
 import           Testnet.Property.Util (integrationRetryWorkspace)
 import           Testnet.Start.Types
+import           Testnet.Types (nodeConnectionInfo)
 
 import           Hedgehog
 import qualified Hedgehog as H
@@ -56,7 +61,7 @@ hprop_rpc_query_pparams = integrationRetryWorkspace 2 "rpc-query-pparams" $ \tem
       creationOptions = def{creationEra = AnyShelleyBasedEra sbe}
       runtimeOptions = def{runtimeEnableRpc = RpcEnabled}
 
-  TestnetRuntime
+  tr@TestnetRuntime
     { testnetMagic
     , configurationFile
     , testnetNodes = node0@TestnetNode{nodeSprocket} : _
@@ -79,6 +84,20 @@ hprop_rpc_query_pparams = integrationRetryWorkspace 2 "rpc-query-pparams" $ \tem
     ChainTipAtGenesis -> H.failure -- impossible
     ChainTip (SlotNo slot) (HeaderHash hash) (BlockNo blockNo) -> pure (slot, SBS.fromShort hash, blockNo)
 
+  -----------------------------------
+  -- Compute expected tip timestamp
+  -----------------------------------
+  connectionInfo <- nodeConnectionInfo tr 0
+  (systemStart, eraHistory) <-
+    (H.leftFail <=< H.leftFailM) . H.evalIO $
+      executeLocalStateQueryExpr connectionInfo VolatileTip $ do
+        ss <- querySystemStart
+        eh <- queryEraHistory
+        pure $ (,) <$> ss <*> eh
+  expectedTimestampMs :: Word64 <- H.leftFail $ do
+    utcTime <- slotToUTCTime systemStart eraHistory (SlotNo slot)
+    pure . round $ utcTimeToPOSIXSeconds utcTime * 1000
+
   --------------
   -- RPC queries
   --------------
@@ -89,7 +108,10 @@ hprop_rpc_query_pparams = integrationRetryWorkspace 2 "rpc-query-pparams" $ \tem
       Rpc.nonStreaming conn (Rpc.rpc @(Rpc.Protobuf U5c.QueryService "readParams")) req
 
     utxos' <- do
-      let req = Rpc.defMessage
+      let req = Rpc.defMessage & U5c.keys .~
+            [ def & U5c.hash .~ serialiseToRawBytes tid & U5c.index .~ fromIntegral tix
+            | (TxIn tid (TxIx tix), _) <- toList utxos
+            ]
       Rpc.nonStreaming conn (Rpc.rpc @(Rpc.Protobuf U5c.QueryService "readUtxos")) req
     pure (pparams', utxos')
 
@@ -99,7 +121,7 @@ hprop_rpc_query_pparams = integrationRetryWorkspace 2 "rpc-query-pparams" $ \tem
   pparamsResponse ^. U5c.ledgerTip . U5c.slot === slot
   pparamsResponse ^. U5c.ledgerTip . U5c.hash === blockHash
   pparamsResponse ^. U5c.ledgerTip . U5c.height === blockNo
-  pparamsResponse ^. U5c.ledgerTip . U5c.timestamp === 0 -- not possible to implement at this moment
+  H.assertWithinTolerance (pparamsResponse ^. U5c.ledgerTip . U5c.timestamp) expectedTimestampMs 1000
 
   -- https://docs.cardano.org/about-cardano/explore-more/parameter-guide
   let chainParams = pparamsResponse ^. U5c.values . U5c.cardano
@@ -107,9 +129,10 @@ hprop_rpc_query_pparams = integrationRetryWorkspace 2 "rpc-query-pparams" $ \tem
     pparams ^. L.ppCoinsPerUTxOByteL . to L.unCoinPerByte . to L.fromCompact . to L.unCoin
       ===^ chainParams ^. U5c.coinsPerUtxoByte . to utxoRpcBigIntToInteger
     pparams ^. L.ppMaxTxSizeL === chainParams ^. U5c.maxTxSize . to fromIntegral
-    pparams ^. L.ppTxFeeFixedL ===^ chainParams ^. U5c.minFeeCoefficient . to (fmap L.Coin . utxoRpcBigIntToInteger)
-    pparams ^. L.ppTxFeePerByteL . to L.unCoinPerByte . to L.fromCompact . to L.unCoin
+    pparams ^. L.ppTxFeeFixedL . to L.unCoin
       ===^ chainParams ^. U5c.minFeeConstant . to utxoRpcBigIntToInteger
+    pparams ^. L.ppTxFeePerByteL . to L.unCoinPerByte . to L.fromCompact . to L.unCoin
+      ===^ chainParams ^. U5c.minFeeCoefficient . to utxoRpcBigIntToInteger
     pparams ^. L.ppMaxBBSizeL === chainParams ^. U5c.maxBlockBodySize . to fromIntegral
     pparams ^. L.ppMaxBHSizeL === chainParams ^. U5c.maxBlockHeaderSize . to fromIntegral
     pparams ^. L.ppKeyDepositL ===^ chainParams ^. U5c.stakeKeyDeposit . to (fmap L.Coin . utxoRpcBigIntToInteger)

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/SearchUtxos.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/SearchUtxos.hs
@@ -1,0 +1,207 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.Testnet.Test.Rpc.SearchUtxos
+  ( hprop_rpc_search_utxos
+  )
+where
+
+import           Cardano.Api
+import qualified Cardano.Api.Ledger as L
+
+import           Cardano.Rpc.Client (Proto)
+import qualified Cardano.Rpc.Client as Rpc
+import qualified Cardano.Rpc.Proto.Api.UtxoRpc.Query as U5c
+import qualified Cardano.Rpc.Proto.Api.UtxoRpc.Query as UtxoRpc
+import qualified Cardano.Rpc.Proto.Api.UtxoRpc.Submit as U5c
+import qualified Cardano.Rpc.Proto.Api.UtxoRpc.Submit as UtxoRpc
+import           Cardano.Rpc.Server.Internal.UtxoRpc.Predicate (serialisePaymentCredential)
+import           Cardano.Rpc.Server.Internal.UtxoRpc.Type
+import           Cardano.Testnet
+
+import           Prelude
+
+import           Control.Monad.Trans.Control (liftBaseOp)
+import           Data.ByteString (ByteString)
+import           Data.Default.Class
+import           GHC.Stack
+import           Lens.Micro
+
+import           Testnet.Components.Query (TestnetWaitPeriod (..), getEpochStateView, retryUntilM)
+import           Testnet.Property.Util (integrationRetryWorkspace)
+import           Testnet.Types
+
+import           Hedgehog
+import qualified Hedgehog as H
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.TestWatchdog as H
+
+-- | E2E test for the SearchUtxos gRPC method.
+--
+-- Spins up a testnet, submits a transaction to create UTxOs at a known address,
+-- waits for them to appear in the UTxO set, then exercises SearchUtxos with
+-- exact-address and payment-credential predicates.
+--
+-- Run with:
+-- @TASTY_PATTERN='/RPC SearchUtxos/' cabal test cardano-testnet-test@
+hprop_rpc_search_utxos :: Property
+hprop_rpc_search_utxos = integrationRetryWorkspace 2 "rpc-search-utxos" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
+  conf <- mkConf tempAbsBasePath'
+  let (ceo, eraProxy) =
+        (conwayBasedEra, asType) :: era ~ ConwayEra => (ConwayEraOnwards era, AsType era)
+      sbe = convert ceo
+      options = def{cardanoNodeEra = AnyShelleyBasedEra sbe, cardanoEnableRpc = RpcEnabled}
+      addressInEra = AsAddressInEra eraProxy
+
+  TestnetRuntime
+    { configurationFile
+    , testnetNodes = node0 : _
+    , wallets = wallet0@(PaymentKeyInfo _ addrTxt0) : (PaymentKeyInfo _ addrTxt1) : _
+    } <-
+    createAndRunTestnet options def conf
+
+  epochStateView <- getEpochStateView configurationFile $ nodeSocketPath node0
+  rpcSocket <- H.note . unFile $ nodeRpcSocketPath node0
+
+  H.noteShow_ addrTxt0
+  address0 <- H.nothingFail $ deserialiseAddress addressInEra addrTxt0
+
+  H.noteShow_ addrTxt1
+  address1 <- H.nothingFail $ deserialiseAddress addressInEra addrTxt1
+
+  wit0 :: ShelleyWitnessSigningKey <-
+    H.leftFailM . H.evalIO $
+      readFileTextEnvelopeAnyOf
+        [FromSomeType asType WitnessGenesisUTxOKey]
+        (signingKey $ paymentKeyInfoPair wallet0)
+
+  let rpcServer = Rpc.ServerUnix rpcSocket
+
+  ----------------------
+  -- Build and submit tx
+  ----------------------
+  (pparamsResponse, initialSearch) <- H.noteShowM . H.evalIO . Rpc.withConnection def rpcServer $ \conn -> do
+    pparams' <-
+      Rpc.nonStreaming conn (Rpc.rpc @(Rpc.Protobuf UtxoRpc.QueryService "readParams")) def
+
+    search' <-
+      Rpc.nonStreaming conn (Rpc.rpc @(Rpc.Protobuf UtxoRpc.QueryService "searchUtxos")) $
+        def & U5c.predicate .~ addressPredicate address0
+    pure (pparams', search')
+
+  pparams <- H.leftFail $ utxoRpcPParamsToProtocolParams (convert ceo) $ pparamsResponse ^. U5c.values . U5c.cardano
+
+  txOut0 : _ <- H.noteShow $ initialSearch ^. U5c.items
+  txIn0 <- txoRefToTxIn $ txOut0 ^. U5c.txoRef
+
+  outputCoin <- H.leftFail $ txOut0 ^. U5c.cardano . U5c.coin . to utxoRpcBigIntToInteger
+  let amount = 200_000_000
+      fee = 500
+      change = outputCoin - amount - fee
+      txOut = TxOut address1 (lovelaceToTxOutValue sbe $ L.Coin amount) TxOutDatumNone ReferenceScriptNone
+      changeTxOut = TxOut address0 (lovelaceToTxOutValue sbe $ L.Coin change) TxOutDatumNone ReferenceScriptNone
+      content =
+        defaultTxBodyContent sbe
+          & setTxIns [(txIn0, pure $ KeyWitness KeyWitnessForSpending)]
+          & setTxFee (TxFeeExplicit sbe (L.Coin fee))
+          & setTxOuts [txOut, changeTxOut]
+          & setTxProtocolParams (pure . pure $ LedgerProtocolParameters pparams)
+
+  txBody <- H.leftFail $ createTransactionBody sbe content
+  let signedTx = signShelleyTransaction sbe txBody [wit0]
+
+  liftBaseOp (Rpc.withConnection def rpcServer) $ \conn -> do
+    _submitResponse <- H.noteShowM . H.evalIO $
+      Rpc.nonStreaming conn (Rpc.rpc @(Rpc.Protobuf UtxoRpc.SubmitService "submitTx")) $
+        def & U5c.tx .~ (def & U5c.raw .~ serialiseToCBOR signedTx)
+
+    -------------------------------------------
+    -- Wait for UTxOs to appear at address1
+    -------------------------------------------
+    H.note_ $ "Wait for 2 UTxOs at address " <> show addrTxt1
+    utxosAtAddress1 <- retryUntilM epochStateView (WaitForBlocks 10)
+      (do searchResult <- H.evalIO $
+            Rpc.nonStreaming conn (Rpc.rpc @(Rpc.Protobuf UtxoRpc.QueryService "searchUtxos")) $
+              def & U5c.predicate .~ addressPredicate address1
+          pure $ searchResult ^. U5c.items
+      )
+      (\xs -> length xs == 2)
+
+    -------------------------------------------
+    -- Test 1: exact address predicate returns correct amounts
+    -------------------------------------------
+    H.note_ "Test 1: Verify exact address search returns correct coin values"
+    let outputAmounts = map (^. U5c.cardano . U5c.coin) utxosAtAddress1
+    H.assertWith outputAmounts $ elem (inject amount)
+
+    -------------------------------------------
+    -- Test 2: payment credential predicate
+    -------------------------------------------
+    H.note_ "Test 2: Verify payment credential predicate matches same UTxOs"
+    let paymentCredBytes :: ByteString
+        paymentCredBytes = case address1 of
+          AddressInEra ShelleyAddressInEra{} (ShelleyAddress _ payCred _) ->
+            serialisePaymentCredential $ fromShelleyPaymentCredential payCred
+          _ -> error "Expected a Shelley address"
+        paymentPredicate :: Proto UtxoRpc.UtxoPredicate
+        paymentPredicate =
+          def
+            & U5c.match
+              .~ ( def
+                     & U5c.cardano
+                       .~ (def & U5c.address .~ (def & U5c.paymentPart .~ paymentCredBytes))
+                 )
+    payCredSearch <- H.noteShowM . H.evalIO $
+      Rpc.nonStreaming conn (Rpc.rpc @(Rpc.Protobuf UtxoRpc.QueryService "searchUtxos")) $
+        def & U5c.predicate .~ paymentPredicate
+
+    let payCredUtxos = payCredSearch ^. U5c.items
+    H.assertWith payCredUtxos $ \xs -> length xs == 2
+
+    -------------------------------------------
+    -- Test 3: search with non-matching address returns empty
+    -------------------------------------------
+    H.note_ "Test 3: Verify search with non-existent address returns empty"
+    let bogusAddressPredicate :: Proto UtxoRpc.UtxoPredicate
+        bogusAddressPredicate =
+          def
+            & U5c.match
+              .~ ( def
+                     & U5c.cardano
+                       .~ (def & U5c.address .~ (def & U5c.exactAddress .~ "\x00\x01\x02\x03"))
+                 )
+    emptySearch <- H.noteShowM . H.evalIO $
+      Rpc.nonStreaming conn (Rpc.rpc @(Rpc.Protobuf UtxoRpc.QueryService "searchUtxos")) $
+        def & U5c.predicate .~ bogusAddressPredicate
+
+    H.assertWith (emptySearch ^. U5c.items) null
+
+    -------------------------------------------
+    -- Test 4: search without predicate returns all UTxOs
+    -------------------------------------------
+    H.note_ "Test 4: Verify search without predicate returns all UTxOs"
+    allUtxosSearch <- H.noteShowM . H.evalIO $
+      Rpc.nonStreaming conn (Rpc.rpc @(Rpc.Protobuf UtxoRpc.QueryService "searchUtxos")) def
+
+    H.assertWith (allUtxosSearch ^. U5c.items) $ \xs -> length xs > 2
+
+txoRefToTxIn :: (HasCallStack, MonadTest m) => Proto UtxoRpc.TxoRef -> m TxIn
+txoRefToTxIn r = withFrozenCallStack $ do
+  txId' <- H.leftFail $ deserialiseFromRawBytes AsTxId $ r ^. U5c.hash
+  pure $ TxIn txId' (TxIx . fromIntegral $ r ^. U5c.index)
+
+addressPredicate :: IsCardanoEra era => AddressInEra era -> Proto UtxoRpc.UtxoPredicate
+addressPredicate address =
+  def
+    & U5c.match
+      .~ ( def
+             & U5c.cardano
+               .~ (def & U5c.address .~ (def & U5c.exactAddress .~ serialiseToRawBytes address))
+         )

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/Transaction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/Transaction.hs
@@ -17,7 +17,7 @@ import qualified Cardano.Api.Ledger as L
 
 import           Cardano.Rpc.Client (Proto)
 import qualified Cardano.Rpc.Client as Rpc
-import qualified Cardano.Rpc.Proto.Api.UtxoRpc.Query as U5c hiding (cardano, items, tx)
+import qualified Cardano.Rpc.Proto.Api.UtxoRpc.Query as U5c hiding (cardano)
 import qualified Cardano.Rpc.Proto.Api.UtxoRpc.Query as UtxoRpc
 import qualified Cardano.Rpc.Proto.Api.UtxoRpc.Submit as U5c
 import qualified Cardano.Rpc.Proto.Api.UtxoRpc.Submit as UtxoRpc
@@ -26,10 +26,8 @@ import           Cardano.Testnet
 
 import           Prelude
 
-import           Control.Monad
 import           Control.Monad.Trans.Control (liftBaseOp)
 import           Data.Default.Class
-import qualified Data.Text.Encoding as T
 import           GHC.Stack
 import           Lens.Micro
 
@@ -41,8 +39,6 @@ import           Hedgehog
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.TestWatchdog as H
-
-import           RIO (ByteString)
 
 -- | Run with:
 -- @TASTY_PATTERN='/RPC Transaction Submit/' cabal test cardano-testnet-test@
@@ -84,21 +80,18 @@ hprop_rpc_transaction = integrationRetryWorkspace 2 "rpc-tx" $ \tempAbsBasePath'
   -- RPC queries
   --------------
   let rpcServer = Rpc.ServerUnix rpcSocket
-  (pparamsResponse, utxosResponse) <- H.noteShowM . H.evalIO . Rpc.withConnection def rpcServer $ \conn -> do
-    pparams' <- do
-      let req = def
-      Rpc.nonStreaming conn (Rpc.rpc @(Rpc.Protobuf UtxoRpc.QueryService "readParams")) req
+  (pparamsResponse, searchResponse) <- H.noteShowM . H.evalIO . Rpc.withConnection def rpcServer $ \conn -> do
+    pparams' <-
+      Rpc.nonStreaming conn (Rpc.rpc @(Rpc.Protobuf UtxoRpc.QueryService "readParams")) def
 
-    utxos' <- do
-      let req = def -- & # U5c.keys .~ [T.encodeUtf8 addrTxt0]
-      Rpc.nonStreaming conn (Rpc.rpc @(Rpc.Protobuf UtxoRpc.QueryService "readUtxos")) req
-    pure (pparams', utxos')
+    search' <-
+      Rpc.nonStreaming conn (Rpc.rpc @(Rpc.Protobuf UtxoRpc.QueryService "searchUtxos")) $
+        def & U5c.predicate .~ addressPredicate addr0
+    pure (pparams', search')
 
   pparams <- H.leftFail $ utxoRpcPParamsToProtocolParams (convert ceo) $ pparamsResponse ^. U5c.values . U5c.cardano
 
-  txOut0 : _ <- H.noteShowM . flip filterM (utxosResponse ^. U5c.items) $ \utxo -> do
-    utxoAddress <- deserialiseAddressBs addrInEra $ utxo ^. U5c.cardano . U5c.address
-    pure $ addr0 == utxoAddress
+  txOut0 : _ <- H.noteShow $ searchResponse ^. U5c.items
   txIn0 <- txoRefToTxIn $ txOut0 ^. U5c.txoRef
 
   outputCoin <- H.leftFail $ txOut0 ^. U5c.cardano . U5c.coin . to utxoRpcBigIntToInteger
@@ -119,7 +112,7 @@ hprop_rpc_transaction = integrationRetryWorkspace 2 "rpc-tx" $ \tempAbsBasePath'
   let signedTx = signShelleyTransaction sbe txBody [wit0]
   txId' <- H.noteShow . getTxId $ getTxBody signedTx
 
-  H.noteShowPretty_ utxosResponse
+  H.noteShowPretty_ searchResponse
 
   liftBaseOp (Rpc.withConnection def rpcServer) $ \conn -> do
     submitResponse <- H.noteShowM . H.evalIO $
@@ -131,14 +124,12 @@ hprop_rpc_transaction = integrationRetryWorkspace 2 "rpc-tx" $ \tempAbsBasePath'
     H.note_ "Ensure that submitTx returns the same transaction ID as the locally computed signed transaction ID"
     txId' === submittedTxId
 
-    -- TODO use searchUtxos when available
     H.note_ $ "Ensure that there are 2 UTXOs in the address " <> show addrTxt1
     utxosForAddress <- retryUntilM epochStateView (WaitForBlocks 10)
-      (do utxos <- H.evalIO $
-            Rpc.nonStreaming conn (Rpc.rpc @(Rpc.Protobuf UtxoRpc.QueryService "readUtxos")) def
-          flip filterM (utxos ^. U5c.items) $ \utxo -> do
-            utxoAddress <- deserialiseAddressBs addrInEra $ utxo ^. U5c.cardano . U5c.address
-            pure $ addr1 == utxoAddress
+      (do searchResult <- H.evalIO $
+            Rpc.nonStreaming conn (Rpc.rpc @(Rpc.Protobuf UtxoRpc.QueryService "searchUtxos")) $
+              def & U5c.predicate .~ addressPredicate addr1
+          pure $ searchResult ^. U5c.items
       )
       (\xs -> length xs == 2)
 
@@ -151,5 +142,11 @@ txoRefToTxIn r = withFrozenCallStack $ do
   txId' <- H.leftFail $ deserialiseFromRawBytes AsTxId $ r ^. U5c.hash
   pure $ TxIn txId' (TxIx . fromIntegral $ r ^. U5c.index)
 
-deserialiseAddressBs :: (MonadTest m, SerialiseAddress c) => AsType c -> ByteString -> m c
-deserialiseAddressBs addrInEra = H.nothingFail . deserialiseAddress addrInEra <=< H.leftFail . T.decodeUtf8'
+addressPredicate :: IsCardanoEra era => AddressInEra era -> Proto UtxoRpc.UtxoPredicate
+addressPredicate addr =
+  def
+    & U5c.match
+      .~ ( def
+             & U5c.cardano
+               .~ (def & U5c.address .~ (def & U5c.exactAddress .~ serialiseToRawBytes addr))
+         )

--- a/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
+++ b/cardano-testnet/test/cardano-testnet-test/cardano-testnet-test.hs
@@ -36,6 +36,7 @@ import qualified Cardano.Testnet.Test.MainnetParams
 import qualified Cardano.Testnet.Test.Node.Shutdown
 import qualified Cardano.Testnet.Test.Parser
 import qualified Cardano.Testnet.Test.Rpc.Query
+import qualified Cardano.Testnet.Test.Rpc.SearchUtxos
 import qualified Cardano.Testnet.Test.Rpc.Transaction
 import qualified Cardano.Testnet.Test.RunTestnet
 import qualified Cardano.Testnet.Test.SanityCheck
@@ -147,6 +148,7 @@ tests = do
         ]
     , T.testGroup "RPC"
         [ ignoreOnWindows "RPC Query Protocol Params" Cardano.Testnet.Test.Rpc.Query.hprop_rpc_query_pparams
+        , ignoreOnWindows "RPC SearchUtxos" Cardano.Testnet.Test.Rpc.SearchUtxos.hprop_rpc_search_utxos
         , ignoreOnWindows "RPC Transaction Submit" Cardano.Testnet.Test.Rpc.Transaction.hprop_rpc_transaction
         ]
     , T.testGroup "NodesWithOptions parser"


### PR DESCRIPTION
# Description
Add tests of searchUtxos gRPC query: 
- https://github.com/IntersectMBO/cardano-api/pull/1123

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
