### PR TITLE
cardano-testnet: Clean up conf constructor naming in cardano-testnet

### DIFF
--- a/cardano-node-chairman/.changes/20260804_213638_palas_cleanup_conf_constructor_naming.yml
+++ b/cardano-node-chairman/.changes/20260804_213638_palas_cleanup_conf_constructor_naming.yml
@@ -1,0 +1,6 @@
+pr: 6637
+kind:
+  - test
+description: |
+  - Adapted the chairman test to the removal of `mkConf` from `cardano-testnet`:
+    use the pure `mkConfig` instead.

--- a/cardano-node-chairman/test/Spec/Chairman/Cardano.hs
+++ b/cardano-node-chairman/test/Spec/Chairman/Cardano.hs
@@ -17,7 +17,7 @@ import           Spec.Chairman.Chairman (chairmanOver)
 
 hprop_chairman :: H.Property
 hprop_chairman = integrationRetryWorkspace 2 "cardano-chairman" $ \tempAbsPath' -> H.runWithDefaultWatchdog_ $ do
-  conf <- mkConf tempAbsPath'
+  let conf = mkConfig tempAbsPath'
 
   let creationOptions = def{ creationNodes = cardanoDefaultTestnetNodesWithOptions }
   allNodes <- testnetNodes <$> createAndRunTestnet creationOptions def conf

--- a/cardano-testnet/.changes/20260804_213638_palas_cleanup_conf_constructor_naming.yml
+++ b/cardano-testnet/.changes/20260804_213638_palas_cleanup_conf_constructor_naming.yml
@@ -2,11 +2,6 @@ pr: 6637
 kind:
   - breaking
 description: |
-  - Cleaned up the naming of the `Conf` constructors in `Testnet.Start.Types`:
-    - Removed `mkConf`. Its only difference with `mkConfig` was noting the path in the test log,
-      which was redundant: every call site passes a workspace path that hedgehog-extras'
-      `workspace` already annotates on creation. Test code now uses the pure `mkConfig`
-      directly, which is now exported (and re-exported from `Cardano.Testnet` in place of
-      `mkConf`).
-    - Renamed `mkConfigAbs` to `mkConfigAbsolute`, and documented that, besides making the
-      path absolute, it also creates the directory if it doesn't exist yet.
+  - Cleaned up the naming of the `*Conf*` constructors in `Testnet.Start.Types`:
+    - Removed `mkConf`. Its only difference with `mkConfig` was noting the path in the test log, which was redundant. Test code now uses the pure `mkConfig` directly, now exported in place of `mkConf`.
+    - Renamed `mkConfigAbs` to `mkConfigAbsolute`, and documented that, besides making the path absolute, it also creates the directory if it doesn't exist yet.

--- a/cardano-testnet/.changes/20260804_213638_palas_cleanup_conf_constructor_naming.yml
+++ b/cardano-testnet/.changes/20260804_213638_palas_cleanup_conf_constructor_naming.yml
@@ -1,0 +1,12 @@
+pr: 6637
+kind:
+  - breaking
+description: |
+  - Cleaned up the naming of the `Conf` constructors in `Testnet.Start.Types`:
+    - Removed `mkConf`. Its only difference with `mkConfig` was noting the path in the test log,
+      which was redundant: every call site passes a workspace path that hedgehog-extras'
+      `workspace` already annotates on creation. Test code now uses the pure `mkConfig`
+      directly, which is now exported (and re-exported from `Cardano.Testnet` in place of
+      `mkConf`).
+    - Renamed `mkConfigAbs` to `mkConfigAbsolute`, and documented that, besides making the
+      path absolute, it also creates the directory if it doesn't exist yet.

