### PR TITLE
cardano-testnet: strengthen RPC ReadGenesis test coverage

### DIFF
--- a/cardano-testnet/.changes/20260820_124721_mgalazyn_reenable_rpc_readgenesis_initialfunds_assertion.yml
+++ b/cardano-testnet/.changes/20260820_124721_mgalazyn_reenable_rpc_readgenesis_initialfunds_assertion.yml
@@ -1,0 +1,5 @@
+pr: 6657
+kind:
+  - test
+description: |
+  Strengthened the UTxO RPC `ReadGenesis` test: re-enabled the `initialFunds` assertion and upgraded it to an exact comparison with the funds embedded in the genesis file, checked the returned genesis hash against the Blake2b-256 hash of the Shelley genesis file, and added coverage for the `FAILED_PRECONDITION` error when the genesis file changes after node startup.

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/Genesis.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/Genesis.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Cardano.Testnet.Test.Rpc.Genesis
@@ -12,13 +13,21 @@ where
 import           Cardano.Api
 import qualified Cardano.Api.Experimental as Exp
 
+import qualified Cardano.Crypto.Hash.Blake2b as Crypto
+import qualified Cardano.Crypto.Hash.Class as Crypto
 import qualified Cardano.Rpc.Client as Rpc
 import qualified Cardano.Rpc.Proto.Api.UtxoRpc.Query as U5c
 import           Cardano.Testnet
 
 import           Prelude
 
+import           Control.Applicative ((<|>))
 import           Control.Monad (void)
+import           Control.Monad.Catch (try)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Aeson
+import qualified Data.Aeson.KeyMap as Aeson
+import qualified Data.Aeson.Lens as Aeson
 import qualified Data.ByteString as BS
 import           Data.Default.Class
 import           Data.List.NonEmpty (NonEmpty ((:|)))
@@ -26,6 +35,7 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Text as Text
 import           Data.Word (Word32)
 import           Lens.Micro
+import           Network.GRPC.Spec (GrpcError (..), GrpcException (..))
 
 import           Testnet.Property.Util (integrationRetryWorkspace)
 
@@ -44,7 +54,8 @@ hprop_rpc_read_genesis = integrationRetryWorkspace 2 "rpc-read-genesis" $ \tempA
       runtimeOptions = def{runtimeEnableRpc = RpcEnabled}
 
   TestnetRuntime
