### PR TITLE
Fix haddock generation in CI by using GHC 9.12.4

### DIFF
--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -26,8 +26,9 @@ jobs:
         extra_nix_config: |
           experimental-features = nix-command flakes
           allow-import-from-derivation = true
-          extra-substituters = https://cache.iog.io/
-          extra-trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
+          # The substituters (cache.iog.io) come from the flake's nixConfig:
+          accept-flake-config = true
+          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
@@ -35,20 +36,18 @@ jobs:
 
     # The `.#haddock` shell (see flake.nix) provides a GHC whose haddock does not
     # panic on `type data` declarations (GHC issue #25739): GHC 9.6.7's does.
-    - name: Fetch nix cache and update cabal indices
-      run: |
-        nix develop .#haddock --command \
-          cabal update
+    - uses: rrbutani/use-nix-shell-action@59a52b2b9bbfe3cc0e7deb8f9059abe37a439edf # v1
+      with:
+        devShell: .#haddock
+
+    - name: Update cabal indices
+      run: cabal update
 
     - name: Build whole project
-      run: |
-        nix develop .#haddock --command \
-          cabal build all
+      run: cabal build all
 
     - name: Build documentation
-      run: |
-        nix develop .#haddock --command \
-          cabal haddock-project --local --output=./haddocks --internal --foreign-libraries
+      run: cabal haddock-project --local --output=./haddocks --internal --foreign-libraries
 
     - name: Compress haddocks
       run: |
@@ -61,6 +60,16 @@ jobs:
       with:
         name: haddocks
         path: ./haddocks.tgz
+
+    # cabal only prints a summary line when building docs for a dependency
+    # fails; the actual haddock error is hidden in these logs.
+    - name: Upload cabal logs
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      if: ${{ failure() }}
+      continue-on-error: true
+      with:
+        name: cabal-haddock-logs
+        path: ~/.cache/cabal/logs/
 
     - name: Deploy documentation to gh-pages 🚀
       if: github.ref == 'refs/heads/master'

--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -1,6 +1,9 @@
 name: "Haddock documentation"
 
 on:
+  # Allows testing this workflow on a branch before merging (the deploy step
+  # below only runs for master).
+  workflow_dispatch:
   push:
     branches:
       - master
@@ -30,19 +33,21 @@ jobs:
       with:
         persist-credentials: false
 
+    # The `.#ghc9124` shell (see flake.nix) provides a GHC whose haddock does not
+    # panic on `type data` declarations (GHC issue #25739): GHC 9.6.7's does.
     - name: Fetch nix cache and update cabal indices
       run: |
-        nix develop --command \
+        nix develop .#ghc9124 --command \
           cabal update
 
     - name: Build whole project
       run: |
-        nix develop --command \
+        nix develop .#ghc9124 --command \
           cabal build all
 
     - name: Build documentation
       run: |
-        nix develop --command \
+        nix develop .#ghc9124 --command \
           cabal haddock-project --local --output=./haddocks --internal --foreign-libraries
 
     - name: Compress haddocks

--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -33,21 +33,21 @@ jobs:
       with:
         persist-credentials: false
 
-    # The `.#ghc9124` shell (see flake.nix) provides a GHC whose haddock does not
+    # The `.#haddock` shell (see flake.nix) provides a GHC whose haddock does not
     # panic on `type data` declarations (GHC issue #25739): GHC 9.6.7's does.
     - name: Fetch nix cache and update cabal indices
       run: |
-        nix develop .#ghc9124 --command \
+        nix develop .#haddock --command \
           cabal update
 
     - name: Build whole project
       run: |
-        nix develop .#ghc9124 --command \
+        nix develop .#haddock --command \
           cabal build all
 
     - name: Build documentation
       run: |
-        nix develop .#ghc9124 --command \
+        nix develop .#haddock --command \
           cabal haddock-project --local --output=./haddocks --internal --foreign-libraries
 
     - name: Compress haddocks

--- a/flake.nix
+++ b/flake.nix
@@ -85,6 +85,9 @@
 
     windowsCompilerNixName = "ghc9122";
 
+    # Used by the "Haddock documentation" workflow (github-page.yml)
+    haddockCompilerNixName = "ghc9124";
+
     supportedSystems = import ./nix/supported-systems.nix;
     defaultSystem = head supportedSystems;
     customConfig =
@@ -187,12 +190,24 @@
       # This is used by `nix develop .` to open a devShell
       devShells = let
         shell = import ./shell.nix {inherit pkgs customConfig;};
-      in {
-        inherit (shell) devops workbench-shell;
-        default = shell.dev;
-        cluster = shell;
-        profiled = project.profiled.shell;
-      };
+      in
+        {
+          inherit (shell) devops workbench-shell;
+          default = shell.dev;
+          cluster = shell;
+          profiled = project.profiled.shell;
+        }
+        # Shell used by the "Haddock documentation" workflow (github-page.yml)
+        // optionalAttrs (hostPlatform.system == "x86_64-linux") {
+          ghc9124 =
+            (project.appendModule {
+              compiler-nix-name = haddockCompilerNixName;
+              # hoogle would be built with the alternative compiler; the haddock
+              # workflow doesn't need it.
+              shell.withHoogle = lib.mkForce false;
+              shell.tools = lib.mkForce {};
+            }).shell;
+        };
 
       # NixOS tests a sandboxed mainnet edge node with submit-api, ensuring
       # startup and port listening functionality using the nixos service. It