--- a/cardano-testnet/src/Cardano/Testnet.hs
+++ b/cardano-testnet/src/Cardano/Testnet.hs
@@ -25,7 +25,7 @@ module Cardano.Testnet (
   TmpAbsolutePath(..),
   NodeConfiguration,
   NodeConfigurationYaml,
-  mkConf,
+  mkConfig,
   makeLogDir,
   makeSocketDir,
   makeTmpBaseAbsPath,

--- a/cardano-testnet/src/Parsers/Run.hs
+++ b/cardano-testnet/src/Parsers/Run.hs
@@ -64,7 +64,7 @@ createEnvOptions CardanoTestnetCreateEnvOptions
   { createEnvCreationOptions=creationOptions
   , createEnvOutputDir=outputDir
   } = do
-      conf <- mkConfigAbs outputDir
+      conf <- mkConfigAbsolute outputDir
       void $ createTestnetEnv
         creationOptions
         -- Do not add hashes to the main config file, so that genesis files
@@ -78,7 +78,7 @@ runCardanoOptions = \case
     -- It is not necessary to update timestamps here, because
     -- the genesis files will be created with up-to-date stamps already.
     let dirName = fromMaybe "testnet" noEnvOutputDir
-    conf <- mkConfigAbs dirName
+    conf <- mkConfigAbsolute dirName
     runSimpleApp . runResourceT $ do
       logInfo $ "Creating environment: " <> display (tempAbsPath conf)
       createTestnetEnv noEnvCreationOptions conf
@@ -90,7 +90,7 @@ runCardanoOptions = \case
     -- Run cardano-testnet in the sandbox provided by the user
     let dirName = envPath fromEnvOptions
     unlessM (doesDirectoryExist dirName) $ error $ "The provided path does not exist or is not a directory: " <> dirName
-    conf <- mkConfigAbs dirName
+    conf <- mkConfigAbsolute dirName
     nodes <- readNodesWithOptionsFromEnv (unTmpAbsPath (tempAbsPath conf))
     runSimpleApp . runResourceT $ do
       logInfo $ "Starting testnet in environment: " <> display (tempAbsPath conf)

--- a/cardano-testnet/src/Testnet/Property/Run.hs
+++ b/cardano-testnet/src/Testnet/Property/Run.hs
@@ -33,7 +33,7 @@ import           Text.Printf (printf)
 
 import           Testnet.Process.RunIO
 import           Testnet.Property.Util (integration, integrationWorkspace)
-import           Testnet.Start.Types (Conf, mkConf)
+import           Testnet.Start.Types (Conf, mkConfig)
 
 import           Testnet.Types (TestnetNode (..), TestnetRuntime (..), spoNodes)
 
@@ -109,7 +109,7 @@ testnetProperty env runTn =
   case env of
       NoUserProvidedEnv -> do
         integrationWorkspace "testnet" $ \workspaceDir -> do
-          mkConf workspaceDir >>= forkAndRunTestnet
+          forkAndRunTestnet $ mkConfig workspaceDir
       UserProvidedEnv userOutputDir ->
         integration $ do
           absUserOutputDir <- H.evalIO $ makeAbsolute userOutputDir
@@ -120,8 +120,7 @@ testnetProperty env runTn =
           else do
             liftIOAnnotated $ createDirectory absUserOutputDir
             H.note_ $ "Created " <> absUserOutputDir
-          conf <- mkConf absUserOutputDir
-          forkAndRunTestnet conf
+          forkAndRunTestnet $ mkConfig absUserOutputDir
   where
     forkAndRunTestnet conf = do
       -- Fork a thread to keep alive indefinitely any resources allocated by testnet.

--- a/cardano-testnet/src/Testnet/Start/Types.hs
+++ b/cardano-testnet/src/Testnet/Start/Types.hs
@@ -44,8 +44,8 @@ module Testnet.Start.Types
   , GenesisHashesPolicy (..)
   , NodeConfiguration
   , NodeConfigurationYaml
-  , mkConf
-  , mkConfigAbs
+  , mkConfig
+  , mkConfigAbsolute
   ) where
 
 import           Cardano.Api hiding (cardanoEra)
@@ -65,15 +65,11 @@ import           Data.List.NonEmpty (NonEmpty ((:|)))
 import qualified Data.List.NonEmpty as NEL
 import qualified Data.Text as Text
 import           Data.Word
-import           GHC.Stack
 import qualified Network.HTTP.Simple as HTTP
 import           System.Directory (createDirectory, doesDirectoryExist, makeAbsolute)
 import           System.FilePath (addTrailingPathSeparator)
 
 import           Testnet.Filepath
-
-import           Hedgehog (MonadTest)
-import qualified Hedgehog.Extras as H
 
 -- | The default value for the --testnet-magic option for `cardano-testnet`
 defaultTestnetMagic :: Int
@@ -323,15 +319,9 @@ data Conf = Conf
   , updateTimestamps :: UpdateTimestamps
   } deriving (Eq, Show)
 
--- |  Same as mkConfig except that it renders the path
--- when failing in a property test.
-mkConf :: (HasCallStack, MonadTest m) => FilePath -> m Conf
-mkConf tempAbsPath' = withFrozenCallStack $ do
-  H.note_ tempAbsPath'
-  pure $ mkConfig tempAbsPath'
-
 -- | Create a 'Conf' from a temporary absolute path, with Genesis Hashes enabled
--- and updating time stamps disabled.
+-- and updating time stamps disabled. This function is pure: the directory is
+-- neither created nor checked for existence.
 mkConfig :: FilePath -> Conf
 mkConfig tempAbsPath' =
   Conf
@@ -340,10 +330,10 @@ mkConfig tempAbsPath' =
     , updateTimestamps = DontUpdateTimestamps
     }
 
