### PR TITLE
Re-enable the fragment PR-number check

### DIFF
--- a/.github/workflows/herald-validate.yml
+++ b/.github/workflows/herald-validate.yml
@@ -40,7 +40,3 @@ jobs:
           # defaults to 0.1.1.0. Pin explicitly until herald-validate is
           # re-released with a newer default, then this can be dropped.
           herald-ref: github:input-output-hk/cardano-dev/herald-0.1.2.0
-          # Temporarily disabled: the fragments converted from scriv keep the
-          # PR number of the change each one describes, so they cannot match
-          # this pull request.  Re-enable once the changelogs are backfilled.
-          pr: 'false'


### PR DESCRIPTION
# Description

Removes the temporary `pr: 'false'` override from `.github/workflows/herald-validate.yml`, which was added in the herald migration PR (#6631). The override is deleted rather than replaced with `pr: 'true'`, because the `herald-validate` action already defaults that input to `'true'`.

It was disabled there because the 27 `cardano-testnet` fragments converted from scriv deliberately keep the PR number of the change each one describes, so they can never match the pull request that introduced them.

From now on, any newly added changelog fragment must reference the pull request it arrives in. The `--diff` check (every modified project needs a fragment) was never disabled and is unaffected.

This PR is stacked on top of #6631 and should merge after it. GitHub will retarget it to `master` automatically once #6631 merges. Reviewers only need to look at the single commit here, not the migration commits.

Scope: one file, four lines deleted.

## Verification

- `actionlint` passes on the workflow.
- The step's `with:` block now contains only the `herald-ref` pin (herald 0.1.2.0, needed because per-package `changes-dir` support landed in that version while the released action still defaults to 0.1.1.0).
- The check is not configured as a required status check, so it reports without blocking.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
  - `cardano-node-chairman`, `cardano-submit-api` and `cardano-testnet` instead need a
    changelog fragment in `<package>/.changes/`, because their `CHANGELOG.md` is generated
    from fragments at release time.  Copy `_TEMPLATE.yml` from that directory, or run
    `nix run github:input-output-hk/cardano-dev#herald -- new`
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
