### PR TITLE
Integrate Consensus PR 2141 (LeiosNotify: accept but ignore proper MsgLeiosBlockAnnouncement messages)

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -88,8 +88,8 @@ allow-newer:
 source-repository-package
   type: git
   location: https://github.com/IntersectMBO/ouroboros-consensus
-  tag: a7fa6b6f6888272e76e32a7aeb1f82776e1142ec
-  --sha256: sha256-MiECfkFw7tjHuQsCQuWTXeLqodIrStjt3TY9rE/rHf8=
+  tag: b71bd2c89d576d8112a0748adf3b890475f9d170
+  --sha256: sha256-tIjrQkEkS79FdYarjV5Dy+U/Q7kIkOXjdFcddkwA3Us=
 
 -- Points to ouroboros-ledger/leios-prototype
 source-repository-package

--- a/cardano-node/src/Cardano/Node/TraceConstraints.hs
+++ b/cardano-node/src/Cardano/Node/TraceConstraints.hs
@@ -47,6 +47,7 @@ type TraceConstraints blk =
     , HasIssuer blk
 
     , ToJSON (HeaderHash blk)
+    , Show (Header blk)
 
     , LogFormatting (ApplyTxErr blk)
     , LogFormatting (GenTx blk)

--- a/cardano-node/src/Cardano/Node/Tracing/Consistency.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Consistency.hs
@@ -275,7 +275,7 @@ getAllNamespaces =
         leiosNotifyNS = map (nsGetTuple . nsReplacePrefix
                                         ["LeiosNotify", "Remote"])
                              (allNamespaces :: [Namespace
-                                 (AnyMessage (LN.LeiosNotify LeiosPoint () LeiosVote))])
+                                 (AnyMessage (LN.LeiosNotify LeiosPoint (Header blk) LeiosVote))])
         leiosFetchNS = map (nsGetTuple . nsReplacePrefix
                                         ["LeiosFetch", "Remote"])
                              (allNamespaces :: [Namespace

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/NodeToNode.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/NodeToNode.hs
@@ -19,7 +19,8 @@ import qualified LeiosDemoOnlyTestFetch as LF
 import qualified LeiosDemoOnlyTestNotify as LN
 import           LeiosDemoTypes (LeiosEb, LeiosPoint, LeiosTx, LeiosVote,
                    messageLeiosFetchToObject, messageLeiosNotifyToObject)
-import           Ouroboros.Consensus.Block (ConvertRawHash, GetHeader, StandardHash, getHeader)
+import           Ouroboros.Consensus.Block (ConvertRawHash, GetHeader, Header, StandardHash,
+                   getHeader)
 import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTx, HasTxId, HasTxs,
                    LedgerSupportsMempool, extractTxs, txId)
 import           Ouroboros.Consensus.Node.Run (SerialiseNodeToNodeConstraints, estimateBlockSize)
@@ -476,7 +477,8 @@ instance MetaTrace (TraceKeepAliveClient remotePeer) where
 -- CBOR payload that the derived 'Show' would dump.
 --------------------------------------------------------------------------------
 
-instance LogFormatting (AnyMessage (LN.LeiosNotify LeiosPoint () LeiosVote)) where
+instance ( Show (Header blk)
+         ) => LogFormatting (AnyMessage (LN.LeiosNotify LeiosPoint (Header blk) LeiosVote)) where
   forHuman = showT
 
   forMachine _dtal (AnyMessageAndAgency _stok msg) =
@@ -488,7 +490,7 @@ instance LogFormatting (AnyMessage (LF.LeiosFetch LeiosPoint LeiosEb LeiosTx)) w
   forMachine _dtal (AnyMessageAndAgency _stok msg) =
     messageLeiosFetchToObject msg
 
-instance MetaTrace (AnyMessage (LN.LeiosNotify LeiosPoint () LeiosVote)) where
+instance MetaTrace (AnyMessage (LN.LeiosNotify LeiosPoint (Header blk) LeiosVote)) where
   namespaceFor (AnyMessageAndAgency _stok msg) = case msg of
     LN.MsgLeiosNotificationRequestNext{} -> Namespace [] ["RequestNext"]
     LN.MsgLeiosBlockAnnouncement{}       -> Namespace [] ["BlockAnnouncement"]


### PR DESCRIPTION
Merely integrates the consensus PR https://github.com/IntersectMBO/ouroboros-consensus/pull/2142, which changes the type of `LeiosNotify` messages to have `Header blk` payloads in the MsgLeiosBlockAnnouncement instead of `()`.