--- | Create a 'Conf' from an absolute path, with Genesis Hashes enabled
--- and updating time stamps disabled.
-mkConfigAbs :: FilePath -> IO Conf
-mkConfigAbs userOutputDir = do
+-- | Like 'mkConfig', except that the path is first made absolute, and the
+-- directory is created if it doesn't exist yet.
+mkConfigAbsolute :: FilePath -> IO Conf
+mkConfigAbsolute userOutputDir = do
   absUserOutputDir <-  makeAbsolute userOutputDir
   dirExists <- doesDirectoryExist absUserOutputDir
   let conf = mkConfig absUserOutputDir

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Api/TxReferenceInputDatum.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Api/TxReferenceInputDatum.hs
@@ -56,7 +56,7 @@ import qualified Hedgehog.Extras.Test.TestWatchdog as H
 -- This test tests that such datums are made available to the script.
 hprop_tx_refin_datum :: Property
 hprop_tx_refin_datum = integrationRetryWorkspace 2 "api-tx-refin-dat" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
-  conf@Conf{tempAbsPath} <- mkConf tempAbsBasePath'
+  let conf@Conf{tempAbsPath} = mkConfig tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
 
   let era = Exp.ConwayEra

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/StakeSnapshot.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Conway/StakeSnapshot.hs
@@ -32,7 +32,7 @@ import qualified Hedgehog.Extras.Test.TestWatchdog as H
 hprop_stakeSnapshot :: Property
 hprop_stakeSnapshot = integrationRetryWorkspace 2 "conway-stake-snapshot" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   H.note_ SYS.os
-  conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
+  let conf@Conf { tempAbsPath } = mkConfig tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
       tempBaseAbsPath = makeTmpBaseAbsPath $ TmpAbsolutePath tempAbsPath'
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/KesPeriodInfo.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/KesPeriodInfo.hs
@@ -61,9 +61,8 @@ import qualified Hedgehog.Extras.Test.TestWatchdog as H
 hprop_kes_period_info :: Property
 hprop_kes_period_info = integrationRetryWorkspace 2 "kes-period-info" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   H.note_ SYS.os
-  conf@Conf { tempAbsPath=tempAbsPath@(TmpAbsolutePath work) }
-    -- TODO: Move yaml filepath specification into individual node options
-    <- mkConf tempAbsBasePath'
+  -- TODO: Move yaml filepath specification into individual node options
+  let conf@Conf { tempAbsPath=tempAbsPath@(TmpAbsolutePath work) } = mkConfig tempAbsBasePath'
 
   let tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
       ceo = ConwayEraOnwardsConway

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/LeadershipSchedule.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/LeadershipSchedule.hs
@@ -64,7 +64,7 @@ import qualified Hedgehog.Extras.Test.TestWatchdog as H
 hprop_leadershipSchedule :: Property
 hprop_leadershipSchedule = integrationRetryWorkspace 2 "leadership-schedule" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   H.note_ SYS.os
-  conf@Conf { tempAbsPath=tempAbsPath@(TmpAbsolutePath work) } <- mkConf tempAbsBasePath'
+  let conf@Conf { tempAbsPath=tempAbsPath@(TmpAbsolutePath work) } = mkConfig tempAbsBasePath'
   let tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
       ceo = ConwayEraOnwardsConway
       sbe = convert ceo

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Plutus/BuildRaw.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Plutus/BuildRaw.hs
@@ -44,7 +44,7 @@ import qualified Hedgehog.Extras.Test.TestWatchdog as H
 hprop_build_raw_ref_script_spend :: Property
 hprop_build_raw_ref_script_spend = integrationRetryWorkspace 2 "build-raw-ref-script" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
     H.note_ SYS.os
-    conf@Conf{tempAbsPath} <- mkConf tempAbsBasePath'
+    let conf@Conf{tempAbsPath} = mkConfig tempAbsBasePath'
     let tempAbsPath' = unTmpAbsPath tempAbsPath
     work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Plutus/CostCalculation.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Plutus/CostCalculation.hs
@@ -57,7 +57,7 @@ import qualified Hedgehog.Extras.Test.TestWatchdog as H
 hprop_ref_plutus_cost_calculation :: Property
 hprop_ref_plutus_cost_calculation = integrationRetryWorkspace 2 "ref-plutus-script" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   H.note_ SYS.os
-  conf@Conf{tempAbsPath} <- mkConf tempAbsBasePath'
+  let conf@Conf{tempAbsPath} = mkConfig tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
   work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
 
@@ -213,7 +213,7 @@ hprop_ref_plutus_cost_calculation = integrationRetryWorkspace 2 "ref-plutus-scri
 hprop_included_plutus_cost_calculation :: Property
 hprop_included_plutus_cost_calculation = integrationRetryWorkspace 2 "included-plutus-script" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   H.note_ SYS.os
-  conf@Conf{tempAbsPath} <- mkConf tempAbsBasePath'
+  let conf@Conf{tempAbsPath} = mkConfig tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
   work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
 
@@ -325,7 +325,7 @@ hprop_included_plutus_cost_calculation = integrationRetryWorkspace 2 "included-p
 hprop_included_simple_script_cost_calculation :: Property
 hprop_included_simple_script_cost_calculation = integrationRetryWorkspace 2 "included-simple-script" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   H.note_ SYS.os
