### PR TITLE
workbench: fix git commit detection for worktree checkouts

### DIFF
--- a/nix/workbench/manifest.sh
+++ b/nix/workbench/manifest.sh
@@ -246,9 +246,16 @@ case "${op}" in
     * ) usage_manifest;; esac
 }
 
+manifest_is_git_checkout() {
+    local dir=$1
+    # Note: 'test -d "$dir"/.git' would be wrong here, as .git is a file
+    # (not a directory) in git worktree and submodule checkouts.
+    git -C "$dir" rev-parse --git-dir >/dev/null 2>&1
+}
+
 manifest_git_head_commit() {
     local dir=$1
-    if test -d "$dir"/.git
+    if manifest_is_git_checkout "$dir"
     then git -C "$dir" rev-parse HEAD
     else echo      -n "0000000000000000000000000000000000000000"
     fi
@@ -256,7 +263,7 @@ manifest_git_head_commit() {
 
 manifest_git_checkout_state_desc() {
     local dir=$1
-    if test -d "$dir"/.git
+    if manifest_is_git_checkout "$dir"
     then if git -C "$dir" diff --quiet --exit-code
          then echo -n "clean"
          else echo -n "modified"
@@ -267,7 +274,7 @@ manifest_git_checkout_state_desc() {
 
 manifest_local_repo_branch() {
     local dir=$1 rev=${2:-HEAD}
-    if test -d "$dir"/.git
+    if manifest_is_git_checkout "$dir"
     then git -C "$dir" describe --all "$rev" |
             sed 's_^\(.*/\|\)\([^/]*\)$_\2_'
     else echo      -n "unknown-branch"


### PR DESCRIPTION
## Description

When a benchmarking run is generated (e.g. `make ci-bench-auto`) from a git worktree checkout, the run tag contains an all-zeros commit prefix, e.g. `./run/2026-08-06-09-30-00000-1101-ci-bench-coay-sup`.

The cause is in `nix/workbench/manifest.sh`: the helpers `manifest_git_head_commit`, `manifest_git_checkout_state_desc` and `manifest_local_repo_branch` decided whether a directory is a git checkout via `test -d "$dir"/.git`. In a worktree (or submodule) checkout, `.git` is a *file* containing a `gitdir:` pointer, not a directory, so the check failed and the manifest fell back to the all-zeros commit, `unknown-branch` and `not-a-git-checkout` — which also ends up in the run's `meta.json`.

This PR replaces the filesystem test with a query to git itself (`git -C "$dir" rev-parse --git-dir`), which works for regular checkouts, worktrees and submodules alike. Non-git directories (e.g. a nix store source copy) keep the existing fallback behaviour.

Verified in a worktree checkout: the commit now resolves to the actual HEAD hash instead of zeros, checkout state resolves to `clean`/`modified`, and a non-git directory still yields the zero commit and `not-a-git-checkout`. Shellcheck reports no new warnings.