### PR TITLE
workbench: make the tx-generator a workload

### DIFF
--- a/bench/cardano-profile/data/all-profiles.json
+++ b/bench/cardano-profile/data/all-profiles.json
@@ -106558,9 +106558,6 @@
       }
     },
     "overlay": {
-      "generator": {
-        "tx_fee": 1892175
-      },
       "genesis": {
         "alonzo": {
           "maxBlockExUnits": {
@@ -106597,7 +106594,7 @@
           },
           "tps": 0.85,
           "tx_count": 61200,
-          "tx_fee": 1360000
+          "tx_fee": 1892175
         },
         "phase": "load",
         "placement": "explorer",
@@ -107893,9 +107890,6 @@
       }
     },
     "overlay": {
-      "generator": {
-        "tx_fee": 2463246
-      },
       "genesis": {
         "alonzo": {
           "maxBlockExUnits": {
@@ -107932,7 +107926,7 @@
           },
           "tps": 0.85,
           "tx_count": 61200,
-          "tx_fee": 1360000
+          "tx_fee": 2463246
         },
         "phase": "load",
         "placement": "explorer",
@@ -116518,9 +116512,6 @@
       }
     },
     "overlay": {
-      "generator": {
-        "tx_fee": 2463246
-      },
       "genesis": {
         "alonzo": {
           "maxBlockExUnits": {
@@ -116557,7 +116548,7 @@
           },
           "tps": 0.4,
           "tx_count": 3600,
-          "tx_fee": 1360000
+          "tx_fee": 2463246
         },
         "phase": "load",
         "placement": "explorer",

--- a/bench/cardano-profile/data/all-profiles.json
+++ b/bench/cardano-profile/data/all-profiles.json
@@ -86,20 +86,6 @@
       "utxo_stuffed": 500000
     },
     "desc": "Miniature dataset, CI-friendly duration, bench scale",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 9000,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -1270,7 +1256,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 9000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "10-notracer": {
     "analysis": {
@@ -1359,20 +1367,6 @@
       "utxo_stuffed": 500000
     },
     "desc": "Miniature dataset, CI-friendly duration, bench scale",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 9000,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -2543,7 +2537,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 9000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "10-plutus": {
     "analysis": {
@@ -2634,23 +2650,6 @@
       "utxo_stuffed": 500000
     },
     "desc": "Miniature dataset, CI-friendly duration, bench scale",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "int": 1000000
-        },
-        "script": "Loop",
-        "type": "LimitSaturationLoop"
-      },
-      "tps": 0.2,
-      "tx_count": 120,
-      "tx_fee": 1360000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -3821,7 +3820,32 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "int": 1000000
+            },
+            "script": "Loop",
+            "type": "LimitSaturationLoop"
+          },
+          "tps": 0.2,
+          "tx_count": 120,
+          "tx_fee": 1360000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "6-dense": {
     "analysis": {
@@ -3913,20 +3937,6 @@
       "utxo_stuffed": 500000
     },
     "desc": "Miniature dataset, dense topology on local cluster, 64k blocks",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 12,
-      "tx_count": 21600,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -4752,7 +4762,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 12,
+          "tx_count": 21600,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "6-dense-1h": {
     "analysis": {
@@ -4844,20 +4876,6 @@
       "utxo_stuffed": 500000
     },
     "desc": "Miniature dataset, dense topology on local cluster, 64k blocks",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 6,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 12,
-      "tx_count": 43200,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -5683,7 +5701,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 6,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 12,
+          "tx_count": 43200,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "6-dense-1h-timeseries": {
     "analysis": {
@@ -5775,20 +5815,6 @@
       "utxo_stuffed": 500000
     },
     "desc": "Miniature dataset, dense topology on local cluster, 64k blocks",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 6,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 12,
-      "tx_count": 43200,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -6614,7 +6640,29 @@
       "timeseries": true,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 6,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 12,
+          "tx_count": 43200,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "6-dense-4h": {
     "analysis": {
@@ -6706,20 +6754,6 @@
       "utxo_stuffed": 500000
     },
     "desc": "Miniature dataset, dense topology on local cluster, 64k blocks",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 24,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 12,
-      "tx_count": 172800,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -7545,7 +7579,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 24,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 12,
+          "tx_count": 172800,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "chainsync-early-alonzo": {
     "analysis": {
@@ -7637,20 +7693,6 @@
       "utxo_stuffed": 0
     },
     "desc": "Mainnet chain syncing benchmark",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 12,
-      "tx_count": 466819068,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -8822,7 +8864,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 12,
+          "tx_count": 466819068,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "chainsync-early-alonzo-notracer": {
     "analysis": {
@@ -8914,20 +8978,6 @@
       "utxo_stuffed": 0
     },
     "desc": "Mainnet chain syncing benchmark",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 12,
-      "tx_count": 466819068,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -10099,7 +10149,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 12,
+          "tx_count": 466819068,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "chainsync-early-byron": {
     "analysis": {
@@ -10191,20 +10263,6 @@
       "utxo_stuffed": 0
     },
     "desc": "Mainnet chain syncing benchmark",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 12,
-      "tx_count": 2851188,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -11376,7 +11434,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 12,
+          "tx_count": 2851188,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "chainsync-early-byron-notracer": {
     "analysis": {
@@ -11468,20 +11548,6 @@
       "utxo_stuffed": 0
     },
     "desc": "Mainnet chain syncing benchmark",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 12,
-      "tx_count": 2851188,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -12653,7 +12719,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 12,
+          "tx_count": 2851188,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "ci-bench": {
     "analysis": {
@@ -12742,20 +12830,6 @@
       "utxo_stuffed": 500000
     },
     "desc": "Miniature dataset, CI-friendly duration, bench scale",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 9000,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -13926,7 +14000,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 9000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "ci-bench-drep": {
     "analysis": {
@@ -14015,20 +14111,6 @@
       "utxo_stuffed": 500000
     },
     "desc": "Miniature dataset, CI-friendly duration, bench scale",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 9000,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -15199,7 +15281,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 9000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "ci-bench-lsmt": {
     "analysis": {
@@ -15288,20 +15392,6 @@
       "utxo_stuffed": 500000
     },
     "desc": "Miniature dataset, CI-friendly duration, bench scale",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 9000,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -16472,7 +16562,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 9000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "ci-bench-nomadperf": {
     "analysis": {
@@ -16595,20 +16707,6 @@
       "utxo_stuffed": 500000
     },
     "desc": "Miniature dataset, CI-friendly duration, bench scale",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 9000,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -17779,7 +17877,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 9000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "ci-bench-notracer": {
     "analysis": {
@@ -17868,20 +17988,6 @@
       "utxo_stuffed": 500000
     },
     "desc": "Miniature dataset, CI-friendly duration, bench scale",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 9000,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -19052,7 +19158,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 9000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "ci-bench-plutus": {
     "analysis": {
@@ -19143,23 +19271,6 @@
       "utxo_stuffed": 500000
     },
     "desc": "Miniature dataset, CI-friendly duration, bench scale",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "int": 1000000
-        },
-        "script": "Loop",
-        "type": "LimitSaturationLoop"
-      },
-      "tps": 0.2,
-      "tx_count": 120,
-      "tx_fee": 1360000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -19729,7 +19840,32 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "int": 1000000
+            },
+            "script": "Loop",
+            "type": "LimitSaturationLoop"
+          },
+          "tps": 0.2,
+          "tx_count": 120,
+          "tx_fee": 1360000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "ci-bench-plutus-secp-ecdsa": {
     "analysis": {
@@ -19820,37 +19956,6 @@
       "utxo_stuffed": 500000
     },
     "desc": "Miniature dataset, CI-friendly duration, bench scale",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "constructor": 0,
-          "fields": [
-            {
-              "int": 1000000
-            },
-            {
-              "bytes": "0392d7b94bc6a11c335a043ee1ff326b6eacee6230d3685861cd62bce350a172e0"
-            },
-            {
-              "bytes": "16e0bf1f85594a11e75030981c0b670370b3ad83a43f49ae58a2fd6f6513cde9"
-            },
-            {
-              "bytes": "5fb12954b28be6456feb080cfb8467b6f5677f62eb9ad231de7a575f4b6857512754fb5ef7e0e60e270832e7bb0e2f0dc271012fa9c46c02504aa0e798be6295"
-            }
-          ]
-        },
-        "script": "EcdsaSecp256k1Loop",
-        "type": "LimitTxPerBlock_8"
-      },
-      "tps": 0.48,
-      "tx_count": 288,
-      "tx_fee": 1008000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -20420,7 +20525,46 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "constructor": 0,
+              "fields": [
+                {
+                  "int": 1000000
+                },
+                {
+                  "bytes": "0392d7b94bc6a11c335a043ee1ff326b6eacee6230d3685861cd62bce350a172e0"
+                },
+                {
+                  "bytes": "16e0bf1f85594a11e75030981c0b670370b3ad83a43f49ae58a2fd6f6513cde9"
+                },
+                {
+                  "bytes": "5fb12954b28be6456feb080cfb8467b6f5677f62eb9ad231de7a575f4b6857512754fb5ef7e0e60e270832e7bb0e2f0dc271012fa9c46c02504aa0e798be6295"
+                }
+              ]
+            },
+            "script": "EcdsaSecp256k1Loop",
+            "type": "LimitTxPerBlock_8"
+          },
+          "tps": 0.48,
+          "tx_count": 288,
+          "tx_fee": 1008000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "ci-bench-plutus-secp-schnorr": {
     "analysis": {
@@ -20511,37 +20655,6 @@
       "utxo_stuffed": 500000
     },
     "desc": "Miniature dataset, CI-friendly duration, bench scale",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "constructor": 0,
-          "fields": [
-            {
-              "int": 1000000
-            },
-            {
-              "bytes": "599de3e582e2a3779208a210dfeae8f330b9af00a47a7fb22e9bb8ef596f301b"
-            },
-            {
-              "bytes": "30303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030"
-            },
-            {
-              "bytes": "5a56da88e6fd8419181dec4d3dd6997bab953d2fc71ab65e23cfc9e7e3d1a310613454a60f6703819a39fdac2a410a094442afd1fc083354443e8d8bb4461a9b"
-            }
-          ]
-        },
-        "script": "SchnorrSecp256k1Loop",
-        "type": "LimitTxPerBlock_8"
-      },
-      "tps": 0.48,
-      "tx_count": 288,
-      "tx_fee": 1004000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -21111,7 +21224,46 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "constructor": 0,
+              "fields": [
+                {
+                  "int": 1000000
+                },
+                {
+                  "bytes": "599de3e582e2a3779208a210dfeae8f330b9af00a47a7fb22e9bb8ef596f301b"
+                },
+                {
+                  "bytes": "30303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030"
+                },
+                {
+                  "bytes": "5a56da88e6fd8419181dec4d3dd6997bab953d2fc71ab65e23cfc9e7e3d1a310613454a60f6703819a39fdac2a410a094442afd1fc083354443e8d8bb4461a9b"
+                }
+              ]
+            },
+            "script": "SchnorrSecp256k1Loop",
+            "type": "LimitTxPerBlock_8"
+          },
+          "tps": 0.48,
+          "tx_count": 288,
+          "tx_fee": 1004000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "ci-bench-plutus24": {
     "analysis": {
@@ -21202,23 +21354,6 @@
       "utxo_stuffed": 500000
     },
     "desc": "Miniature dataset, CI-friendly duration, bench scale",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "int": 1000000
-        },
-        "script": "Loop2024",
-        "type": "LimitSaturationLoop"
-      },
-      "tps": 0.2,
-      "tx_count": 120,
-      "tx_fee": 1412000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -21788,7 +21923,32 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "int": 1000000
+            },
+            "script": "Loop2024",
+            "type": "LimitSaturationLoop"
+          },
+          "tps": 0.2,
+          "tx_count": 120,
+          "tx_fee": 1412000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "ci-bench-plutusv3-blst": {
     "analysis": {
@@ -21879,44 +22039,6 @@
       "utxo_stuffed": 500000
     },
     "desc": "Miniature dataset, CI-friendly duration, bench scale",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "constructor": 0,
-          "fields": [
-            {
-              "int": 1000000
-            },
-            {
-              "list": [
-                {
-                  "bytes": "714805c6"
-                },
-                {
-                  "bytes": "c413111e"
-                },
-                {
-                  "bytes": "2d7eb870"
-                },
-                {
-                  "bytes": "4ecbd6a1"
-                }
-              ]
-            }
-          ]
-        },
-        "script": "HashOntoG2AndAdd",
-        "type": "LimitTxPerBlock_8"
-      },
-      "tps": 0.48,
-      "tx_count": 288,
-      "tx_fee": 940000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -23085,7 +23207,53 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "constructor": 0,
+              "fields": [
+                {
+                  "int": 1000000
+                },
+                {
+                  "list": [
+                    {
+                      "bytes": "714805c6"
+                    },
+                    {
+                      "bytes": "c413111e"
+                    },
+                    {
+                      "bytes": "2d7eb870"
+                    },
+                    {
+                      "bytes": "4ecbd6a1"
+                    }
+                  ]
+                }
+              ]
+            },
+            "script": "HashOntoG2AndAdd",
+            "type": "LimitTxPerBlock_8"
+          },
+          "tps": 0.48,
+          "tx_count": 288,
+          "tx_fee": 940000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "ci-bench-plutusv3-ripemd": {
     "analysis": {
@@ -23176,31 +23344,6 @@
       "utxo_stuffed": 500000
     },
     "desc": "Miniature dataset, CI-friendly duration, bench scale",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "constructor": 0,
-          "fields": [
-            {
-              "int": 1000000
-            },
-            {
-              "bytes": "5a56da88e6fd8419181dec4d3dd6997bab953d2f"
-            }
-          ]
-        },
-        "script": "Ripemd160",
-        "type": "LimitTxPerBlock_8"
-      },
-      "tps": 0.48,
-      "tx_count": 288,
-      "tx_fee": 940000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -24369,7 +24512,40 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "constructor": 0,
+              "fields": [
+                {
+                  "int": 1000000
+                },
+                {
+                  "bytes": "5a56da88e6fd8419181dec4d3dd6997bab953d2f"
+                }
+              ]
+            },
+            "script": "Ripemd160",
+            "type": "LimitTxPerBlock_8"
+          },
+          "tps": 0.48,
+          "tx_count": 288,
+          "tx_fee": 940000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "ci-bench-plutusv3-ripemd-step2x": {
     "analysis": {
@@ -24460,31 +24636,6 @@
       "utxo_stuffed": 500000
     },
     "desc": "Miniature dataset, CI-friendly duration, bench scale",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "constructor": 0,
-          "fields": [
-            {
-              "int": 1000000
-            },
-            {
-              "bytes": "5a56da88e6fd8419181dec4d3dd6997bab953d2f"
-            }
-          ]
-        },
-        "script": "Ripemd160",
-        "type": "LimitTxPerBlock_8"
-      },
-      "tps": 0.48,
-      "tx_count": 288,
-      "tx_fee": 940000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -25655,7 +25806,40 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "constructor": 0,
+              "fields": [
+                {
+                  "int": 1000000
+                },
+                {
+                  "bytes": "5a56da88e6fd8419181dec4d3dd6997bab953d2f"
+                }
+              ]
+            },
+            "script": "Ripemd160",
+            "type": "LimitTxPerBlock_8"
+          },
+          "tps": 0.48,
+          "tx_count": 288,
+          "tx_fee": 940000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "ci-test": {
     "analysis": {
@@ -25744,20 +25928,6 @@
       "utxo_stuffed": 0
     },
     "desc": "Miniature dataset, CI-friendly duration (2-3min), test scale",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 2,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 9000,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -26928,7 +27098,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 2,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 9000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "ci-test-dense10": {
     "analysis": {
@@ -27017,20 +27209,6 @@
       "utxo_stuffed": 0
     },
     "desc": "Miniature dataset, CI-friendly duration (2-3min), test scale",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 2,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 9000,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -28201,7 +28379,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 2,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 9000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "ci-test-hydra": {
     "analysis": {
@@ -28292,23 +28492,6 @@
       "utxo_stuffed": 0
     },
     "desc": "Miniature dataset, CI-friendly duration (2-3min), test scale",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 2,
-      "init_cooldown": 5,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "int": 1000000
-        },
-        "script": "Loop",
-        "type": "LimitSaturationLoop"
-      },
-      "tps": 0.2,
-      "tx_count": 120,
-      "tx_fee": 1380000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -28879,7 +29062,32 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 2,
+          "init_cooldown": 5,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "int": 1000000
+            },
+            "script": "Loop",
+            "type": "LimitSaturationLoop"
+          },
+          "tps": 0.2,
+          "tx_count": 120,
+          "tx_fee": 1380000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "ci-test-nomadperf": {
     "analysis": {
@@ -29002,20 +29210,6 @@
       "utxo_stuffed": 0
     },
     "desc": "Miniature dataset, CI-friendly duration (2-3min), test scale",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 2,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 9000,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -30186,7 +30380,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 2,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 9000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "ci-test-notracer": {
     "analysis": {
@@ -30275,20 +30491,6 @@
       "utxo_stuffed": 0
     },
     "desc": "Miniature dataset, CI-friendly duration (2-3min), test scale",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 2,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 9000,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -31459,7 +31661,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 2,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 9000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "ci-test-plutus": {
     "analysis": {
@@ -31550,23 +31774,6 @@
       "utxo_stuffed": 0
     },
     "desc": "Miniature dataset, CI-friendly duration (2-3min), test scale",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 2,
-      "init_cooldown": 5,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "int": 1000000
-        },
-        "script": "Loop",
-        "type": "LimitSaturationLoop"
-      },
-      "tps": 0.2,
-      "tx_count": 120,
-      "tx_fee": 1360000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -32737,7 +32944,32 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 2,
+          "init_cooldown": 5,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "int": 1000000
+            },
+            "script": "Loop",
+            "type": "LimitSaturationLoop"
+          },
+          "tps": 0.2,
+          "tx_count": 120,
+          "tx_fee": 1360000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "default": {
     "analysis": {
@@ -32826,20 +33058,6 @@
       "utxo_delegated": 6,
       "utxo_generated": 43200,
       "utxo_stuffed": 0
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 12,
-      "tx_count": 21600,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -34011,7 +34229,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 12,
+          "tx_count": 21600,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "default-nomadperf": {
     "analysis": {
@@ -34134,20 +34374,6 @@
       "utxo_delegated": 6,
       "utxo_generated": 43200,
       "utxo_stuffed": 0
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 12,
-      "tx_count": 21600,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -35319,7 +35545,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 12,
+          "tx_count": 21600,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "devops": {
     "analysis": {
@@ -35408,20 +35656,6 @@
       "utxo_delegated": 6,
       "utxo_generated": 14400,
       "utxo_stuffed": 0
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 12,
-      "tx_count": 7200,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.1,
@@ -36593,7 +36827,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 12,
+          "tx_count": 7200,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "dish": {
     "analysis": {
@@ -36682,20 +36938,6 @@
       "utxo_delegated": 0,
       "utxo_generated": 666668,
       "utxo_stuffed": 30000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 138.88888888888889,
-      "tx_count": 333334,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -37867,7 +38109,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 138.88888888888889,
+          "tx_count": 333334,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "dish-10M": {
     "analysis": {
@@ -37956,20 +38220,6 @@
       "utxo_delegated": 0,
       "utxo_generated": 666668,
       "utxo_stuffed": 10000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 138.88888888888889,
-      "tx_count": 333334,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -39141,7 +39391,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 138.88888888888889,
+          "tx_count": 333334,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "dish-10M-plutus": {
     "analysis": {
@@ -39230,23 +39502,6 @@
       "utxo_delegated": 0,
       "utxo_generated": 480,
       "utxo_stuffed": 10000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "int": 1000000
-        },
-        "script": "Loop",
-        "type": "LimitSaturationLoop"
-      },
-      "tps": 0.2,
-      "tx_count": 480,
-      "tx_fee": 1360000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -40418,7 +40673,32 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "int": 1000000
+            },
+            "script": "Loop",
+            "type": "LimitSaturationLoop"
+          },
+          "tps": 0.2,
+          "tx_count": 480,
+          "tx_fee": 1360000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "dish-plutus": {
     "analysis": {
@@ -40507,23 +40787,6 @@
       "utxo_delegated": 0,
       "utxo_generated": 480,
       "utxo_stuffed": 30000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "int": 1000000
-        },
-        "script": "Loop",
-        "type": "LimitSaturationLoop"
-      },
-      "tps": 0.2,
-      "tx_count": 480,
-      "tx_fee": 1360000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -41695,7 +41958,32 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "int": 1000000
+            },
+            "script": "Loop",
+            "type": "LimitSaturationLoop"
+          },
+          "tps": 0.2,
+          "tx_count": 480,
+          "tx_fee": 1360000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "epoch-transition": {
     "analysis": {
@@ -41784,20 +42072,6 @@
       "utxo_stuffed": 0
     },
     "desc": "2 low-footprint nodes, 15 minutes runtime",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 13500,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -42968,7 +43242,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 13500,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "fast": {
     "analysis": {
@@ -43057,20 +43353,6 @@
       "utxo_stuffed": 0
     },
     "desc": "Stop as soon as we've seen a single block",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 9000,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -44241,7 +44523,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 9000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "fast-nomadperf": {
     "analysis": {
@@ -44364,20 +44668,6 @@
       "utxo_stuffed": 0
     },
     "desc": "Stop as soon as we've seen a single block",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 9000,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -44947,7 +45237,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 9000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "fast-nomadperfssd": {
     "analysis": {
@@ -45092,20 +45404,6 @@
       "utxo_stuffed": 0
     },
     "desc": "Stop as soon as we've seen a single block",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 9000,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -45675,7 +45973,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 9000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "fast-notracer": {
     "analysis": {
@@ -45764,20 +46084,6 @@
       "utxo_stuffed": 0
     },
     "desc": "Stop as soon as we've seen a single block",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 9000,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -46948,7 +47254,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 9000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "fast-plutus": {
     "analysis": {
@@ -47039,23 +47367,6 @@
       "utxo_stuffed": 0
     },
     "desc": "Stop as soon as we've seen a single block",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "int": 1000000
-        },
-        "script": "Loop",
-        "type": "LimitSaturationLoop"
-      },
-      "tps": 0.2,
-      "tx_count": 120,
-      "tx_fee": 1360000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -48226,7 +48537,32 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "int": 1000000
+            },
+            "script": "Loop",
+            "type": "LimitSaturationLoop"
+          },
+          "tps": 0.2,
+          "tx_count": 120,
+          "tx_fee": 1360000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "fast-solo": {
     "analysis": {
@@ -48315,20 +48651,6 @@
       "utxo_stuffed": 0
     },
     "desc": "Stop as soon as we've seen a single block",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 9000,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -49499,7 +49821,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 9000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "faststartup-24M": {
     "analysis": {
@@ -49588,20 +49932,6 @@
       "utxo_stuffed": 24000000
     },
     "desc": "Stop as soon as we've seen a single block",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 9000,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -50772,7 +51102,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 9000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "forge-stress": {
     "analysis": {
@@ -50861,20 +51213,6 @@
       "utxo_delegated": 1300000,
       "utxo_generated": 72000,
       "utxo_stuffed": 10000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 36000,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -52046,7 +52384,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 36000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "forge-stress-large": {
     "analysis": {
@@ -52135,20 +52495,6 @@
       "utxo_delegated": 1300000,
       "utxo_generated": 144000,
       "utxo_stuffed": 10000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 7,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 72000,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -53320,7 +53666,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 7,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 72000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "forge-stress-notracer": {
     "analysis": {
@@ -53409,20 +53777,6 @@
       "utxo_delegated": 1300000,
       "utxo_generated": 72000,
       "utxo_stuffed": 10000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 36000,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -54594,7 +54948,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 36000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "forge-stress-plutus": {
     "analysis": {
@@ -54683,23 +55059,6 @@
       "utxo_delegated": 1300000,
       "utxo_generated": 480,
       "utxo_stuffed": 10000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "int": 1000000
-        },
-        "script": "Loop",
-        "type": "LimitSaturationLoop"
-      },
-      "tps": 0.2,
-      "tx_count": 480,
-      "tx_fee": 1360000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -55871,7 +56230,32 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "int": 1000000
+            },
+            "script": "Loop",
+            "type": "LimitSaturationLoop"
+          },
+          "tps": 0.2,
+          "tx_count": 480,
+          "tx_fee": 1360000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "forge-stress-plutus-solo": {
     "analysis": {
@@ -55960,23 +56344,6 @@
       "utxo_delegated": 1300000,
       "utxo_generated": 480,
       "utxo_stuffed": 10000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "int": 1000000
-        },
-        "script": "Loop",
-        "type": "LimitSaturationLoop"
-      },
-      "tps": 0.2,
-      "tx_count": 480,
-      "tx_fee": 1360000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -57146,7 +57513,32 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "int": 1000000
+            },
+            "script": "Loop",
+            "type": "LimitSaturationLoop"
+          },
+          "tps": 0.2,
+          "tx_count": 480,
+          "tx_fee": 1360000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "forge-stress-plutusv3-solo": {
     "analysis": {
@@ -57235,23 +57627,6 @@
       "utxo_delegated": 1300000,
       "utxo_generated": 720,
       "utxo_stuffed": 10000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "int": 1000000
-        },
-        "script": "LoopV3",
-        "type": "LimitSaturationLoop"
-      },
-      "tps": 0.3,
-      "tx_count": 720,
-      "tx_fee": 1412000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -58421,7 +58796,32 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "int": 1000000
+            },
+            "script": "LoopV3",
+            "type": "LimitSaturationLoop"
+          },
+          "tps": 0.3,
+          "tx_count": 720,
+          "tx_fee": 1412000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "forge-stress-pre": {
     "analysis": {
@@ -58510,20 +58910,6 @@
       "utxo_delegated": 1000000,
       "utxo_generated": 72000,
       "utxo_stuffed": 4000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 36000,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -59695,7 +60081,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 36000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "forge-stress-pre-large": {
     "analysis": {
@@ -59784,20 +60192,6 @@
       "utxo_delegated": 1000000,
       "utxo_generated": 144000,
       "utxo_stuffed": 4000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 7,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 72000,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -60969,7 +61363,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 7,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 72000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "forge-stress-pre-large-rtsN3": {
     "analysis": {
@@ -61058,20 +61474,6 @@
       "utxo_delegated": 1000000,
       "utxo_generated": 144000,
       "utxo_stuffed": 4000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 7,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 72000,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -62245,7 +62647,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 7,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 72000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "forge-stress-pre-large-rtsN4": {
     "analysis": {
@@ -62334,20 +62758,6 @@
       "utxo_delegated": 1000000,
       "utxo_generated": 144000,
       "utxo_stuffed": 4000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 7,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 72000,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -63521,7 +63931,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 7,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 72000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "forge-stress-pre-notracer": {
     "analysis": {
@@ -63610,20 +64042,6 @@
       "utxo_delegated": 1000000,
       "utxo_generated": 72000,
       "utxo_stuffed": 4000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 36000,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -64795,7 +65213,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 36000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "forge-stress-pre-plutus": {
     "analysis": {
@@ -64884,23 +65324,6 @@
       "utxo_delegated": 1000000,
       "utxo_generated": 480,
       "utxo_stuffed": 4000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "int": 1000000
-        },
-        "script": "Loop",
-        "type": "LimitSaturationLoop"
-      },
-      "tps": 0.2,
-      "tx_count": 480,
-      "tx_fee": 1360000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -66072,7 +66495,32 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "int": 1000000
+            },
+            "script": "Loop",
+            "type": "LimitSaturationLoop"
+          },
+          "tps": 0.2,
+          "tx_count": 480,
+          "tx_fee": 1360000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "forge-stress-pre-plutus-solo": {
     "analysis": {
@@ -66161,23 +66609,6 @@
       "utxo_delegated": 1000000,
       "utxo_generated": 480,
       "utxo_stuffed": 4000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "int": 1000000
-        },
-        "script": "Loop",
-        "type": "LimitSaturationLoop"
-      },
-      "tps": 0.2,
-      "tx_count": 480,
-      "tx_fee": 1360000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -67347,7 +67778,32 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "int": 1000000
+            },
+            "script": "Loop",
+            "type": "LimitSaturationLoop"
+          },
+          "tps": 0.2,
+          "tx_count": 480,
+          "tx_fee": 1360000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "forge-stress-pre-rtsA4m": {
     "analysis": {
@@ -67436,20 +67892,6 @@
       "utxo_delegated": 1000000,
       "utxo_generated": 72000,
       "utxo_stuffed": 4000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 36000,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -68623,7 +69065,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 36000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "forge-stress-pre-rtsA4mN3": {
     "analysis": {
@@ -68712,20 +69176,6 @@
       "utxo_delegated": 1000000,
       "utxo_generated": 72000,
       "utxo_stuffed": 4000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 36000,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -69900,7 +70350,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 36000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "forge-stress-pre-rtsA64m": {
     "analysis": {
@@ -69989,20 +70461,6 @@
       "utxo_delegated": 1000000,
       "utxo_generated": 72000,
       "utxo_stuffed": 4000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 36000,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -71176,7 +71634,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 36000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "forge-stress-pre-rtsA64mN3": {
     "analysis": {
@@ -71265,20 +71745,6 @@
       "utxo_delegated": 1000000,
       "utxo_generated": 72000,
       "utxo_stuffed": 4000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 36000,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -72453,7 +72919,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 36000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "forge-stress-pre-rtsN3": {
     "analysis": {
@@ -72542,20 +73030,6 @@
       "utxo_delegated": 1000000,
       "utxo_generated": 72000,
       "utxo_stuffed": 4000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 36000,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -73729,7 +74203,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 36000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "forge-stress-pre-rtsxn": {
     "analysis": {
@@ -73818,20 +74314,6 @@
       "utxo_delegated": 1000000,
       "utxo_generated": 72000,
       "utxo_stuffed": 4000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 36000,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -75005,7 +75487,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 36000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "forge-stress-pre-solo": {
     "analysis": {
@@ -75094,20 +75598,6 @@
       "utxo_delegated": 1000000,
       "utxo_generated": 72000,
       "utxo_stuffed": 4000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 36000,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -76277,7 +76767,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 36000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "forge-stress-pre-solo-xl": {
     "analysis": {
@@ -76366,20 +76878,6 @@
       "utxo_delegated": 1000000,
       "utxo_generated": 144000,
       "utxo_stuffed": 4000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 7,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 72000,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -77549,7 +78047,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 7,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 72000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "forge-stress-pre-solo-xs": {
     "analysis": {
@@ -77638,20 +78158,6 @@
       "utxo_delegated": 1000000,
       "utxo_generated": 36000,
       "utxo_stuffed": 4000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 1,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 18000,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -78821,7 +79327,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 1,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 18000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "forge-stress-solo": {
     "analysis": {
@@ -78910,20 +79438,6 @@
       "utxo_delegated": 1300000,
       "utxo_generated": 72000,
       "utxo_stuffed": 10000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 36000,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -80093,7 +80607,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 36000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "forge-stress-solo-xs": {
     "analysis": {
@@ -80182,20 +80718,6 @@
       "utxo_delegated": 1300000,
       "utxo_generated": 36000,
       "utxo_stuffed": 10000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 1,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 18000,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -81365,7 +81887,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 1,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 18000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "fschain-768k": {
     "analysis": {
@@ -81454,20 +81998,6 @@
       "utxo_delegated": 1000000,
       "utxo_generated": 180000,
       "utxo_stuffed": 4000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 100,
-      "tx_count": 90000,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.015,
@@ -82639,7 +83169,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 100,
+          "tx_count": 90000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "fschain-768k-xs": {
     "analysis": {
@@ -82728,20 +83280,6 @@
       "utxo_delegated": 1000000,
       "utxo_generated": 180000,
       "utxo_stuffed": 4000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 1,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 100,
-      "tx_count": 90000,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.015,
@@ -83913,7 +84451,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 1,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 100,
+          "tx_count": 90000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "fschain-8io": {
     "analysis": {
@@ -84002,20 +84562,6 @@
       "utxo_delegated": 1000000,
       "utxo_generated": 576000,
       "utxo_stuffed": 4000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 7,
-      "init_cooldown": 5,
-      "inputs_per_tx": 8,
-      "outputs_per_tx": 8,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 72000,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -85185,7 +85731,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 7,
+          "init_cooldown": 5,
+          "inputs_per_tx": 8,
+          "outputs_per_tx": 8,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 72000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "idle": {
     "analysis": {
@@ -85276,20 +85844,6 @@
       "utxo_stuffed": 0
     },
     "desc": "Idle scenario:  start nodes & detach from tty;  no cluster termination",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 12,
-      "tx_count": 21600,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -86460,7 +87014,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 12,
+          "tx_count": 21600,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "k3-3ep-18kTx-10000kU-1300kD-64kbs-10tps-fixed-loaded": {
     "analysis": {
@@ -86549,20 +87125,6 @@
       "utxo_delegated": 1300000,
       "utxo_generated": 36000,
       "utxo_stuffed": 10000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 10,
-      "tx_count": 18000,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -87734,7 +88296,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 10,
+          "tx_count": 18000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "k3-3ep-5kTx-10000kU-1300kD-64kbs-fixed-loaded": {
     "analysis": {
@@ -87823,20 +88407,6 @@
       "utxo_delegated": 1300000,
       "utxo_generated": 8640,
       "utxo_stuffed": 10000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 12,
-      "tx_count": 4320,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -89008,7 +89578,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 12,
+          "tx_count": 4320,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "k3-3ep-9kTx-10000kU-1300kD-64kbs-5tps-fixed-loaded": {
     "analysis": {
@@ -89097,20 +89689,6 @@
       "utxo_delegated": 1300000,
       "utxo_generated": 18000,
       "utxo_stuffed": 10000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 5,
-      "tx_count": 9000,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -90282,7 +90860,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 5,
+          "tx_count": 9000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "latency-nomadperf": {
     "analysis": {
@@ -90405,20 +91005,6 @@
       "utxo_stuffed": 0
     },
     "desc": "AWS perf class cluster, stop when all latency services stop",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 12,
-      "tx_count": 21600,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -90990,13 +91576,32 @@
     },
     "workloads": [
       {
-        "before_nodes": false,
-        "entrypoints": {
-          "pre_generator": null,
-          "producers": "latency"
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 12,
+          "tx_count": 21600,
+          "tx_fee": 1000000
         },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      },
+      {
+        "entrypoint": "latency",
         "name": "latency",
         "parameters": {},
+        "phase": "load",
+        "placement": "producers",
         "wait_pools": false
       }
     ]
@@ -91144,20 +91749,6 @@
       "utxo_stuffed": 0
     },
     "desc": "AWS perf-ssd class cluster, stop when all latency services stop",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 12,
-      "tx_count": 21600,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -91729,13 +92320,32 @@
     },
     "workloads": [
       {
-        "before_nodes": false,
-        "entrypoints": {
-          "pre_generator": null,
-          "producers": "latency"
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 12,
+          "tx_count": 21600,
+          "tx_fee": 1000000
         },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      },
+      {
+        "entrypoint": "latency",
         "name": "latency",
         "parameters": {},
+        "phase": "load",
+        "placement": "producers",
         "wait_pools": false
       }
     ]
@@ -91830,37 +92440,6 @@
       "utxo_stuffed": 10000000
     },
     "desc": "Status-quo dataset, 7 epochs",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 7,
-      "init_cooldown": 45,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "constructor": 0,
-          "fields": [
-            {
-              "int": 1000000
-            },
-            {
-              "bytes": "0392d7b94bc6a11c335a043ee1ff326b6eacee6230d3685861cd62bce350a172e0"
-            },
-            {
-              "bytes": "16e0bf1f85594a11e75030981c0b670370b3ad83a43f49ae58a2fd6f6513cde9"
-            },
-            {
-              "bytes": "5fb12954b28be6456feb080cfb8467b6f5677f62eb9ad231de7a575f4b6857512754fb5ef7e0e60e270832e7bb0e2f0dc271012fa9c46c02504aa0e798be6295"
-            }
-          ]
-        },
-        "script": "EcdsaSecp256k1Loop",
-        "type": "LimitTxPerBlock_8"
-      },
-      "tps": 0.4,
-      "tx_count": 22400,
-      "tx_fee": 1008000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -93029,7 +93608,46 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 7,
+          "init_cooldown": 45,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "constructor": 0,
+              "fields": [
+                {
+                  "int": 1000000
+                },
+                {
+                  "bytes": "0392d7b94bc6a11c335a043ee1ff326b6eacee6230d3685861cd62bce350a172e0"
+                },
+                {
+                  "bytes": "16e0bf1f85594a11e75030981c0b670370b3ad83a43f49ae58a2fd6f6513cde9"
+                },
+                {
+                  "bytes": "5fb12954b28be6456feb080cfb8467b6f5677f62eb9ad231de7a575f4b6857512754fb5ef7e0e60e270832e7bb0e2f0dc271012fa9c46c02504aa0e798be6295"
+                }
+              ]
+            },
+            "script": "EcdsaSecp256k1Loop",
+            "type": "LimitTxPerBlock_8"
+          },
+          "tps": 0.4,
+          "tx_count": 22400,
+          "tx_fee": 1008000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "model-secp-ecdsa-stepx2": {
     "analysis": {
@@ -93121,37 +93739,6 @@
       "utxo_stuffed": 10000000
     },
     "desc": "Status-quo dataset, 7 epochs",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 7,
-      "init_cooldown": 45,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "constructor": 0,
-          "fields": [
-            {
-              "int": 1000000
-            },
-            {
-              "bytes": "0392d7b94bc6a11c335a043ee1ff326b6eacee6230d3685861cd62bce350a172e0"
-            },
-            {
-              "bytes": "16e0bf1f85594a11e75030981c0b670370b3ad83a43f49ae58a2fd6f6513cde9"
-            },
-            {
-              "bytes": "5fb12954b28be6456feb080cfb8467b6f5677f62eb9ad231de7a575f4b6857512754fb5ef7e0e60e270832e7bb0e2f0dc271012fa9c46c02504aa0e798be6295"
-            }
-          ]
-        },
-        "script": "EcdsaSecp256k1Loop",
-        "type": "LimitTxPerBlock_8"
-      },
-      "tps": 0.4,
-      "tx_count": 22400,
-      "tx_fee": 1008000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -94322,7 +94909,46 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 7,
+          "init_cooldown": 45,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "constructor": 0,
+              "fields": [
+                {
+                  "int": 1000000
+                },
+                {
+                  "bytes": "0392d7b94bc6a11c335a043ee1ff326b6eacee6230d3685861cd62bce350a172e0"
+                },
+                {
+                  "bytes": "16e0bf1f85594a11e75030981c0b670370b3ad83a43f49ae58a2fd6f6513cde9"
+                },
+                {
+                  "bytes": "5fb12954b28be6456feb080cfb8467b6f5677f62eb9ad231de7a575f4b6857512754fb5ef7e0e60e270832e7bb0e2f0dc271012fa9c46c02504aa0e798be6295"
+                }
+              ]
+            },
+            "script": "EcdsaSecp256k1Loop",
+            "type": "LimitTxPerBlock_8"
+          },
+          "tps": 0.4,
+          "tx_count": 22400,
+          "tx_fee": 1008000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "model-value": {
     "analysis": {
@@ -94414,20 +95040,6 @@
       "utxo_stuffed": 10000000
     },
     "desc": "Status-quo dataset, 7 epochs",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 7,
-      "init_cooldown": 45,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 9,
-      "tx_count": 504000,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -95596,7 +96208,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 7,
+          "init_cooldown": 45,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 9,
+          "tx_count": 504000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "model-value-test": {
     "analysis": {
@@ -95688,20 +96322,6 @@
       "utxo_stuffed": 1000000
     },
     "desc": "Status-quo dataset, 7 epochs",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 7,
-      "init_cooldown": 45,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 9,
-      "tx_count": 504000,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -96870,7 +97490,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 7,
+          "init_cooldown": 45,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 9,
+          "tx_count": 504000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "plutus": {
     "analysis": {
@@ -96959,23 +97601,6 @@
       "utxo_delegated": 6,
       "utxo_generated": 360,
       "utxo_stuffed": 0
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "int": 1000000
-        },
-        "script": "Loop",
-        "type": "LimitSaturationLoop"
-      },
-      "tps": 0.2,
-      "tx_count": 360,
-      "tx_fee": 1380000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -97546,7 +98171,32 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "int": 1000000
+            },
+            "script": "Loop",
+            "type": "LimitSaturationLoop"
+          },
+          "tps": 0.2,
+          "tx_count": 360,
+          "tx_fee": 1380000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "plutus-drep100k-nomadperf": {
     "analysis": {
@@ -97672,23 +98322,6 @@
       "utxo_stuffed": 4000000
     },
     "desc": "AWS c5-2xlarge cluster dataset, 9 ep, Plutus workload",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 9,
-      "init_cooldown": 45,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "int": 1000000
-        },
-        "script": "Loop",
-        "type": "LimitSaturationLoop"
-      },
-      "tps": 0.85,
-      "tx_count": 61200,
-      "tx_fee": 1360000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -98258,7 +98891,32 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 9,
+          "init_cooldown": 45,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "int": 1000000
+            },
+            "script": "Loop",
+            "type": "LimitSaturationLoop"
+          },
+          "tps": 0.85,
+          "tx_count": 61200,
+          "tx_fee": 1360000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "plutus-drep10k-nomadperf": {
     "analysis": {
@@ -98384,23 +99042,6 @@
       "utxo_stuffed": 4000000
     },
     "desc": "AWS c5-2xlarge cluster dataset, 9 ep, Plutus workload",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 9,
-      "init_cooldown": 45,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "int": 1000000
-        },
-        "script": "Loop",
-        "type": "LimitSaturationLoop"
-      },
-      "tps": 0.85,
-      "tx_count": 61200,
-      "tx_fee": 1360000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -98970,7 +99611,32 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 9,
+          "init_cooldown": 45,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "int": 1000000
+            },
+            "script": "Loop",
+            "type": "LimitSaturationLoop"
+          },
+          "tps": 0.85,
+          "tx_count": 61200,
+          "tx_fee": 1360000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "plutus-drep1k-nomadperf": {
     "analysis": {
@@ -99096,23 +99762,6 @@
       "utxo_stuffed": 4000000
     },
     "desc": "AWS c5-2xlarge cluster dataset, 9 ep, Plutus workload",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 9,
-      "init_cooldown": 45,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "int": 1000000
-        },
-        "script": "Loop",
-        "type": "LimitSaturationLoop"
-      },
-      "tps": 0.85,
-      "tx_count": 61200,
-      "tx_fee": 1360000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -99682,7 +100331,32 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 9,
+          "init_cooldown": 45,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "int": 1000000
+            },
+            "script": "Loop",
+            "type": "LimitSaturationLoop"
+          },
+          "tps": 0.85,
+          "tx_count": 61200,
+          "tx_fee": 1360000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "plutus-nomadperf": {
     "analysis": {
@@ -99808,23 +100482,6 @@
       "utxo_stuffed": 4000000
     },
     "desc": "AWS c5-2xlarge cluster dataset, 9 ep, Plutus workload",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 9,
-      "init_cooldown": 45,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "int": 1000000
-        },
-        "script": "Loop",
-        "type": "LimitSaturationLoop"
-      },
-      "tps": 0.85,
-      "tx_count": 61200,
-      "tx_fee": 1360000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -100394,7 +101051,32 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 9,
+          "init_cooldown": 45,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "int": 1000000
+            },
+            "script": "Loop",
+            "type": "LimitSaturationLoop"
+          },
+          "tps": 0.85,
+          "tx_count": 61200,
+          "tx_fee": 1360000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "plutus-secp-ecdsa": {
     "analysis": {
@@ -100483,37 +101165,6 @@
       "utxo_delegated": 6,
       "utxo_generated": 360,
       "utxo_stuffed": 0
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "constructor": 0,
-          "fields": [
-            {
-              "int": 1000000
-            },
-            {
-              "bytes": "0392d7b94bc6a11c335a043ee1ff326b6eacee6230d3685861cd62bce350a172e0"
-            },
-            {
-              "bytes": "16e0bf1f85594a11e75030981c0b670370b3ad83a43f49ae58a2fd6f6513cde9"
-            },
-            {
-              "bytes": "5fb12954b28be6456feb080cfb8467b6f5677f62eb9ad231de7a575f4b6857512754fb5ef7e0e60e270832e7bb0e2f0dc271012fa9c46c02504aa0e798be6295"
-            }
-          ]
-        },
-        "script": "EcdsaSecp256k1Loop",
-        "type": "LimitTxPerBlock_8"
-      },
-      "tps": 0.2,
-      "tx_count": 360,
-      "tx_fee": 1008000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -101084,7 +101735,46 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "constructor": 0,
+              "fields": [
+                {
+                  "int": 1000000
+                },
+                {
+                  "bytes": "0392d7b94bc6a11c335a043ee1ff326b6eacee6230d3685861cd62bce350a172e0"
+                },
+                {
+                  "bytes": "16e0bf1f85594a11e75030981c0b670370b3ad83a43f49ae58a2fd6f6513cde9"
+                },
+                {
+                  "bytes": "5fb12954b28be6456feb080cfb8467b6f5677f62eb9ad231de7a575f4b6857512754fb5ef7e0e60e270832e7bb0e2f0dc271012fa9c46c02504aa0e798be6295"
+                }
+              ]
+            },
+            "script": "EcdsaSecp256k1Loop",
+            "type": "LimitTxPerBlock_8"
+          },
+          "tps": 0.2,
+          "tx_count": 360,
+          "tx_fee": 1008000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "plutus-secp-ecdsa-nomadperf": {
     "analysis": {
@@ -101210,37 +101900,6 @@
       "utxo_stuffed": 4000000
     },
     "desc": "AWS c5-2xlarge cluster dataset, 9 ep, Plutus workload",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 9,
-      "init_cooldown": 45,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "constructor": 0,
-          "fields": [
-            {
-              "int": 1000000
-            },
-            {
-              "bytes": "0392d7b94bc6a11c335a043ee1ff326b6eacee6230d3685861cd62bce350a172e0"
-            },
-            {
-              "bytes": "16e0bf1f85594a11e75030981c0b670370b3ad83a43f49ae58a2fd6f6513cde9"
-            },
-            {
-              "bytes": "5fb12954b28be6456feb080cfb8467b6f5677f62eb9ad231de7a575f4b6857512754fb5ef7e0e60e270832e7bb0e2f0dc271012fa9c46c02504aa0e798be6295"
-            }
-          ]
-        },
-        "script": "EcdsaSecp256k1Loop",
-        "type": "LimitTxPerBlock_8"
-      },
-      "tps": 2,
-      "tx_count": 144000,
-      "tx_fee": 1008000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -101810,7 +102469,46 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 9,
+          "init_cooldown": 45,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "constructor": 0,
+              "fields": [
+                {
+                  "int": 1000000
+                },
+                {
+                  "bytes": "0392d7b94bc6a11c335a043ee1ff326b6eacee6230d3685861cd62bce350a172e0"
+                },
+                {
+                  "bytes": "16e0bf1f85594a11e75030981c0b670370b3ad83a43f49ae58a2fd6f6513cde9"
+                },
+                {
+                  "bytes": "5fb12954b28be6456feb080cfb8467b6f5677f62eb9ad231de7a575f4b6857512754fb5ef7e0e60e270832e7bb0e2f0dc271012fa9c46c02504aa0e798be6295"
+                }
+              ]
+            },
+            "script": "EcdsaSecp256k1Loop",
+            "type": "LimitTxPerBlock_8"
+          },
+          "tps": 2,
+          "tx_count": 144000,
+          "tx_fee": 1008000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "plutus-secp-schnorr": {
     "analysis": {
@@ -101899,37 +102597,6 @@
       "utxo_delegated": 6,
       "utxo_generated": 360,
       "utxo_stuffed": 0
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "constructor": 0,
-          "fields": [
-            {
-              "int": 1000000
-            },
-            {
-              "bytes": "599de3e582e2a3779208a210dfeae8f330b9af00a47a7fb22e9bb8ef596f301b"
-            },
-            {
-              "bytes": "30303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030"
-            },
-            {
-              "bytes": "5a56da88e6fd8419181dec4d3dd6997bab953d2fc71ab65e23cfc9e7e3d1a310613454a60f6703819a39fdac2a410a094442afd1fc083354443e8d8bb4461a9b"
-            }
-          ]
-        },
-        "script": "SchnorrSecp256k1Loop",
-        "type": "LimitTxPerBlock_8"
-      },
-      "tps": 0.2,
-      "tx_count": 360,
-      "tx_fee": 1004000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -102500,7 +103167,46 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "constructor": 0,
+              "fields": [
+                {
+                  "int": 1000000
+                },
+                {
+                  "bytes": "599de3e582e2a3779208a210dfeae8f330b9af00a47a7fb22e9bb8ef596f301b"
+                },
+                {
+                  "bytes": "30303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030"
+                },
+                {
+                  "bytes": "5a56da88e6fd8419181dec4d3dd6997bab953d2fc71ab65e23cfc9e7e3d1a310613454a60f6703819a39fdac2a410a094442afd1fc083354443e8d8bb4461a9b"
+                }
+              ]
+            },
+            "script": "SchnorrSecp256k1Loop",
+            "type": "LimitTxPerBlock_8"
+          },
+          "tps": 0.2,
+          "tx_count": 360,
+          "tx_fee": 1004000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "plutus-secp-schnorr-nomadperf": {
     "analysis": {
@@ -102626,37 +103332,6 @@
       "utxo_stuffed": 4000000
     },
     "desc": "AWS c5-2xlarge cluster dataset, 9 ep, Plutus workload",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 9,
-      "init_cooldown": 45,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "constructor": 0,
-          "fields": [
-            {
-              "int": 1000000
-            },
-            {
-              "bytes": "599de3e582e2a3779208a210dfeae8f330b9af00a47a7fb22e9bb8ef596f301b"
-            },
-            {
-              "bytes": "30303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030"
-            },
-            {
-              "bytes": "5a56da88e6fd8419181dec4d3dd6997bab953d2fc71ab65e23cfc9e7e3d1a310613454a60f6703819a39fdac2a410a094442afd1fc083354443e8d8bb4461a9b"
-            }
-          ]
-        },
-        "script": "SchnorrSecp256k1Loop",
-        "type": "LimitTxPerBlock_8"
-      },
-      "tps": 2,
-      "tx_count": 144000,
-      "tx_fee": 1004000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -103226,7 +103901,46 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 9,
+          "init_cooldown": 45,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "constructor": 0,
+              "fields": [
+                {
+                  "int": 1000000
+                },
+                {
+                  "bytes": "599de3e582e2a3779208a210dfeae8f330b9af00a47a7fb22e9bb8ef596f301b"
+                },
+                {
+                  "bytes": "30303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030"
+                },
+                {
+                  "bytes": "5a56da88e6fd8419181dec4d3dd6997bab953d2fc71ab65e23cfc9e7e3d1a310613454a60f6703819a39fdac2a410a094442afd1fc083354443e8d8bb4461a9b"
+                }
+              ]
+            },
+            "script": "SchnorrSecp256k1Loop",
+            "type": "LimitTxPerBlock_8"
+          },
+          "tps": 2,
+          "tx_count": 144000,
+          "tx_fee": 1004000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "plutus-volt-lsmt-nomadperf": {
     "analysis": {
@@ -103361,23 +104075,6 @@
       "utxo_stuffed": 4000000
     },
     "desc": "AWS c5-2xlarge cluster dataset, 9 ep, Plutus workload",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 9,
-      "init_cooldown": 45,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "int": 1000000
-        },
-        "script": "Loop",
-        "type": "LimitSaturationLoop"
-      },
-      "tps": 0.85,
-      "tx_count": 61200,
-      "tx_fee": 1360000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -104546,7 +105243,32 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 9,
+          "init_cooldown": 45,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "int": 1000000
+            },
+            "script": "Loop",
+            "type": "LimitSaturationLoop"
+          },
+          "tps": 0.85,
+          "tx_count": 61200,
+          "tx_fee": 1360000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "plutus-volt-memx15-nomadperf": {
     "analysis": {
@@ -104672,23 +105394,6 @@
       "utxo_stuffed": 4000000
     },
     "desc": "AWS c5-2xlarge cluster dataset, 9 ep, Plutus workload",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 9,
-      "init_cooldown": 45,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "int": 1000000
-        },
-        "script": "Loop",
-        "type": "LimitSaturationLoop"
-      },
-      "tps": 0.85,
-      "tx_count": 61200,
-      "tx_fee": 1892175
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -105873,7 +106578,32 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 9,
+          "init_cooldown": 45,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "int": 1000000
+            },
+            "script": "Loop",
+            "type": "LimitSaturationLoop"
+          },
+          "tps": 0.85,
+          "tx_count": 61200,
+          "tx_fee": 1360000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "plutus-volt-memx2-nomadperf": {
     "analysis": {
@@ -105999,23 +106729,6 @@
       "utxo_stuffed": 4000000
     },
     "desc": "AWS c5-2xlarge cluster dataset, 9 ep, Plutus workload",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 9,
-      "init_cooldown": 45,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "int": 1000000
-        },
-        "script": "Loop",
-        "type": "LimitSaturationLoop"
-      },
-      "tps": 0.85,
-      "tx_count": 61200,
-      "tx_fee": 2463246
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -107200,7 +107913,32 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 9,
+          "init_cooldown": 45,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "int": 1000000
+            },
+            "script": "Loop",
+            "type": "LimitSaturationLoop"
+          },
+          "tps": 0.85,
+          "tx_count": 61200,
+          "tx_fee": 1360000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "plutus-volt-nomadperf": {
     "analysis": {
@@ -107326,23 +108064,6 @@
       "utxo_stuffed": 4000000
     },
     "desc": "AWS c5-2xlarge cluster dataset, 9 ep, Plutus workload",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 9,
-      "init_cooldown": 45,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "int": 1000000
-        },
-        "script": "Loop",
-        "type": "LimitSaturationLoop"
-      },
-      "tps": 0.85,
-      "tx_count": 61200,
-      "tx_fee": 1360000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -108511,7 +109232,32 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 9,
+          "init_cooldown": 45,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "int": 1000000
+            },
+            "script": "Loop",
+            "type": "LimitSaturationLoop"
+          },
+          "tps": 0.85,
+          "tx_count": 61200,
+          "tx_fee": 1360000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "plutus-voting-double-volt-nomadperf": {
     "analysis": {
@@ -108637,23 +109383,6 @@
       "utxo_stuffed": 4000000
     },
     "desc": "AWS c5-2xlarge cluster dataset, 9 ep, Plutus workload+ voting",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 9,
-      "init_cooldown": 45,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "int": 1000000
-        },
-        "script": "Loop",
-        "type": "LimitSaturationLoop"
-      },
-      "tps": 0.85,
-      "tx_count": 61200,
-      "tx_fee": 1360000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -109815,17 +110544,51 @@
     },
     "workloads": [
       {
-        "before_nodes": false,
-        "entrypoints": {
-          "pre_generator": "workflow_generator",
-          "producers": "workflow_producer"
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 9,
+          "init_cooldown": 45,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "int": 1000000
+            },
+            "script": "Loop",
+            "type": "LimitSaturationLoop"
+          },
+          "tps": 0.85,
+          "tx_count": 61200,
+          "tx_fee": 1360000
         },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      },
+      {
+        "entrypoint": "workflow_setup",
+        "name": "voting-setup",
+        "parameters": {
+          "outs_per_split_transaction": 193,
+          "submit_vote": true,
+          "votes_per_tx": 2
+        },
+        "phase": "setup",
+        "placement": "explorer",
+        "wait_pools": true
+      },
+      {
+        "entrypoint": "workflow_producer",
         "name": "voting",
         "parameters": {
           "outs_per_split_transaction": 193,
           "submit_vote": true,
           "votes_per_tx": 2
         },
+        "phase": "load",
+        "placement": "producers",
         "wait_pools": true
       }
     ]
@@ -109954,23 +110717,6 @@
       "utxo_stuffed": 4000000
     },
     "desc": "AWS c5-2xlarge cluster dataset, 9 ep, Plutus workload+ voting",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 9,
-      "init_cooldown": 45,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "int": 1000000
-        },
-        "script": "Loop",
-        "type": "LimitSaturationLoop"
-      },
-      "tps": 0.85,
-      "tx_count": 61200,
-      "tx_fee": 1360000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -111132,16 +111878,49 @@
     },
     "workloads": [
       {
-        "before_nodes": false,
-        "entrypoints": {
-          "pre_generator": "workflow_generator",
-          "producers": "workflow_producer"
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 9,
+          "init_cooldown": 45,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "int": 1000000
+            },
+            "script": "Loop",
+            "type": "LimitSaturationLoop"
+          },
+          "tps": 0.85,
+          "tx_count": 61200,
+          "tx_fee": 1360000
         },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      },