-  conf@Conf{tempAbsPath} <- mkConf tempAbsBasePath'
+  let conf@Conf{tempAbsPath} = mkConfig tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
   work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Plutus/MultiAssetReturnCollateral.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Plutus/MultiAssetReturnCollateral.hs
@@ -36,7 +36,7 @@ import qualified Hedgehog.Extras as H
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/Collateral With Multiassets/"'@
 hprop_collateral_with_tokens :: Property
 hprop_collateral_with_tokens = integrationRetryWorkspace 2 "collateral-with-tokens" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
-  conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
+  let conf@Conf { tempAbsPath } = mkConfig tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
   work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Plutus/Scripts.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Plutus/Scripts.hs
@@ -48,7 +48,7 @@ import qualified Hedgehog.Extras as H
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/PlutusV3 purposes/"'@
 hprop_plutus_purposes_v3 :: Property
 hprop_plutus_purposes_v3 = integrationRetryWorkspace 2 "all-plutus-script-purposes" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
-  conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
+  let conf@Conf { tempAbsPath } = mkConfig tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
   work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
 
@@ -198,7 +198,7 @@ hprop_plutus_purposes_v3 = integrationRetryWorkspace 2 "all-plutus-script-purpos
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/PlutusV2 transaction with two script certs/"'@
 hprop_tx_two_script_certs_v2 :: Property
 hprop_tx_two_script_certs_v2 = integrationRetryWorkspace 2 "tx-2-script-certs" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
-  conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
+  let conf@Conf { tempAbsPath } = mkConfig tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
   work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Query.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Query.hs
@@ -78,8 +78,7 @@ import           RIO (runRIO)
 -- RECREATE_GOLDEN_FILES=1 as its prefix
 hprop_cli_queries :: Property
 hprop_cli_queries = integrationRetryWorkspace 2 "cli-queries" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
-  conf@Conf { tempAbsPath=tempAbsPath@(TmpAbsolutePath work) }
-    <- mkConf tempAbsBasePath'
+  let conf@Conf { tempAbsPath=tempAbsPath@(TmpAbsolutePath work) } = mkConfig tempAbsBasePath'
   let tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
 
   let sbe = ShelleyBasedEraConway

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/QuerySlotNumber.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/QuerySlotNumber.hs
@@ -40,7 +40,7 @@ import qualified Hedgehog.Internal.Property as H
 hprop_querySlotNumber :: Property
 hprop_querySlotNumber = integrationRetryWorkspace 2 "query-slot-number" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   H.note_ SYS.os
-  conf <- mkConf tempAbsBasePath'
+  let conf = mkConfig tempAbsBasePath'
 
   let tempBaseAbsPath' = makeTmpBaseAbsPath $ tempAbsPath conf
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Scripts/Simple/CostCalculation.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Scripts/Simple/CostCalculation.hs
@@ -42,7 +42,7 @@ import qualified Hedgehog.Extras.Test.TestWatchdog as H
 hprop_ref_simple_script_mint :: Property
 hprop_ref_simple_script_mint = integrationRetryWorkspace 2 "ref-simple-script" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   H.note_ SYS.os
-  conf@Conf{tempAbsPath} <- mkConf tempAbsBasePath'
+  let conf@Conf{tempAbsPath} = mkConfig tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
   work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Scripts/Simple/Mint.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Scripts/Simple/Mint.hs
@@ -39,7 +39,7 @@ import qualified Hedgehog.Extras as H
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/Simple Script.Simple Script Mint/"'@
 hprop_simple_script_mint :: Property
 hprop_simple_script_mint = integrationRetryWorkspace 2 "simple-script-mint" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
-  conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
+  let conf@Conf { tempAbsPath } = mkConfig tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
   work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/StakeSnapshot.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/StakeSnapshot.hs
@@ -33,7 +33,7 @@ import qualified Hedgehog.Extras.Test.TestWatchdog as H
 hprop_stakeSnapshot :: Property
 hprop_stakeSnapshot = integrationRetryWorkspace 2 "stake-snapshot" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   H.note_ SYS.os
-  conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
+  let conf@Conf { tempAbsPath } = mkConfig tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
       tempBaseAbsPath = makeTmpBaseAbsPath $ TmpAbsolutePath tempAbsPath'
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction.hs
@@ -45,7 +45,7 @@ import qualified Hedgehog.Extras.Test.TestWatchdog as H
 hprop_transaction :: Property
 hprop_transaction = integrationRetryWorkspace 2 "simple transaction build" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   H.note_ SYS.os
-  conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
+  let conf@Conf { tempAbsPath } = mkConfig tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
   work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction/BuildEstimate.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction/BuildEstimate.hs
@@ -40,7 +40,7 @@ import qualified Hedgehog.Extras as H
 hprop_tx_build_estimate :: Property
 hprop_tx_build_estimate = integrationRetryWorkspace 2 "transaction-build-estimate" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   -- Start a local test net