-    { testnetMagic
+    { shelleyGenesisFile
+    , testnetMagic
     , testnetNodes = node0 :| _
     } <-
     createAndRunTestnet creationOptions runtimeOptions conf
@@ -52,12 +63,34 @@ hprop_rpc_read_genesis = integrationRetryWorkspace 2 "rpc-read-genesis" $ \tempA
   rpcSocket <- H.note . unFile $ nodeRpcSocketPath node0
   let rpcServer = Rpc.ServerUnix rpcSocket
 
+  originalGenesisBytes <- H.evalIO $ BS.readFile shelleyGenesisFile
+
+  H.note_ "The handler caches the parsed genesis only on a successful read (TimedCache.hs), so this hash-mismatch check must run before any successful ReadGenesis call: a successful call first would warm the cache and hide the corruption for up to five idle minutes"
+  H.evalIO $ BS.writeFile shelleyGenesisFile (originalGenesisBytes <> " ")
+
+  H.note_ "ReadGenesis fails with FAILED_PRECONDITION when the genesis file's bytes no longer match the hash the node computed at startup"
+  readGenesisHashMismatchResult <-
+    H.evalIO . try . Rpc.withConnection def rpcServer $ \conn ->
+      Rpc.nonStreaming conn (Rpc.rpc @(Rpc.Protobuf U5c.QueryService "readGenesis")) def
+  case readGenesisHashMismatchResult of
+    Left GrpcException{grpcError}
+      | grpcError == GrpcFailedPrecondition -> pure ()
+      | otherwise -> do
+          H.note_ $ "expected " <> show GrpcFailedPrecondition <> ", got: " <> show grpcError
+          H.failure
+    Right (_ :: Rpc.Proto U5c.ReadGenesisResponse) -> do
+      H.note_ $ "expected " <> show GrpcFailedPrecondition <> ", but the call succeeded"
+      H.failure
+
+  H.evalIO $ BS.writeFile shelleyGenesisFile originalGenesisBytes
+
   response <-
     H.evalIO . Rpc.withConnection def rpcServer $ \conn ->
       Rpc.nonStreaming conn (Rpc.rpc @(Rpc.Protobuf U5c.QueryService "readGenesis")) def
 
-  H.note_ "genesis is the 32-byte Shelley genesis hash"
-  H.assertWith (response ^. U5c.genesis) $ (== 32) . BS.length
+  H.note_ "genesis is the Blake2b-256 hash of the raw Shelley genesis file bytes, exactly as the node computed it at startup"
+  response ^. U5c.genesis
+    H.=== Crypto.hashToBytes (Crypto.hashWith id originalGenesisBytes :: Crypto.Hash Crypto.Blake2b_256 BS.ByteString)
 
   H.note_ "caip2 is derived from the testnet's own network magic"
   response ^. U5c.caip2 H.=== networkMagicToCaip2 (fromIntegral testnetMagic)
@@ -71,11 +104,32 @@ hprop_rpc_read_genesis = integrationRetryWorkspace 2 "rpc-read-genesis" $ \tempA
   H.assertWith (cardanoGenesis ^. U5c.systemStart) $ not . Text.null
   void $ H.nothingFail (cardanoGenesis ^. U5c.maybe'protocolParams)
 
-  -- TODO: re-enable once cardano-rpc resolves initial funds from sgExtraConfig.
-  -- cardano-cli create-testnet-data funds wallets via sgExtraConfig.secInitialFunds and leaves the legacy sgInitialFunds field empty, so the RPC response's initialFunds map is currently always empty for testnet genesis.
-  -- Handler fix pending on cardano-api branch mgalazyn/fix/rpc-initial-funds-extraconfig.
-  -- H.note_ "initialFunds is non-empty: only the uncompacted boot-time genesis carries it, and cardano-testnet funds its wallets there"
-  -- H.assertWith (cardanoGenesis ^. U5c.initialFunds) $ not . Map.null
+  H.note_ "initialFunds matches exactly the funds embedded in the genesis file: only the uncompacted boot-time genesis carries them, and cardano-testnet funds its wallets there. create-testnet-data currently writes them to extraConfig.initialFunds.data; the legacy top-level initialFunds field covers older genesis layouts"
+  genesisJson <- H.leftFail (Aeson.eitherDecodeStrict' originalGenesisBytes :: Either String Aeson.Value)
+  -- The genesis carries funds in exactly one of these locations: ledger's 'resolveInjectionSource' rejects both being set.
+  initialFundsObject <-
+    H.nothingFail $
+      (genesisJson ^? Aeson.key "extraConfig" . Aeson.key "initialFunds" . Aeson.key "data" . Aeson._Object)
+        <|> (genesisJson ^? Aeson.key "initialFunds" . Aeson._Object)
+
+  expectedInitialFunds <-
+    Map.fromList
+      <$> H.nothingFail
+        ( traverse
+            (\(addressKey, amount) -> (,) (Aeson.toText addressKey) <$> amount ^? Aeson._Integer)
+            (Aeson.toList initialFundsObject)
+        )
+
+  H.note_ "initialFunds is non-empty (regression guard for #6655: cardano-testnet must always fund its wallets)"
+  H.assertWith expectedInitialFunds $ not . Map.null
+
+  actualInitialFunds <-
+    Map.fromList
+      <$> traverse
+        (\(addressHex, amount) -> (,) addressHex . toInteger <$> H.nothingFail (amount ^. U5c.maybe'int))
+        (Map.toList (cardanoGenesis ^. U5c.initialFunds))
+
+  actualInitialFunds H.=== expectedInitialFunds
 
   H.note_ "Byron: protocolConsts, startTime, bootStakeholders"
   protocolConsts <- H.nothingFail (cardanoGenesis ^. U5c.maybe'protocolConsts)


### PR DESCRIPTION
# Description

Strengthens the UTxO RPC `ReadGenesis` integration test in cardano-testnet.

- Re-enables the `initialFunds` assertion (temporarily relaxed in 764a27fbfa) and upgrades it to an exact comparison: the RPC response must match the funds embedded in the genesis file.
  The expectation prefers `extraConfig.initialFunds.data`, where `cardano-cli create-testnet-data` embeds the funds, and falls back to the legacy top-level `initialFunds`, so the test keeps working when a future cardano-cli moves the funds back to the top level.
- Checks the returned genesis hash against the Blake2b-256 hash of the raw Shelley genesis file bytes, replacing the previous length-only check.
- Adds an error-path check: `ReadGenesis` fails with `FAILED_PRECONDITION` when the genesis file changed since the node started.
  This check runs before the first successful call, because the server caches the parsed genesis only on success.

Stacked on #6668, merge that first.
The strengthened assertions rely on cardano-rpc 11.3 server behaviour (IntersectMBO/cardano-api#1305, resolving initial funds from `sgExtraConfig`), and the cardano-testnet test suite only compiles with the cardano-rpc 11.3 bump carried by #6668.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
  - `cardano-node-chairman`, `cardano-submit-api` and `cardano-testnet` instead need a
    changelog fragment in `<package>/.changes/`, because their `CHANGELOG.md` is generated
    from fragments at release time. Copy `_TEMPLATE.yml` from that directory, or run
    `nix run github:input-output-hk/cardano-dev#herald -- new`
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI. The following CI checks are required:
  - [ ] Code is linted with `hlint`. See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`. See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