+      {
+        "entrypoint": "workflow_setup",
+        "name": "voting-setup",
+        "parameters": {
+          "outs_per_split_transaction": 193,
+          "submit_vote": false
+        },
+        "phase": "setup",
+        "placement": "explorer",
+        "wait_pools": true
+      },
+      {
+        "entrypoint": "workflow_producer",
         "name": "voting",
         "parameters": {
           "outs_per_split_transaction": 193,
           "submit_vote": false
         },
+        "phase": "load",
+        "placement": "producers",
         "wait_pools": true
       }
     ]
@@ -111270,23 +112049,6 @@
       "utxo_stuffed": 4000000
     },
     "desc": "AWS c5-2xlarge cluster dataset, 9 ep, Plutus workload+ voting",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 9,
-      "init_cooldown": 45,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "int": 1000000
-        },
-        "script": "Loop",
-        "type": "LimitSaturationLoop"
-      },
-      "tps": 0.85,
-      "tx_count": 61200,
-      "tx_fee": 1360000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -112448,17 +113210,51 @@
     },
     "workloads": [
       {
-        "before_nodes": false,
-        "entrypoints": {
-          "pre_generator": "workflow_generator",
-          "producers": "workflow_producer"
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 9,
+          "init_cooldown": 45,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "int": 1000000
+            },
+            "script": "Loop",
+            "type": "LimitSaturationLoop"
+          },
+          "tps": 0.85,
+          "tx_count": 61200,
+          "tx_fee": 1360000
         },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      },
+      {
+        "entrypoint": "workflow_setup",
+        "name": "voting-setup",
+        "parameters": {
+          "outs_per_split_transaction": 193,
+          "submit_vote": true,
+          "votes_per_tx": 1
+        },
+        "phase": "setup",
+        "placement": "explorer",
+        "wait_pools": true
+      },
+      {
+        "entrypoint": "workflow_producer",
         "name": "voting",
         "parameters": {
           "outs_per_split_transaction": 193,
           "submit_vote": true,
           "votes_per_tx": 1
         },
+        "phase": "load",
+        "placement": "producers",
         "wait_pools": true
       }
     ]
@@ -112587,23 +113383,6 @@
       "utxo_stuffed": 4000000
     },
     "desc": "AWS c5-2xlarge cluster dataset, 9 ep, Plutus workload",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 9,
-      "init_cooldown": 45,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "int": 1000000
-        },
-        "script": "Loop2024",
-        "type": "LimitSaturationLoop"
-      },
-      "tps": 0.85,
-      "tx_count": 61200,
-      "tx_fee": 1412000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -113173,7 +113952,32 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 9,
+          "init_cooldown": 45,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "int": 1000000
+            },
+            "script": "Loop2024",
+            "type": "LimitSaturationLoop"
+          },
+          "tps": 0.85,
+          "tx_count": 61200,
+          "tx_fee": 1412000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "plutuscall-loop": {
     "analysis": {
@@ -113265,23 +114069,6 @@
       "utxo_stuffed": 1000000
     },
     "desc": "Small dataset, honest 15 epochs duration",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 15,
-      "init_cooldown": 5,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "int": 1000000
-        },
-        "script": "Loop",
-        "type": "LimitSaturationLoop"
-      },
-      "tps": 0.4,
-      "tx_count": 3600,
-      "tx_fee": 1360000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -114450,7 +115237,32 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 15,
+          "init_cooldown": 5,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "int": 1000000
+            },
+            "script": "Loop",
+            "type": "LimitSaturationLoop"
+          },
+          "tps": 0.4,
+          "tx_count": 3600,
+          "tx_fee": 1360000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "plutuscall-loop-memx2": {
     "analysis": {
@@ -114542,23 +115354,6 @@
       "utxo_stuffed": 1000000
     },
     "desc": "Small dataset, honest 15 epochs duration",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 15,
-      "init_cooldown": 5,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "int": 1000000
-        },
-        "script": "Loop",
-        "type": "LimitSaturationLoop"
-      },
-      "tps": 0.4,
-      "tx_count": 3600,
-      "tx_fee": 2463246
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -115743,7 +116538,32 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 15,
+          "init_cooldown": 5,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "int": 1000000
+            },
+            "script": "Loop",
+            "type": "LimitSaturationLoop"
+          },
+          "tps": 0.4,
+          "tx_count": 3600,
+          "tx_fee": 1360000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "plutuscall-secp-ecdsa": {
     "analysis": {
@@ -115835,37 +116655,6 @@
       "utxo_stuffed": 1000000
     },
     "desc": "Small dataset, honest 15 epochs duration",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 15,
-      "init_cooldown": 5,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "constructor": 0,
-          "fields": [
-            {
-              "int": 1000000
-            },
-            {
-              "bytes": "0392d7b94bc6a11c335a043ee1ff326b6eacee6230d3685861cd62bce350a172e0"
-            },
-            {
-              "bytes": "16e0bf1f85594a11e75030981c0b670370b3ad83a43f49ae58a2fd6f6513cde9"
-            },
-            {
-              "bytes": "5fb12954b28be6456feb080cfb8467b6f5677f62eb9ad231de7a575f4b6857512754fb5ef7e0e60e270832e7bb0e2f0dc271012fa9c46c02504aa0e798be6295"
-            }
-          ]
-        },
-        "script": "EcdsaSecp256k1Loop",
-        "type": "LimitTxPerBlock_8"
-      },
-      "tps": 0.4,
-      "tx_count": 3600,
-      "tx_fee": 1008000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -117034,7 +117823,46 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 15,
+          "init_cooldown": 5,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "constructor": 0,
+              "fields": [
+                {
+                  "int": 1000000
+                },
+                {
+                  "bytes": "0392d7b94bc6a11c335a043ee1ff326b6eacee6230d3685861cd62bce350a172e0"
+                },
+                {
+                  "bytes": "16e0bf1f85594a11e75030981c0b670370b3ad83a43f49ae58a2fd6f6513cde9"
+                },
+                {
+                  "bytes": "5fb12954b28be6456feb080cfb8467b6f5677f62eb9ad231de7a575f4b6857512754fb5ef7e0e60e270832e7bb0e2f0dc271012fa9c46c02504aa0e798be6295"
+                }
+              ]
+            },
+            "script": "EcdsaSecp256k1Loop",
+            "type": "LimitTxPerBlock_8"
+          },
+          "tps": 0.4,
+          "tx_count": 3600,
+          "tx_fee": 1008000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "plutuscall-secp-ecdsa-stepx2": {
     "analysis": {
@@ -117126,37 +117954,6 @@
       "utxo_stuffed": 1000000
     },
     "desc": "Small dataset, honest 15 epochs duration",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 15,
-      "init_cooldown": 5,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "constructor": 0,
-          "fields": [
-            {
-              "int": 1000000
-            },
-            {
-              "bytes": "0392d7b94bc6a11c335a043ee1ff326b6eacee6230d3685861cd62bce350a172e0"
-            },
-            {
-              "bytes": "16e0bf1f85594a11e75030981c0b670370b3ad83a43f49ae58a2fd6f6513cde9"
-            },
-            {
-              "bytes": "5fb12954b28be6456feb080cfb8467b6f5677f62eb9ad231de7a575f4b6857512754fb5ef7e0e60e270832e7bb0e2f0dc271012fa9c46c02504aa0e798be6295"
-            }
-          ]
-        },
-        "script": "EcdsaSecp256k1Loop",
-        "type": "LimitTxPerBlock_8"
-      },
-      "tps": 0.4,
-      "tx_count": 3600,
-      "tx_fee": 1008000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -118327,7 +119124,46 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 15,
+          "init_cooldown": 5,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "constructor": 0,
+              "fields": [
+                {
+                  "int": 1000000
+                },
+                {
+                  "bytes": "0392d7b94bc6a11c335a043ee1ff326b6eacee6230d3685861cd62bce350a172e0"
+                },
+                {
+                  "bytes": "16e0bf1f85594a11e75030981c0b670370b3ad83a43f49ae58a2fd6f6513cde9"
+                },
+                {
+                  "bytes": "5fb12954b28be6456feb080cfb8467b6f5677f62eb9ad231de7a575f4b6857512754fb5ef7e0e60e270832e7bb0e2f0dc271012fa9c46c02504aa0e798be6295"
+                }
+              ]
+            },
+            "script": "EcdsaSecp256k1Loop",
+            "type": "LimitTxPerBlock_8"
+          },
+          "tps": 0.4,
+          "tx_count": 3600,
+          "tx_fee": 1008000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "plutuscall-secp-schnorr": {
     "analysis": {
@@ -118419,37 +119255,6 @@
       "utxo_stuffed": 1000000
     },
     "desc": "Small dataset, honest 15 epochs duration",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 15,
-      "init_cooldown": 5,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "constructor": 0,
-          "fields": [
-            {
-              "int": 1000000
-            },
-            {
-              "bytes": "599de3e582e2a3779208a210dfeae8f330b9af00a47a7fb22e9bb8ef596f301b"
-            },
-            {
-              "bytes": "30303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030"
-            },
-            {
-              "bytes": "5a56da88e6fd8419181dec4d3dd6997bab953d2fc71ab65e23cfc9e7e3d1a310613454a60f6703819a39fdac2a410a094442afd1fc083354443e8d8bb4461a9b"
-            }
-          ]
-        },
-        "script": "SchnorrSecp256k1Loop",
-        "type": "LimitTxPerBlock_8"
-      },
-      "tps": 0.4,
-      "tx_count": 3600,
-      "tx_fee": 1004000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -119618,7 +120423,46 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 15,
+          "init_cooldown": 5,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "constructor": 0,
+              "fields": [
+                {
+                  "int": 1000000
+                },
+                {
+                  "bytes": "599de3e582e2a3779208a210dfeae8f330b9af00a47a7fb22e9bb8ef596f301b"
+                },
+                {
+                  "bytes": "30303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030"
+                },
+                {
+                  "bytes": "5a56da88e6fd8419181dec4d3dd6997bab953d2fc71ab65e23cfc9e7e3d1a310613454a60f6703819a39fdac2a410a094442afd1fc083354443e8d8bb4461a9b"
+                }
+              ]
+            },
+            "script": "SchnorrSecp256k1Loop",
+            "type": "LimitTxPerBlock_8"
+          },
+          "tps": 0.4,
+          "tx_count": 3600,
+          "tx_fee": 1004000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "plutuscall-secp-schnorr-stepx2": {
     "analysis": {
@@ -119710,37 +120554,6 @@
       "utxo_stuffed": 1000000
     },
     "desc": "Small dataset, honest 15 epochs duration",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 15,
-      "init_cooldown": 5,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "constructor": 0,
-          "fields": [
-            {
-              "int": 1000000
-            },
-            {
-              "bytes": "599de3e582e2a3779208a210dfeae8f330b9af00a47a7fb22e9bb8ef596f301b"
-            },
-            {
-              "bytes": "30303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030"
-            },
-            {
-              "bytes": "5a56da88e6fd8419181dec4d3dd6997bab953d2fc71ab65e23cfc9e7e3d1a310613454a60f6703819a39fdac2a410a094442afd1fc083354443e8d8bb4461a9b"
-            }
-          ]
-        },
-        "script": "SchnorrSecp256k1Loop",
-        "type": "LimitTxPerBlock_8"
-      },
-      "tps": 0.4,
-      "tx_count": 3600,
-      "tx_fee": 1004000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -120911,7 +121724,46 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 15,
+          "init_cooldown": 5,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "constructor": 0,
+              "fields": [
+                {
+                  "int": 1000000
+                },
+                {
+                  "bytes": "599de3e582e2a3779208a210dfeae8f330b9af00a47a7fb22e9bb8ef596f301b"
+                },
+                {
+                  "bytes": "30303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030"
+                },
+                {
+                  "bytes": "5a56da88e6fd8419181dec4d3dd6997bab953d2fc71ab65e23cfc9e7e3d1a310613454a60f6703819a39fdac2a410a094442afd1fc083354443e8d8bb4461a9b"
+                }
+              ]
+            },
+            "script": "SchnorrSecp256k1Loop",
+            "type": "LimitTxPerBlock_8"
+          },
+          "tps": 0.4,
+          "tx_count": 3600,
+          "tx_fee": 1004000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "plutuscall-volt-blst": {
     "analysis": {
@@ -121002,44 +121854,6 @@
       "utxo_stuffed": 1000000
     },
     "desc": "Small dataset, honest 15 epochs duration",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 15,
-      "init_cooldown": 5,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "constructor": 0,
-          "fields": [
-            {
-              "int": 1000000
-            },
-            {
-              "list": [
-                {
-                  "bytes": "714805c6"
-                },
-                {
-                  "bytes": "c413111e"
-                },
-                {
-                  "bytes": "2d7eb870"
-                },
-                {
-                  "bytes": "4ecbd6a1"
-                }
-              ]
-            }
-          ]
-        },
-        "script": "HashOntoG2AndAdd",
-        "type": "LimitTxPerBlock_8"
-      },
-      "tps": 0.48,
-      "tx_count": 4320,
-      "tx_fee": 940000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -122208,7 +123022,53 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 15,
+          "init_cooldown": 5,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "constructor": 0,
+              "fields": [
+                {
+                  "int": 1000000
+                },
+                {
+                  "list": [
+                    {
+                      "bytes": "714805c6"
+                    },
+                    {
+                      "bytes": "c413111e"
+                    },
+                    {
+                      "bytes": "2d7eb870"
+                    },
+                    {
+                      "bytes": "4ecbd6a1"
+                    }
+                  ]
+                }
+              ]
+            },
+            "script": "HashOntoG2AndAdd",
+            "type": "LimitTxPerBlock_8"
+          },
+          "tps": 0.48,
+          "tx_count": 4320,
+          "tx_fee": 940000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "plutuscall-volt-loop": {
     "analysis": {
@@ -122299,23 +123159,6 @@
       "utxo_stuffed": 1000000
     },
     "desc": "Small dataset, honest 15 epochs duration",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 15,
-      "init_cooldown": 5,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "int": 1000000
-        },
-        "script": "Loop",
-        "type": "LimitSaturationLoop"
-      },
-      "tps": 0.48,
-      "tx_count": 4320,
-      "tx_fee": 1360000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -123484,7 +124327,32 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 15,
+          "init_cooldown": 5,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "int": 1000000
+            },
+            "script": "Loop",
+            "type": "LimitSaturationLoop"
+          },
+          "tps": 0.48,
+          "tx_count": 4320,
+          "tx_fee": 1360000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "plutuscall-volt-ripemd": {
     "analysis": {
@@ -123575,31 +124443,6 @@
       "utxo_stuffed": 1000000
     },
     "desc": "Small dataset, honest 15 epochs duration",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 15,
-      "init_cooldown": 5,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "constructor": 0,
-          "fields": [
-            {
-              "int": 1000000
-            },
-            {
-              "bytes": "5a56da88e6fd8419181dec4d3dd6997bab953d2f"
-            }
-          ]
-        },
-        "script": "Ripemd160",
-        "type": "LimitTxPerBlock_8"
-      },
-      "tps": 0.48,
-      "tx_count": 4320,
-      "tx_fee": 940000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -124768,7 +125611,40 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 15,
+          "init_cooldown": 5,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "constructor": 0,
+              "fields": [
+                {
+                  "int": 1000000
+                },
+                {
+                  "bytes": "5a56da88e6fd8419181dec4d3dd6997bab953d2f"
+                }
+              ]
+            },
+            "script": "Ripemd160",
+            "type": "LimitTxPerBlock_8"
+          },
+          "tps": 0.48,
+          "tx_count": 4320,
+          "tx_fee": 940000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "plutusv3-blst-nomadperf": {
     "analysis": {
@@ -124894,44 +125770,6 @@
       "utxo_stuffed": 4000000
     },
     "desc": "AWS c5-2xlarge cluster dataset, 9 ep, Plutus workload",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 9,
-      "init_cooldown": 45,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "constructor": 0,
-          "fields": [
-            {
-              "int": 1000000
-            },
-            {
-              "list": [
-                {
-                  "bytes": "714805c6"
-                },
-                {
-                  "bytes": "c413111e"
-                },
-                {
-                  "bytes": "2d7eb870"
-                },
-                {
-                  "bytes": "4ecbd6a1"
-                }
-              ]
-            }
-          ]
-        },
-        "script": "HashOntoG2AndAdd",
-        "type": "LimitTxPerBlock_8"
-      },
-      "tps": 2,
-      "tx_count": 144000,
-      "tx_fee": 940000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -126100,7 +126938,53 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 9,
+          "init_cooldown": 45,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "constructor": 0,
+              "fields": [
+                {
+                  "int": 1000000
+                },
+                {
+                  "list": [
+                    {
+                      "bytes": "714805c6"
+                    },
+                    {
+                      "bytes": "c413111e"
+                    },
+                    {
+                      "bytes": "2d7eb870"
+                    },
+                    {
+                      "bytes": "4ecbd6a1"
+                    }
+                  ]
+                }
+              ]
+            },
+            "script": "HashOntoG2AndAdd",
+            "type": "LimitTxPerBlock_8"
+          },
+          "tps": 2,
+          "tx_count": 144000,
+          "tx_fee": 940000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "plutusv3-blst-stepx15-nomadperf": {
     "analysis": {
@@ -126226,44 +127110,6 @@
       "utxo_stuffed": 4000000
     },
     "desc": "AWS c5-2xlarge cluster dataset, 9 ep, Plutus workload",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 9,
-      "init_cooldown": 45,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "constructor": 0,
-          "fields": [
-            {
-              "int": 1000000
-            },
-            {
-              "list": [
-                {
-                  "bytes": "714805c6"
-                },
-                {
-                  "bytes": "c413111e"
-                },
-                {
-                  "bytes": "2d7eb870"
-                },
-                {
-                  "bytes": "4ecbd6a1"
-                }
-              ]
-            }
-          ]
-        },
-        "script": "HashOntoG2AndAdd",
-        "type": "LimitTxPerBlock_8"
-      },
-      "tps": 2,
-      "tx_count": 144000,
-      "tx_fee": 940000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -127434,7 +128280,53 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 9,
+          "init_cooldown": 45,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "constructor": 0,
+              "fields": [
+                {
+                  "int": 1000000
+                },
+                {
+                  "list": [
+                    {
+                      "bytes": "714805c6"
+                    },
+                    {
+                      "bytes": "c413111e"
+                    },
+                    {
+                      "bytes": "2d7eb870"
+                    },
+                    {
+                      "bytes": "4ecbd6a1"
+                    }
+                  ]
+                }
+              ]
+            },
+            "script": "HashOntoG2AndAdd",
+            "type": "LimitTxPerBlock_8"
+          },
+          "tps": 2,
+          "tx_count": 144000,
+          "tx_fee": 940000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "plutusv3-blst-stepx2-nomadperf": {
     "analysis": {
@@ -127560,44 +128452,6 @@
       "utxo_stuffed": 4000000
     },
     "desc": "AWS c5-2xlarge cluster dataset, 9 ep, Plutus workload",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 9,
-      "init_cooldown": 45,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "constructor": 0,
-          "fields": [
-            {
-              "int": 1000000
-            },
-            {
-              "list": [
-                {
-                  "bytes": "714805c6"
-                },
-                {
-                  "bytes": "c413111e"
-                },
-                {
-                  "bytes": "2d7eb870"
-                },
-                {
-                  "bytes": "4ecbd6a1"
-                }
-              ]
-            }
-          ]
-        },
-        "script": "HashOntoG2AndAdd",
-        "type": "LimitTxPerBlock_8"
-      },
-      "tps": 2,
-      "tx_count": 144000,
-      "tx_fee": 940000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -128768,7 +129622,53 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 9,
+          "init_cooldown": 45,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "constructor": 0,
+              "fields": [
+                {
+                  "int": 1000000
+                },
+                {
+                  "list": [
+                    {
+                      "bytes": "714805c6"
+                    },
+                    {
+                      "bytes": "c413111e"
+                    },
+                    {
+                      "bytes": "2d7eb870"
+                    },
+                    {
+                      "bytes": "4ecbd6a1"
+                    }
+                  ]
+                }
+              ]
+            },
+            "script": "HashOntoG2AndAdd",
+            "type": "LimitTxPerBlock_8"
+          },
+          "tps": 2,
+          "tx_count": 144000,
+          "tx_fee": 940000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "plutusv3-ripemd-nomadperf": {
     "analysis": {
@@ -128894,31 +129794,6 @@
       "utxo_stuffed": 4000000
     },
     "desc": "AWS c5-2xlarge cluster dataset, 9 ep, Plutus workload",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 9,
-      "init_cooldown": 45,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "constructor": 0,
-          "fields": [
-            {
-              "int": 1000000
-            },
-            {
-              "bytes": "5a56da88e6fd8419181dec4d3dd6997bab953d2f"
-            }
-          ]
-        },
-        "script": "Ripemd160",
-        "type": "LimitTxPerBlock_8"
-      },
-      "tps": 2,
-      "tx_count": 144000,
-      "tx_fee": 940000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -130087,7 +130962,40 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 9,
+          "init_cooldown": 45,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "constructor": 0,
+              "fields": [
+                {
+                  "int": 1000000
+                },
+                {
+                  "bytes": "5a56da88e6fd8419181dec4d3dd6997bab953d2f"
+                }
+              ]
+            },
+            "script": "Ripemd160",
+            "type": "LimitTxPerBlock_8"
+          },
+          "tps": 2,
+          "tx_count": 144000,
+          "tx_fee": 940000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "plutusv3-ripemd-stepx15-nomadperf": {
     "analysis": {
@@ -130213,31 +131121,6 @@
       "utxo_stuffed": 4000000
     },
     "desc": "AWS c5-2xlarge cluster dataset, 9 ep, Plutus workload",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 9,
-      "init_cooldown": 45,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "constructor": 0,
-          "fields": [
-            {
-              "int": 1000000
-            },
-            {
-              "bytes": "5a56da88e6fd8419181dec4d3dd6997bab953d2f"
-            }
-          ]
-        },
-        "script": "Ripemd160",
-        "type": "LimitTxPerBlock_8"
-      },
-      "tps": 2,
-      "tx_count": 144000,
-      "tx_fee": 940000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -131408,7 +132291,40 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 9,
+          "init_cooldown": 45,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "constructor": 0,
+              "fields": [
+                {
+                  "int": 1000000
+                },
+                {
+                  "bytes": "5a56da88e6fd8419181dec4d3dd6997bab953d2f"
+                }
+              ]
+            },
+            "script": "Ripemd160",
+            "type": "LimitTxPerBlock_8"
+          },
+          "tps": 2,
+          "tx_count": 144000,
+          "tx_fee": 940000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "plutusv3-ripemd-stepx2-nomadperf": {
     "analysis": {
@@ -131534,31 +132450,6 @@
       "utxo_stuffed": 4000000
     },
     "desc": "AWS c5-2xlarge cluster dataset, 9 ep, Plutus workload",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 9,
-      "init_cooldown": 45,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "constructor": 0,
-          "fields": [
-            {
-              "int": 1000000
-            },
-            {
-              "bytes": "5a56da88e6fd8419181dec4d3dd6997bab953d2f"
-            }
-          ]
-        },
-        "script": "Ripemd160",
-        "type": "LimitTxPerBlock_8"
-      },
-      "tps": 2,
-      "tx_count": 144000,
-      "tx_fee": 940000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -132729,7 +133620,40 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 9,
+          "init_cooldown": 45,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "constructor": 0,
+              "fields": [
+                {
+                  "int": 1000000
+                },
+                {
+                  "bytes": "5a56da88e6fd8419181dec4d3dd6997bab953d2f"
+                }
+              ]
+            },
+            "script": "Ripemd160",
+            "type": "LimitTxPerBlock_8"
+          },
+          "tps": 2,
+          "tx_count": 144000,
+          "tx_fee": 940000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "plutusv3-volt-nomadperf": {
     "analysis": {
@@ -132855,23 +133779,6 @@
       "utxo_stuffed": 4000000
     },
     "desc": "AWS c5-2xlarge cluster dataset, 9 ep, Plutus workload",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 9,
-      "init_cooldown": 45,
-      "inputs_per_tx": 1,
-      "outputs_per_tx": 1,
-      "plutus": {
-        "redeemer": {
-          "int": 1000000
-        },
-        "script": "LoopV3",
-        "type": "LimitSaturationLoop"
-      },
-      "tps": 0.85,
-      "tx_count": 61200,
-      "tx_fee": 1412000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -134040,7 +134947,32 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 9,
+          "init_cooldown": 45,
+          "inputs_per_tx": 1,
+          "outputs_per_tx": 1,
+          "plutus": {
+            "redeemer": {
+              "int": 1000000
+            },
+            "script": "LoopV3",
+            "type": "LimitSaturationLoop"
+          },
+          "tps": 0.85,
+          "tx_count": 61200,
+          "tx_fee": 1412000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "trace-bench": {
     "analysis": {
@@ -134129,20 +135061,6 @@
       "utxo_stuffed": 0
     },
     "desc": "6 low-footprint nodes in a torus topology, 5 minutes runtime",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 9000,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -135313,7 +136231,29 @@
       "timeseries": false,
       "withresources": true
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 9000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "trace-bench-notracer": {
     "analysis": {
@@ -135402,20 +136342,6 @@
       "utxo_stuffed": 0
     },
     "desc": "6 low-footprint nodes in a torus topology, 5 minutes runtime",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 9000,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -136586,7 +137512,29 @@
       "timeseries": false,
       "withresources": true
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 9000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "trace-full": {
     "analysis": {
@@ -136675,20 +137623,6 @@
       "utxo_stuffed": 0
     },
     "desc": "6 low-footprint nodes in a torus topology, 20 minutes runtime",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 15,
-      "tx_count": 18000,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -137859,7 +138793,29 @@
       "timeseries": false,
       "withresources": true
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 15,
+          "tx_count": 18000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "tracer-only": {
     "analysis": {
@@ -137950,20 +138906,6 @@
       "utxo_stuffed": 0
     },
     "desc": "Idle scenario:  start only the tracer & detach from tty;  no termination",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 3,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 12,
-      "tx_count": 21600,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -139134,7 +140076,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 3,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 12,
+          "tx_count": 21600,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "utxoscale-solo-12M16G-nomadperfssd": {
     "analysis": {
@@ -139278,20 +140242,6 @@
       "utxo_delegated": 1200000,
       "utxo_generated": 172800,
       "utxo_stuffed": 12000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 6,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 12,
-      "tx_count": 86400,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -139864,7 +140814,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 6,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 12,
+          "tx_count": 86400,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "utxoscale-solo-12M64G-nomadperfssd": {
     "analysis": {
@@ -140008,20 +140980,6 @@
       "utxo_delegated": 1200000,
       "utxo_generated": 172800,
       "utxo_stuffed": 12000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 6,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 12,
-      "tx_count": 86400,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -140592,7 +141550,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 6,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 12,
+          "tx_count": 86400,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "utxoscale-solo-24M64G-nomadperfssd": {
     "analysis": {
@@ -140736,20 +141716,6 @@
       "utxo_delegated": 1200000,
       "utxo_generated": 172800,
       "utxo_stuffed": 24000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 6,
-      "init_cooldown": 5,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 12,
-      "tx_count": 86400,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -141320,7 +142286,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 6,
+          "init_cooldown": 5,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 12,
+          "tx_count": 86400,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "value-drep100k-nomadperf": {
     "analysis": {
@@ -141446,20 +142434,6 @@
       "utxo_stuffed": 4000000
     },
     "desc": "AWS c5-2xlarge cluster dataset, 7 ep, value workload",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 8,
-      "init_cooldown": 45,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 12,
-      "tx_count": 768000,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -142029,7 +143003,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 8,
+          "init_cooldown": 45,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 12,
+          "tx_count": 768000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "value-drep10k-nomadperf": {
     "analysis": {
@@ -142155,20 +143151,6 @@
       "utxo_stuffed": 4000000
     },
     "desc": "AWS c5-2xlarge cluster dataset, 7 ep, value workload",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 8,
-      "init_cooldown": 45,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 12,
-      "tx_count": 768000,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -142738,7 +143720,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 8,
+          "init_cooldown": 45,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 12,
+          "tx_count": 768000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "value-drep1k-nomadperf": {
     "analysis": {
@@ -142864,20 +143868,6 @@
       "utxo_stuffed": 4000000
     },
     "desc": "AWS c5-2xlarge cluster dataset, 7 ep, value workload",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 8,
-      "init_cooldown": 45,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 12,
-      "tx_count": 768000,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -143447,7 +144437,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 8,
+          "init_cooldown": 45,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 12,
+          "tx_count": 768000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "value-nomadperf": {
     "analysis": {
@@ -143573,20 +144585,6 @@
       "utxo_stuffed": 4000000
     },
     "desc": "AWS c5-2xlarge cluster dataset, 7 ep, value workload",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 8,
-      "init_cooldown": 45,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 12,
-      "tx_count": 768000,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -144156,7 +145154,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 8,
+          "init_cooldown": 45,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 12,
+          "tx_count": 768000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "value-nomadperfssd": {
     "analysis": {
@@ -144302,20 +145322,6 @@
       "utxo_delegated": 1000000,
       "utxo_generated": 1536000,
       "utxo_stuffed": 4000000
-    },
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 8,
-      "init_cooldown": 45,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 12,
-      "tx_count": 768000,
-      "tx_fee": 1000000
     },
     "genesis": {
       "active_slots_coeff": 0.050,
@@ -144886,7 +145892,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 8,
+          "init_cooldown": 45,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 12,
+          "tx_count": 768000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "value-volt-cgmem-nomadperf": {
     "analysis": {
@@ -145021,20 +146049,6 @@
       "utxo_stuffed": 4000000
     },
     "desc": "AWS c5-2xlarge cluster dataset, 7 ep, value workload",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 8,
-      "init_cooldown": 45,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 12,
-      "tx_count": 768000,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -146205,13 +147219,32 @@
     },
     "workloads": [
       {
-        "before_nodes": true,
-        "entrypoints": {
-          "pre_generator": null,
-          "producers": "cgroup_memory"
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 8,
+          "init_cooldown": 45,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 12,
+          "tx_count": 768000,
+          "tx_fee": 1000000
         },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      },
+      {
+        "entrypoint": "cgroup_memory",
         "name": "cgroup_memory",
         "parameters": {},
+        "phase": "before-nodes",
+        "placement": "producers",
         "wait_pools": true
       }
     ]
@@ -146349,20 +147382,6 @@
       "utxo_stuffed": 4000000
     },
     "desc": "AWS c5-2xlarge cluster dataset, 7 ep, value workload",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 8,
-      "init_cooldown": 45,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 12,
-      "tx_count": 768000,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -147531,7 +148550,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 8,
+          "init_cooldown": 45,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 12,
+          "tx_count": 768000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "value-volt-nomadperf": {
     "analysis": {
@@ -147657,20 +148698,6 @@
       "utxo_stuffed": 4000000
     },
     "desc": "AWS c5-2xlarge cluster dataset, 7 ep, value workload",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 8,
-      "init_cooldown": 45,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 12,
-      "tx_count": 768000,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -148839,7 +149866,29 @@
       "timeseries": false,
       "withresources": false
     },
-    "workloads": []
+    "workloads": [
+      {
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 8,
+          "init_cooldown": 45,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 12,
+          "tx_count": 768000,
+          "tx_fee": 1000000
+        },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      }
+    ]
   },
   "value-voting-double-volt-nomadperf": {
     "analysis": {
@@ -148965,20 +150014,6 @@
       "utxo_stuffed": 4000000
     },
     "desc": "AWS c5-2xlarge cluster dataset, 7 ep, value workload+ voting",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 8,
-      "init_cooldown": 45,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 12,
-      "tx_count": 768000,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -150140,17 +151175,48 @@
     },
     "workloads": [
       {
-        "before_nodes": false,
-        "entrypoints": {
-          "pre_generator": "workflow_generator",
-          "producers": "workflow_producer"
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 8,
+          "init_cooldown": 45,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 12,
+          "tx_count": 768000,
+          "tx_fee": 1000000
         },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      },
+      {
+        "entrypoint": "workflow_setup",
+        "name": "voting-setup",
+        "parameters": {
+          "outs_per_split_transaction": 193,
+          "submit_vote": true,
+          "votes_per_tx": 2
+        },
+        "phase": "setup",
+        "placement": "explorer",
+        "wait_pools": true
+      },
+      {
+        "entrypoint": "workflow_producer",
         "name": "voting",
         "parameters": {
           "outs_per_split_transaction": 193,
           "submit_vote": true,
           "votes_per_tx": 2
         },
+        "phase": "load",
+        "placement": "producers",
         "wait_pools": true
       }
     ]
@@ -150279,20 +151345,6 @@
       "utxo_stuffed": 4000000
     },
     "desc": "AWS c5-2xlarge cluster dataset, 7 ep, value workload+ voting",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 8,
-      "init_cooldown": 45,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 12,
-      "tx_count": 768000,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -151454,16 +152506,46 @@
     },
     "workloads": [
       {
-        "before_nodes": false,
-        "entrypoints": {
-          "pre_generator": "workflow_generator",
-          "producers": "workflow_producer"
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 8,
+          "init_cooldown": 45,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 12,
+          "tx_count": 768000,
+          "tx_fee": 1000000
         },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      },
+      {
+        "entrypoint": "workflow_setup",
+        "name": "voting-setup",
+        "parameters": {
+          "outs_per_split_transaction": 193,
+          "submit_vote": false
+        },
+        "phase": "setup",
+        "placement": "explorer",
+        "wait_pools": true
+      },
+      {
+        "entrypoint": "workflow_producer",
         "name": "voting",
         "parameters": {
           "outs_per_split_transaction": 193,
           "submit_vote": false
         },
+        "phase": "load",
+        "placement": "producers",
         "wait_pools": true
       }
     ]
@@ -151592,20 +152674,6 @@
       "utxo_stuffed": 4000000
     },
     "desc": "AWS c5-2xlarge cluster dataset, 7 ep, value workload+ voting",
-    "generator": {
-      "add_tx_size": 100,
-      "epochs": 8,
-      "init_cooldown": 45,
-      "inputs_per_tx": 2,
-      "outputs_per_tx": 2,
-      "plutus": {
-        "script": null,
-        "type": null
-      },
-      "tps": 12,
-      "tx_count": 768000,
-      "tx_fee": 1000000
-    },
     "genesis": {
       "active_slots_coeff": 0.050,
       "alonzo": {
@@ -152767,17 +153835,48 @@
     },
     "workloads": [
       {
-        "before_nodes": false,
-        "entrypoints": {
-          "pre_generator": "workflow_generator",
-          "producers": "workflow_producer"
+        "entrypoint": "tx_generator",
+        "name": "tx-generator",
+        "parameters": {
+          "add_tx_size": 100,
+          "epochs": 8,
+          "init_cooldown": 45,
+          "inputs_per_tx": 2,
+          "outputs_per_tx": 2,
+          "plutus": {
+            "script": null,
+            "type": null
+          },
+          "tps": 12,
+          "tx_count": 768000,
+          "tx_fee": 1000000
         },
+        "phase": "load",
+        "placement": "explorer",
+        "wait_pools": true
+      },
+      {
+        "entrypoint": "workflow_setup",
+        "name": "voting-setup",
+        "parameters": {
+          "outs_per_split_transaction": 193,
+          "submit_vote": true,
+          "votes_per_tx": 1
+        },
+        "phase": "setup",
+        "placement": "explorer",
+        "wait_pools": true
+      },
+      {
+        "entrypoint": "workflow_producer",
         "name": "voting",
         "parameters": {
           "outs_per_split_transaction": 193,
           "submit_vote": true,
           "votes_per_tx": 1
         },
+        "phase": "load",
+        "placement": "producers",
         "wait_pools": true
       }
     ]

--- a/bench/cardano-profile/data/test/chainsync-early-alonzo-coay/profile.json
+++ b/bench/cardano-profile/data/test/chainsync-early-alonzo-coay/profile.json
@@ -264,21 +264,29 @@
     "pool_coin": 0,
     "delegator_coin": 0
   },
-  "generator": {
-    "add_tx_size": 100,
-    "init_cooldown": 5,
-    "inputs_per_tx": 2,
-    "outputs_per_tx": 2,
-    "tx_fee": 1000000,
-    "epochs": 3,
-    "tps": 12,
-    "plutus": {
-      "type": null,
-      "script": null
-    },
-    "tx_count": 466819068
-  },
-  "workloads": [],
+  "workloads": [
+    {
+      "name": "tx-generator",
+      "parameters": {
+        "add_tx_size": 100,
+        "init_cooldown": 5,
+        "inputs_per_tx": 2,
+        "outputs_per_tx": 2,
+        "tx_fee": 1000000,
+        "epochs": 3,
+        "tps": 12,
+        "plutus": {
+          "type": null,
+          "script": null
+        },
+        "tx_count": 466819068
+      },
+      "entrypoint": "tx_generator",
+      "phase": "load",
+      "placement": "explorer",
+      "wait_pools": true
+    }
+  ],
   "node": {
     "rts_flags_override": [],
     "heap_limit": null,

--- a/bench/cardano-profile/data/test/chainsync-early-byron-coay/profile.json
+++ b/bench/cardano-profile/data/test/chainsync-early-byron-coay/profile.json
@@ -264,21 +264,29 @@
     "pool_coin": 0,
     "delegator_coin": 0
   },
-  "generator": {
-    "add_tx_size": 100,
-    "init_cooldown": 5,
-    "inputs_per_tx": 2,
-    "outputs_per_tx": 2,
-    "tx_fee": 1000000,
-    "epochs": 3,
-    "tps": 12,
-    "plutus": {
-      "type": null,
-      "script": null
-    },
-    "tx_count": 2851188
-  },
-  "workloads": [],
+  "workloads": [
+    {
+      "name": "tx-generator",
+      "parameters": {
+        "add_tx_size": 100,
+        "init_cooldown": 5,
+        "inputs_per_tx": 2,
+        "outputs_per_tx": 2,
+        "tx_fee": 1000000,
+        "epochs": 3,
+        "tps": 12,
+        "plutus": {
+          "type": null,
+          "script": null
+        },
+        "tx_count": 2851188
+      },
+      "entrypoint": "tx_generator",
+      "phase": "load",
+      "placement": "explorer",
+      "wait_pools": true
+    }
+  ],
   "node": {
     "rts_flags_override": [],
     "heap_limit": null,

--- a/bench/cardano-profile/data/test/ci-test-bage.json
+++ b/bench/cardano-profile/data/test/ci-test-bage.json
@@ -86,20 +86,6 @@
   },
   "desc": "Miniature dataset, CI-friendly duration (2-3min), test scale",
   "era": "babbage",
-  "generator": {
-    "add_tx_size": 100,
-    "epochs": 2,
-    "init_cooldown": 5,
-    "inputs_per_tx": 2,
-    "outputs_per_tx": 2,
-    "plutus": {
-      "script": null,
-      "type": null
-    },
-    "tps": 15,
-    "tx_count": 9000,
-    "tx_fee": 1000000
-  },
   "genesis": {
     "active_slots_coeff": 0.05,
     "alonzo": {
@@ -368,5 +354,27 @@
     "withresources": false,
     "timeseries": false
   },
-  "workloads": []
+  "workloads": [
+    {
+      "name": "tx-generator",
+      "parameters": {
+        "add_tx_size": 100,
+        "epochs": 2,
+        "init_cooldown": 5,
+        "inputs_per_tx": 2,
+        "outputs_per_tx": 2,
+        "plutus": {
+          "script": null,
+          "type": null
+        },
+        "tps": 15,
+        "tx_count": 9000,
+        "tx_fee": 1000000
+      },
+      "entrypoint": "tx_generator",
+      "phase": "load",
+      "placement": "explorer",
+      "wait_pools": true
+    }
+  ]
 }

--- a/bench/cardano-profile/data/test/ci-test-coay/profile.json
+++ b/bench/cardano-profile/data/test/ci-test-coay/profile.json
@@ -263,21 +263,29 @@
     "pool_coin": 1000000000000000,
     "delegator_coin": 0
   },
-  "generator": {
-    "add_tx_size": 100,
-    "init_cooldown": 5,
-    "inputs_per_tx": 2,
-    "outputs_per_tx": 2,
-    "tx_fee": 1000000,
-    "epochs": 3,
-    "tps": 15,
-    "plutus": {
-      "type": null,
-      "script": null
-    },
-    "tx_count": 9000
-  },
-  "workloads": [],
+  "workloads": [
+    {
+      "name": "tx-generator",
+      "parameters": {
+        "add_tx_size": 100,
+        "init_cooldown": 5,
+        "inputs_per_tx": 2,
+        "outputs_per_tx": 2,
+        "tx_fee": 1000000,
+        "epochs": 3,
+        "tps": 15,
+        "plutus": {
+          "type": null,
+          "script": null
+        },
+        "tx_count": 9000
+      },
+      "entrypoint": "tx_generator",
+      "phase": "load",
+      "placement": "explorer",
+      "wait_pools": true
+    }
+  ],
   "node": {
     "rts_flags_override": [],
     "heap_limit": null,

--- a/bench/cardano-profile/data/test/ci-test-dense10-coay/profile.json
+++ b/bench/cardano-profile/data/test/ci-test-dense10-coay/profile.json
@@ -263,21 +263,29 @@
     "pool_coin": 1000000000000000,
     "delegator_coin": 0
   },
-  "generator": {
-    "add_tx_size": 100,
-    "init_cooldown": 5,
-    "inputs_per_tx": 2,
-    "outputs_per_tx": 2,
-    "tx_fee": 1000000,
-    "epochs": 3,
-    "tps": 15,
-    "plutus": {
-      "type": null,
-      "script": null
-    },
-    "tx_count": 9000
-  },
-  "workloads": [],
+  "workloads": [
+    {
+      "name": "tx-generator",
+      "parameters": {
+        "add_tx_size": 100,
+        "init_cooldown": 5,
+        "inputs_per_tx": 2,
+        "outputs_per_tx": 2,
+        "tx_fee": 1000000,
+        "epochs": 3,
+        "tps": 15,
+        "plutus": {
+          "type": null,
+          "script": null
+        },
+        "tx_count": 9000
+      },
+      "entrypoint": "tx_generator",
+      "phase": "load",
+      "placement": "explorer",
+      "wait_pools": true
+    }
+  ],
   "node": {
     "rts_flags_override": [],
     "heap_limit": null,
@@ -323,7 +331,7 @@
   "name": "ci-test-dense10-coay",
   "overlay": {},
   "derived": {
-    "supply_delegated": 1e+16,
+    "supply_delegated": 1E+16,
     "supply_total": 10010000000000000,
     "utxo_delegated": 0,
     "utxo_generated": 18000,

--- a/bench/cardano-profile/data/test/default-coay/profile.json
+++ b/bench/cardano-profile/data/test/default-coay/profile.json
@@ -263,21 +263,29 @@
     "pool_coin": 1000000000000000,
     "delegator_coin": 1000000000000000
   },
-  "generator": {
-    "add_tx_size": 100,
-    "init_cooldown": 5,
-    "inputs_per_tx": 2,
-    "outputs_per_tx": 2,
-    "tx_fee": 1000000,
-    "epochs": 3,
-    "tps": 12,
-    "plutus": {
-      "type": null,
-      "script": null
-    },
-    "tx_count": 21600
-  },
-  "workloads": [],
+  "workloads": [
+    {
+      "name": "tx-generator",
+      "parameters": {
+        "add_tx_size": 100,
+        "init_cooldown": 5,
+        "inputs_per_tx": 2,
+        "outputs_per_tx": 2,
+        "tx_fee": 1000000,
+        "epochs": 3,
+        "tps": 12,
+        "plutus": {
+          "type": null,
+          "script": null
+        },
+        "tx_count": 21600
+      },
+      "entrypoint": "tx_generator",
+      "phase": "load",
+      "placement": "explorer",
+      "wait_pools": true
+    }
+  ],
   "node": {
     "rts_flags_override": [],
     "heap_limit": null,

--- a/bench/cardano-profile/data/test/fast-nomadperf-coay/profile.json
+++ b/bench/cardano-profile/data/test/fast-nomadperf-coay/profile.json
@@ -458,21 +458,29 @@
     "pool_coin": 1000000000000000,
     "delegator_coin": 0
   },
-  "generator": {
-    "add_tx_size": 100,
-    "init_cooldown": 5,
-    "inputs_per_tx": 2,
-    "outputs_per_tx": 2,
-    "tx_fee": 1000000,
-    "epochs": 3,
-    "tps": 15,
-    "plutus": {
-      "type": null,
-      "script": null
-    },
-    "tx_count": 9000
-  },
-  "workloads": [],
+  "workloads": [
+    {
+      "name": "tx-generator",
+      "parameters": {
+        "add_tx_size": 100,
+        "init_cooldown": 5,
+        "inputs_per_tx": 2,
+        "outputs_per_tx": 2,
+        "tx_fee": 1000000,
+        "epochs": 3,
+        "tps": 15,
+        "plutus": {
+          "type": null,
+          "script": null
+        },
+        "tx_count": 9000
+      },
+      "entrypoint": "tx_generator",
+      "phase": "load",
+      "placement": "explorer",
+      "wait_pools": true
+    }
+  ],
   "node": {
     "rts_flags_override": [],
     "heap_limit": null,

--- a/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Builtin/Cloud.hs
+++ b/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Builtin/Cloud.hs
@@ -203,12 +203,12 @@ profilesCloud =
       loopVoting   = plutusVoting & plutusLoopBase . V.plutusTypeLoop . P.analysisSizeSmall
   in [
   -- Voting
-    valueVoting & P.name "value-voting-utxo-volt-nomadperf"              . P.dreps  10000 . P.workloadAppend W.votingWorkloadUtxo
-  , valueVoting & P.name "value-voting-volt-nomadperf"                   . P.dreps  10000 . P.workloadAppend W.votingWorkloadx1
-  , valueVoting & P.name "value-voting-double-volt-nomadperf"            . P.dreps  10000 . P.workloadAppend W.votingWorkloadx2
-  , loopVoting  & P.name "plutus-voting-utxo-volt-nomadperf"             . P.dreps  10000 . P.workloadAppend W.votingWorkloadUtxo
-  , loopVoting  & P.name "plutus-voting-volt-nomadperf"                  . P.dreps  10000 . P.workloadAppend W.votingWorkloadx1
-  , loopVoting  & P.name "plutus-voting-double-volt-nomadperf"           . P.dreps  10000 . P.workloadAppend W.votingWorkloadx2
+    valueVoting & P.name "value-voting-utxo-volt-nomadperf"              . P.dreps  10000 . P.workloadsAppend W.votingWorkloadUtxo
+  , valueVoting & P.name "value-voting-volt-nomadperf"                   . P.dreps  10000 . P.workloadsAppend W.votingWorkloadx1
+  , valueVoting & P.name "value-voting-double-volt-nomadperf"            . P.dreps  10000 . P.workloadsAppend W.votingWorkloadx2
+  , loopVoting  & P.name "plutus-voting-utxo-volt-nomadperf"             . P.dreps  10000 . P.workloadsAppend W.votingWorkloadUtxo
+  , loopVoting  & P.name "plutus-voting-volt-nomadperf"                  . P.dreps  10000 . P.workloadsAppend W.votingWorkloadx1
+  , loopVoting  & P.name "plutus-voting-double-volt-nomadperf"           . P.dreps  10000 . P.workloadsAppend W.votingWorkloadx2
   ]
   -----------
   -- Latency.

--- a/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Builtin/Cloud.hs
+++ b/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Builtin/Cloud.hs
@@ -21,7 +21,7 @@ import           Data.Function ((&))
 -- Package: self.
 import qualified Cardano.Benchmarking.Profile.Builtin.Empty as E
 import qualified Cardano.Benchmarking.Profile.Builtin.Scenario.Base as B
-import qualified Cardano.Benchmarking.Profile.Playground as Pl (calibrateLoopBlockMemx15, calibrateLoopBlockMemx2)
+import qualified Cardano.Benchmarking.Profile.Playground as Pl (calibrateLoopBlockMemx15, calibrateLoopBlockMemx15TxFee, calibrateLoopBlockMemx2, calibrateLoopBlockMemx2TxFee)
 import qualified Cardano.Benchmarking.Profile.Primitives as P
 import qualified Cardano.Benchmarking.Profile.Types as Types
 import qualified Cardano.Benchmarking.Profile.Vocabulary as V
@@ -141,8 +141,10 @@ profilesCloud =
       blst     = plutusVolt & plutusBlstBase   . V.plutusTypeBLST     . P.analysisSizeModerate2
       ripemd   = plutusVolt & plutusRipemdBase . V.plutusTypeRIPEMD   . P.analysisSizeSmall
       -- PParams overlays and calibration for 4 tx per block memory full.
-      blockMem15x = P.budgetBlockMemoryOneAndAHalf . P.overlay Pl.calibrateLoopBlockMemx15
-      blockMem2x  = P.budgetBlockMemoryDouble      . P.overlay Pl.calibrateLoopBlockMemx2
+      blockMem15x =   P.budgetBlockMemoryOneAndAHalf . P.overlay Pl.calibrateLoopBlockMemx15
+                    . P.txFeeOverwrite Pl.calibrateLoopBlockMemx15TxFee
+      blockMem2x  =   P.budgetBlockMemoryDouble      . P.overlay Pl.calibrateLoopBlockMemx2
+                    . P.txFeeOverwrite Pl.calibrateLoopBlockMemx2TxFee
       -- LSMT helper. Node config add the "hostvolume"s as a cluster constraint.
       ephemeral =
                 -- The name of the defined volume in the Nomad Client config and

--- a/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Builtin/Plutuscall.hs
+++ b/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Builtin/Plutuscall.hs
@@ -13,7 +13,7 @@ module Cardano.Benchmarking.Profile.Builtin.Plutuscall (
 import           Prelude
 import           Data.Function ((&))
 -- Package: self.
-import qualified Cardano.Benchmarking.Profile.Playground as Pl (calibrateLoopBlockMemx2)
+import qualified Cardano.Benchmarking.Profile.Playground as Pl (calibrateLoopBlockMemx2, calibrateLoopBlockMemx2TxFee)
 import qualified Cardano.Benchmarking.Profile.Primitives as P
 import qualified Cardano.Benchmarking.Profile.Types as Types
 import qualified Cardano.Benchmarking.Profile.Vocabulary as V
@@ -55,7 +55,7 @@ profilesPlutuscall =
       postPlomin      = V.genesisVariantVoltaire
   in [
     loop        & P.name "plutuscall-loop"                 . postPlomin
-  , loop        & P.name "plutuscall-loop-memx2"           . postPlomin . P.budgetBlockMemoryDouble . P.overlay Pl.calibrateLoopBlockMemx2
+  , loop        & P.name "plutuscall-loop-memx2"           . postPlomin . P.budgetBlockMemoryDouble . P.overlay Pl.calibrateLoopBlockMemx2 . P.txFeeOverwrite Pl.calibrateLoopBlockMemx2TxFee
   , ecdsa       & P.name "plutuscall-secp-ecdsa"           . postPlomin
   , ecdsa       & P.name "plutuscall-secp-ecdsa-stepx2"    . postPlomin . P.budgetBlockStepsDouble
   , schnorr     & P.name "plutuscall-secp-schnorr"         . postPlomin

--- a/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Playground.hs
+++ b/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Playground.hs
@@ -107,6 +107,6 @@ profilesPlayground =
   -- Voting profiles.
   , voting & P.name "development-voting"
            . P.dreps 1000
-           . P.workloadAppend W.votingWorkloadx2
+           . P.workloadsAppend W.votingWorkloadx2
            . P.traceForwardingOn
   ]

--- a/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Playground.hs
+++ b/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Playground.hs
@@ -5,7 +5,9 @@
 
 module Cardano.Benchmarking.Profile.Playground (
     calibrateLoopBlockMemx15
+  , calibrateLoopBlockMemx15TxFee
   , calibrateLoopBlockMemx2
+  , calibrateLoopBlockMemx2TxFee
   , profilesPlayground
 ) where
 
@@ -39,11 +41,14 @@ calibrateLoopBlockMemx15 =
         ])
       ])
     ])
-  , ("generator", Aeson.Object $ KeyMap.fromList [
-      -- "ns":"Mempool.RejectedTx","data":{"err":{"fee":1000000,"kind":"FeeTooSmallUTxO","minimum":1892175}
-      ("tx_fee", Aeson.Number 1892175)
-    ])
   ]
+
+-- The `tx_fee` that goes with `calibrateLoopBlockMemx15`, applied with
+-- `txFeeOverwrite` because the generator is not part of the profile's JSON
+-- encoding that the overlay above is merged with.
+-- "ns":"Mempool.RejectedTx","data":{"err":{"fee":1000000,"kind":"FeeTooSmallUTxO","minimum":1892175}
+calibrateLoopBlockMemx15TxFee :: Integer
+calibrateLoopBlockMemx15TxFee = 1892175
 
 -- Corrections to fill the block memory budget with 4 txs per block.
 calibrateLoopBlockMemx2 :: Aeson.Object
@@ -59,11 +64,14 @@ calibrateLoopBlockMemx2 =
         ])
       ])
     ])
-  , ("generator", Aeson.Object $ KeyMap.fromList [
-      -- "ns":"Mempool.RejectedTx","data":{"err":{"fee":1000000,"kind":"FeeTooSmallUTxO","minimum":2463246}
-      ("tx_fee", Aeson.Number 2463246)
-    ])
   ]
+
+-- The `tx_fee` that goes with `calibrateLoopBlockMemx2`, applied with
+-- `txFeeOverwrite` because the generator is not part of the profile's JSON
+-- encoding that the overlay above is merged with.
+-- "ns":"Mempool.RejectedTx","data":{"err":{"fee":1000000,"kind":"FeeTooSmallUTxO","minimum":2463246}
+calibrateLoopBlockMemx2TxFee :: Integer
+calibrateLoopBlockMemx2TxFee = 2463246
 
 compressedFor3Epochs :: Types.Profile -> Types.Profile
 compressedFor3Epochs =
@@ -101,9 +109,9 @@ profilesPlayground =
   -- Budget profiles.
     ciBenchLike & P.name "calibrate-volt"
   , ciBenchLike & P.name "calibrate-blockmem-x1.5-volt"      . mem15x
-  , ciBenchLike & P.name "calibrate-blockmem-x1.5-volt-fill" . mem15x . P.overlay calibrateLoopBlockMemx15
+  , ciBenchLike & P.name "calibrate-blockmem-x1.5-volt-fill" . mem15x . P.overlay calibrateLoopBlockMemx15 . P.txFeeOverwrite calibrateLoopBlockMemx15TxFee
   , ciBenchLike & P.name "calibrate-blockmem-x2-volt"        . mem2x
-  , ciBenchLike & P.name "calibrate-blockmem-x2-volt-fill"   . mem2x  . P.overlay calibrateLoopBlockMemx2
+  , ciBenchLike & P.name "calibrate-blockmem-x2-volt-fill"   . mem2x  . P.overlay calibrateLoopBlockMemx2  . P.txFeeOverwrite calibrateLoopBlockMemx2TxFee
   -- Voting profiles.
   , voting & P.name "development-voting"
            . P.dreps 1000

--- a/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Primitives.hs
+++ b/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Primitives.hs
@@ -116,6 +116,7 @@ import           Data.Maybe (isJust)
 import           GHC.Stack (HasCallStack)
 -- Package: aeson.
 import qualified Data.Aeson           as Aeson
+import qualified Data.Aeson.KeyMap    as KeyMap
 -- Package: scientific.
 import qualified Data.Scientific as Scientific
 -- Package: time.
@@ -929,7 +930,13 @@ preset str p =
   else p {Types.preset = Just str}
 
 overlay :: HasCallStack => Aeson.Object -> Types.Profile -> Types.Profile
-overlay obj p =
-  if Types.overlay p /= mempty
-  then error "overlay: `overlay` already set (not an empty JSON object)."
-  else p {Types.overlay = obj}
+overlay obj p
+  -- The overlay is merged with the profile's JSON encoding, where the
+  -- generator is a "tx-generator" entry of the "workloads" array and not a
+  -- top-level property anymore. A "generator" key here would be silently
+  -- dropped when decoding the merged JSON back into a `Profile`.
+  | KeyMap.member "generator" obj =
+      error "overlay: the generator is not a top-level JSON property anymore (it's a \"tx-generator\" workload), use the generator primitives (`txFeeOverwrite`, ...) instead."
+  | Types.overlay p /= mempty =
+      error "overlay: `overlay` already set (not an empty JSON object)."
+  | otherwise = p {Types.overlay = obj}

--- a/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Primitives.hs
+++ b/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Primitives.hs
@@ -90,6 +90,7 @@ module Cardano.Benchmarking.Profile.Primitives (
 
   -- Workload params.
   , workloadAppend
+  , workloadsAppend
 
   -- Tracer's params.
   , tracerWithresources, tracerTimeseries
@@ -762,7 +763,10 @@ generatorEpochs i = generator
 --------------------------------------------------------------------------------
 
 workloadAppend :: Types.Workload -> Types.Profile -> Types.Profile
-workloadAppend w p = p {Types.workloads = Types.workloads p ++ [w]}
+workloadAppend w = workloadsAppend [w]
+
+workloadsAppend :: [Types.Workload] -> Types.Profile -> Types.Profile
+workloadsAppend ws p = p {Types.workloads = Types.workloads p ++ ws}
 
 -- Tracer.
 --------------------------------------------------------------------------------

--- a/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Types.hs
+++ b/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Types.hs
@@ -25,7 +25,9 @@ module Cardano.Benchmarking.Profile.Types (
 , Plutus (..), Redeemer (..)
 
 , Workload (..)
-, Entrypoints (..)
+, WorkloadPhase (..)
+, WorkloadPlacement (..)
+, generatorWorkload
 
 , Tracer (..)
 
@@ -49,6 +51,7 @@ module Cardano.Benchmarking.Profile.Types (
 --------------------------------------------------------------------------------
 
 import           Prelude
+import           Data.List (partition)
 import           Data.Maybe (isJust)
 import           GHC.Generics
 -- Package: aeson.
@@ -101,16 +104,40 @@ data Profile = Profile
   }
   deriving (Eq, Show, Generic)
 
+-- The generator has no dedicated top-level JSON property: it's exposed as a
+-- "tx-generator" entry of the "workloads" list, like any other workload. The
+-- typed `Generator` record is kept internally (derived properties need it),
+-- so the translation happens here, at the JSON boundary.
 instance Aeson.ToJSON Profile where
-  toJSON = Aeson.genericToJSON
-    -- TODO: Remove after removing `jq` profiles.
-    -- To compare JSONs without "desc", "chaindb" and "preset" properties.
-    (Aeson.defaultOptions {Aeson.omitNothingFields = True})
+  toJSON p =
+    case Aeson.genericToJSON
+           -- TODO: Remove after removing `jq` profiles.
+           -- To compare JSONs without "desc", "chaindb" and "preset" properties.
+           (Aeson.defaultOptions {Aeson.omitNothingFields = True})
+           p
+    of
+      (Aeson.Object obj) -> Aeson.Object $
+        KM.insert
+          "workloads"
+          (Aeson.toJSON $ generatorWorkload (generator p) : workloads p)
+          (KM.delete "generator" obj)
+      _ -> error "ToJSON Profile: not encoded as an Aeson.Object"
 
 instance Aeson.FromJSON Profile where
-  parseJSON = Aeson.genericParseJSON
-    -- TODO: Change to `True` after removing `jq` profiles.
-    (Aeson.defaultOptions {Aeson.rejectUnknownFields = False})
+  parseJSON = Aeson.withObject "Profile" $ \obj -> do
+    wls <- obj Aeson..:? "workloads" Aeson..!= ([] :: [Workload])
+    (gen, wls') <- case partition ((== "tx-generator") . workloadName) wls of
+      ([g], rest) -> return (parameters g, rest)
+      ([] , _   ) -> fail "Profile: no \"tx-generator\" workload"
+      _           -> fail "Profile: multiple \"tx-generator\" workloads"
+    Aeson.genericParseJSON
+      -- TODO: Change to `True` after removing `jq` profiles.
+      (Aeson.defaultOptions {Aeson.rejectUnknownFields = False})
+      (Aeson.Object $
+        KM.insert "generator" (Aeson.Object gen) $
+        KM.insert "workloads" (Aeson.toJSON wls')
+          obj
+      )
 
 profileProtocolVersion :: Profile -> Maybe (Int, Int)
 profileProtocolVersion Profile{genesis = Genesis{shelley = shey}} = do
@@ -500,26 +527,47 @@ instance Aeson.FromJSON Redeemer where
 data Workload = Workload
   { workloadName :: String
   , parameters :: Aeson.Object
-  , entrypoints :: Entrypoints
-  , before_nodes :: Bool
+  -- Name of the workload script's function to call, without arguments, after
+  -- the workload script is sourced (the script is built from the Nix template
+  -- of the same name in "nix/workbench/workload/").
+  , entrypoint :: String
+  , phase :: WorkloadPhase
+  , placement :: WorkloadPlacement
+  -- True if the workload does not bound the run: the scenario waits for the
+  -- pools to finish instead of waiting for this workload's exit.
   , wait_pools :: Bool
   }
   deriving (Eq, Show, Generic)
 
-data Entrypoints = Entrypoints
-  { pre_generator :: Maybe String
-  , producers :: String
-  }
+-- | When the workload runs relative to the nodes and the load window.
+data WorkloadPhase
+  -- Started before the nodes are up.
+  = BeforeNodes
+  -- Runs to completion after the nodes are up and before the load starts.
+  | Setup
+  -- Started after the nodes are up and the setup workloads have finished.
+  | Load
+  deriving (Eq, Show, Generic)
+
+-- | On which machines of the cluster the workload runs (only meaningful for
+-- distributed backends like Nomad, local backends run every workload once).
+data WorkloadPlacement
+  -- One instance next to each producer node.
+  = Producers
+  -- One instance next to the "explorer" node ("node-0" if there is none),
+  -- the machine the tx-generator runs on.
+  | Explorer
   deriving (Eq, Show, Generic)
 
 instance Aeson.ToJSON Workload where
   toJSON p =
     Aeson.object
-      [ "name"         Aeson..= workloadName p
-      , "parameters"   Aeson..= parameters   p
-      , "entrypoints"  Aeson..= entrypoints  p
-      , "before_nodes" Aeson..= before_nodes p
-      , "wait_pools"   Aeson..= wait_pools   p
+      [ "name"       Aeson..= workloadName p
+      , "parameters" Aeson..= parameters   p
+      , "entrypoint" Aeson..= entrypoint   p
+      , "phase"      Aeson..= phase        p
+      , "placement"  Aeson..= placement    p
+      , "wait_pools" Aeson..= wait_pools   p
       ]
 
 instance Aeson.FromJSON Workload where
@@ -528,15 +576,45 @@ instance Aeson.FromJSON Workload where
       Workload
         <$> o Aeson..: "name"
         <*> o Aeson..: "parameters"
-        <*> o Aeson..: "entrypoints"
-        <*> o Aeson..: "before_nodes"
+        <*> o Aeson..: "entrypoint"
+        <*> o Aeson..: "phase"
+        <*> o Aeson..: "placement"
         <*> o Aeson..: "wait_pools"
 
-instance Aeson.ToJSON Entrypoints
+instance Aeson.ToJSON WorkloadPhase where
+  toJSON BeforeNodes = Aeson.toJSON ("before-nodes" :: Text.Text)
+  toJSON Setup       = Aeson.toJSON ("setup"        :: Text.Text)
+  toJSON Load        = Aeson.toJSON ("load"         :: Text.Text)
 
-instance Aeson.FromJSON Entrypoints where
-  parseJSON = Aeson.genericParseJSON
-    (Aeson.defaultOptions {Aeson.rejectUnknownFields = True})
+instance Aeson.FromJSON WorkloadPhase where
+  parseJSON = Aeson.withText "WorkloadPhase" $ \t -> case t of
+    "before-nodes" -> return BeforeNodes
+    "setup"        -> return Setup
+    "load"         -> return Load
+    _ -> fail $ "Unknown WorkloadPhase: \"" ++ Text.unpack t ++ "\""
+
+instance Aeson.ToJSON WorkloadPlacement where
+  toJSON Producers = Aeson.toJSON ("producers" :: Text.Text)
+  toJSON Explorer  = Aeson.toJSON ("explorer"  :: Text.Text)
+
+instance Aeson.FromJSON WorkloadPlacement where
+  parseJSON = Aeson.withText "WorkloadPlacement" $ \t -> case t of
+    "producers" -> return Producers
+    "explorer"  -> return Explorer
+    _ -> fail $ "Unknown WorkloadPlacement: \"" ++ Text.unpack t ++ "\""
+
+-- | The tx-generator as a "workloads" list entry.
+generatorWorkload :: Generator -> Workload
+generatorWorkload gen = Workload
+  { workloadName = "tx-generator"
+  , parameters = case Aeson.toJSON gen of
+      (Aeson.Object obj) -> obj
+      _ -> error "generatorWorkload: Generator not encoded as an Aeson.Object"
+  , entrypoint = "tx_generator"
+  , phase = Load
+  , placement = Explorer
+  , wait_pools = True
+  }
 
 --------------------------------------------------------------------------------
 

--- a/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Workload/CGroupMemory.hs
+++ b/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Workload/CGroupMemory.hs
@@ -19,10 +19,8 @@ cgroupMemoryWorkload :: Types.Workload
 cgroupMemoryWorkload = Types.Workload {
     Types.workloadName = "cgroup_memory"
   , Types.parameters = mempty
-  , Types.entrypoints = Types.Entrypoints {
-      Types.pre_generator = Nothing
-    , Types.producers = "cgroup_memory"
-    }
-  , Types.before_nodes = True
+  , Types.entrypoint = "cgroup_memory"
+  , Types.phase = Types.BeforeNodes
+  , Types.placement = Types.Producers
   , Types.wait_pools = True
 }

--- a/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Workload/Latency.hs
+++ b/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Workload/Latency.hs
@@ -19,10 +19,8 @@ latencyWorkload :: Types.Workload
 latencyWorkload = Types.Workload {
     Types.workloadName = "latency"
   , Types.parameters = mempty
-  , Types.entrypoints = Types.Entrypoints {
-      Types.pre_generator = Nothing
-    , Types.producers = "latency"
-    }
-  , Types.before_nodes = False
+  , Types.entrypoint = "latency"
+  , Types.phase = Types.Load
+  , Types.placement = Types.Producers
   , Types.wait_pools = False
 }

--- a/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Workload/Voting.hs
+++ b/bench/cardano-profile/src/Cardano/Benchmarking/Profile/Workload/Voting.hs
@@ -18,26 +18,37 @@ import qualified Cardano.Benchmarking.Profile.Types as Types
 
 --------------------------------------------------------------------------------
 
-votingWorkload :: KeyMap.KeyMap Aeson.Value -> Types.Workload
-votingWorkload parameters = Types.Workload {
-    Types.workloadName = "voting"
-  , Types.parameters = parameters
-  , Types.entrypoints = Types.Entrypoints {
-      Types.pre_generator = Just "workflow_generator"
-    , Types.producers = "workflow_producer"
+-- Two workloads: proposal creation / fund splitting must complete before the
+-- load window opens (phase "setup"), vote submission runs alongside the
+-- tx-generator (phase "load").
+votingWorkload :: KeyMap.KeyMap Aeson.Value -> [Types.Workload]
+votingWorkload parameters = [
+    Types.Workload {
+      Types.workloadName = "voting-setup"
+    , Types.parameters = parameters
+    , Types.entrypoint = "workflow_setup"
+    , Types.phase = Types.Setup
+    , Types.placement = Types.Explorer
+    , Types.wait_pools = True
     }
-  , Types.before_nodes = False
-  , Types.wait_pools = True
-}
+  , Types.Workload {
+      Types.workloadName = "voting"
+    , Types.parameters = parameters
+    , Types.entrypoint = "workflow_producer"
+    , Types.phase = Types.Load
+    , Types.placement = Types.Producers
+    , Types.wait_pools = True
+    }
+  ]
 
-votingWorkloadUtxo :: Types.Workload
+votingWorkloadUtxo :: [Types.Workload]
 votingWorkloadUtxo = votingWorkload $
   KeyMap.fromList [
     ("outs_per_split_transaction", Aeson.Number 193)
   , ("submit_vote", Aeson.Bool False)
   ]
 
-votingWorkloadx1 :: Types.Workload
+votingWorkloadx1 :: [Types.Workload]
 votingWorkloadx1 = votingWorkload $
   KeyMap.fromList [
     ("outs_per_split_transaction", Aeson.Number 193)
@@ -45,7 +56,7 @@ votingWorkloadx1 = votingWorkload $
   , ("votes_per_tx", Aeson.Number 1)
   ]
 
-votingWorkloadx2 :: Types.Workload
+votingWorkloadx2 :: [Types.Workload]
 votingWorkloadx2 = votingWorkload $
   KeyMap.fromList [
     ("outs_per_split_transaction", Aeson.Number 193)

--- a/bench/cardano-profile/utils/diff.sh
+++ b/bench/cardano-profile/utils/diff.sh
@@ -29,8 +29,7 @@ do
            "$1/${profile_name}/profile/${filename}" \
            "$2/${profile_name}/profile/${filename}" \
       || read -r
-    elif test "${filename}" = "generator-service.json"   \
-      || test "${filename}" = "healthcheck-service.json" \
+    elif test "${filename}" = "healthcheck-service.json" \
       || test "${filename}" = "tracer-service.json"
     then
       for key in $(jq -r 'keys | join (" ")' "$1/${profile_name}/profile/${filename}")

--- a/bench/locli/src/Cardano/Analysis/API/Context.hs
+++ b/bench/locli/src/Cardano/Analysis/API/Context.hs
@@ -226,7 +226,10 @@ instance FromJSON Metadata where
                          <|> compatParseManifest v
       profile          <- v .: "profile"
       profile_content  <- v .: "profile_content"
-      generator        <- profile_content .: "generator"
+      -- Only a top-level "profile_content" property on legacy runs, later
+      -- moved into the "workloads" list (only "era" is used as a fallback,
+      -- see `eraGenerator`, so no need to look into "workloads").
+      generator        <- profile_content .:? "generator" .!= mempty
 
       ident            <- (v .:? "ident")
                          <&> fromMaybe (unVersion . ciVersion $

--- a/bench/locli/src/Cardano/Analysis/API/Run.hs
+++ b/bench/locli/src/Cardano/Analysis/API/Run.hs
@@ -7,6 +7,7 @@ import Cardano.Prelude
 
 import Data.Aeson qualified as Aeson
 import Data.Aeson ((.=))
+import Data.Aeson.Types (parseFail)
 
 import Cardano.Util
 import Cardano.Analysis.API.ChainFilter
@@ -38,7 +39,21 @@ type Run        = ARunWith Genesis
 instance FromJSON RunPartial where
   parseJSON = withObject "Run" $ \v -> do
     metadata         <- v .: "meta"
-    generator        <- profile_content metadata .: "generator"
+    -- The generator's configuration: a "tx-generator" entry of the
+    -- "workloads" list, or a top-level "generator" property on legacy runs.
+    mbGenerator      <- profile_content metadata .:? "generator"
+    generator        <- case mbGenerator of
+      Just gen -> pure gen
+      Nothing  -> do
+        workloads <- profile_content metadata .: "workloads"
+        let findGenerator [] =
+              parseFail "Neither a \"generator\" property nor a \"tx-generator\" workload in \"profile_content\""
+            findGenerator (w:ws) = do
+              name <- w .: "name"
+              if name == ("tx-generator" :: Text)
+              then w .: "parameters"
+              else findGenerator ws
+        findGenerator workloads
     --
     genesisSpec      <- profile_content metadata .: "genesis"
     generatorProfile <- parseJSON $ Aeson.Object generator

--- a/nix/workbench/backend/backend.sh
+++ b/nix/workbench/backend/backend.sh
@@ -19,13 +19,12 @@ usage_backend() {
     get-node-socket-path RUNDIR [NODE]
                      Given a run directory, print a given node's node socket path
                        for 'cardano-cli'
-    start-generator RUNDIR
-                     Start generator
-
     wait-pools-stopped RUNDIR
                      Wait until all pools are stopped
+    wait-workload-stopped RUNDIR WORKLOAD-NAME
+                     Wait until the workload is stopped, fail if it failed
     wait-workloads-stopped RUNDIR
-                     Wait until all workloads are stopped
+                     Wait until all run-bounding workloads are stopped
     stop-cluster RUNDIR
     cleanup-cluster RUNDIR
                      Wipe cluster state to pristine
@@ -51,7 +50,6 @@ case "${op}" in
     # Sceneario functions
     start-tracers )              backend_$WB_BACKEND_NAME "$@";;
     start-nodes )                backend_$WB_BACKEND_NAME "$@";;
-    start-generator )            backend_$WB_BACKEND_NAME "$@";;
     start-workload-by-name )     backend_$WB_BACKEND_NAME "$@";;
     start-healthchecks )         backend_$WB_BACKEND_NAME "$@";;
     # Fine grained
@@ -61,6 +59,7 @@ case "${op}" in
     wait-node-stopped )          backend_$WB_BACKEND_NAME "$@";;
     get-node-socket-path )       backend_$WB_BACKEND_NAME "$@";;
     wait-pools-stopped )         backend_$WB_BACKEND_NAME "$@";;
+    wait-workload-stopped )      backend_$WB_BACKEND_NAME "$@";;
     wait-workloads-stopped )     backend_$WB_BACKEND_NAME "$@";;
     # Stop functions
     stop-all )                   backend_$WB_BACKEND_NAME "$@";;

--- a/nix/workbench/backend/nomad-job.nix
+++ b/nix/workbench/backend/nomad-job.nix
@@ -747,8 +747,6 @@ let
                       then {}
                       else {"${nodeSpec.name}"=nodeSpec;}
                     ;
-                    # Only for the node that will run the generator
-                    withGenerator = taskName == generatorTaskName;
                     # Only if "tracer" was requested.
                     # And, if tracer task or also nodes if oneTracerPerNode.
                     withTracer =
@@ -874,25 +872,27 @@ let
             }
           ])
           ++
-          # Generator
-          (lib.optionals (taskName == generatorTaskName) (
+          # workloads
+          (lib.lists.concatMap (workload:
             [
-              ## Generator start.sh script.
+              ## workload start.sh script.
               {
                 env = false;
-                destination = "local/${stateDir}/generator/start.sh";
-                data = escapeTemplate
-                  profileBundle.generator-service.start;
+                destination = "local/${stateDir}/workloads/${workload.name}/start.sh";
+                data = escapeTemplate workload.start;
                 change_mode = "noop";
                 error_on_missing_key = true;
                 perms = "744"; # Only for every "start.sh" script. Default: "644"
               }
-              ## Generator configuration file.
+            ]
+            ++
+            ## Workload configuration file (the tx-generator's "run-script.json").
+            lib.optionals ((workload.config or null) != null) [
               {
                 env = false;
-                destination = "local/${stateDir}/generator/run-script.json";
+                destination = "local/${stateDir}/workloads/${workload.name}/run-script.json";
                 data = escapeTemplate (
-                  let runScript = profileBundle.generator-service.config;
+                  let runScript = workload.config;
                   in
                      # Recreate the "run-script.json" with IPs and ports that are
                      # nomad template variables.
@@ -914,42 +914,29 @@ let
               }
             ]
             ++
-            ## Generator Plutus redeemer.
-            lib.optionals ((profileBundle.generator-service.plutus-redeemer or null) != null) [
+            ## Workload Plutus redeemer.
+            lib.optionals ((workload.plutus-redeemer or null) != null) [
               {
                 env = false;
-                destination = "local/${stateDir}/generator/plutus-redeemer.json";
+                destination = "local/${stateDir}/workloads/${workload.name}/plutus-redeemer.json";
                 data = escapeTemplate (lib.generators.toJSON {}
-                  profileBundle.generator-service.plutus-redeemer);
+                  workload.plutus-redeemer);
                 change_mode = "noop";
                 error_on_missing_key = true;
               }
             ]
             ++
-            ## Generator Plutus datum.
-            lib.optionals ((profileBundle.generator-service.plutus-datum or null) != null) [
+            ## Workload Plutus datum.
+            lib.optionals ((workload.plutus-datum or null) != null) [
               {
                 env = false;
-                destination = "local/${stateDir}/generator/plutus-datum.json";
+                destination = "local/${stateDir}/workloads/${workload.name}/plutus-datum.json";
                 data = escapeTemplate (lib.generators.toJSON {}
-                  profileBundle.generator-service.plutus-datum);
+                  workload.plutus-datum);
                 change_mode = "noop";
                 error_on_missing_key = true;
               }
             ]
-          ))
-          ++
-          # workloads
-          (builtins.map (workload:
-            ## workload start.sh script.
-            {
-              env = false;
-              destination = "local/${stateDir}/workloads/${workload.name}/start.sh";
-              data = escapeTemplate workload.start;
-              change_mode = "noop";
-              error_on_missing_key = true;
-              perms = "744"; # Only for every "start.sh" script. Default: "644"
-            }
           ) profileBundle.workloads-service)
           ++
           # healthcheck

--- a/nix/workbench/backend/nomad.sh
+++ b/nix/workbench/backend/nomad.sh
@@ -33,7 +33,6 @@ backend_nomad() {
     # - allocate-run-directory-supervisor      RUN-DIR              (Nomad only)
     # - allocate-run-directory-tracers         RUN-DIR              (Nomad only)
     # - allocate-run-directory-nodes           RUN-DIR              (Nomad only)
-    # - allocate-run-directory-generator       RUN-DIR              (Nomad only)
     # - allocate-run-directory-workloads       RUN-DIR              (Nomad only)
     # - allocate-run-directory-healthchecks    RUN-DIR              (Nomad only)
     # - allocate-run-nomad-job-patch-name      RUN-DIR NAME         (Nomad only)
@@ -50,9 +49,9 @@ backend_nomad() {
     ;;
 
     # After `allocate-run` the Nomad job is running (supervisord) waiting for
-    # genesis to be deployed and tracer/cardano-nodes/generator to be started.
+    # genesis to be deployed and tracer/cardano-nodes/workloads to be started.
     #
-    # "generator", "tracer", "node", "workloads" and "healthcheck" folder
+    # "tracer", "node", "workloads" and "healthcheck" folder
     # contents (start.sh, config files, etc) are included in the Nomad Job spec
     # file as "template" stanzas and are materialized inside the container when
     # the job is started. This is how it works for every environment combination
@@ -82,7 +81,6 @@ backend_nomad() {
       backend_nomad allocate-run-directory-supervisor   "${dir}"
       backend_nomad allocate-run-directory-tracers      "${dir}"
       backend_nomad allocate-run-directory-nodes        "${dir}"
-      backend_nomad allocate-run-directory-generator    "${dir}"
       backend_nomad allocate-run-directory-workloads    "${dir}"
       backend_nomad allocate-run-directory-healthchecks "${dir}"
 
@@ -178,16 +176,6 @@ backend_nomad() {
       done
     ;;
 
-    allocate-run-directory-generator )
-      local usage="USAGE: wb backend $op RUN-DIR"
-      local dir=${1:?$usage}; shift
-      # Not much to do!
-      # Generator actually runs inside Task/container "node-0" for local runs
-      # and "explorer" for cloud runs.
-      # See: `local generator_task=$(envjqr 'generator_task_name')`
-      mkdir -p "${dir}"/generator
-    ;;
-
     allocate-run-directory-workloads )
       local usage="USAGE: wb backend $op RUN-DIR"
       local dir=${1:?$usage}; shift
@@ -197,8 +185,8 @@ backend_nomad() {
       for workload in $(jq_tolist '.workloads | map(.name)' "$dir"/profile.json)
       do
         mkdir "${dir}"/workloads/"${workload}"
-        # Workload may or may not run something in all producers.
-        local nodes=($(jq_tolist 'map(select(.isProducer) | .name)' "$dir"/node-specs.json))
+        # Workload may or may not run something in all its target nodes.
+        local nodes=($(backend_nomad workload-target-nodes "${dir}" "${workload}"))
         for node in ${nodes[*]}
         do
           # File "start.sh" that usually goes in here is copied from the
@@ -423,16 +411,12 @@ backend_nomad() {
         backend_nomad download-config-node        "${dir}" "${node}" &
         jobs_tasks+=("$!")
       done
-      # The `tx-generator` config files, running in one of the Tasks were
-      # `cardano-node` is deployed.
-      backend_nomad download-config-generator     "${dir}" &
-      jobs_tasks+=("$!")
       # For every workload
       for workload in $(jq_tolist '.workloads | map(.name)' "$dir"/profile.json)
       do
         # For every node (not including a possible tracer Task) ...
-        # Workload may or may not run something in all producers.
-        local nodes=($(jq_tolist 'map(select(.isProducer) | .name)' "$dir"/node-specs.json))
+        # Workload may or may not run something in all its target nodes.
+        local nodes=($(backend_nomad workload-target-nodes "${dir}" "${workload}"))
         for node in ${nodes[*]}
         do
           # Only used for debugging!
@@ -765,7 +749,6 @@ backend_nomad() {
     # - stop-all              RUN-DIR
     # - stop-all-healthchecks RUN-DIR                               (Nomad only)
     # - stop-all-workloads    RUN-DIR                               (Nomad only)
-    # - stop-all-generator    RUN-DIR                               (Nomad only)
     # - stop-all-nodes        RUN-DIR                               (Nomad only)
     # - stop-all-tracers      RUN-DIR                               (Nomad only)
     # - fetch-logs            RUN-DIR
@@ -775,10 +758,24 @@ backend_nomad() {
     ############################################################################
     # * Functions in the backend "interface" must use `fatal` when errors!
 
+    # Which nodes/tasks a workload runs next to, depending on its "placement".
+    workload-target-nodes )
+      local usage="USAGE: wb backend $op RUN-DIR WORKLOAD-NAME"
+      local dir=${1:?$usage}; shift
+      local workload=${1:?$usage}; shift
+      local placement=$(jq -r ".workloads | map(select(.name == \"${workload}\"))[0] | .placement" "${dir}"/profile.json)
+      if test "${placement}" = "explorer"
+      then
+        # The machine where the tx-generator runs ("explorer" or "node-0").
+        envjqr 'generator_task_name'
+      else
+        jq_tolist 'map(select(.isProducer) | .name)' "${dir}"/node-specs.json
+      fi
+    ;;
+
     stop-all )
       local usage="USAGE: wb backend $op RUN-DIR"
       local dir=${1:?$usage}; shift
-      local generator_task=$(envjqr 'generator_task_name')
 
       # Stop healthcheck(s).
       ######################
@@ -798,8 +795,8 @@ backend_nomad() {
       # For every workload
       for workload in $(jq_tolist '.workloads | map(.name)' "$dir"/profile.json)
       do
-        # Workload may or may not run something in all producers.
-        for node in $(jq_tolist 'map(select(.isProducer) | .name)' "$dir"/node-specs.json)
+        # Workload may or may not run something in all its target nodes.
+        for node in $(backend_nomad workload-target-nodes "${dir}" "${workload}")
         do
           backend_nomad stop-all-workloads "${dir}" "${workload}" "${node}" &
           jobs_workloads_array+=("$!")
@@ -809,9 +806,6 @@ backend_nomad() {
       then
         msg "$(red "Failed to stop workload(s)")"
       fi
-      # Stop generator.
-      #################
-      backend_nomad stop-all-generator "${dir}" "${generator_task}"
       # Stop node(s).
       ###############
       local jobs_nodes_array=()
@@ -924,45 +918,6 @@ backend_nomad() {
             fi
           else
             msg "$(yellow "WARNING: Program \"${workload}\" inside Task \"${task}\" was not running, should it?")"
-          fi
-        fi
-      fi
-    ;;
-
-    stop-all-generator )
-      local usage="USAGE: wb backend $op RUN-DIR"
-      local dir=${1:?$usage}; shift
-      local task=${1:?$usage}; shift
-      # Only if it was started
-      if test -f "${dir}"/generator/started && !(test -f "${dir}"/"${node}"/stopped || test -f "${dir}"/"${node}"/quit)
-      then
-        if backend_nomad is-task-program-running "${dir}" "${task}" generator
-        then
-          if ! backend_nomad task-program-stop "${dir}" "${task}" generator
-          then
-            # A race condition were we try to stop the generator just after it
-            # quits automatically can happen.
-            msg "$(yellow "WARNING: Program \"generator\" inside Task \"${task}\" failed to stop")"
-          else
-            touch "${dir}"/generator/stopped
-            msg "$(green "supervisord program \"generator\" inside Nomad Task \"${task}\" down!")"
-          fi
-        else
-          touch "${dir}"/generator/quit
-          if backend_nomad is-task-program-failed "${dir}" "${task}" generator
-          then
-            # If the node quits (due to `--shutdown_on_slot_synced X` or
-            # `--shutdown_on_block_synced X`) the generator quits with an error.
-            local generator_can_fail=$(jq ".\"${task}\".shutdown_on_slot_synced or .\"${task}\".shutdown_on_block_synced" "${dir}"/node-specs.json)
-            if test "${generator_can_fail}" = "false" || backend_nomad is-task-program-running "${dir}" "${task}" "${task}"
-            then
-              # Do not fail here, because nobody will be able to stop the cluster!
-              msg "$(red "FATAL: \"generator\" quit unexpectedly")"
-            else
-              msg "$(yellow "INFO: Program \"generator\" inside Task \"${task}\" failed, but expected when \"${task}\" automatically exits first")"
-            fi
-          else
-            msg "$(yellow "WARNING: Program \"generator\" inside Task \"${task}\" was not running, should it?")"
           fi
         fi
       fi
@@ -1127,8 +1082,8 @@ backend_nomad() {
         # Download retry "infinite" loop.
         local workloads_array
         # Fetch the nodes that don't have all the log files in its directory
-        # Workload may or may not run something in all producers.
-        workloads_array=($(jq_tolist 'map(select(.isProducer) | .name)' "$dir"/node-specs.json))
+        # Workload may or may not run something in all its target nodes.
+        workloads_array=($(backend_nomad workload-target-nodes "${dir}" "${workload}"))
         while test -n "${workloads_array:-}"
         do
           local workloads_jobs_array=()
@@ -1153,15 +1108,6 @@ backend_nomad() {
         done
       done
       msg "$(green "Finished downloading workload(s) logs")"
-      # Download generator logs. ###############################################
-      ##########################################################################
-      # Download retry "infinite" loop.
-      while ! backend_nomad download-logs-generator "${dir}" "${generator_task}"
-      do
-        msg "Retrying \"generator\" logs download"
-        read -p "Hit enter to continue ..."
-      done
-      msg "$(green "Finished downloading \"generator\" logs")"
       # Download node(s) logs. #################################################
       ##########################################################################
       # Download retry "infinite" loop.
@@ -1646,8 +1592,8 @@ backend_nomad() {
       local workload=${1:?$usage}; shift
 
       local jobs_array=()
-      # Workload may or may not run something in all producers.
-      local nodes=($(jq_tolist 'map(select(.isProducer) | .name)' "$dir"/node-specs.json))
+      # Workload may or may not run something in all its target nodes.
+      local nodes=($(backend_nomad workload-target-nodes "${dir}" "${workload}"))
       for node in ${nodes[*]}
       do
         backend_nomad start-workload "${dir}" "${workload}" "${node}" &
@@ -1709,7 +1655,6 @@ backend_nomad() {
     # Functions to start/stop individual cluster "programs":
     # - start-tracer       RUN-DIR           (Nomad backend specific subcommand)
     # - start-node         RUN-DIR NODE-NAME
-    # - start-generator    RUN-DIR
     # - start-workload     RUN-DIR WORKLOAD-NAME TASK-NAME (Nomad backend .....)
     # - start-healthcheck  RUN-DIR TASK-NAME (Nomad backend specific subcommand)
     # - wait-tracer        RUN-DIR TASK-NAME (Nomad backend specific subcommand)
@@ -1717,7 +1662,6 @@ backend_nomad() {
     # - stop-node          RUN-DIR NODE-NAME
     #
     # TODO: They are up here as "stop-cluster-*"
-    # - stop-generator     RUN-DIR TASK-NAME (Nomad backend specific subcommand)
     # - stop-workload      RUN-DIR WORKLOAD-NAME TASK-NAME (Nomad backend .....)
     # - stop-tracer        RUN-DIR TASK-NAME (Nomad backend specific subcommand)
     # - stop-healthcheck   RUN-DIR TASK-NAME (Nomad backend specific subcommand)
@@ -1909,73 +1853,6 @@ backend_nomad() {
           # Failed to start, mostly timeout before listening socket was found.
           fatal "Node \"${node}\" startup did not succeed"
         fi
-      fi
-    ;;
-
-    # Called by `scenario.sh` with the exit trap (`scenario_setup_exit_trap`) set!
-    start-generator )
-      local usage="USAGE: wb backend $op RUN-DIR"
-      local dir=${1:?$usage}; shift
-      local generator_task=$(envjqr 'generator_task_name')
-
-      while test $# -gt 0
-      do case "$1" in
-        --* ) msg "FATAL:  unknown flag '$1'"; usage_nomadbackend;;
-          * ) break;; esac; shift; done
-
-      if ! backend_nomad task-program-start "${dir}" "${generator_task}" generator
-      then
-        msg "$(red "FATAL: Program \"generator\" (inside \"${generator_task}\") startup failed")"
-        # TODO: Let the download fail when everything fails?
-        backend_nomad download-logs-entrypoint "${dir}" "${generator_task}" || true
-        backend_nomad download-logs-generator  "${dir}" "${generator_task}" || true
-        # Should show the output/log of `supervisord` (runs as "entrypoint").
-        msg "$(yellow "${dir}/nomad/${generator_task}/stdout:")"
-        cat                                                             \
-          <(echo "-------------------- log start --------------------") \
-          "${dir}"/nomad/"${generator_task}"/stdout                     \
-          <(echo "-------------------- log end   --------------------")
-        msg "$(yellow "${dir}/nomad/${generator_task}/stderr:")"
-        cat                                                             \
-          <(echo "-------------------- log start --------------------") \
-          "${dir}"/nomad/"${generator_task}"/stderr                     \
-          <(echo "-------------------- log end   --------------------")
-        # Depending on when the start command failed, logs may not be available!
-        if test -f "${dir}"/generator/stdout
-        then
-          msg "$(yellow "${dir}/generator/stdout:")"
-          cat                                                           \
-          <(echo "-------------------- log start --------------------") \
-          "$dir"/generator/stdout                                       \
-          <(echo "-------------------- log end   --------------------")
-        fi
-        # Depending on when the start command failed, logs may not be available!
-        if test -f "${dir}"/generator/stderr
-        then
-          msg "$(yellow "${dir}/generator/stderr:")"
-          cat                                                             \
-            <(echo "-------------------- log start --------------------") \
-            "${dir}"/generator/stderr                                     \
-            <(echo "-------------------- log end   --------------------")
-        fi
-        fatal "Failed to start program \"generator\""
-      else
-        # Link to "live" logs only available when running local.
-        local nomad_environment=$(envjqr 'nomad_environment')
-        if test "${nomad_environment}" != "cloud"
-        then
-          ln -s                                                                      \
-            ../nomad/alloc/"${generator_task}"/local/run/current/generator/stdout    \
-            "${dir}"/generator/stdout
-          ln -s                                                                      \
-            ../nomad/alloc/"${generator_task}"/local/run/current/generator/stderr    \
-            "${dir}"/generator/stderr
-          ln -s                                                                      \
-            ../nomad/alloc/"${generator_task}"/local/run/current/generator/exit_code \
-            "${dir}"/generator/exit_code
-        fi
-        # It was "intentionally started and should not automagically stop" flag!
-        touch "${dir}"/generator/started
       fi
     ;;
 
@@ -2276,20 +2153,20 @@ backend_nomad() {
               msg_ne "nomad: $(blue Waiting) until all pool nodes are stopped: 000000"
             fi
           fi
-          # Always check that a started generator has not FAILED!
+          # Always check that a started tx-generator workload has not FAILED!
           if \
-                test -f "${dir}"/generator/started                              \
-            &&                                                                  \
-              ! test -f "${dir}"/generator/quit                                 \
-            &&                                                                  \
-              ! backend_nomad is-task-program-running "${dir}" "${generator_task}" generator 5
+                test -f "${dir}"/workloads/tx-generator/"${generator_task}"/started \
+            &&                                                                      \
+              ! test -f "${dir}"/workloads/tx-generator/"${generator_task}"/quit    \
+            &&                                                                      \
+              ! backend_nomad is-task-program-running "${dir}" "${generator_task}" tx-generator 5
           then
-            if backend_nomad is-task-program-failed   "${dir}" "${generator_task}" generator 5
+            if backend_nomad is-task-program-failed   "${dir}" "${generator_task}" tx-generator 5
             then
               # If the node in "${generator_task}" quits generators fails with:
               # tx-generator: MuxError MuxBearerClosed "<socket: 12> closed when reading data, waiting on next header True"
               # Service binary 'tx-generator' returned status: 1
-              msg "$(yellow "WARNING: supervisord program \"generator\" (inside Nomad Task \"${generator_task}\") quit with an error exit code!")"
+              msg "$(yellow "WARNING: supervisord program \"tx-generator\" (inside Nomad Task \"${generator_task}\") quit with an error exit code!")"
               # Give the node where tx-generator runs some time to quit.
               msg "$(yellow " Waiting 60s to check the status of supervisord program \"${generator_task}\" (inside Nomad Task \"${generator_task}\")")"
               sleep 30
@@ -2299,7 +2176,7 @@ backend_nomad() {
                 # But check it wasn't a race condition of a stopping cluster!
                 if ! test -f "${dir}"/flag/cluster-stopping
                 then
-                  msg "$(red "ERROR: supervisord program \"generator\" (inside Nomad Task \"${generator_task}\") quit with an error exit code while supervisord program \"${generator_task}\" (inside Nomad Task \"${generator_task}\") is still running!")"
+                  msg "$(red "ERROR: supervisord program \"tx-generator\" (inside Nomad Task \"${generator_task}\") quit with an error exit code while supervisord program \"${generator_task}\" (inside Nomad Task \"${generator_task}\") is still running!")"
                   # The tx-generator can fail because something happened with
                   # the nodes (out of memory?), this gives the nodes more time
                   # to shutdown properly and/or show any possible cause of
@@ -2307,24 +2184,24 @@ backend_nomad() {
                   msg "$(yellow "WARNING: Waiting one minute so nodes are not killed immediately")"
                   sleep 60
                   touch "${dir}"/flag/cluster-stopping
-                  fatal "Generator quit unexpectedly!!!"
+                  fatal "tx-generator quit unexpectedly!!!"
                 fi
               else
                 # The whole cluster is about to finish!
-                touch "${dir}"/generator/quit
+                touch "${dir}"/workloads/tx-generator/"${generator_task}"/quit
                 # Show the warning and continue with the counter
                 echo -ne "\n"
-                msg "$(yellow "WARNING: supervisord program \"generator\" (inside Nomad Task \"${generator_task}\") quit with an error exit code but expected when supervisord program \"${generator_task}\" (inside Nomad Task \"${generator_task}\") is not running")"
+                msg "$(yellow "WARNING: supervisord program \"tx-generator\" (inside Nomad Task \"${generator_task}\") quit with an error exit code but expected when supervisord program \"${generator_task}\" (inside Nomad Task \"${generator_task}\") is not running")"
                 msg_ne "nomad: $(blue Waiting) until all pool nodes are stopped: 000000"
               fi
             else
-              touch "${dir}"/generator/quit
+              touch "${dir}"/workloads/tx-generator/"${generator_task}"/quit
               # Show the warning and continue with the counter
               echo -ne "\n"
-              msg "$(yellow "WARNING: supervisord program \"generator\" (inside Nomad Task \"${generator_task}\") quit with a non-error exit code")"
+              msg "$(yellow "WARNING: supervisord program \"tx-generator\" (inside Nomad Task \"${generator_task}\") quit with a non-error exit code")"
               msg_ne "nomad: $(blue Waiting) until all pool nodes are stopped: 000000"
             fi
-          fi # Finish generator checks.
+          fi # Finish tx-generator checks.
           local elapsed="$(($(date +%s) - start_time))"
           echo -ne "\b\b\b\b\b\b"
           printf "%6d" "${elapsed}"
@@ -2357,6 +2234,56 @@ backend_nomad() {
       fi
     ;;
 
+    wait-workload-stopped )
+      local usage="USAGE: wb backend $op SLEEP-SECONDS RUN-DIR WORKLOAD-NAME"
+      # This parameters is added by the nomad backend being used.
+      local sleep_seconds=${1:?$usage}; shift
+      local dir=${1:?$usage}; shift
+      local workload=${1:?$usage}; shift
+
+      local start_time=$(date +%s)
+      msg_ne "nomad: $(blue Waiting) until workload \"${workload}\" is stopped: 000000"
+      # Workload may or may not run something in all its target nodes.
+      local nodes=($(backend_nomad workload-target-nodes "${dir}" "${workload}"))
+      for node in ${nodes[*]}
+      do
+        while \
+            ! test -f "${dir}"/flag/cluster-stopping \
+          && \
+            backend_nomad is-task-program-running "${dir}" "${node}" "${workload}" 5 > /dev/null
+        do
+          local elapsed="$(($(date +%s) - start_time))"
+          echo -ne "\b\b\b\b\b\b"
+          printf "%6d" "${elapsed}"
+          # This time is different between local and cloud backends to avoid
+          # unnecesary Nomad specific traffic and at the same time be less
+          # sensitive to network failures.
+          sleep "${sleep_seconds}"
+        done # While
+      done >&2 # For
+      echo -ne "\b\b\b\b\b\b"
+
+      local elapsed=$(($(date +%s) - start_time))
+      if test -f "${dir}"/flag/cluster-stopping
+      then
+        echo -ne "\n"
+        msg "Termination requested                -- after $(yellow ${elapsed})s"
+      else
+        echo -ne "\n"
+        msg "Workload \"${workload}\" exited -- after $(yellow ${elapsed})s"
+        # Fail hard if the workload failed: the run must not continue with a
+        # half-done setup phase!
+        for node in ${nodes[*]}
+        do
+          if backend_nomad is-task-program-failed "${dir}" "${node}" "${workload}" 5
+          then
+            backend_nomad download-logs-workload "${dir}" "${workload}" "${node}" || true
+            fatal "Workload \"${workload}\" inside Task \"${node}\" failed"
+          fi
+        done
+      fi
+    ;;
+
     wait-workloads-stopped )
       local usage="USAGE: wb backend $op SLEEP-SECONDS RUN-DIR"
       # This parameters is added by the nomad backend being used.
@@ -2364,11 +2291,15 @@ backend_nomad() {
       local dir=${1:?$usage}; shift
 
       local start_time=$(date +%s)
-      msg_ne "nomad: $(blue Waiting) until all workloads are stopped: 000000"
-      for workload in $(jq_tolist '.workloads | map(.name)' "$dir"/profile.json)
+      msg_ne "nomad: $(blue Waiting) until all run-bounding workloads are stopped: 000000"
+      # Only the workloads that bound the run's duration are waited for
+      # (phase "load" and "wait_pools" false), the rest are stopped with the
+      # cluster ("wait_pools" true means the pools bound the run and "setup"
+      # workloads already ran to completion).
+      for workload in $(jq_tolist '.workloads | map(select(.phase == "load" and .wait_pools == false)) | map(.name)' "$dir"/profile.json)
       do
-        # Workload may or may not run something in all producers.
-        local nodes=($(jq_tolist 'map(select(.isProducer) | .name)' "${dir}"/node-specs.json))
+        # Workload may or may not run something in all its target nodes.
+        local nodes=($(backend_nomad workload-target-nodes "${dir}" "${workload}"))
         for node in ${nodes[*]}
         do
           while \
@@ -2414,10 +2345,11 @@ backend_nomad() {
       local dir=${1:?$usage}; shift
       local generator_task=$(envjqr 'generator_task_name')
       local array=()
-      # Generator
-      if ! test -f "${dir}"/generator/started
+      # The tx-generator workload
+      if jqtest '.workloads | any(.name == "tx-generator")' "${dir}"/profile.json \
+         && ! test -f "${dir}"/workloads/tx-generator/"${generator_task}"/started
       then
-        backend_nomad is-task-program-running "${dir}" "${generator_task}" generator || array+=("generator")
+        backend_nomad is-task-program-running "${dir}" "${generator_task}" tx-generator || array+=("tx-generator")
       fi
       # Nodes
       local nodes=($(jq_tolist keys "${dir}"/node-specs.json))
@@ -2520,32 +2452,6 @@ backend_nomad() {
         then
           rm "${dir}"/workloads/"${workload}"/"${task}"/download_failed
         fi
-        return 0
-      fi
-    ;;
-
-    # For debugging when something fails, downloads and prints details!
-    download-logs-generator )
-      local usage="USAGE: wb backend pass $op RUN-DIR TASK-NAME"
-      local dir=${1:?$usage}; shift
-      local task=${1:?$usage}; shift
-      local download_ok="true"
-      # Remove "live" symlinks before downloading the "originals"
-      local nomad_environment=$(envjqr 'nomad_environment')
-      if test "${nomad_environment}" != "cloud"
-      then
-        rm -f "${dir}"/generator/{stdout,stderr,exit_code}
-      fi
-      # Downloads "exit_code", "stdout", "stderr" and GHC files.
-      # Depending on when the start command failed, logs may not be available!
-      backend_nomad download-zstd-generator "${dir}" "${task}" \
-      || download_ok="false"
-      # Return
-      if test "${download_ok}" = "false"
-      then
-        msg "$(red "Failed to download \"generator\" run files from \"${task}\"")"
-        return 1
-      else
         return 0
       fi
     ;;
@@ -2732,20 +2638,6 @@ backend_nomad() {
           --no-same-owner --no-same-permissions
     ;;
 
-    download-zstd-generator )
-      local usage="USAGE: wb backend pass $op RUN-DIR TASK-NAME"
-      local dir=${1:?$usage}; shift
-      local task=${1:?$usage}; shift
-
-      msg "$(blue Fetching) $(yellow "\"generator\"") run files from Nomad $(yellow "Task \"${task}\"") ..."
-      # TODO: Add compression, either "--zstd" or "--xz"
-        backend_nomad task-exec-program-run-files-tar-zstd        \
-          "${dir}" "${task}" "generator"                          \
-      | tar --extract                                             \
-          --directory="${dir}"/generator/ --file=-                \
-          --no-same-owner --no-same-permissions
-    ;;
-
     download-zstd-node )
       local usage="USAGE: wb backend pass $op RUN-DIR NODE-NAME"
       local dir=${1:?$usage}; shift