-  conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
+  let conf@Conf { tempAbsPath } = mkConfig tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
       tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction/RegisterDeregisterStakeAddress.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction/RegisterDeregisterStakeAddress.hs
@@ -43,7 +43,7 @@ import qualified Hedgehog.Extras as H
 hprop_tx_register_deregister_stake_address :: Property
 hprop_tx_register_deregister_stake_address = integrationRetryWorkspace 2 "register-deregister-stake-addr" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   -- Start a local test net
-  conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
+  let conf@Conf { tempAbsPath } = mkConfig tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
       tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction/WithdrawalReward.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Transaction/WithdrawalReward.hs
@@ -52,7 +52,7 @@ import qualified Hedgehog.Extras as H
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/transaction build with withdrawal/"'@
 hprop_tx_withdrawal_reward :: Property
 hprop_tx_withdrawal_reward = integrationRetryWorkspace 2 "tx-withdrawal-reward" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
-  conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
+  let conf@Conf { tempAbsPath } = mkConfig tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
       tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
 
@@ -127,7 +127,7 @@ hprop_tx_withdrawal_reward = integrationRetryWorkspace 2 "tx-withdrawal-reward" 
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/transaction build with plutus withdrawal/"'@
 hprop_tx_withdrawal_reward_plutus_v3 :: Property
 hprop_tx_withdrawal_reward_plutus_v3 = integrationRetryWorkspace 2 "tx-withdrawal-reward-plutus-v3" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
-  conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
+  let conf@Conf { tempAbsPath } = mkConfig tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
       tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/DumpConfig.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/DumpConfig.hs
@@ -41,7 +41,7 @@ hprop_dump_config = integrationRetryWorkspace 2 "dump-config-files" $ \tmpDir ->
       shelleyGenesisFile = tmpDir </> "shelley-genesis.json"
 
   -- Generate the sandbox
-  conf <- mkConf tmpDir
+  let conf = mkConfig tmpDir
 
   liftToIntegration $ createTestnetEnv
     creationOptions

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/FoldEpochState.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/FoldEpochState.hs
@@ -26,7 +26,7 @@ import qualified Hedgehog.Extras.Test as H
 
 prop_foldEpochState :: H.Property
 prop_foldEpochState = integrationRetryWorkspace 2 "foldEpochState" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
-  conf <- TN.mkConf tempAbsBasePath'
+  let conf = TN.mkConfig tempAbsBasePath'
 
   let tempAbsPath' = unTmpAbsPath $ tempAbsPath conf
       sbe = ShelleyBasedEraConway

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/CommitteeAddNew.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/CommitteeAddNew.hs
@@ -59,7 +59,7 @@ import qualified Hedgehog.Extras as H
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/Committee Add New/"'@
 hprop_constitutional_committee_add_new :: Property
 hprop_constitutional_committee_add_new = integrationRetryWorkspace 2 "constitutional-committee-add-new" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
-  conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
+  let conf@Conf { tempAbsPath } = mkConfig tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
       tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepActivity.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepActivity.hs
@@ -53,7 +53,7 @@ import qualified Hedgehog.Extras as H
 hprop_check_drep_activity :: Property
 hprop_check_drep_activity = integrationRetryWorkspace 2 "test-activity" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog $ \watchdog -> do
   -- Start a local test net
-  conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
+  let conf@Conf { tempAbsPath } = mkConfig tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
       tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepDeposit.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepDeposit.hs
@@ -36,7 +36,7 @@ hprop_ledger_events_drep_deposits :: Property
 hprop_ledger_events_drep_deposits = integrationRetryWorkspace 2 "drep-deposits" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
 
 
-  conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
+  let conf@Conf { tempAbsPath } = mkConfig tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
       tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepRetirement.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/DRepRetirement.hs
@@ -43,7 +43,7 @@ sbe = ShelleyBasedEraConway
 hprop_drep_retirement :: Property
 hprop_drep_retirement = integrationRetryWorkspace 2 "drep-retirement" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   -- Start a local test net
-  conf@Conf { tempAbsPath } <- H.noteShowM $ mkConf tempAbsBasePath'
+  conf@Conf { tempAbsPath } <- H.noteShow $ mkConfig tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
       tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/GovActionTimeout.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/GovActionTimeout.hs
@@ -42,7 +42,7 @@ hprop_check_gov_action_timeout :: Property
 hprop_check_gov_action_timeout = integrationRetryWorkspace 2 "gov-action-timeout" $ \tempAbsBasePath' ->
                                  H.runWithDefaultWatchdog_ $ do
   -- Start a local test net
-  conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
+  let conf@Conf { tempAbsPath } = mkConfig tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
       tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/InfoAction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/InfoAction.hs
@@ -53,7 +53,7 @@ hprop_ledger_events_info_action :: Property
 hprop_ledger_events_info_action = integrationRetryWorkspace 2 "info-hash" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
 
 
-  conf@Conf { tempAbsPath } <- H.noteShowM $ mkConf tempAbsBasePath'
+  conf@Conf { tempAbsPath } <- H.noteShow $ mkConfig tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
       tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/NoConfidence.hs
@@ -57,7 +57,7 @@ import qualified Hedgehog.Extras.Stock.IO.Network.Sprocket as IO
 hprop_gov_no_confidence :: Property
 hprop_gov_no_confidence = integrationRetryWorkspace 2 "no-confidence" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
 
-  conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
+  let conf@Conf { tempAbsPath } = mkConfig tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
       tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PParamChangeFailsSPO.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PParamChangeFailsSPO.hs
@@ -51,7 +51,7 @@ hprop_check_pparam_fails_spo :: Property
 hprop_check_pparam_fails_spo = integrationRetryWorkspace 2 "test-pparam-spo" $ \tempAbsBasePath' ->
                                  H.runWithDefaultWatchdog_ $ do
   -- Start a local test net
-  conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
+  let conf@Conf { tempAbsPath } = mkConfig tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
       tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/PredefinedAbstainDRep.hs
@@ -66,7 +66,7 @@ import qualified Hedgehog.Extras as H
 hprop_check_predefined_abstain_drep :: Property
 hprop_check_predefined_abstain_drep = H.integrationRetryWorkspace 2 "test-activity" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   -- Start a local test net
-  conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
+  let conf@Conf { tempAbsPath } = mkConfig tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
       tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
   work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitution.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitution.hs
@@ -65,7 +65,7 @@ import qualified Hedgehog.Extras as H
 hprop_ledger_events_propose_new_constitution :: Property
 hprop_ledger_events_propose_new_constitution = integrationRetryWorkspace 2 "propose-new-constitution" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   -- Start a local test net
-  conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
+  let conf@Conf { tempAbsPath } = mkConfig tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
       tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitutionSPO.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/ProposeNewConstitutionSPO.hs
@@ -49,8 +49,7 @@ import qualified Hedgehog.Extras as H
 -- @cabal test cardano-testnet-test --test-options '-p "/Propose New Constitution SPO/"'@
 hprop_ledger_events_propose_new_constitution_spo :: Property
 hprop_ledger_events_propose_new_constitution_spo = integrationRetryWorkspace 2 "propose-new-constitution-spo" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
-  conf@Conf { tempAbsPath=tempAbsPath@(TmpAbsolutePath work) }
-    <- mkConf tempAbsBasePath'
+  let conf@Conf { tempAbsPath=tempAbsPath@(TmpAbsolutePath work) } = mkConfig tempAbsBasePath'
   let tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
 
   let ceo = ConwayEraOnwardsConway

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/Transaction/HashMismatch.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/Transaction/HashMismatch.hs
@@ -41,7 +41,7 @@ import qualified Hedgehog.Extras as H
 hprop_transaction_build_wrong_hash :: Property
 hprop_transaction_build_wrong_hash = integrationRetryWorkspace 2 "wrong-hash" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
 
-  conf@Conf { tempAbsPath } <- H.noteShowM $ mkConf tempAbsBasePath'
+  conf@Conf { tempAbsPath } <- H.noteShow $ mkConfig tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
       tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryDonation.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryDonation.hs
@@ -41,8 +41,7 @@ import qualified Hedgehog.Extras as H
 -- @DISABLE_RETRIES=1 cabal test cardano-testnet-test --test-options '-p "/Treasury Donation/"'@
 hprop_ledger_events_treasury_donation :: Property
 hprop_ledger_events_treasury_donation = integrationRetryWorkspace 2 "treasury-donation" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
-  conf@Conf { tempAbsPath=tempAbsPath@(TmpAbsolutePath work) }
-    <- mkConf tempAbsBasePath'
+  let conf@Conf { tempAbsPath=tempAbsPath@(TmpAbsolutePath work) } = mkConfig tempAbsBasePath'
   let tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
 
   let ceo = ConwayEraOnwardsConway

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryGrowth.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryGrowth.hs
@@ -37,7 +37,7 @@ import qualified Hedgehog.Extras.Test as H
 prop_check_if_treasury_is_growing :: H.Property
 prop_check_if_treasury_is_growing = integrationRetryWorkspace 2 "growing-treasury" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   -- Start testnet
