### PR TITLE
Make it build with ghc-9.14

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         # If you edit these versions, make sure the version in the lonely macos-latest job below is updated accordingly
-        ghc: [&ghc-stable "9.6", &ghc-latest "9.12"]
+        ghc: [&ghc-stable "9.6", &ghc-latest "9.12", "9.14"]
         cabal: [&cabal-version "3.16"]
         sys:
           - { os: ubuntu-latest, shell: bash }

--- a/bench/tx-generator/test/ApiTest.hs
+++ b/bench/tx-generator/test/ApiTest.hs
@@ -101,10 +101,12 @@ main
         putStrLn $ "* Did I manage to extract a genesis fund?\n--> " ++ checkFund nixService genesis sigKey
         putStrLn "* Can I pre-execute a plutus script?"
         let plutus = _nix_plutus nixService
-        case plutusType <$> plutus of
-          Just BenchCustomCall      -> checkPlutusBuiltin protoParamPath'
-          Just{}                    -> checkPlutusLoop protoParamPath' plutus
+        case plutus of
           Nothing                   -> putStrLn "--> no Plutus configuration found - skipping"
+          Just (PlutusOn {plutusType = pt})
+            | pt == BenchCustomCall
+                                    -> checkPlutusBuiltin protoParamPath'
+          Just{}                    -> checkPlutusLoop protoParamPath' plutus
         exitSuccess
 
 -- The type annotations within patterns or expressions that would be

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -49,12 +49,17 @@ library
                         -Wno-prepositive-qualified-module
                         -Wno-unticked-promoted-constructors
                         -Wpartial-fields
-                        -Wredundant-constraints
                         -fno-warn-safe
                         -fno-warn-unsafe
                         -fno-warn-missing-import-lists
                         -fobject-code -fno-ignore-interface-pragmas
                         -fno-omit-interface-pragmas
+
+  -- ghc-9.14 gives redundant constraint warnings on some constraints
+  -- that are needed for earlier compilers.
+  if impl(ghc <9.14)
+    ghc-options:
+      -Wredundant-constraints
 
   exposed-modules:      Cardano.Benchmarking.Command
                         Cardano.Benchmarking.Compiler

--- a/cabal.project
+++ b/cabal.project
@@ -84,3 +84,84 @@ allow-newer:
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
+
+constraints:
+  , cuddle>=1.1 && <1.1.2
+
+-- cabal-allow-newer begin
+if impl(ghc >= 9.14)
+  allow-newer:
+    , async-timer:unliftio-core
+    , attoparsec-iso8601:time
+    , bytestring-trie:base
+    , canonical-json:containers
+    , cborg:base
+    , cborg:containers
+    , cborg-json:aeson
+    , cborg-json:base
+    , compact:base
+    , crypton-connection:tls
+    , dependent-map:containers
+    , diff-containers:base
+    , dictionary-sharing:containers
+    , dmq-node:containers
+    , dmq-node:time
+    , ekg-json:aeson
+    , ekg-json:text
+    , ekg-prometheus-adapter:containers
+    , ekg-wai:time
+    , errors:transformers-compat
+    , fs-sim:QuickCheck
+    , grapesy:aeson
+    , grapesy:base
+    , grapesy:containers
+    , grapesy:time-manager
+    , grapesy:tls
+    , grpc-spec:aeson
+    , grpc-spec:base
+    , grpc-spec:containers
+    , iohk-monitoring:contra-tracer
+    , lens-family:containers
+    , lens-family-core:containers
+    , locli:ouroboros-network
+    , microstache:aeson
+    , monad-control:transformers-compat
+    , nothunks:containers
+    , nothunks:time
+    , optparse-generic:time
+    , partial-order:containers
+    , pipes-safe:containers
+    , pipes-safe:mtl
+    , pipes-safe:primitive
+    , pipes-safe:transformers
+    , prometheus:containers
+    , safe-wild-cards:template-haskell
+    , serdoc-core:template-haskell
+    , serialise:base
+    , serialise:containers
+    , serialise:time
+    , servant:QuickCheck
+    , servant:base
+    , servant-server:aeson
+    , servant-server:attoparsec
+    , servant-server:base
+    , servant-server:base-compat
+    , servant-server:base64-bytestring
+    , servant-server:bytestring
+    , servant-server:containers
+    , servant-server:http-api-data
+    , servant-server:http-types
+    , servant-server:network
+    , servant-server:servant
+    , servant-server:text
+    , servant-server:transformers
+    , servant-server:warp
+    , strict-checked-vars:io-classes
+    , strict-stm:base
+    , strict-stm:io-classes
+    , tdigest:base
+    , time-locale-compat:time
+    , tracer-transformers:contra-tracer
+    , vary:aeson
+    , with-utf8:base
+-- cabal-allow-newer end

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -36,8 +36,18 @@ common project-config
                         -Wincomplete-uni-patterns
                         -Wno-unticked-promoted-constructors
                         -Wpartial-fields
-                        -Wredundant-constraints
                         -Wunused-packages
+  -- ghc-9.14 gives redundant constraint warnings on some constraints
+  -- that are needed for earlier compilers.
+  if impl(ghc <9.14)
+    ghc-options:
+      -Wredundant-constraints
+
+  -- In ghc-9.14 the `pattern` namespace specifier is deprecated.
+  if impl(ghc >=9.14)
+    ghc-options:
+      -Wno-pattern-namespace-specifier
+
 common maybe-Win32
   if os(windows)
     build-depends:      Win32
@@ -154,7 +164,7 @@ library
                       , generic-data
                       , hashable
                       , hostname
-                      , io-classes:{io-classes,strict-stm,si-timers} ^>= 1.8
+                      , io-classes:{io-classes,strict-stm,si-timers} ^>= 1.8 || ^>= 1.9
                       , kes-agent ^>=1.2
                       , microlens
                       , mmap

--- a/trace-forward/test/Test/Trace/Forward/Protocol/DataPoint/Tests.hs
+++ b/trace-forward/test/Test/Trace/Forward/Protocol/DataPoint/Tests.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
@@ -37,7 +38,7 @@ tests :: TestTree
 tests = testGroup "Trace.Forward.Protocol.DataPoint"
   [ testProperty "codec"          prop_codec_DataPointForward
   , testProperty "codec 2-splits" prop_codec_splits2_DataPointForward
-  , testProperty "codec 3-splits" (withMaxSuccess 33 prop_codec_splits3_DataPointForward)
+  , testProperty "codec 3-splits" (withNumTests 33 prop_codec_splits3_DataPointForward)
   , testProperty "direct"         prop_direct_DataPointForward
   , testProperty "connect"        prop_connect_DataPointForward
   , testProperty "channel ST"     prop_channel_ST_DataPointForward
@@ -145,3 +146,8 @@ prop_channel_IO_DataPointForward
   -> Property
 prop_channel_IO_DataPointForward f (NonNegative n) =
   ioProperty (prop_channel f n)
+
+#if ! MIN_VERSION_QuickCheck(2,18,0)
+withNumTests :: Testable prop => Int -> prop -> Property
+withNumTests = withMaxSuccess
+#endif

--- a/trace-forward/test/Test/Trace/Forward/Protocol/TraceObject/Item.hs
+++ b/trace-forward/test/Test/Trace/Forward/Protocol/TraceObject/Item.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -9,7 +10,9 @@ module Test.Trace.Forward.Protocol.TraceObject.Item
 import           Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
 
 import           Codec.Serialise (Serialise (..))
+#if ! MIN_VERSION_QuickCheck(2,18,0)
 import           Data.List.NonEmpty (NonEmpty, fromList)
+#endif
 import           Data.Text (Text)
 import           GHC.Generics
 
@@ -57,5 +60,7 @@ instance Arbitrary TraceItem where
     <*> oneof [pure "nixos", pure "Darwin", pure "testHost"]
     <*> oneof [pure "1", pure "10", pure "14"]
 
+#if ! MIN_VERSION_QuickCheck(2,18,0)
 instance Arbitrary (NonEmpty TraceItem) where
   arbitrary = fromList <$> listOf1 arbitrary
+#endif

--- a/trace-forward/test/Test/Trace/Forward/Protocol/TraceObject/Tests.hs
+++ b/trace-forward/test/Test/Trace/Forward/Protocol/TraceObject/Tests.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 
@@ -37,7 +38,7 @@ tests :: TestTree
 tests = testGroup "Trace.Forward.Protocol.TraceObject"
   [ testProperty "codec"          prop_codec_TraceObjectForward
   , testProperty "codec 2-splits" prop_codec_splits2_TraceObjectForward
-  , testProperty "codec 3-splits" (withMaxSuccess 33 prop_codec_splits3_TraceObjectForward)
+  , testProperty "codec 3-splits" (withNumTests 33 prop_codec_splits3_TraceObjectForward)
   , testProperty "direct"         prop_direct_TraceObjectForward
   , testProperty "connect"        prop_connect_TraceObjectForward
   , testProperty "channel ST"     prop_channel_ST_TraceObjectForward
@@ -142,3 +143,8 @@ prop_channel_IO_TraceObjectForward
   -> Property
 prop_channel_IO_TraceObjectForward f (NonNegative n) =
   ioProperty (prop_channel f n)
+
+#if ! MIN_VERSION_QuickCheck(2,18,0)
+withNumTests :: Testable prop => Int -> prop -> Property
+withNumTests = withMaxSuccess
+#endif


### PR DESCRIPTION
# Description

Make it build with ghc-9.14
# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
  - `cardano-node-chairman`, `cardano-submit-api` and `cardano-testnet` instead need a
    changelog fragment in `<package>/.changes/`, because their `CHANGELOG.md` is generated
    from fragments at release time.  Copy `_TEMPLATE.yml` from that directory, or run
    `nix run github:input-output-hk/cardano-dev#herald -- new`
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
