### PR TITLE
Fixes two `severityFor`bugs

### DIFF
--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/ConsensusStartupException.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/ConsensusStartupException.hs
@@ -27,7 +27,7 @@ instance LogFormatting ConsensusStartupException where
 instance MetaTrace ConsensusStartupException where
   namespaceFor ConsensusStartupException {} = Namespace [] ["ConsensusStartupException"]
 
-  severityFor (Namespace _ ["ConsensusStartupException"]) Nothing = Just Error
+  severityFor (Namespace _ ["ConsensusStartupException"]) _ = Just Error
   severityFor _ _ = Nothing
 
   documentFor (Namespace _ ["ConsensusStartupException"]) = Just

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/NodeToNode.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/NodeToNode.hs
@@ -454,7 +454,7 @@ instance Show remotePeer => LogFormatting (TraceKeepAliveClient remotePeer) wher
 instance MetaTrace (TraceKeepAliveClient remotePeer) where
   namespaceFor AddSample {} = Namespace [] ["KeepAliveClient"]
 
-  severityFor (Namespace _ ["KeepAliveClient"]) Nothing = Just Info
+  severityFor (Namespace _ ["KeepAliveClient"]) _ = Just Info
   severityFor _ _ = Nothing
 
   documentFor (Namespace _ ["KeepAliveClient"]) = Just


### PR DESCRIPTION

Fixes two `severityFor` implementations that only match the `Nothing` value case, so a real trace message always falls through to `severityFor _ _ = Nothing` instead of resolving a severity:

- `Cardano.Node.Tracing.Tracers.ConsensusStartupException`: `severityFor (Namespace _ ["ConsensusStartupException"]) Nothing = Just Error`
- `Cardano.Node.Tracing.Tracers.NodeToNode` (`TraceKeepAliveClient`): `severityFor (Namespace _ ["KeepAliveClient"]) Nothing = Just Info`

In both cases the real message is traced as `Just v`, which doesn't match the `Nothing`-only equation and falls through to the catch-all `severityFor _ _ = Nothing`.

**Impact:** `trace-dispatcher`'s `filterSeverityFromConfig` treats a `Nothing` severity as "always visible," silently bypassing whatever severity threshold is configured, and `Formatter.hs` defaults the *displayed* severity to `Info` via `fromMaybe Info`. Concretely: a real `ConsensusStartupException` — meant to be `Error` — currently displays as `Info` and can never be filtered out by a severity threshold. `KeepAliveClient`'s display happens to coincide with `Info` by luck, but it's equally unfilterable.

**Origin:** found while reviewing [ouroboros-network#5402](https://github.com/IntersectMBO/ouroboros-network/pull/5402) ("Rearrange severity query for new tracing"), which fixed the same shape of bug in `DiffusionTracer` (there, severity was matched purely on the runtime *value* constructor instead of the namespace). The ensuing discussion on that PR established the operating principle for this codebase: severity should always be resolvable from the namespace alone; matching on the runtime value is reserved for the genuinely rare case where one namespace legitimately carries different severities for different payloads (e.g. `Decline` in `Cardano.Node.Tracing.Tracers.Consensus`, which discriminates by rejection reason). Neither `ConsensusStartupException` nor `KeepAliveClient` is such a case — each has exactly one namespace and one severity — so matching on `Nothing` instead of the namespace was never intentional, just an oversight of the same kind fixed upstream.

**Fix:** replace `Nothing` with a wildcard `_` in both equations, so severity resolves regardless of whether a value is present:

```haskell
severityFor (Namespace _ ["ConsensusStartupException"]) _ = Just Error
severityFor (Namespace _ ["KeepAliveClient"]) _ = Just Info
```

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes
- [x] Self-reviewed the diff