--- a/flake.nix
+++ b/flake.nix
@@ -85,9 +85,6 @@
 
     windowsCompilerNixName = "ghc9122";
 
-    # Used by the "Haddock documentation" workflow (github-page.yml)
-    haddockCompilerNixName = "ghc9124";
-
     supportedSystems = import ./nix/supported-systems.nix;
     defaultSystem = head supportedSystems;
     customConfig =
@@ -199,14 +196,7 @@
         }
         # Shell used by the "Haddock documentation" workflow (github-page.yml)
         // optionalAttrs (hostPlatform.system == "x86_64-linux") {
-          ghc9124 =
-            (project.appendModule {
-              compiler-nix-name = haddockCompilerNixName;
-              # hoogle would be built with the alternative compiler; the haddock
-              # workflow doesn't need it.
-              shell.withHoogle = lib.mkForce false;
-              shell.tools = lib.mkForce {};
-            }).shell;
+          haddock = project.haddocked.shell;
         };
 
       # NixOS tests a sandboxed mainnet edge node with submit-api, ensuring

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -137,8 +137,14 @@ let
             packages.cardano-node-chairman.components.tests.chairman-tests.buildable = lib.mkForce pkgs.stdenv.hostPlatform.isUnix;
             package-keys = ["plutus-tx-plugin"];
             packages.plutus-tx-plugin.components.library.platforms = with lib.platforms; [ linux darwin ];
-
-            # GHC 9.6.7 haddock panics on TopTx type family (tyConStupidTheta)
+          })
+          # The haddock of GHC < 9.12.3 panics on `type data` declarations, e.g. the
+          # TopTx type family or AllLedgerPeers ("tyConStupidTheta" panic, GHC issue
+          # #25739, fixed in GHC 9.12.3). Disable haddock of the affected dependencies
+          # for those compilers only, so that shells with a fixed compiler (e.g. the
+          # `.#ghc9124` one used by github-page.yml) still provide dependencies with
+          # documentation.
+          ({ config, lib, ... }: lib.mkIf (builtins.compareVersions config.compiler.version "9.12.3" < 0) {
             packages.cardano-api.components.library.doHaddock = false;
             packages.fs-api.components.library.doHaddock = false;
             packages.cardano-ledger-allegra.components.library.doHaddock = false;
@@ -150,8 +156,8 @@ let
             packages.cardano-ledger-shelley.components.library.doHaddock = false;
             packages.cardano-protocol-tpraos.components.library.doHaddock = false;
             packages.ouroboros-consensus.components.library.doHaddock = false;
-            packages.ouroboros-network.components.library.doHaddock = false; # Currently broken
-            packages.cardano-diffusion.components.library.doHaddock = false; # Currently broken
+            packages.ouroboros-network.components.library.doHaddock = false;
+            packages.cardano-diffusion.components.library.doHaddock = false;
             packages.plutus-ledger-api.components.library.doHaddock = false;
           })
           ({ lib, pkgs, ...}: lib.mkIf (pkgs.stdenv.hostPlatform.isWindows) {

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -142,9 +142,9 @@ let
           # TopTx type family or AllLedgerPeers ("tyConStupidTheta" panic, GHC issue
           # #25739, fixed in GHC 9.12.3). Disable haddock of the affected dependencies
           # for those compilers only, so that shells with a fixed compiler (e.g. the
-          # `.#ghc9124` one used by github-page.yml) still provide dependencies with
+          # `.#haddock` one used by github-page.yml) still provide dependencies with
           # documentation.
-          ({ config, lib, ... }: lib.mkIf (builtins.compareVersions config.compiler.version "9.12.3" < 0) {
+          ({ config, lib, ... }: lib.mkIf (lib.versionOlder config.compiler.version "9.12.3") {
             packages.cardano-api.components.library.doHaddock = false;
             packages.fs-api.components.library.doHaddock = false;
             packages.cardano-ledger-allegra.components.library.doHaddock = false;
@@ -423,6 +423,15 @@ project.appendOverlays (with haskellLib.projectOverlays; [
           ]
             (name: { flags.asserts = true; });
         }];
+      };
+      # Used by the "Haddock documentation" workflow through devShells.haddock
+      # (see flake.nix): a compiler recent enough to avoid the `type data`
+      # haddock panic worked around above. Hoogle is not needed there and would
+      # be built with the alternative compiler.
+      haddocked = final.appendModule {
+        compiler-nix-name = "ghc9124";
+        shell.withHoogle = lib.mkForce false;
+        shell.tools = lib.mkForce {};
       };
       # add passthru to hsPkgs:
       hsPkgs = lib.mapAttrsRecursiveCond (v: !(lib.isDerivation v))


### PR DESCRIPTION
# Description

The GitHub Pages haddock generation workflow is currently broken. This PR tries to address it by adding a nix development shell with `ghc9124`, to the flake and using it when building the haddock documentation in `.github/workflows/github-page.yml`.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
  - `cardano-node-chairman`, `cardano-submit-api` and `cardano-testnet` instead need a
    changelog fragment in `<package>/.changes/`, because their `CHANGELOG.md` is generated
    from fragments at release time.  Copy `_TEMPLATE.yml` from that directory, or run
    `nix run github:input-output-hk/cardano-dev#herald -- new`
- [ ] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff

