### PR TITLE
tx-generator: make it buildable in leios-prototype

### DIFF
--- a/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/NodeToNode.hs
+++ b/bench/tx-generator/src/Cardano/Benchmarking/GeneratorTx/NodeToNode.hs
@@ -27,6 +27,7 @@ import qualified Data.Map.Strict as Map
 import           Data.Proxy (Proxy (..))
 import           Data.Void (Void, absurd)
 import qualified Network.Mux as Mux
+import           Network.Mux.Channel (Reception)
 import           Network.Socket (AddrInfo (..))
 import           System.Random (newStdGen)
 
@@ -115,7 +116,7 @@ benchmarkConnectTxSubmit EnvConsts { .. } handshakeTracer submissionTracer codec
   supportedVers = supportedNodeToNodeVersions (Proxy @blk)
   myCodecs :: Codecs blk NtN.RemoteAddress DeserialiseFailure IO
                 ByteString ByteString ByteString ByteString ByteString ByteString
-                ByteString
+                ByteString ByteString ByteString
   myCodecs  = defaultCodecs codecConfig blkN2nVer encodeRemoteAddress decodeRemoteAddress n2nVer
   peerMultiplex :: NtN.Versions NodeToNodeVersion
                                 NtN.NodeToNodeVersionData
@@ -173,14 +174,14 @@ benchmarkConnectTxSubmit EnvConsts { .. } handshakeTracer submissionTracer codec
     => NodeToNodeVersion
     -> remotePeer
     -> Channel IO ByteString
-    -> IO ((), Maybe ByteString)
+    -> IO ((), Maybe (Reception ByteString))
   kaClient _version them channel = do
     keepAliveRng <- newStdGen
     peerGSVMap <- liftIO . newTVarIO $ Map.singleton them defaultGSV
     runPeerWithLimits
       mempty
       (cKeepAliveCodec myCodecs)
-      (byteLimitsKeepAlive (const 0)) -- TODO: Real Bytelimits, see #1727
+      byteLimitsKeepAlive -- TODO: Real Bytelimits, see #1727
       timeLimitsKeepAlive
       channel
       $ keepAliveClientPeer


### PR DESCRIPTION
# Description

Fixes for building tx-generator binary in the leios-prototype branch.

- Codecs gained cLeiosNotifyCodec/cLeiosFetchCodec fields; extend myCodecs signature with two extra ByteString params.
- byteLimitsKeepAlive no longer takes a size function; drop (const 0).
- runPeer/runPeerWithLimits now return Maybe (Reception bytes); update kaClient return type and import Reception from Network.Mux.Channel.

The `nix build .#tx-generator -o nix-build-tx-gen` works with the fixes.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff