### PR TITLE
Remove constraint on crypton-x509-system

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -22,7 +22,9 @@ active-repositories:
 
 constraints:
   -- haskell.nix patch does not work for 1.6.8
-  , any.crypton-x509-system < 1.6.8
+  -- grapesy currently depends on crypton-x509-system (>=1.6 && <1.7)
+  , any.crypton-x509-system < 1.6.8 || >= 1.7
+
   -- haskell.nix tries to use 0.7.1.5 for some reason
   , any.proto-lens >= 0.7.1.7
   -- https://github.com/channable/alfred-margaret/pull/76

--- a/cabal.project
+++ b/cabal.project
@@ -13,8 +13,8 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state:
-  , hackage.haskell.org 2026-04-17T09:20:55Z
-  , cardano-haskell-packages 2026-05-27T09:43:46Z
+  , hackage.haskell.org 2026-08-09T23:27:58Z
+  , cardano-haskell-packages 2026-08-07T15:03:01Z
 
 active-repositories:
   , :rest

--- a/cardano-testnet/.changes/20270806_-84400_erikd_golden_output.yml
+++ b/cardano-testnet/.changes/20270806_-84400_erikd_golden_output.yml
@@ -1,0 +1,15 @@
+# Changelog fragment template - copy this file and fill in the fields.
+# Or use 'herald new' for interactive creation.
+#
+# Files starting with _ are ignored by herald.
+#
+# Available projects and kinds are defined in .herald.yml
+
+# project: is omitted here - it is inferred from this fragment's per-project changes-dir
+# Pull request number associated with this change
+pr: 6647
+# One or more change kinds (see 'kinds' in .herald.yml)
+kind:
+  - maintenance
+description: |
+  Accept golden test output format changes.

--- a/cardano-testnet/src/Parsers/Run.hs
+++ b/cardano-testnet/src/Parsers/Run.hs
@@ -17,6 +17,8 @@ import           Control.Monad (void)
 import           Data.Maybe (fromMaybe)
 import           Options.Applicative
 import qualified Options.Applicative as Opt
+import qualified Options.Applicative.Help.Pretty as PP
+import qualified Prettyprinter.Internal as PPI
 import           System.Directory (doesDirectoryExist)
 
 import           Testnet.Filepath (unTmpAbsPath)
@@ -31,7 +33,25 @@ import           UnliftIO.Resource (runResourceT)
 import           Cardano.Prelude (unlessM)
 
 pref :: ParserPrefs
-pref = Opt.prefs $ showHelpOnEmpty <> showHelpOnError
+pref =
+  Opt.prefs $
+    mconcat
+      [ showHelpOnEmpty
+      , showHelpOnError
+      , helpEmbedBriefDesc compactBriefDesc
+      ]
+
+-- | Undo the 'PP.align' that optparse-applicative-fork >= 0.19 wraps around
+-- the usage's brief description, restoring the pre-0.19 layout: overflow
+-- hangs at a two-space indent instead of aligning with the command name.
+compactBriefDesc :: PP.Doc -> PP.Doc
+compactBriefDesc d
+  | PPI.Column f <- d
+  , PPI.Nesting g <- f 0 =
+      -- 'align' is @column (\k -> nesting (\i -> nest (k - i) doc))@, so
+      -- evaluating both closures at 0 recovers the unaligned doc.
+      g 0
+  | otherwise = d
 
 opts :: EnvCli -> ParserInfo CardanoTestnetCommands
 opts envCli = Opt.info (commands envCli <**> helper) idm

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
@@ -1,4 +1,4 @@
-Usage: cardano-testnet (cardano | create-env | version | help)
+Usage: cardano-testnet (cardano | create-env | version | help) 
 
 Usage: cardano-testnet cardano 
   [ --node-env FILEPATH [--preserve-timestamps]
@@ -16,6 +16,7 @@ Usage: cardano-testnet cardano
   [--enable-grpc]
   [--use-kes-agent]
   [--disable-chain-stall-watchdog]
+  
 
   Start a testnet and keep it running until stopped
 
@@ -29,6 +30,7 @@ Usage: cardano-testnet create-env
   [--active-slots-coeff DOUBLE]
   [--params-file FILEPATH | --params-mainnet]
   --output DIRECTORY
+  
 
   Create a sandbox for Cardano testnet
 

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/cardano.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/cardano.cli
@@ -14,6 +14,7 @@ Usage: cardano-testnet cardano
   [--enable-grpc]
   [--use-kes-agent]
   [--disable-chain-stall-watchdog]
+  
 
   Start a testnet and keep it running until stopped
 

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/create-env.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/create-env.cli
@@ -8,6 +8,7 @@ Usage: cardano-testnet create-env
   [--active-slots-coeff DOUBLE]
   [--params-file FILEPATH | --params-mainnet]
   --output DIRECTORY
+  
 
   Create a sandbox for Cardano testnet
 

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1779876270,
-        "narHash": "sha256-FA9E1EaQvPITpO/8weQyi7p3KHgyNb9GiwM6F96Aoeo=",
+        "lastModified": 1786144108,
+        "narHash": "sha256-gZ88v8rrj2PFQLUaDWPoZRBPd99cnJjSzoYf3uGy3c4=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "cb63b6483a5d6ce36fb07815736315bd4408162e",
+        "rev": "d6d753a5267ad45f5d629305bf4961477e074d27",
         "type": "github"
       },
       "original": {
@@ -431,11 +431,11 @@
     "hackageNix_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1778061448,
-        "narHash": "sha256-cPUF8+l1ej7x4UZcuuf6IDsxU1WWmGWC0vFBH+6jXZk=",
+        "lastModified": 1786321587,
+        "narHash": "sha256-di/RWNvMgSP0uOT6lrH8V+bqXyD97A0MZQTIek34tus=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "ba6ab6f3b781c8f308cba4fa384eafa48033f3cc",
+        "rev": "0e8681c71b2b7ee9c8ec3143282f9fd0a62676d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Description

This constraint was a blocker on upgrading to crypton >= 1.1 and the migration from the memory package to the ram package.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
  - `cardano-node-chairman`, `cardano-submit-api` and `cardano-testnet` instead need a
    changelog fragment in `<package>/.changes/`, because their `CHANGELOG.md` is generated
    from fragments at release time.  Copy `_TEMPLATE.yml` from that directory, or run
    `nix run github:input-output-hk/cardano-dev#herald -- new`
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [ ] Self-reviewed the diff

