### PR TITLE
Leios prototype tx-firehose: dynamically allow for txs with more outputs

### DIFF
--- a/bench/tx-firehose/README.md
+++ b/bench/tx-firehose/README.md
@@ -29,13 +29,32 @@ The address is derived from `--signing-key-file` (payment key hash). Pass
 that address before starting, the tool exits if it finds no UTxO. Use `--help`
 for a full list of options.
 
+## Transaction shape
+
+Two modes, selected by whether `--inputs-per-tx` is given:
+
+**Both given** — every tx is built to exactly that shape: `--inputs-per-tx`
+inputs, `--outputs-per-tx` outputs. The UTxO set grows or shrinks accordingly,
+and the tool exits once fewer than `--inputs-per-tx` funds remain.
+
+**Only `--outputs-per-tx N`** — the input count is derived to keep the UTxO set
+size constant: steady-state txs spend `N` inputs into `N` outputs, so tx size is
+constant too. While the fund set holds fewer than `N` entries — at startup with
+a freshly funded address, say — a single tx fans the highest-value fund out into
+`N` outputs; that one tx is enough to reach the steady state, and no further
+fan-out happens. The default `N = 1` gives the classic 1-in/1-out self-payment.
+
+Every output is an equal split of (inputs − fee), so values stay balanced across
+the set. `--fee` must be covered by the inputs and each resulting output must
+clear min-UTxO; otherwise the build fails (traced as `TxFirehose.Build.Fail`).
+
 ## Output
 
 One JSON line per event on **stderr**, in the cardano-node trace schema (`{at,
 sev, host, thread, ns, data}`). Namespaces:
 
 - `TxFirehose.Startup.Query` / `TxFirehose.Startup.Seeded`
-- `TxFirehose.Submit.Success` — `{txId, size}`
+- `TxFirehose.Submit.Success` — `{txId, size, inputs, outputs}`
 - `TxFirehose.Submit.Reject` — `{txId, size, reason}`
 - `TxFirehose.Build.Fail`
 - `TxFirehose.Exit.MaxErrors`
@@ -47,7 +66,7 @@ Pipe stderr into Loki/Vector to filter on `ns` in Grafana.
 The process exits non-zero on:
 
 - empty UTxO at startup,
-- fund set draining below `--inputs-per-tx` (recycling stalled),
+- fund set draining below the tx's input count (recycling stalled),
 - `--max-consecutive-errors` consecutive rejects.
 
 Run it under a supervisor (systemd, k8s, `runit`) that restarts it; on restart

--- a/bench/tx-firehose/app/Main.hs
+++ b/bench/tx-firehose/app/Main.hs
@@ -44,7 +44,7 @@ import Cardano.Api
   )
 import Cardano.Api qualified as Api
 import Cardano.Benchmarking.TxFirehose.Tx
-  ( BuiltTx (BuiltTx, btxId, btxOutputs, btxSigned, btxSize)
+  ( BuiltTx (BuiltTx, btxId, btxInputs, btxOutputs, btxSigned, btxSize)
   , Fund (Fund, fundTxIn, fundValue)
   )
 import Cardano.Benchmarking.TxFirehose.Tx qualified as Tx
@@ -57,8 +57,10 @@ import Control.Monad.Trans.Except (runExceptT)
 import Data.Aeson (Value, (.=))
 import Data.Aeson qualified as Aeson
 import Data.ByteString.Lazy.Char8 qualified as BSL
+import Data.List (isInfixOf, sortOn)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
+import Data.Maybe (fromMaybe)
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -83,7 +85,7 @@ data Options = Options
   , optSigningKey :: !FilePath
   , optStakingKey :: !(Maybe FilePath)
   , optTps :: !Double
-  , optInputsPerTx :: !Natural
+  , optInputsPerTx :: !(Maybe Natural)
   , optOutputsPerTx :: !Natural
   , optFee :: !Integer
   , optMaxConsecutiveErrors :: !Int
@@ -131,13 +133,15 @@ optionsParser =
           <> Opt.metavar "NATURAL"
           <> Opt.help "Target submissions per second (rate ceiling)"
       )