@@ -2864,20 +2756,14 @@ backend_nomad() {
       backend_nomad task-file-contents "${dir}" "${node}"   \
         run/current/workloads/"${workload}"/start.sh        \
       > "${dir}"/workloads/"${workload}"/"${node}"/start.sh
-    ;;
-
-    download-config-generator )
-      local usage="USAGE: wb backend pass $op RUN-DIR"
-      local dir=${1:?$usage}; shift
-      local generator_task=$(envjqr 'generator_task_name')
-      # Generator runs inside task/supervisord "${generator_task}"
-      # Node files that may suffer interpolation/sed replace.
-      backend_nomad task-file-contents "${dir}" "${generator_task}" \
-        run/current/generator/start.sh                              \
-      > "${dir}"/generator/start.sh
-      backend_nomad task-file-contents "${dir}" "${generator_task}" \
-        run/current/generator/run-script.json                       \
-      > "${dir}"/generator/run-script.json
+      # Config file that may suffer interpolation/sed replace (the
+      # tx-generator's "run-script.json").
+      if test "$(jq "map(select(.name == \"${workload}\"))[0] | .config" "${dir}"/profile/workloads-service.json 2>/dev/null)" != "null"
+      then
+        backend_nomad task-file-contents "${dir}" "${node}"      \
+          run/current/workloads/"${workload}"/run-script.json    \
+        > "${dir}"/workloads/"${workload}"/"${node}"/run-script.json
+      fi
     ;;
 
     download-config-node )

--- a/nix/workbench/backend/nomad/cloud.sh
+++ b/nix/workbench/backend/nomad/cloud.sh
@@ -81,6 +81,15 @@ backend_nomadcloud() {
       backend_nomad wait-pools-stopped     60 "$@"
     ;;
 
+    wait-workload-stopped )
+      # It passes the sleep time (in seconds) required argument.
+      # This time is different between local and cloud backends to avoid
+      # unnecessary Nomad specific traffic (~99% happens waiting for node-0, the
+      # first one it waits to stop inside a loop) and at the same time be less
+      # sensitive to network failures.
+      backend_nomad wait-workload-stopped  60 "$@"
+    ;;
+
     wait-workloads-stopped )
       # It passes the sleep time (in seconds) required argument.
       # This time is different between local and cloud backends to avoid
@@ -140,10 +149,6 @@ backend_nomadcloud() {
 
     start-nodes )
       backend_nomad start-nodes             "$@"
-    ;;
-
-    start-generator )
-      backend_nomad start-generator         "$@"
     ;;
 
     start-workload-by-name )
@@ -1122,9 +1127,16 @@ fetch-logs-ssh-node() {
   # For every workload
   for workload in $(jq_tolist '.workloads | map(.name)' "$dir"/profile.json)
   do
+    # Skip workloads that don't run on this node (because of its "placement").
+    local workload_nodes
+    workload_nodes=($(backend_nomad workload-target-nodes "${dir}" "${workload}"))
+    if [[ " ${workload_nodes[*]} " != *" ${node} "* ]]
+    then
+      continue
+    fi
     msg "$(blue "Fetching") $(yellow "program \"${workload}\" workload") run files from $(yellow "\"${node}\" (\"${public_ipv4}\")") ..."
     if ! rsync -e "${ssh_command}" -au                                      \
-           -f'- start.sh'                                                   \
+           -f'- start.sh' -f'- run-script.json'                             \
            "${public_ipv4}":/local/run/current/workloads/"${workload}"/     \
            "${dir}"/workloads/"${workload}"/"${node}"/
     then
@@ -1133,21 +1145,6 @@ fetch-logs-ssh-node() {
       msg "$(red Error fetching) $(yellow "program \"${workload}\" workload") $(red "run files from") $(yellow "\"${node}\" (\"${public_ipv4}\")") ..."
     fi
   done
-  # Download generator logs. ###################################################
-  ##############################################################################
-  if test "${node}" = "explorer"
-  then
-    msg "$(blue Fetching) $(yellow "program \"generator\"") run files from $(yellow "\"${node}\" (\"${public_ipv4}\")") ..."
-    if ! rsync -e "${ssh_command}" -au                    \
-           -f'- start.sh' -f'- run-script.json'           \
-           "${public_ipv4}":/local/run/current/generator/ \
-           "${dir}"/generator/
-    then
-      node_ok="false"
-      touch "${dir}"/nomad/"${node}"/download_failed
-      msg "$(red Error fetching) $(yellow "program \"generator\"") $(red "run files from") $(yellow "\"${node}\" (\"${public_ipv4}\")") ..."
-    fi
-  fi
   # Download node(s) logs. #####################################################
   ##############################################################################
   msg "$(blue Fetching) $(yellow "program \"node\"") run files from $(yellow "\"${node}\" (\"${public_ipv4}\")") ..."

--- a/nix/workbench/backend/nomad/exec.sh
+++ b/nix/workbench/backend/nomad/exec.sh
@@ -61,6 +61,15 @@ backend_nomadexec() {
       backend_nomad wait-pools-stopped      1 "$@"
     ;;
 
+    wait-workload-stopped )
+      # It passes the sleep time (in seconds) required argument.
+      # This time is different between local and cloud backends to avoid
+      # unnecessary Nomad specific traffic (~99% happens waiting for node-0, the
+      # first one it waits to stop inside a loop) and at the same time be less
+      # sensitive to network failures.
+      backend_nomad wait-workload-stopped   1 "$@"
+    ;;
+
     wait-workloads-stopped )
       # It passes the sleep time (in seconds) required argument.
       # This time is different between local and cloud backends to avoid
@@ -101,10 +110,6 @@ backend_nomadexec() {
 
     start-nodes )
       backend_nomad start-nodes             "$@"
-    ;;
-
-    start-generator )
-      backend_nomad start-generator         "$@"
     ;;
 
     start-workload-by-name )

--- a/nix/workbench/backend/runner.nix
+++ b/nix/workbench/backend/runner.nix
@@ -205,8 +205,8 @@ let
         if test $status != 0
         then echo "wb start failed"
              cd run/current
-             echo "==========  txgen  stdout:"; cat generator/stdout || true
-             echo "==========  txgen  stderr:"; cat generator/stderr || true
+             echo "==========  txgen  stdout:"; cat workloads/tx-generator/stdout || true
+             echo "==========  txgen  stderr:"; cat workloads/tx-generator/stderr || true
              echo "==========  node-0 stdout:"; cat node-0/stdout || true
              echo "==========  node-0 stderr:"; cat node-0/stderr || true
              wb call fail "wb start failed"

--- a/nix/workbench/backend/supervisor-conf.nix
+++ b/nix/workbench/backend/supervisor-conf.nix
@@ -3,7 +3,6 @@
 , profile
 , profiling
 , nodeSpecs
-, withGenerator
 , withTracer
 , withSsh
 , unixHttpServerPort ? null
@@ -155,29 +154,6 @@ let
         ;
       })
     nodeSpecs))
-    //
-    lib.attrsets.optionalAttrs withGenerator
-    {
-      "program:generator" = {
-        # "command" below assumes "directory" is set accordingly.
-        directory      = "${stateDir}/generator";
-        command        = "${command}";
-        stdout_logfile = "${stateDir}/generator/stdout";
-        stderr_logfile = "${stateDir}/generator/stderr";
-        # Set these values to 0 to indicate an unlimited log size / no rotation.
-        stdout_logfile_maxbytes = 0;
-        stderr_logfile_maxbytes = 0;
-        # Send stop and kill signals to the whole process group.
-        stopasgroup    = true;
-        killasgroup    = true;
-        autostart      = false;
-        autorestart    = false;
-        # Don't attempt any restart!
-        startretries   = 0;
-        # Seconds it needs to stay running to consider the start successful
-        startsecs      = 5;
-      };
-    }
     //
     {
       "program:healthcheck" = {

--- a/nix/workbench/backend/supervisor-conf.nix
+++ b/nix/workbench/backend/supervisor-conf.nix
@@ -198,8 +198,14 @@ let
         autorestart    = false;
         # Don't attempt any restart!
         startretries   = 0;
-        # Seconds it needs to stay running to consider the start successful
-        startsecs      = 5;
+        # Seconds it needs to stay running to consider the start successful.
+        # A "setup" phase workload is expected to run to completion, and a
+        # short one must not be reported as a failed start: the scenario waits
+        # for it and fails the run using its "exit_code" file instead (see
+        # `wait-workload-stopped`). The other phases are long running, where
+        # these seconds are what makes an immediate crash a start failure with
+        # its logs dumped.
+        startsecs      = if workload.phase == "setup" then 0 else 5;
       };
     }) profile.workloads))
 

--- a/nix/workbench/backend/supervisor.nix
+++ b/nix/workbench/backend/supervisor.nix
@@ -25,7 +25,6 @@ let
           profile = profileBundle.profile.value;
           inherit profiling;
           nodeSpecs = profileBundle.node-specs.value;
-          withGenerator = true;
           withTracer = profileBundle.profile.value.node.tracer;
           withSsh = false;
           inetHttpServerPort = "127.0.0.1:9001";

--- a/nix/workbench/backend/supervisor.sh
+++ b/nix/workbench/backend/supervisor.sh
@@ -57,7 +57,6 @@ case "$op" in
         cp -f $supervisor_conf "$dir"/supervisor/supervisord.conf
 
         local svcs=$dir/profile/node-services.json
-        local gtor=$dir/profile/generator-service.json
         local work=$dir/profile/workloads-service.json
         local trac=$dir/profile/tracer-service.json
         local hche=$dir/profile/healthcheck-service.json
@@ -71,30 +70,30 @@ case "$op" in
            cp $(jq '."'"$node"'"."topology"' -r $svcs)  "$node_dir"/topology.json
         done
 
-        local gen_dir="$dir"/generator
-        mkdir -p                                         "$gen_dir"
-        jq ".start"                          -r $gtor >  "$gen_dir"/start.sh
-        chmod +x                                         "$gen_dir"/start.sh
-        jq ".config"                            $gtor >  "$gen_dir"/run-script.json
-        # Optional "plutus-redeemer" file!
-        if test "$(jq -r '."plutus-redeemer"'   $gtor)" != "null"
-        then
-            jq '."plutus-redeemer"'          -r $gtor > "$gen_dir"/plutus-redeemer.json
-        fi
-        # Optional "plutus-datum" file!
-        if test "$(jq -r '."plutus-datum"'      $gtor)" != "null"
-        then
-            jq '."plutus-datum"'             -r $gtor > "$gen_dir"/plutus-datum.json
-        fi
-
         local work_dir="$dir"/workloads
         mkdir -p                                        "$work_dir"
         for workload in $(jq_tolist 'map(.name)' "$work")
         do
+            local wentry="map(select(.name == \"${workload}\"))[0]"
             mkdir -p                      "$work_dir"/"${workload}"
-              jq "map(select(.name == \"${workload}\"))[0] | .start" -r $work \
+              jq "${wentry} | .start" -r $work \
             >                             "$work_dir"/"${workload}"/start.sh
             chmod +x                      "$work_dir"/"${workload}"/start.sh
+            # Optional config file (the tx-generator's "run-script.json")!
+            if test "$(jq "${wentry} | .config" $work)" != "null"
+            then
+                jq "${wentry} | .config"       $work > "$work_dir"/"${workload}"/run-script.json
+            fi
+            # Optional "plutus-redeemer" file!
+            if test "$(jq -r "${wentry} | .\"plutus-redeemer\"" $work)" != "null"
+            then
+                jq -r "${wentry} | .\"plutus-redeemer\"" $work > "$work_dir"/"${workload}"/plutus-redeemer.json
+            fi
+            # Optional "plutus-datum" file!
+            if test "$(jq -r "${wentry} | .\"plutus-datum\"" $work)" != "null"
+            then
+                jq -r "${wentry} | .\"plutus-datum\"" $work > "$work_dir"/"${workload}"/plutus-datum.json
+            fi
         done
 
         local trac_dir="$dir"/tracer
@@ -275,29 +274,6 @@ EOF
         fi
         backend_supervisor save-child-pids "$dir";;
 
-    start-generator )
-        local usage="USAGE: wb backend $op RUN-DIR"
-        local dir=${1:?$usage}; shift
-
-        while test $# -gt 0
-        do case "$1" in
-               --* ) msg "FATAL:  unknown flag '$1'"; usage_supervisor;;
-               * ) break;; esac; shift; done
-
-        ls -l $dir/{tracer/tracer,node-{0,1}/node}.socket || true
-        if ! supervisorctl start generator
-        then progress "supervisor" "$(red fatal: failed to start) $(white generator)"
-             echo "$(red run-script.json) ------------------------------------" >&2
-             cat "$dir"/generator/run-script.json
-             echo "$(red generator stdout) -----------------------------------" >&2
-             cat "$dir"/generator/stdout
-             echo "$(red generator stderr) -----------------------------------" >&2
-             cat "$dir"/generator/stderr
-             echo "$(white -------------------------------------------------)" >&2
-             fatal "could not start $(white supervisord)"
-        fi
-        backend_supervisor save-child-pids "$dir";;
-
     start-workload-by-name )
         local usage="USAGE: wb backend $op RUN-DIR"
         local dir=${1:?$usage}; shift
@@ -367,13 +343,58 @@ EOF
         fi
         ;;
 
+    wait-workload-stopped )
+        local usage="USAGE: wb backend $op RUN-DIR WORKLOAD-NAME"
+        local dir=${1:?$usage}; shift
+        local workload=${1:?$usage}; shift
+
+        local start_time=$(date +%s)
+        msg_ne "supervisor:  waiting until workload \"${workload}\" is stopped: 000000"
+        while \
+            ! test -f "${dir}"/flag/cluster-stopping \
+            && \
+            supervisorctl status "${workload}" > /dev/null
+        do
+            echo -ne "\b\b\b\b\b\b"
+            printf "%6d" "$(($(date +%s) - start_time))"
+            sleep 1
+        done >&2
+        echo -ne "\b\b\b\b\b\b"
+        local elapsed=$(($(date +%s) - start_time))
+        if test -f "${dir}"/flag/cluster-stopping
+        then
+            echo " Termination requested       -- after $(yellow ${elapsed})s" >&2
+        else
+            echo " Workload \"${workload}\" exited -- after $(yellow ${elapsed})s" >&2
+            # Programs echo their exit code to a file named `exit_code` after
+            # the script runs (can't be obtained using `supervisorctl status`).
+            # Give the program's wrapper a moment to write the file.
+            sleep 1
+            local exit_code
+            exit_code="$(cat "${dir}"/workloads/"${workload}"/exit_code 2>/dev/null || true)"
+            if test "${exit_code}" != "0"
+            then
+                echo "$(red "${workload}" workload stdout) ----------------------" >&2
+                cat "$dir"/workloads/"${workload}"/stdout
+                echo "$(red "${workload}" workload stderr) ----------------------" >&2
+                cat "$dir"/workloads/"${workload}"/stderr
+                echo "$(white -------------------------------------------------)" >&2
+                fatal "workload $(white "${workload}") failed (exit code \"${exit_code}\")"
+            fi
+        fi
+        ;;
+
     wait-workloads-stopped )
         local usage="USAGE: wb backend $op RUN-DIR"
         local dir=${1:?$usage}; shift
 
         local start_time=$(date +%s)
-        msg_ne "supervisor:  waiting until all workloads are stopped: 000000"
-        for workload in $(jq_tolist '.workloads | map(.name)' "$dir"/profile.json)
+        msg_ne "supervisor:  waiting until all run-bounding workloads are stopped: 000000"
+        # Only the workloads that bound the run's duration are waited for
+        # (phase "load" and "wait_pools" false), the rest are stopped with the
+        # cluster ("wait_pools" true means the pools bound the run and "setup"
+        # workloads already ran to completion).
+        for workload in $(jq_tolist '.workloads | map(select(.phase == "load" and .wait_pools == false)) | map(.name)' "$dir"/profile.json)
         do
             while \
                 ! test -f "${dir}"/flag/cluster-stopping \

--- a/nix/workbench/profile/profile.nix
+++ b/nix/workbench/profile/profile.nix
@@ -79,32 +79,37 @@ let
         )
         node-services
       ;
-      inherit
-        (import
-          ../service/generator.nix
-          { inherit pkgs;
-            inherit (workbenchNix) haskellProject;
-            inherit backend profile eraName nodeSpecs;
-            inherit node-services;
-          }
-        )
-        generator-service
-      ;
+      # A workload's Nix template can either return the workload script
+      # directly (a string) or an attrset with the script as "start" plus
+      # optional extra files to materialize in the workload's run directory
+      # (like the tx-generator's "run-script.json" as "config").
       workloads-service = builtins.map
-        (workload: rec {
-          name = workload.name;
-          start =
-            ''
-            ${import ../workload/${name}.nix
+        (workload:
+          let template =
+            import ../workload/${workload.name}.nix
               { inherit pkgs;
                 inherit (workbenchNix) haskellProject;
-                inherit profile nodeSpecs workload;
+                inherit backend eraName profile nodeSpecs workload;
               }
-            }
-            ${workload.entrypoints.producers}
-            ''
           ;
-        })
+              bundle =
+            if builtins.isAttrs template
+            then template
+            else { start = template; }
+          ;
+          in {
+            name = workload.name;
+            start =
+              ''
+              ${bundle.start}
+              ${workload.entrypoint}
+              ''
+            ;
+            config            = bundle.config or null;
+            plutus-redeemer   = bundle.plutus-redeemer or null;
+            plutus-datum      = bundle.plutus-datum or null;
+          }
+        )
         profile.workloads
       ;
       inherit
@@ -142,7 +147,6 @@ let
       };
       inherit
         node-services
-        generator-service
         workloads-service
         tracer-service
         healthcheck-service
@@ -153,7 +157,7 @@ let
   ##############################################################################
 
   materialise-profile = { profileBundle }:
-    # Output (node-services + generator-service) depends on the era.
+    # Output (node-services + the tx-generator workload) depends on the era.
     pkgs.runCommand "workbench-profile-data-${profileName}-${profileBundle.eraName}"
       { buildInputs = [];
         inherit profileJsonPath;
@@ -170,17 +174,14 @@ let
             profileBundle.node-services
           )
         ;
-        generatorService = __toJSON
-          { name            = "generator";
-            inherit (profileBundle.generator-service) start config;
-            # Not present on every profile. Can be null.
-            inherit (profileBundle.generator-service) plutus-redeemer;
-            # Not present on every profile. Can be null.
-            inherit (profileBundle.generator-service) plutus-datum;
-          }
-        ;
         workloadsService = __toJSON (builtins.map (workload:
           { inherit (workload) name start;
+            # Only present for the "tx-generator" workload. Can be null.
+            inherit (workload) config;
+            # Not present on every profile. Can be null.
+            inherit (workload) plutus-redeemer;
+            # Not present on every profile. Can be null.
+            inherit (workload) plutus-datum;
           }
         ) profileBundle.workloads-service);
         tracerService = __toJSON
@@ -196,7 +197,6 @@ let
         passAsFile =
           [
             "nodeServices"
-            "generatorService"
             "workloadsService"
             "tracerService"
             "healthcheckService"
@@ -209,7 +209,6 @@ let
       cp    $topologyDotPath              $out/topology.dot
       cp    $nodeSpecsJsonPath            $out/node-specs.json
       cp    $nodeServicesPath             $out/node-services.json
-      cp    $generatorServicePath         $out/generator-service.json
       cp    $workloadsServicePath         $out/workloads-service.json
       cp    $tracerServicePath            $out/tracer-service.json
       cp    $healthcheckServicePath       $out/healthcheck-service.json

--- a/nix/workbench/profile/profile.sh
+++ b/nix/workbench/profile/profile.sh
@@ -81,7 +81,7 @@ case "$op" in
               , "    - stuffed:            \(.derived.utxo_stuffed)"
               , "  - delegators:         \(.genesis.delegators)"
               , "  - generator duration: \(.derived.generator_duration              | tostring)s"
-              , "    - requested epochs:   \(.generator.epochs                      | tostring)ep"
+              , "    - requested epochs:   \(.workloads | map(select(.name == "tx-generator"))[0].parameters.epochs | tostring)ep"
               , "    - effective epochs:   \(.derived.effective_epochs              | tostring)ep"
               , "    - transaction count:  \(.derived.generator_tx_count | . / 1000 | ceil | tostring)kTx"
               , "    - full blocks:        \(.derived.generator_blocks_lower_bound  | tostring)"

--- a/nix/workbench/run.sh
+++ b/nix/workbench/run.sh
@@ -58,7 +58,7 @@ usage_run() {
 
     $(helpcmd stop RUN)              Stop the named run
 
-    $(helpcmd restart [--no-generator] BACKEND-START-ARGS..)
+    $(helpcmd restart BACKEND-START-ARGS..)
                           Stop and restart the current run (without a new allocation)
 
   $(red run) $(blue options):
@@ -901,6 +901,9 @@ run_remote_get() {
         genesis.alonzo.json
         genesis-shelley.json
         profile.json
+        workloads/tx-generator/protocol-parameters-queried.json
+        workloads/tx-generator/plutus-budget-summary.json
+        ## The generator's directory before it became a workload.
         generator/protocol-parameters-queried.json
         generator/plutus-budget-summary.json
     )
@@ -981,7 +984,12 @@ legacy_run_timing() {
     )
     jq '
     .meta.profile_content                                       as $prof
-  | ($stamp + ($prof.generator.tx_count / $prof.generator.tps)) as $stamp_end
+    ## The generator: a top-level property on legacy runs, a "workloads"
+    ## list entry afterwards.
+  | ($prof.generator
+     // ($prof.workloads | map(select(.name == "tx-generator"))[0].parameters)
+    )                                                           as $gtor
+  | ($stamp + ($gtor.tx_count / $gtor.tps))                     as $stamp_end
   |
   { future_offset:   "0 seconds"
   , start:           $stamp

--- a/nix/workbench/scenario.sh
+++ b/nix/workbench/scenario.sh
@@ -67,26 +67,49 @@ case "$op" in
     fixed-loaded )
         backend start-tracers        "$dir"
 
+        # The pools bound the run's duration unless a load workload with
+        # "wait_pools" false is present (then that workload's exit does).
+        local wait_pools_p
+        if jqtest '.workloads | map(select(.phase == "load")) | all(.wait_pools)' "$dir"/profile.json
+        then wait_pools_p='true'
+        else wait_pools_p='false'
+        fi
+
         scenario_setup_exit_trap     "$dir"
         # Trap start
         ############
-        # Workloads that do not request that the nodes have already started.
-        for workload in $(jq -r '.workloads[] | select(.before_nodes == true) | .name' "$dir"/profile.json)
+        # Workloads that run before the nodes have started.
+        for workload in $(jq -r '.workloads[] | select(.phase == "before-nodes") | .name' "$dir"/profile.json)
         do
             backend start-workload-by-name "$dir" "$workload"
         done
         backend start-nodes          "$dir"
-        backend start-generator      "$dir"
-        # Workloads that request that the nodes have already started.
-        for workload in $(jq -r '.workloads[] | select(.before_nodes == false) | .name' "$dir"/profile.json)
+        if test "$wait_pools_p" = 'true'
+        then
+            # Armed before the "setup" phase so a stuck workload can't hang
+            # the run forever (end time is absolute, from "meta.json").
+            # NOTE: must come after "start-nodes", its bare `wait` would block
+            # on the watcher process.
+            scenario_setup_workload_termination   "$dir"
+        fi
+        # Workloads that run to completion after the nodes have started and
+        # before the load workloads (the tx-generator among them) are started.
+        for workload in $(jq -r '.workloads[] | select(.phase == "setup") | .name' "$dir"/profile.json)
+        do
+            backend start-workload-by-name "$dir" "$workload"
+        done
+        for workload in $(jq -r '.workloads[] | select(.phase == "setup") | .name' "$dir"/profile.json)
+        do
+            backend wait-workload-stopped "$dir" "$workload"
+        done
+        # The load workloads.
+        for workload in $(jq -r '.workloads[] | select(.phase == "load") | .name' "$dir"/profile.json)
         do
             backend start-workload-by-name "$dir" "$workload"
         done
         backend start-healthchecks   "$dir"
-        if     jqtest '.workloads == []'              "$dir"/profile.json \
-            || jqtest '.workloads | any(.wait_pools)' "$dir"/profile.json
+        if test "$wait_pools_p" = 'true'
         then
-            scenario_setup_workload_termination   "$dir"
             backend wait-pools-stopped "$dir"
         else
             backend wait-workloads-stopped "$dir"

--- a/nix/workbench/service/healthcheck.nix
+++ b/nix/workbench/service/healthcheck.nix
@@ -106,7 +106,7 @@ in {
       ########################
 
     generator=0
-    if test -d "../generator"
+    if test -d "../workloads/tx-generator"
     then
       generator=1
       ${coreutils}/bin/echo "Found deployed generator"
@@ -277,7 +277,7 @@ in {
 
     function healthcheck_generator() {
       # Checks if the generator has not exited with errors
-      assert_program_running "generator" || true
+      assert_program_running "workloads/tx-generator" || true
     }
 
     # Error if program exits with a non-zero exit code, else returns

--- a/nix/workbench/service/tracer.nix
+++ b/nix/workbench/service/tracer.nix
@@ -93,7 +93,7 @@ let
       eval.config.services.cardano-tracer;
 
   ##
-  ## generator-service :: (TracerConfig, NixosServiceConfig, Config, StartScript)
+  ## tracer-service :: (TracerConfig, NixosServiceConfig, Config, StartScript)
   ##
   tracer-service =
     (nodeSpecs:

--- a/nix/workbench/workload/cgroup_memory.nix
+++ b/nix/workbench/workload/cgroup_memory.nix
@@ -3,6 +3,7 @@
 , profile
 , nodeSpecs
 , workload
+, ...
 }:
 
 with pkgs.lib;

--- a/nix/workbench/workload/latency.nix
+++ b/nix/workbench/workload/latency.nix
@@ -3,6 +3,7 @@
 , profile
 , nodeSpecs
 , workload
+, ...
 }:
 
 with pkgs.lib;

--- a/nix/workbench/workload/tx-generator.nix
+++ b/nix/workbench/workload/tx-generator.nix
@@ -1,16 +1,20 @@
 { pkgs
 , haskellProject
 , backend
-, profile
 ## Workbench's long-form ledger era name (`conway`, `babbage`, ...).
 , eraName
+, profile
 , nodeSpecs
-, node-services
+, workload
+, ...
 }:
 
 with pkgs.lib;
 
 let
+
+  # The generator's parameters are the "tx-generator" workload's parameters.
+  params = workload.parameters;
 
   # If there is an "explorer" node, the generator will run there!
   # TODO: Repeated code, add the generator's node name to profile.json
@@ -19,35 +23,34 @@ let
     else "node-0"
   ;
 
-  # We're reusing configuration from a cluster node.
-  exemplarNode = node-services."node-0";
-
   nodePublicIP =
     { i, name, ... }@nodeSpec:
     "127.0.0.1";
 
   # The Plutus redeemer value/content.
   plutus-redeemer =
-    if profile.generator.plutus == null || (profile.generator.plutus.redeemer or null) == null
+    if (params.plutus or null) == null || (params.plutus.redeemer or null) == null
     then null
-    else profile.generator.plutus.redeemer
+    else params.plutus.redeemer
   ;
 
   # The Plutus datum value/content.
   plutus-datum =
-    if profile.generator.plutus == null || (profile.generator.plutus.datum or null) == null
+    if (params.plutus or null) == null || (params.plutus.datum or null) == null
     then null
-    else profile.generator.plutus.datum
+    else params.plutus.datum
   ;
 
+  # All paths are relative to the workload's run directory
+  # ("run/current/workloads/tx-generator").
   finaliseGeneratorService =
-    profile: svc: recursiveUpdate svc
+    svc: recursiveUpdate svc
       ({
-        sigKey              = "../genesis/utxo-keys/utxo1/utxo.skey";
+        sigKey              = "../../genesis/utxo-keys/utxo1/utxo.skey";
         runScriptFile       = "run-script.json";
         ## path to the config and socket of the locally running node.
-        nodeConfigFile      = "../${runningNode}/config.json";
-        localNodeSocketPath = "../${runningNode}/node.socket";
+        nodeConfigFile      = "../../${runningNode}/config.json";
+        localNodeSocketPath = "../../${runningNode}/node.socket";
         ## Relative paths to use for the Plutus redeemer and datum properties.
         ## The workbench backend requested handles the creation of these files.
         plutusRedeemerFile  = if plutus-redeemer != null
@@ -59,7 +62,7 @@ let
                               else null
         ;
       } // optionalAttrs profile.node.tracer {
-        tracerSocketPath = "../tracer/tracer.socket";
+        tracerSocketPath = "../../tracer/tracer.socket";
       # Decide where the executable comes from:
       #########################################
       } // optionalAttrs (!backend.useCabalRun) {
@@ -74,19 +77,7 @@ let
   ##
   generatorServiceConfig =
     nodeSpecs:
-    let
-      generatorNodeConfigDefault =
-        (__fromJSON (__readFile ../../../bench/tx-generator-config-base.json))
-        // { inherit (exemplarNode.config)
-               Protocol
-               ByronGenesisFile
-               ShelleyGenesisFile
-               AlonzoGenesisFile
-               ConwayGenesisFile
-               ;
-           };
-    in
-        finaliseGeneratorService profile
+        finaliseGeneratorService
         {
           # tx-generator's NixOS service module accepts the long lowercase
           # ledger era name, which is what the workbench's `eraName` is.
@@ -107,7 +98,7 @@ let
         //
         ((x: recursiveUpdate x
           { tx_count = __ceil x.tx_count; })
-          (removeAttrs profile.generator ["epochs"]));
+          (removeAttrs params ["epochs"]));
 
   ## Given an env config, evaluate it and produce the node service.
   ## Call the given function on this service.
@@ -144,70 +135,35 @@ let
           };
       in eval.config.services.tx-generator;
 
-  ##
-  ## generator-service :: (ServiceConfig, Service, NodeConfig, Script)
-  ##
-  generator-service =
-    (nodeSpecs:
-    let
-      serviceConfig = generatorServiceConfig nodeSpecs;
-      service       = generatorServiceConfigService serviceConfig;
-    in {
-      start =
-        ''
-        #!${pkgs.stdenv.shell}
+  service = generatorServiceConfigService (generatorServiceConfig nodeSpecs);
 
-        ###########################################
-        # Extra workloads start ###################
-        ###########################################
-        ${builtins.concatStringsSep "" (builtins.map (workload:
-            let workload_name = workload.name;
-                entrypoint = workload.entrypoints.pre_generator;
-                node_name = if profile.composition.with_explorer
-                            then "explorer"
-                            else "node-0"
-                ;
-            in
-                ''
-                ###########################################
-                ########## workload start: ${workload_name}
-                ###########################################
-                ${if entrypoint != null
-                  then
-                    ''
-                    ${import ../workload/${workload_name}.nix
-                      {inherit pkgs haskellProject profile nodeSpecs workload;}
-                    }
-                    (cd ../workloads/${workload_name} && ${entrypoint} ${node_name})
-                    ''
-                  else
-                    ''
-                    ''
-                }
-                ###########################################
-                ########## workload end:   ${workload_name}
-                ###########################################
-                ''
-          ) (profile.workloads or []))
-        }
-        #############################################
-        # Extra workloads end #######################
-        #############################################
+in {
 
-        ${service.script}
-        ''
-      ;
+  start =
+    ''
+    #!${pkgs.stdenv.shell}
 
-      config = (service.decideRunScript service);
+    # The entrypoint function.
+    function tx_generator() {
+      # The generator runs on the same machine as the "${runningNode}" node.
+      if ! test -d "../../${runningNode}"
+      then
+        echo "tx-generator: no locally deployed \"${runningNode}\" node, nothing to do"
+        exit 0
+      fi
 
-      # Not present on every profile.
-      # Don't create a derivation to a file containing "null" !!!
-      # The corresponding file is created/deployed by the workbench.
-      inherit plutus-redeemer plutus-datum;
+      ${service.script}
+    }
+    ''
+  ;
 
-    })
-    nodeSpecs;
-in
-{
-  inherit generator-service;
+  # The tx-generator's config file ("run-script.json"), materialized by the
+  # backend in the workload's run directory.
+  config = service.decideRunScript service;
+
+  # Not present on every profile.
+  # Don't create a derivation to a file containing "null" !!!
+  # The corresponding file is created/deployed by the workbench.
+  inherit plutus-redeemer plutus-datum;
+
 }

--- a/nix/workbench/workload/voting-setup.nix
+++ b/nix/workbench/workload/voting-setup.nix
@@ -1,0 +1,3 @@
+# The "voting-setup" workload (phase "setup") shares its script with the
+# "voting" workload (phase "load"): same functions, different entrypoint.
+args: import ./voting.nix args

--- a/nix/workbench/workload/voting.nix
+++ b/nix/workbench/workload/voting.nix
@@ -40,6 +40,10 @@ let
   # the full commit hash doesn't fit.
   cips_commit = "0ed8837a02ed";
 
+  # The document the constitution proposal points to. Content-addressed, so
+  # unlike the anchors above it cannot change under us.
+  constitution_url = "https://ipfs.io/ipfs/Qmdo2J5vkGKVu2ur43PuTrM7FdaeyfeFav8fhovT6C2tto";
+
   # The node next to which the setup phase (fund-splitting / proposal-creation)
   # runs: the same machine as the tx-generator.
   gen_node_name =
@@ -945,12 +949,13 @@ function governance_create_constitution {
   | ${jq}/bin/jq -r                                                  \
       '.nextRatifyState.nextEnactState.prevGovActionIds'
 
-  # Create dummy constitution.
-    ${coreutils}/bin/echo "My Constitution: free mate and asado"     \
-  > ./constitution.txt
-  # Calculate constitution hash.
+  # Calculate the constitution's hash from the document the proposal points to:
+  # `cardano-cli` downloads "--constitution-url" when building the transaction
+  # and refuses to build if it does not hash to "--constitution-hash". It used
+  # to be the hash of a dummy text file created here, which never was the hash
+  # of that document.
   ${cardano-cli}/bin/cardano-cli hash anchor-data                    \
-    --file-text ./constitution.txt                                   \
+    --url       "${constitution_url}"                                \
     --out-file  ./constitution.hash
   # Copy guardrails-script.
   ${coreutils}/bin/cp                                                \
@@ -970,7 +975,7 @@ function governance_create_constitution {
     --testnet \
     --anchor-url "https://raw.githubusercontent.com/cardano-foundation/CIPs/${cips_commit}/CIP-0100/cip-0100.common.schema.json" \
     --anchor-data-hash "c407dda548dbbbfb4dc89b5a980f75fe0b7b6721d33d8f151ea3e711bede3cda" \
-    --constitution-url "https://ipfs.io/ipfs/Qmdo2J5vkGKVu2ur43PuTrM7FdaeyfeFav8fhovT6C2tto" \
+    --constitution-url "${constitution_url}" \
     --constitution-hash        "$(${coreutils}/bin/cat ./constitution.hash)" \
     --constitution-script-hash "$(${coreutils}/bin/cat ./guardrails-script.hash)" \
     --governance-action-deposit "''${action_deposit}" \

--- a/nix/workbench/workload/voting.nix
+++ b/nix/workbench/workload/voting.nix
@@ -32,6 +32,14 @@ let
   # Initial donation from genesis funds to make "valid" withdrawal proposals.
   treasury_donation = 500000;
 
+  # The commit of "github.com/cardano-foundation/CIPs" the proposals' anchor
+  # URLs point to. `cardano-cli` downloads them to check "--anchor-data-hash",
+  # so a mutable reference like "master" breaks proposal creation as soon as
+  # the file changes upstream. Bump together with the hashes below.
+  # Abbreviated: the ledger rejects an anchor URL of more than 128 bytes and
+  # the full commit hash doesn't fit.
+  cips_commit = "0ed8837a02ed";
+
   # The node next to which the setup phase (fund-splitting / proposal-creation)
   # runs: the same machine as the tx-generator.
   gen_node_name =
@@ -954,11 +962,14 @@ function governance_create_constitution {
     --out-file    ./guardrails-script.hash
 
   # Create action.
+  # The anchor URL is pinned to a commit of the CIPs repository: `cardano-cli`
+  # fetches it to check "--anchor-data-hash" and the contents of a branch like
+  # "master" change without notice, breaking every voting run when they do.
   local tx_filename=./create-constitution
   ${cardano-cli}/bin/cardano-cli conway governance action create-constitution \
     --testnet \
-    --anchor-url "https://raw.githubusercontent.com/cardano-foundation/CIPs/master/CIP-0100/cip-0100.common.schema.json" \
-    --anchor-data-hash "9d99fbca260b2d77e6d3012204e1a8658f872637ae94cdb1d8a53f4369400aa9" \
+    --anchor-url "https://raw.githubusercontent.com/cardano-foundation/CIPs/${cips_commit}/CIP-0100/cip-0100.common.schema.json" \
+    --anchor-data-hash "c407dda548dbbbfb4dc89b5a980f75fe0b7b6721d33d8f151ea3e711bede3cda" \
     --constitution-url "https://ipfs.io/ipfs/Qmdo2J5vkGKVu2ur43PuTrM7FdaeyfeFav8fhovT6C2tto" \
     --constitution-hash        "$(${coreutils}/bin/cat ./constitution.hash)" \
     --constitution-script-hash "$(${coreutils}/bin/cat ./guardrails-script.hash)" \
@@ -1032,7 +1043,7 @@ function governance_create_withdrawal {
   # Create action.
   ${cardano-cli}/bin/cardano-cli conway governance action create-treasury-withdrawal \
     --testnet                                                                                                                    \
-    --anchor-url "https://raw.githubusercontent.com/cardano-foundation/CIPs/master/CIP-0108/examples/treasury-withdrawal.jsonld" \
+    --anchor-url "https://raw.githubusercontent.com/cardano-foundation/CIPs/${cips_commit}/CIP-0108/examples/treasury-withdrawal.jsonld" \
     --anchor-data-hash "311b148ca792007a3b1fee75a8698165911e306c3bc2afef6cf0145ecc7d03d4"                                        \
     --governance-action-deposit "''${action_deposit}"                                                                            \
     --transfer 50                                                                                                                \

--- a/nix/workbench/workload/voting.nix
+++ b/nix/workbench/workload/voting.nix
@@ -179,10 +179,11 @@ function calculate_next_utxo {
   local addr=''${2:-null}
 
   local tx_id
-  # Prints a transaction identifier.
+  # Prints a transaction identifier (a JSON object with a "txhash" property).
   tx_id="$( \
-    ${cardano-cli}/bin/cardano-cli conway transaction txid  \
-      --tx-file "''${tx_signed}"                            \
+      ${cardano-cli}/bin/cardano-cli conway transaction txid  \
+        --tx-file "''${tx_signed}"                            \
+    | ${jq}/bin/jq --raw-output .txhash                       \
   )"
   # View transaction as JSON and get index of FIRST output containing "$addr".
     ${cardano-cli}/bin/cardano-cli debug transaction view \
@@ -280,8 +281,9 @@ function is_tx_in_mempool {
 
   local tx_id
   tx_id="$( \
-    ${cardano-cli}/bin/cardano-cli conway transaction txid  \
-      --tx-file "''${tx_signed}"                            \
+      ${cardano-cli}/bin/cardano-cli conway transaction txid  \
+        --tx-file "''${tx_signed}"                            \
+    | ${jq}/bin/jq --raw-output .txhash                       \
   )"
     ${cardano-cli}/bin/cardano-cli conway query tx-mempool           \
         tx-exists         "''${tx_id}"                               \
@@ -579,8 +581,9 @@ function wait_proposal_id {
   # Get proposal's "txId" from the "--tx-file".
   local tx_id
   tx_id="$( \
-    ${cardano-cli}/bin/cardano-cli conway transaction txid    \
-      --tx-file     "''${tx_signed}"                          \
+      ${cardano-cli}/bin/cardano-cli conway transaction txid  \
+        --tx-file   "''${tx_signed}"                          \
+    | ${jq}/bin/jq --raw-output .txhash                       \
   )"
 
   local contains_proposal="false"

--- a/nix/workbench/workload/voting.nix
+++ b/nix/workbench/workload/voting.nix
@@ -1352,8 +1352,12 @@ function workflow_generator {
   ''
   }
   #- Waiting ------------------------------------------------------------------#
+  # Only the proposals this workload creates: the withdrawal ones are created
+  # by the "voting" workload of the "load" phase, which is not started until
+  # this one exits, and which waits for the full `proposals_count` itself
+  # before voting.
   ${coreutils}/bin/echo "wait_proposals_count:            Start: $(${coreutils}/bin/date --rfc-3339=seconds)"
-  wait_proposals_count "''${node_str}" ${toString proposals_count}
+  wait_proposals_count "''${node_str}" ${toString constitutions_from_genesis}
   ${coreutils}/bin/echo "wait_proposals_count:            End:   $(${coreutils}/bin/date --rfc-3339=seconds)"
   #- Log ----------------------------------------------------------------------#
   # Keep a job that periodically stores the proposals from the gov-state.

--- a/nix/workbench/workload/voting.nix
+++ b/nix/workbench/workload/voting.nix
@@ -3,6 +3,7 @@
 , profile
 , nodeSpecs
 , workload
+, ...
 }:
 
 let
@@ -30,6 +31,14 @@ let
   genesis_funds_skey = "../../genesis/utxo-keys/utxo2/utxo.skey";
   # Initial donation from genesis funds to make "valid" withdrawal proposals.
   treasury_donation = 500000;
+
+  # The node next to which the setup phase (fund-splitting / proposal-creation)
+  # runs: the same machine as the tx-generator.
+  gen_node_name =
+    if profile.composition.with_explorer
+    then "explorer"
+    else "node-0"
+  ;
 
   # Filter producers from "node-specs.json".
   producers =
@@ -1345,10 +1354,19 @@ function workflow_generator {
   ${coreutils}/bin/echo "wait_proposals_count:            End:   $(${coreutils}/bin/date --rfc-3339=seconds)"
   #- Log ----------------------------------------------------------------------#
   # Keep a job that periodically stores the proposals from the gov-state.
+  # A background job: the workload script exits (the end of the "setup" phase)
+  # and the orphaned logger keeps running until the cluster is stopped.
   workflow_generator_log_proposals "''${node_str}" &
 
 }
 
+# Entrypoint of the "voting-setup" workload (phase "setup", runs to completion
+# before the load workloads are started, placement "explorer").
+function workflow_setup {
+  workflow_generator "${gen_node_name}"
+}
+
+# Entrypoint of the "voting" workload (phase "load", placement "producers").
 function workflow_producer {
   # Run the producer workflow for each deployed producer.
   local producers=${toString producers_bash_array}


### PR DESCRIPTION
# Description

The tx-generator was a first-class service of the workbench, side by side with the nodes, the tracer and the healthcheck. It is now just an entry of the profile's `workloads` list, named `tx-generator`, which removes the generator-specific code paths from every backend (`start-generator`, `allocate-run-directory-generator`, `stop-all-generator`, `download-{logs,zstd,config}-generator`, `generator-service.json`, the `withGenerator` supervisord program, ...).

Two generalizations of the workloads machinery make this possible:

- **`phase`** (`before-nodes` | `setup` | `load`) replaces the `before_nodes` boolean. Workloads of the new `setup` phase run to completion after the nodes are up and before any load workload is started; the scenario fails the run if a setup workload exits non-zero.
- **`placement`** (`producers` | `explorer`) plus a single `entrypoint` replaces the `entrypoints` pair. Voting's `pre_generator` entrypoint, which used to be textually inlined into the generator's `start.sh`, is now a `voting-setup` workload of the `setup` phase, placed next to the tx-generator.

On the Nomad backends, `placement` is resolved by a new `workload-target-nodes` subcommand, which replaces the hardcoded "every producer" assumption in log fetching, stopping and waiting.

Profile-side, the typed `Generator` record is kept internally (derived properties need it) and translated to/from the `tx-generator` workload entry at the JSON boundary. All 132 golden profiles are regenerated accordingly; the profile name set is unchanged.

Backwards compatibility: `locli` and the run directory keep reading legacy runs — the generator's configuration is looked up as a top-level `generator` property first and as the `tx-generator` workload afterwards — so no historical run needs a `meta.json` migration.

Follow-up commits, all found while reviewing and test-running this:

- **`tx_fee` of the block memory budget profiles.** An overlay's `"generator"` key can no longer reach the generator through the profile's JSON encoding, so `plutus-volt-memx15-nomadperf`, `plutus-volt-memx2-nomadperf`, `plutuscall-loop-memx2` and the two `calibrate-blockmem-*-fill` playground profiles silently lost their calibrated fee and would have rejected every transaction with `FeeTooSmallUTxO`. The fee moves to the `txFeeOverwrite` primitive and `overlay` now rejects a `"generator"` key.
- **`startsecs`** is dropped for `setup` phase workloads, which are expected to run to completion; the other phases keep it as the immediate-crash detector.
- **The setup phase waited for the load phase's proposals.** `workflow_generator` waited for the total `proposals_count`, which includes the withdrawal proposals the producers create in the `load` phase — unreachable now that the phases no longer overlap. It waits for its own constitution instead.
- Two leftover references to the old `generator/` directory.

Three more, all pre-existing breakage of the voting workload that this branch merely surfaced (identical on master, where voting profiles are equally stuck):

- `cardano-cli conway transaction txid` prints JSON now, so `query tx-mempool tx-exists` never resolved and the fund splitting looped forever.
- The proposals' anchor URLs pointed at the CIPs repo's `master` branch, whose content drifted away from the recorded hashes; they are pinned to a commit (abbreviated — the ledger caps an anchor URL at 128 bytes).
- The constitution proposal's `--constitution-hash` was the hash of a dummy local text file, never of the IPFS document `--constitution-url` points at.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff

