### PR TITLE
cardano-recon: replace positional FILE/FILES args with named --formulas/--traces (v1.2.1)

### DIFF
--- a/bench/cardano-recon-framework/CHANGELOG.md
+++ b/bench/cardano-recon-framework/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for cardano-trace-ltl
 
+## 1.2.1 -- May 2026
+
+* Replace positional `FILE` and `FILES` arguments in `cardano-recon` with named `--formulas` and `--traces` options.
+
 ## 1.2.0 -- May 2026
 
 * Add `ContinuousFormula` — the temporal-operator-free fragment of `Formula`, with `retract` for

--- a/bench/cardano-recon-framework/README.md
+++ b/bench/cardano-recon-framework/README.md
@@ -43,7 +43,9 @@ Available options:
   --seek-to-end BOOL       seek to the end of the trace file before ingesting it
                            (default: True)
   --timeunit <hour|minute|second|millisecond|microsecond>
-                           timeunit (default: second)
+                           unit in which numeric arguments of temporal
+                           operators in input formulas are measured
+                           (default: second)
   --on-missing-key <crash|bottom>
                            behaviour when a formula atom references a missing
                            event property key (default: bottom)

--- a/bench/cardano-recon-framework/app/Cardano/ReCon/Cli.hs
+++ b/bench/cardano-recon-framework/app/Cardano/ReCon/Cli.hs
@@ -77,7 +77,7 @@ parseTimeunit = option readTimeunit $
   <> metavar "<hour|minute|second|millisecond|microsecond>"
   <> showDefault
   <> value Second
-  <> help "timeunit"
+  <> help "unit in which numeric arguments of temporal operators in input formulas are measured"
 
 parseEventDuration :: Parser Word
 parseEventDuration = option auto (long "duration" <> metavar "INT" <> help "temporal event duration (μs)")

--- a/bench/cardano-recon-framework/app/Cardano/ReCon/Cli.hs
+++ b/bench/cardano-recon-framework/app/Cardano/ReCon/Cli.hs
@@ -91,7 +91,7 @@ parseDumpMetrics = option readBool $
   <> help "enable periodic metric dumps to stdout"
 
 parseFormulasFile :: Parser FilePath
-parseFormulasFile = argument str (metavar "FILE")
+parseFormulasFile = option str (long "formulas" <> metavar "FILE" <> help "YAML file with a list of formulas to check")
 
 parseTraceDispatcherCfgFile :: Parser (Maybe FilePath)
 parseTraceDispatcherCfgFile =
@@ -102,7 +102,7 @@ parseContext =
   option (optional str) (long "context" <> value Nothing <> metavar "FILE" <> help "context variables")
 
 parseTraceFiles :: Parser [FilePath]
-parseTraceFiles = some (argument str (metavar "FILES"))
+parseTraceFiles = some (option str (long "traces" <> metavar "FILE" <> help "trace log file (repeatable)"))
 
 parseRetention :: Parser Word
 parseRetention = option auto $

--- a/bench/cardano-recon-framework/cardano-recon-framework.cabal
+++ b/bench/cardano-recon-framework/cardano-recon-framework.cabal
@@ -4,7 +4,7 @@ description:        Cardano Re(altime) Con(formance) Framework based on Linear T
 category:           Cardano
                     Testing
 copyright:          2026 Intersect.
-version:            1.2.0
+version:            1.2.1
 license:            Apache-2.0
 license-files:      LICENSE
                     NOTICE


### PR DESCRIPTION
## Summary

- Replace the positional `FILE` argument in `cardano-recon` with a named `--formulas FILE` option.
- Replace the positional `FILES` argument with a repeatable `--traces FILE` option (pass once per file).
- Improve the `--timeunit` help message to clearly describe how the value is used.
- Bump `cardano-recon-framework` version to 1.2.1 and add changelog entry.