### PR TITLE
Mention herald changelog management in RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -60,7 +60,8 @@ This is the release process for node releases.
 6. The community is notified of the release candidate and given time to
    provide feedback.
 7. The Release Engineer creates a draft GitHub Release and asks dev leads to
-   fill in their changelog sections.
+   fill in their changelog sections; for herald-managed packages the
+   changelog section is compiled from fragments, see Versioning.
 8. CPC, TSC, Release Engineer, and SRE Lead sign off → the release is
    published as a **GitHub pre-release**.
 9. QA runs the final integration test suite (`cardano-node-tests`).
@@ -183,6 +184,12 @@ to a full release in GitHub without any code changes or new tags.
 Example: `10.2.1` was published as a GitHub pre-release for approximately one
 month before being promoted to a full release. The tag was always `10.2.1`;
 only the GitHub release type changed.
+
+## Herald-managed packages
+
+`cardano-node-chairman`, `cardano-submit-api` and `cardano-testnet` manage changelogs with herald (see `.herald.yml`): each PR adds a fragment under the package's `.changes/` directory.
+At release time, run `herald batch <package>` (available in the nix dev shell) to compile the changelog and bump the version in the cabal file.
+It bumps relative to the current cabal version, so pass the version explicitly (`-v A.B.C.D`) if that was already bumped by hand.
 
 # Collaboration
 


### PR DESCRIPTION
# Description

Stacked on #6585.

Documents herald changelog management in `RELEASE.md`.
A new "Herald-managed packages" subsection under Versioning explains how to compile changelogs with `herald batch`, that herald performs the actual version bump in the cabal file, and that the version has to be passed explicitly when the cabal version was already bumped by hand.
The release-notes step now points herald-managed packages at that subsection.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
  - `cardano-node-chairman`, `cardano-submit-api` and `cardano-testnet` instead need a
    changelog fragment in `<package>/.changes/`, because their `CHANGELOG.md` is generated
    from fragments at release time.  Copy `_TEMPLATE.yml` from that directory, or run
    `nix run github:input-output-hk/cardano-dev#herald -- new`
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