-  conf@Conf{tempAbsPath=TmpAbsolutePath tempAbsPath'} <- TN.mkConf tempAbsBasePath'
+  let conf@Conf{tempAbsPath=TmpAbsolutePath tempAbsPath'} = TN.mkConfig tempAbsBasePath'
   let tempBaseAbsPath = makeTmpBaseAbsPath $ tempAbsPath conf
 
   let era = ConwayEra

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryWithdrawal.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryWithdrawal.hs
@@ -56,7 +56,7 @@ import qualified Hedgehog.Extras as H
 
 hprop_ledger_events_treasury_withdrawal:: Property
 hprop_ledger_events_treasury_withdrawal = integrationRetryWorkspace 2  "treasury-withdrawal" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
-  conf@Conf { tempAbsPath } <- H.noteShowM $ mkConf tempAbsBasePath'
+  conf@Conf { tempAbsPath } <- H.noteShow $ mkConfig tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
       tempBaseAbsPath = makeTmpBaseAbsPath tempAbsPath
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/MainnetParams.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/MainnetParams.hs
@@ -37,7 +37,7 @@ hprop_mainnet_params = integrationRetryWorkspace 2 "mainnet-params" $ \tmpDir ->
         }
 
   -- Generate the sandbox
-  conf <- mkConf tmpDir
+  let conf = mkConfig tmpDir
   liftToIntegration $ createTestnetEnv creationOptions conf
 
   -- Run testnet with mainnet on-chain params

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Node/Shutdown.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Node/Shutdown.hs
@@ -65,7 +65,7 @@ import qualified Hedgehog.Extras.Test.TestWatchdog as H
 -- TODO: Use cardanoTestnet in hprop_shutdown
 hprop_shutdown :: Property
 hprop_shutdown = integrationRetryWorkspace 2 "shutdown" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
-  conf <- mkConf tempAbsBasePath'
+  let conf = mkConfig tempAbsBasePath'
   let tempBaseAbsPath' = makeTmpBaseAbsPath $ tempAbsPath conf
       tempAbsPath' = unTmpAbsPath $ tempAbsPath conf
       logDir' = makeLogDir $ tempAbsPath conf
@@ -202,7 +202,7 @@ hprop_shutdownOnSlotSynced :: Property
 hprop_shutdownOnSlotSynced = integrationRetryWorkspace 2 "shutdown-on-slot-synced" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   -- Start a local test net
   -- TODO: Move yaml filepath specification into individual node options
-  conf <- mkConf tempAbsBasePath'
+  let conf = mkConfig tempAbsBasePath'
 
   let maxSlot = 150
       epochLength = 300
@@ -254,7 +254,7 @@ hprop_shutdownOnSigint :: Property
 hprop_shutdownOnSigint = integrationRetryWorkspace 2 "shutdown-on-sigint" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   -- Start a local test net
   -- TODO: Move yaml filepath specification into individual node options
-  conf <- mkConf tempAbsBasePath'
+  let conf = mkConfig tempAbsBasePath'
 
   let creationOptions = def
         { creationGenesisOptions = def { genesisEpochLength = 300 }

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/P2PTopology.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/P2PTopology.hs
@@ -8,7 +8,7 @@ module Cardano.Testnet.Test.P2PTopology
 
 import qualified Cardano.Node.Configuration.TopologyP2P as P2P
 import           Cardano.Testnet (TestnetCreationOptions (..), cardanoTestnet, createTestnetEnv,
-                   mkConf)
+                   mkConfig)
 import           Cardano.Testnet.Test.Utils (nodesProduceBlocks)
 
 import           Prelude
@@ -34,7 +34,7 @@ hprop_p2p_topology = integrationRetryWorkspace 2 "p2p-topology" $ \tmpDir -> H.r
       someTopologyFile = tmpDir </> "node-data" </> "node1" </> "topology.json"
 
   -- Generate the sandbox
-  conf <- mkConf tmpDir
+  let conf = mkConfig tmpDir
   liftToIntegration $ createTestnetEnv creationOptions conf
 
   -- Check that the topology is indeed P2P

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/Eval.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/Eval.hs
@@ -56,7 +56,7 @@ import qualified Hedgehog.Extras.Test.TestWatchdog as H
 -- redeemer, and no errors.
 hprop_rpc_eval_tx :: Property
 hprop_rpc_eval_tx = integrationRetryWorkspace 2 "rpc-eval-tx" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
-  conf@Conf{tempAbsPath} <- mkConf tempAbsBasePath'
+  let conf@Conf{tempAbsPath} = mkConfig tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
   work <- H.createDirectoryIfMissing $ tempAbsPath' </> "work"
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/Query.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/Query.hs
@@ -54,7 +54,7 @@ import qualified Hedgehog.Extras.Test.TestWatchdog as H
 -- @TASTY_PATTERN='/RPC Query Protocol Params/' cabal test cardano-testnet-test@
 hprop_rpc_query_pparams :: Property
 hprop_rpc_query_pparams = integrationRetryWorkspace 2 "rpc-query-pparams" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
-  conf@Conf{tempAbsPath} <- mkConf tempAbsBasePath'
+  let conf@Conf{tempAbsPath} = mkConfig tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
 
   let era = Exp.ConwayEra

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/SearchUtxos.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/SearchUtxos.hs
@@ -57,7 +57,7 @@ import qualified Hedgehog.Extras.Test.TestWatchdog as H
 -- @TASTY_PATTERN='/RPC SearchUtxos/' cabal test cardano-testnet-test@
 hprop_rpc_search_utxos :: Property
 hprop_rpc_search_utxos = integrationRetryWorkspace 2 "rpc-search-utxos" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
-  conf <- mkConf tempAbsBasePath'
+  let conf = mkConfig tempAbsBasePath'
   let era = Exp.ConwayEra
       sbe = convert era
       creationOptions = def{creationEra = AnyShelleyBasedEra sbe}

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/Transaction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/Transaction.hs
@@ -46,7 +46,7 @@ import qualified Hedgehog.Extras.Test.TestWatchdog as H
 -- @TASTY_PATTERN='/RPC Transaction Submit/' cabal test cardano-testnet-test@
 hprop_rpc_transaction :: Property
 hprop_rpc_transaction = integrationRetryWorkspace 2 "rpc-tx" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
-  conf <- mkConf tempAbsBasePath'
+  let conf = mkConfig tempAbsBasePath'
   let era = Exp.ConwayEra
       sbe = convert era
       creationOptions = def{creationEra = AnyShelleyBasedEra sbe}

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/RunTestnet.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/RunTestnet.hs
@@ -6,7 +6,7 @@ module Cardano.Testnet.Test.RunTestnet
   ( hprop_run_testnet
   ) where
 
-import           Cardano.Testnet (TestnetCreationOptions (..), createAndRunTestnet, mkConf)
+import           Cardano.Testnet (TestnetCreationOptions (..), createAndRunTestnet, mkConfig)
 import           Cardano.Testnet.Test.Utils (nodesProduceBlocks)
 
 import           Prelude
@@ -28,7 +28,7 @@ hprop_run_testnet = integrationRetryWorkspace 2 "run-testnet" $ \tmpDir -> H.run
         { creationGenesisOptions = def { genesisEpochLength = 200 }
         }
 
-  conf <- mkConf tmpDir
+  let conf = mkConfig tmpDir
   runtime <- createAndRunTestnet creationOptions def conf
 
   nodesProduceBlocks tmpDir runtime

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SanityCheck.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SanityCheck.hs
@@ -49,7 +49,7 @@ newtype AdditionalCatcher
 hprop_ledger_events_sanity_check :: Property
 hprop_ledger_events_sanity_check = integrationRetryWorkspace 2 "ledger-events-sanity-check" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   -- Start a local test net
-  conf <- mkConf tempAbsBasePath'
+  let conf = mkConfig tempAbsBasePath'
 
   let creationOptions = def
         { creationGenesisOptions = def

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SubmitApi/Transaction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/SubmitApi/Transaction.hs
@@ -55,7 +55,7 @@ import qualified Hedgehog.Extras.Test.TestWatchdog as H
 hprop_transaction :: Property
 hprop_transaction = integrationRetryWorkspace 2 "submit-api-transaction" $ \tempAbsBasePath' -> H.runWithDefaultWatchdog_ $ do
   H.note_ SYS.os
-  conf@Conf { tempAbsPath } <- mkConf tempAbsBasePath'
+  let conf@Conf { tempAbsPath } = mkConfig tempAbsBasePath'
   let tempAbsPath' = unTmpAbsPath tempAbsPath
       sbe = ShelleyBasedEraConway
       eraString = eraToString sbe

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/UpdateTimeStamps.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/UpdateTimeStamps.hs
@@ -32,7 +32,7 @@ hprop_update_time_stamps = integrationRetryWorkspace 2 "update-time-stamps" $ \t
   let creationOptions = def { creationGenesisOptions = def { genesisEpochLength = 200 } }
 
   -- Generate the sandbox
-  conf <- mkConf tmpDir
+  let conf = mkConfig tmpDir
   liftToIntegration $ createTestnetEnv
     creationOptions
     -- Do not add hashes to the main config file, so that genesis files


### PR DESCRIPTION
# Description

`Testnet.Start.Types` had three constructors for `*Conf*` whose names did not communicate how they differ: `mkConf`, `mkConfig` and `mkConfigAbs`. See issue: https://github.com/IntersectMBO/cardano-node/issues/6569

This PR:
- Removes `mkConf` (Its only difference with the pure `mkConfig` was noting the directory in the test log, which was redundant, since every call site passes a workspace path that `hedgehog-extras` `workspace` already annotates it on creation ("Workspace: <dir>").
- Test code now uses `mkConfig` directly, which is now exported (and re-exported from `Cardano.Testnet` in place of `mkConf`). The call sites that additionally wrapped `mkConf` in `H.noteShowM` keep their `Conf` annotation via `H.noteShow`.
- Renames `mkConfigAbs` to `mkConfigAbsolute`, and documents that, besides making the path absolute, it also creates the directory if it does not exist yet.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
  - `cardano-node-chairman`, `cardano-submit-api` and `cardano-testnet` instead need a
    changelog fragment in `<package>/.changes/`, because their `CHANGELOG.md` is generated
    from fragments at release time.  Copy `_TEMPLATE.yml` from that directory, or run
    `nix run github:input-output-hk/cardano-dev#herald -- new`
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff
