### PR TITLE
Resolve relative `LeiosDbConfig` paths against --database-path

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -129,8 +129,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/IntersectMBO/cardano-api
-  tag: 959c3180b8d23ca8a5fc85a2150c47a9fdea06eb
-  --sha256: sha256-ItzSd17AR04RgEUKy+3LJ+1AYxFXAAfUIvhxgNXrpN8=
+  tag: 28e2f4f085eceee4cb63c3eb9103a80e3852ce7a
+  --sha256: sha256-9Wugp6Cd+ERSc8kfIUDFbq3QjuhIr1gu6rRSV3Yo/9M=
   subdir:
     cardano-api
     cardano-api-gen

--- a/cabal.project
+++ b/cabal.project
@@ -87,15 +87,15 @@ allow-newer:
 source-repository-package
   type: git
   location: https://github.com/IntersectMBO/ouroboros-consensus
-  tag: a2a678d305fd0e75aa3ca2a7ff6fb6345ed8002d
-  --sha256: sha256-LOXhMjUpgMOefcOUblg+3y+2wHdjBc/N+7H38RzktaY=
+  tag: b96622537155e11b5d9d91df7ac0600c493d4802
+  --sha256: sha256-pRqgI9vZRiOp7g0gDVt6EauDZM8ZQ0EmiP6YOuIG0Hk=
 
 -- Points to ouroboros-ledger/leios-prototype
 source-repository-package
   type: git
   location: https://github.com/IntersectMBO/cardano-ledger
-  tag: 17a414939eeebaf0d98044400ab860332539e921
-  -- sha256: sha256-niO9e6uaUrsALkQbSH0D68GedoAG0F7h4o9HFUVoIkA=
+  tag: 9edd1c664054803348e5f9edfa13529e4e844284
+  --sha256: sha256-TkgeO5d1p18VwTMtuNY8SsPZXXyn1HIrZBZ4IHVTWuE=
   subdir:
     libs/cardano-data
     libs/cardano-ledger-api

--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## Next version
 
+* Resolve relative `LeiosDbConfig` SQLite paths against `--database-path`, so the default `leios.db` is placed alongside `immutable/` and `volatile/`.
+
 * Added txsSyncDurationTotal counter for tracking the total time spent syncing the mempool.
 
 * Added EKG metrics for soft and hard timeouts and included defensive mempool

--- a/cardano-node/src/Cardano/Node/Configuration/POM.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/POM.hs
@@ -47,8 +47,7 @@ import           Ouroboros.Consensus.Node.Genesis (GenesisConfig, GenesisConfigF
                    defaultGenesisConfigFlags, mkGenesisConfig)
 import           Ouroboros.Consensus.Storage.LedgerDB.Args (QueryBatchSize (..))
 import           Ouroboros.Consensus.Storage.LedgerDB.Snapshots (NumOfDiskSnapshots (..),
-                   SnapshotInterval (..), SnapshotPolicyArgs (..),
-                   defaultSnapshotPolicyArgs)
+                   SnapshotInterval (..), SnapshotPolicyArgs (..), defaultSnapshotPolicyArgs)
 import           Ouroboros.Network.Diffusion.Configuration as Configuration
 import qualified Ouroboros.Network.Diffusion.Configuration as Ouroboros
 import qualified Ouroboros.Network.Mux as Mux
@@ -65,7 +64,6 @@ import           Data.Hashable (Hashable)
 import           Data.Maybe
 import           Data.Monoid (Last (..))
 import           Data.Text (Text)
-import qualified Data.Text as Text
 import           Data.Time.Clock (DiffTime, secondsToDiffTime)
 import           Data.Yaml (decodeFileThrow)
 import           GHC.Generics (Generic)

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -155,7 +155,7 @@ import           Data.Time.Clock (getCurrentTime)
 import           Network.DNS (Resolver)
 import           Network.Socket (Socket)
 import           System.Directory (canonicalizePath, createDirectoryIfMissing, makeAbsolute)
-import           System.FilePath (takeDirectory, (</>))
+import           System.FilePath (isAbsolute, takeDirectory, (</>))
 import           System.IO (hPutStrLn)
 #ifdef UNIX
 import           GHC.Weak (deRefWeak)
@@ -360,10 +360,14 @@ handleSimpleNode blockType runP tracers nc networkMagic onKernel = do
 
   leiosDB <- case ncLeiosDbConfig nc of
     LeiosDbInMemory -> newLeiosDBInMemory
-    LeiosDbSQLite leiosDbPath ->
+    LeiosDbSQLite leiosDbPath -> do
+      let resolvedPath
+            | isAbsolute leiosDbPath = leiosDbPath
+            | otherwise = nonImmutableDbPath dbPath </> leiosDbPath
+      createDirectoryIfMissing True (takeDirectory resolvedPath)
       newLeiosDBSQLite
         (contramap TraceLeiosDb (Consensus.leiosKernelTracer (consensusTracers tracers)))
-        leiosDbPath
+        resolvedPath
 
   withShutdownHandling (ncShutdownConfig nc) (shutdownTracer tracers) $ do
     traceWith (startupTracer tracers)

--- a/cardano-node/src/Cardano/Node/Tracing/Render.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Render.hs
@@ -238,8 +238,8 @@ renderAlonzoPlutusPurpose = \case
     Aeson.object ["spending" .= Api.fromShelleyTxIn txin]
   AlonzoMinting pid ->
     Aeson.object ["minting" .= Aeson.toJSON pid]
-  AlonzoRewarding (AsItem rwdAcct) ->
-    Aeson.object ["rewarding" .= Aeson.String (Api.serialiseAddress $ Api.fromShelleyStakeAddr rwdAcct)]
+  AlonzoWithdrawing (AsItem rwdAcct) ->
+    Aeson.object ["withdrawing" .= Aeson.String (Api.serialiseAddress $ Api.fromShelleyStakeAddr rwdAcct)]
   AlonzoCertifying cert ->
     Aeson.object ["certifying" .= Aeson.toJSON cert]
 
@@ -252,8 +252,8 @@ renderConwayPlutusPurpose = \case
     Aeson.object ["spending" .= Api.fromShelleyTxIn txin]
   ConwayMinting pid ->
     Aeson.object ["minting" .= Aeson.toJSON pid]
-  ConwayRewarding (AsItem rwdAcct) ->
-    Aeson.object ["rewarding" .= Aeson.String (Api.serialiseAddress $ Api.fromShelleyStakeAddr rwdAcct)]
+  ConwayWithdrawing (AsItem rwdAcct) ->
+    Aeson.object ["withdrawing" .= Aeson.String (Api.serialiseAddress $ Api.fromShelleyStakeAddr rwdAcct)]
   ConwayCertifying cert ->
     Aeson.object ["certifying" .= Aeson.toJSON cert]
   ConwayVoting voter ->

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ChainDB.hs
@@ -58,7 +58,6 @@ import           Ouroboros.Network.Block (MaxSlotNo (..))
 import           Data.Aeson (Object, ToJSON, Value (Object, String), object, toJSON, (.=))
 import qualified Data.ByteString.Base16 as B16
 import           Data.Int (Int64)
-import qualified Data.List.NonEmpty as NonEmpty
 import           Data.SOP (All, K (..), hcmap, hcollapse)
 import           Data.Text (Text)
 import qualified Data.Text as Text
@@ -1700,7 +1699,7 @@ instance MetaTrace (PerasCertDB.TraceEvent blk) where
 
   documentFor _ = Nothing
 
-instance (StandardHash blk, ConvertRawHash blk) => LogFormatting (PerasCertDB.TraceEvent blk) where
+instance ConvertRawHash blk => LogFormatting (PerasCertDB.TraceEvent blk) where
   forHuman PerasCertDB.OpenedPerasCertDB =
     "Opened Peras certificate DB"
   forHuman PerasCertDB.ClosedPerasCertDB =
@@ -2111,11 +2110,14 @@ instance MetaTrace LedgerDB.TraceForkerEvent where
 --------------------------------------------------------------------------------
 
 instance LogFormatting LedgerDB.FlavorImplSpecificTrace where
+  forMachine _dtal (LedgerDB.FlavorImplSpecificTraceV1 _ev) = mempty
   forMachine dtal (LedgerDB.FlavorImplSpecificTraceV2 ev) = forMachine dtal ev
 
+  forHuman (LedgerDB.FlavorImplSpecificTraceV1 _ev) = ""
   forHuman (LedgerDB.FlavorImplSpecificTraceV2 ev) = forHuman ev
 
 instance MetaTrace LedgerDB.FlavorImplSpecificTrace where
+  namespaceFor (LedgerDB.FlavorImplSpecificTraceV1 _ev) = Namespace [] []
   namespaceFor (LedgerDB.FlavorImplSpecificTraceV2 ev) =
     nsPrependInner "V2" (namespaceFor ev)
 

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
@@ -27,8 +27,6 @@ module Cardano.Node.Tracing.Tracers.Consensus
 
 import qualified Cardano.KESAgent.Processes.ServiceClient as Agent
 import           Cardano.Logging
-import           LeiosDemoTypes (TraceLeiosKernel (..), TraceLeiosPeer (..),
-                   traceLeiosKernelToObject, traceLeiosPeerToObject)
 import           Cardano.Node.Queries (ConvertTxId (..), HasKESInfo (..))
 import           Cardano.Node.Tracing.Era.Byron ()
 import           Cardano.Node.Tracing.Era.Shelley ()
@@ -67,11 +65,11 @@ import           Ouroboros.Consensus.Util.Enclose
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import qualified Ouroboros.Network.AnchoredSeq as AS
 import           Ouroboros.Network.Block hiding (blockPrevHash)
-import           Ouroboros.Network.OrphanInstances ()
 import           Ouroboros.Network.BlockFetch.ClientState (TraceLabelPeer (..))
 import qualified Ouroboros.Network.BlockFetch.ClientState as BlockFetch
 import           Ouroboros.Network.BlockFetch.Decision
 import           Ouroboros.Network.BlockFetch.Decision.Trace (TraceDecisionEvent (..))
+import           Ouroboros.Network.OrphanInstances ()
 import           Ouroboros.Network.SizeInBytes (SizeInBytes (..))
 
 import           Control.Monad (guard)
@@ -86,6 +84,10 @@ import qualified Data.Text as Text
 import           Data.Time (NominalDiffTime)
 import           Data.Word (Word32, Word64)
 import           Network.TypedProtocol.Core
+
+import           LeiosDemoTypes (TraceLeiosKernel (..), TraceLeiosPeer (..),
+                   traceLeiosKernelToObject, traceLeiosPeerToObject)
+
 enclosingValue :: ToJSON a => Enclosing' a -> Value
 enclosingValue RisingEdge = object [ "edge" .= String "Starting" ]
 enclosingValue (FallingEdgeWith a) = object [ "edge" .= toJSON a ]
@@ -1041,7 +1043,6 @@ instance ( HasHeader blk
 instance MetaTrace SanityCheckIssue where
 
   namespaceFor InconsistentSecurityParam {} = Namespace [] ["SanityCheckIssue"]
-  namespaceFor _ = Namespace [] ["SanityCheckIssue"]
 
   severityFor (Namespace _ ["SanityCheckIssue"]) _ = Just Error
   severityFor _ _ = Nothing
@@ -1056,12 +1057,9 @@ instance LogFormatting SanityCheckIssue where
     mconcat [ "kind" .= String "InconsistentSecurityParam"
             , "error" .= String (Text.pack $ show e)
             ]
-  forMachine _ _ =
-    mconcat [ "kind" .= String "SnapshotIssue"
-            ]
+
   forHuman (InconsistentSecurityParam e) =
     "Configuration contains multiple security parameters: " <> Text.pack (show e)
-  forHuman _ = "SnapshotIssue"
 
 --------------------------------------------------------------------------------
 -- TxSubmissionServer Tracer


### PR DESCRIPTION
The default settings now result in leios.db next to immutable/ and
volatile/ directories.

An absolute path in LeiosDbConfig is obviously unaffected by the --database-path.