-    <*> Opt.option
-      Opt.auto
-      ( Opt.long "inputs-per-tx"
-          <> Opt.metavar "NATURAL"
-          <> Opt.value 1
-          <> Opt.showDefault
-          <> Opt.help "Number of inputs per generated tx"
+    <*> optional
+      ( Opt.option
+          Opt.auto
+          ( Opt.long "inputs-per-tx"
+              <> Opt.metavar "NATURAL"
+              <> Opt.help
+                "Number of inputs per generated tx. Omit to derive it from \
+                \--outputs-per-tx and keep the UTxO set size constant."
+          )
       )
     <*> Opt.option
       Opt.auto
@@ -206,7 +210,7 @@ runInEra (AnyCardanoEra ce) k =
 validateOptions :: Options -> IO ()
 validateOptions opts = do
   when (optTps opts <= 0) $ die "--tps must be > 0"
-  when (optInputsPerTx opts == 0) $ die "--inputs-per-tx must be >= 1"
+  when (optInputsPerTx opts == Just 0) $ die "--inputs-per-tx must be >= 1"
   when (optOutputsPerTx opts == 0) $ die "--outputs-per-tx must be >= 1"
   when (optMaxConsecutiveErrors opts <= 0) $
     die "--max-consecutive-errors must be >= 1"
@@ -275,8 +279,14 @@ mkFirehoseClient sbe opts addr sk initialFunds =
   LocalTxSubmissionClient (step initialFunds 0)
  where
   !period = round (1_000_000 / optTps opts) :: Int
-  !n = fromIntegral (optInputsPerTx opts) :: Int
+  !target = fromIntegral (optOutputsPerTx opts) :: Int
+  !mFixedInputs = fromIntegral <$> optInputsPerTx opts :: Maybe Int
   !maxErrs = optMaxConsecutiveErrors opts
+
+  -- With a fixed input count we can only ever build a tx while that many
+  -- funds are on hand; ramping instead always has a move, down to one
+  -- remaining fund.
+  !minFunds = fromMaybe 1 mFixedInputs
 
   -- One step of the loop, in IO. Returns the next client state.
   step ::
@@ -284,14 +294,19 @@ mkFirehoseClient sbe opts addr sk initialFunds =
     Int ->
     IO (LocalTxClientStIdle TxInMode TxValidationErrorInCardanoMode IO ())
   step !funds !consec
-    | Map.size funds < n =
+    | Map.size funds < minFunds =
         -- We recycle outputs on every success and never lose funds on
         -- reject (inputs stay put), so running dry is catastrophic —
         -- exit and let the supervisor restart with a fresh query.
         pure (SendMsgDone ())
     | otherwise =
-        case Tx.buildTx sbe addr sk inFunds
-              (optOutputsPerTx opts) (Coin (optFee opts)) of
+        case Tx.buildTx
+          sbe
+          addr
+          sk
+          inFunds
+          (optOutputsPerTx opts)
+          (Coin (optFee opts)) of
           Left err -> do
             trace "TxFirehose.Build.Fail" "Error" $
               Aeson.object ["error" .= T.pack err]
@@ -301,7 +316,13 @@ mkFirehoseClient sbe opts addr sk initialFunds =
           Right built ->
             pure (submitStep funds funds' consec built)
    where
-    (chosen, funds') = takeInputs n funds
+    -- Fixed input count: build exactly that shape, whatever it does to
+    -- the UTxO set. Otherwise take the @target@ largest funds, which both
+    -- reaches the steady state from any starting shape and keeps it there:
+    -- @target@ in, @target@ out leaves the set size unchanged.
+    (chosen, funds') = case mFixedInputs of
+      Just n -> takeInputs n funds
+      Nothing -> takeLargest target (optFee opts) funds
     inFunds =
       [ Fund{fundTxIn = tin, fundValue = v}
       | (tin, v) <- chosen
@@ -320,14 +341,18 @@ mkFirehoseClient sbe opts addr sk initialFunds =
     fundsOnFail
     fundsOnSuccess
     !consec
-    BuiltTx{btxSigned, btxId, btxSize, btxOutputs} =
+    BuiltTx{btxSigned, btxId, btxSize, btxInputs, btxOutputs} =
       SendMsgSubmitTx (TxInMode sbe btxSigned) $ \result -> do
         threadDelay period
         case result of
           SubmitSuccess -> do
             trace "TxFirehose.Submit.Success" "Info" $
               Aeson.object
-                ["txId" .= btxId, "size" .= btxSize]
+                [ "txId" .= btxId
+                , "size" .= btxSize
+                , "inputs" .= btxInputs
+                , "outputs" .= length btxOutputs
+                ]
             let !funds'' = foldr addOutput fundsOnSuccess btxOutputs
             step funds'' 0
           SubmitFail reason -> do
@@ -337,7 +362,17 @@ mkFirehoseClient sbe opts addr sk initialFunds =
                 , "size" .= btxSize
                 , "reason" .= T.pack (show reason)
                 ]
-            onError fundsOnFail consec (show reason)
+            -- Keeping the inputs is right for a transient reject, but wrong when
+            -- the ledger says they are gone: 'takeInputs' is deterministic, so
+            -- the retry rebuilds this exact tx and earns this exact rejection,
+            -- forever. Worse at startup with a single UTxO and a fan-out target,
+            -- where that one tx is the only one buildable. Drop them so the next
+            -- build differs; if that drains the set we exit and the supervisor
+            -- restarts with a fresh query, which is the intended recovery.
+            onError
+              (if inputsAreGone (show reason) then fundsOnSuccess else fundsOnFail)
+              consec
+              (show reason)
 
   -- Bump the consecutive-error counter and either exit or loop.
   onError ::
@@ -362,12 +397,55 @@ mkFirehoseClient sbe opts addr sk initialFunds =
    where
     !consec' = consec + 1
 
+-- | Does this rejection mean the inputs we spent no longer exist?
+--
+-- Matched on the rendered error because the useful constructors sit behind
+-- several era-parameterised wrappers; the alternative is threading an era
+-- dictionary through purely to name two of them.
+inputsAreGone :: String -> Bool
+inputsAreGone reason =
+  any (`isInfixOf` reason) ["AllInputsAreSpent", "BadInputsUTxO"]
+
 -- | Deterministically pull @n@ entries out of a fund set.
 takeInputs :: Int -> Map TxIn Integer -> ([(TxIn, Integer)], Map TxIn Integer)
 takeInputs n m = (taken, m')
  where
   taken = take n (Map.toList m)
   m' = foldr (Map.delete . fst) m taken
+
+-- | Every generated output stays comfortably above min-UTxO, so a tx never
+-- creates a fund too small to be spent again.
+outputFloor :: Integer
+outputFloor = 1_500_000
+
+-- | Cap on inputs when consolidating, so a recovery tx cannot outgrow maxTxSize.
+maxConsolidationInputs :: Int
+maxConsolidationInputs = 100
+
+-- | Select inputs for a derived-shape tx: the @target@ largest funds, extended
+-- with the next largest until they cover the fee and leave every one of
+-- @target@ outputs above 'outputFloor'.
+--
+-- Selecting by value is the whole point. 'takeInputs' picks by 'TxIn' order,
+-- which is effectively random, so it can pick @target@ dust entries and split
+-- their sum @target@ ways — producing finer dust, and repeating until the
+-- selection cannot cover a fee. Taking the largest instead never sharpens the
+-- spiral, strands whatever dust exists rather than compounding it, and
+-- consolidates when the top funds alone are not enough.
+takeLargest ::
+  Int -> Integer -> Map TxIn Integer -> ([(TxIn, Integer)], Map TxIn Integer)
+takeLargest target fee m = go [] 0 byValue
+ where
+  byValue = sortOn (negate . snd) (Map.toList m)
+  needed = fee + fromIntegral target * outputFloor
+  done acc = (reverse acc, foldr (Map.delete . fst) m acc)
+  go acc total rest
+    -- Enough value, and at least the target shape (or everything we have).
+    | total >= needed, length acc >= min target (Map.size m) = done acc
+    | length acc >= maxConsolidationInputs = done acc
+    | otherwise = case rest of
+        [] -> done acc
+        (entry : more) -> go (entry : acc) (total + snd entry) more
 
 addOutput :: Fund -> Map TxIn Integer -> Map TxIn Integer
 addOutput f = Map.insert (fundTxIn f) (fundValue f)

--- a/bench/tx-firehose/src/Cardano/Benchmarking/TxFirehose/Tx.hs
+++ b/bench/tx-firehose/src/Cardano/Benchmarking/TxFirehose/Tx.hs
@@ -49,6 +49,7 @@ data BuiltTx era = BuiltTx
   { btxSigned :: !(Api.Tx era)
   , btxId :: !TxId
   , btxSize :: !Word32
+  , btxInputs :: !Int
   , btxOutputs :: ![Fund]
   }
 
@@ -117,6 +118,7 @@ buildTx sbe destAddr signingKey inFunds numOutputs fee
       { btxSigned = Api.ShelleyTx sbe ledgerTx
       , btxId = ledgerTxId
       , btxSize = ledgerTx ^. sizeTxF
+      , btxInputs = length inFunds
       , btxOutputs = outFunds
       }
 


### PR DESCRIPTION
Two bugs stopped --outputs-per-tx > 1 from running for more than a few seconds, both showing up as "insufficient funds - total inputs (364400 lovelace) do not cover fee (1000000)".

takeInputs picks by TxIn order, i.e. effectively at random, so it could select `target` dust entries and split their sum `target` ways — producing finer dust, and repeating. 364,400 lovelace sits exactly in the divide-by-5 sequence down from the original 30M ADA, with the value itself untouched (29,999,924,000,000 across 305 UTxOs) simply because it was never selected. takeLargest instead takes the `target` largest funds, extending with the next largest until they cover fee + target * outputFloor, so an output is never created too small to spend again and stranded dust gets consolidated rather than sharpened. That also subsumes the fan-out case, so takeFattest goes.

Separately, keeping the inputs on a reject is right for a transient failure but wrong when the ledger says they are gone: takeInputs is deterministic, so the retry rebuilt the same tx and earned the same rejection until max-consecutive-errors. Worse at startup with a single UTxO and a fan-out target, where that one tx is the only one buildable.

Measured on dozen-devnet: --outputs-per-tx 5 gives 648 B transactions, 5 in / 5 out, no failures.

# Description

Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
  - `cardano-node-chairman`, `cardano-submit-api` and `cardano-testnet` instead need a
    changelog fragment in `<package>/.changes/`, because their `CHANGELOG.md` is generated
    from fragments at release time.  Copy `_TEMPLATE.yml` from that directory, or run
    `nix run github:input-output-hk/cardano-dev#herald -- new`
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
