### PR TITLE
Call `protocolInfo` only once at startup to avoid rebuilding the ledger state

### DIFF
--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -65,6 +65,7 @@ import           Cardano.Slotting.Slot (WithOrigin (..))
 import           Cardano.Logging.Types (LogFormatting)
 import           Cardano.Logging.Utils (showT)
 
+import           Ouroboros.Consensus.Block.Forging (MkBlockForging)
 import qualified Ouroboros.Consensus.Config as Consensus
 import           Ouroboros.Consensus.Config.SupportsNode (ConfigSupportsNode (..))
 import           Ouroboros.Consensus.Node (SnapshotPolicyArgs (..),
@@ -221,8 +222,8 @@ handleNodeWithTracers
   -> SomeConsensusProtocol
   -> Api.GenesisHashShelley
   -> IO ()
-handleNodeWithTracers cmdPc nc p@(SomeConsensusProtocol blockType runP) shelleyGenesisHash = do
-  (ProtocolInfo{pInfoConfig}, mkBlockForging) <- Api.protocolInfo @IO runP
+handleNodeWithTracers cmdPc nc (SomeConsensusProtocol blockType runP) shelleyGenesisHash = do
+  (pInfo@ProtocolInfo{pInfoConfig}, mkBlockForging) <- Api.protocolInfo @IO runP
   let networkMagic :: Api.NetworkMagic = getNetworkMagic $ Consensus.configBlock pInfoConfig
   -- This IORef contains node kernel structure which holds node kernel.
   -- Used for ledger queries and peer connection status.
@@ -234,12 +235,13 @@ handleNodeWithTracers cmdPc nc p@(SomeConsensusProtocol blockType runP) shelleyG
   tracers <-
     initTraceDispatcher
       nc
-      p
+      blockType
+      pInfoConfig
       networkMagic
       nodeKernelData
       (null blockForging)
 
-  startupInfo <- getStartupInfo nc p fp
+  startupInfo <- getStartupInfo nc blockType pInfoConfig fp
   mapM_ (traceWith $ startupTracer tracers) startupInfo
   traceNodeStartupInfo (nodeStartupInfoTracer tracers) startupInfo
   -- sends initial BlockForgingUpdate
@@ -249,7 +251,7 @@ handleNodeWithTracers cmdPc nc p@(SomeConsensusProtocol blockType runP) shelleyG
                                   then DisabledBlockForging
                                   else EnabledBlockForging))
 
-  handleSimpleNode blockType shelleyGenesisHash runP tracers nc cmdPc networkMagic
+  handleSimpleNode blockType shelleyGenesisHash runP pInfo mkBlockForging tracers nc cmdPc networkMagic
     (\nk -> do
         setNodeKernel nodeKernelData nk
         traceWith (nodeStateTracer tracers) NodeKernelOnline)
@@ -288,6 +290,8 @@ handleSimpleNode
   => Api.BlockType blk
   -> Api.GenesisHashShelley
   -> Api.ProtocolInfoArgs IO blk
+  -> ProtocolInfo blk
+  -> (Tracer IO KESAgentClientTrace -> IO [MkBlockForging IO blk])
   -> Tracers RemoteAddress LocalAddress blk IO
   -> NodeConfiguration
   -> PartialNodeConfiguration
@@ -299,7 +303,7 @@ handleSimpleNode
   -- layer is initialised.  This implies this function must not block,
   -- otherwise the node won't actually start.
   -> IO ()
-handleSimpleNode blockType shelleyGenesisHash runP tracers nc cmdPc networkMagic onKernel = do
+handleSimpleNode blockType shelleyGenesisHash runP pInfo mkBlockForging tracers nc cmdPc networkMagic onKernel = do
   logStartupWarnings
 
   logDeprecatedLedgerDBOptions
@@ -310,8 +314,6 @@ handleSimpleNode blockType shelleyGenesisHash runP tracers nc cmdPc networkMagic
   when (ncValidateDB nc) $
     traceWith (startupTracer tracers)
       StartupDBValidation
-
-  pInfo <- fst <$> Api.protocolInfo @IO runP
 
   (publicIPv4SocketOrAddr, publicIPv6SocketOrAddr, localSocketOrPath) <- do
     result <- runExceptT (gatherConfiguredSockets $ ncSocketConfig nc)
@@ -391,7 +393,6 @@ handleSimpleNode blockType shelleyGenesisHash runP tracers nc cmdPc networkMagic
               }
           , rnNodeKernelHook = \registry nodeKernel -> do
               -- set the initial block forging
-              (_, mkBlockForging) <- Api.protocolInfo runP
               blockForging <- mkBlockForging (Consensus.kesAgentTracer $ consensusTracers tracers)
 
               unless (ncStartAsNonProducingNode nc) $

--- a/cardano-node/src/Cardano/Node/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Startup.hs
@@ -28,7 +28,6 @@ import           Cardano.Network.NodeToNode (DiffusionMode (..), NodeToNodeVersi
 import           Cardano.Node.Configuration.POM (NodeConfiguration (..), ncProtocol)
 import           Cardano.Node.Configuration.Socket
 import           Cardano.Node.Protocol (ProtocolInstantiationError)
-import           Cardano.Node.Protocol.Types (SomeConsensusProtocol (..))
 import           Cardano.Node.Types (PeerSnapshotFile (..))
 import           Cardano.Slotting.Slot (SlotNo)
 import qualified Ouroboros.Consensus.BlockchainTime.WallClock.Types as WCT
@@ -37,7 +36,6 @@ import           Ouroboros.Consensus.Cardano.CanHardFork (shelleyLedgerConfig)
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.HardFork.Combinator.Degenerate
 import           Ouroboros.Consensus.Ledger.Query (getSystemStart)
-import           Ouroboros.Consensus.Node (pInfoConfig)
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion (BlockNodeToClientVersion,
                    BlockNodeToNodeVersion)
 import           Ouroboros.Consensus.Shelley.Ledger.Ledger (shelleyLedgerGenesis)
@@ -206,18 +204,19 @@ data BasicInfoNetwork = BasicInfoNetwork {
 
 -- | Prepare basic info about the node. This info will be sent to 'cardano-tracer'.
 prepareNodeInfo
-  :: NodeConfiguration
-  -> SomeConsensusProtocol
+  :: Api.ConfigSupportsNode blk
+  => NodeConfiguration
+  -> Api.BlockType blk
+  -> TopLevelConfig blk
   -> TraceConfig
   -> UTCTime
   -> IO NodeInfo
-prepareNodeInfo nc (SomeConsensusProtocol whichP pForInfo) tc nodeStartTime = do
+prepareNodeInfo nc blockType cfg tc nodeStartTime = do
   nodeName <- prepareNodeName
-  cfg <- pInfoConfig . fst <$> Api.protocolInfo @IO pForInfo
   let getSystemStartByron = WCT.getSystemStart . getSystemStart . configBlock $ cfg
       systemStartTime :: UTCTime
       systemStartTime =
-        case whichP of
+        case blockType of
           Api.ByronBlockType ->
             getSystemStartByron
           Api.ShelleyBlockType ->

--- a/cardano-node/src/Cardano/Node/Tracing/API.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/API.hs
@@ -12,13 +12,14 @@ module Cardano.Node.Tracing.API
   ( initTraceDispatcher
   ) where
 
+import           Cardano.Api (BlockType)
+
 import           Cardano.Logging hiding (traceWith)
 import           Cardano.Logging.Prometheus.TCPServer
 import           Cardano.Network.NodeToClient (LocalAddress, withIOManager)
 import           Cardano.Network.NodeToNode (RemoteAddress)
 import           Cardano.Node.Configuration.NodeAddress (PortNumber)
 import           Cardano.Node.Configuration.POM (NodeConfiguration (..))
-import           Cardano.Node.Protocol.Types
 import           Cardano.Node.Queries
 import           Cardano.Node.Startup
 import           Cardano.Node.TraceConstraints
@@ -29,6 +30,7 @@ import           Cardano.Node.Tracing.Tracers
 import           Cardano.Node.Tracing.Tracers.LedgerMetrics
 import           Cardano.Node.Tracing.Tracers.Resources (startResourceTracer)
 import           Cardano.Node.Types
+import           Ouroboros.Consensus.Config (TopLevelConfig)
 import           Ouroboros.Consensus.Ledger.Inspect (LedgerEvent)
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client (TraceChainSyncClientEvent)
 import           Ouroboros.Consensus.Node.GSM
@@ -62,12 +64,13 @@ initTraceDispatcher ::
   , LogFormatting (TraceGsmEvent (Tip blk))
   )
   => NodeConfiguration
-  -> SomeConsensusProtocol
+  -> BlockType blk
+  -> TopLevelConfig blk
   -> NetworkMagic
   -> NodeKernelData blk
   -> Bool
   -> IO (Tracers RemoteAddress LocalAddress blk  IO)
-initTraceDispatcher nc p networkMagic nodeKernel noBlockForging = do
+initTraceDispatcher nc blockType cfg networkMagic nodeKernel noBlockForging = do
   trConfig <- readConfigurationWithDefault
                 (FromFile (unConfigPath $ ncConfigFile nc))
                 defaultCardanoConfig
@@ -77,7 +80,7 @@ initTraceDispatcher nc p networkMagic nodeKernel noBlockForging = do
   -- The NodeInfo DataPoint needs to be fully evaluated and stored
   -- before it is queried for the first time by cardano-tracer.
   -- Hence, we delay initiating the forwarding connection.
-  nodeInfo <- prepareNodeInfo nc p trConfig =<< getCurrentTime
+  nodeInfo <- prepareNodeInfo nc blockType cfg trConfig =<< getCurrentTime
   nodeInfo `deepseq` traceWith (nodeInfoTracer tracers) nodeInfo
 
   kickoffForwarder
@@ -150,7 +153,6 @@ initTraceDispatcher nc p networkMagic nodeKernel noBlockForging = do
       (Just ekgTrace)
       dpTracer
       trConfig
-      p
 
     let
       kickoffPrometheusSimple = case prometheusSimple of

--- a/cardano-node/src/Cardano/Node/Tracing/StateRep.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/StateRep.hs
@@ -24,7 +24,6 @@ import           Cardano.Api (textShow)
 import           Cardano.Logging
 import           Cardano.Logging.Prometheus.TCPServer (TracePrometheusSimple (..))
 import           Cardano.Node.Handlers.Shutdown (ShutdownTrace)
-import           Cardano.Node.Protocol.Types (SomeConsensusProtocol (..))
 import qualified Cardano.Node.Startup as Startup
 import           Cardano.Slotting.Slot (EpochNo, SlotNo (..), WithOrigin, withOrigin)
 import qualified Ouroboros.Consensus.Block.RealPoint as RP
@@ -253,11 +252,10 @@ instance MetaTrace NodeState where
 
 
 traceNodeStateChainDB
-  :: SomeConsensusProtocol
-  -> Trace IO NodeState
+  :: Trace IO NodeState
   -> ChainDB.TraceEvent blk
   -> IO ()
-traceNodeStateChainDB _scp tr ev =
+traceNodeStateChainDB tr ev =
   case ev of
     ChainDB.TraceOpenEvent ev' ->
       case ev' of

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
@@ -23,7 +23,6 @@ import           Cardano.Network.NodeToClient.Version ()
 import           Cardano.Network.NodeToNode (RemoteAddress)
 import           Cardano.Network.NodeToNode.Version ()
 import           Cardano.Network.OrphanInstances ()
-import           Cardano.Node.Protocol.Types (SomeConsensusProtocol)
 import           Cardano.Node.Queries (NodeKernelData)
 import           Cardano.Node.TraceConstraints
 import           Cardano.Node.Tracing
@@ -87,10 +86,9 @@ mkDispatchTracers
   -> Maybe (Trace IO FormattedMessage)
   -> Trace IO DataPoint
   -> TraceConfig
-  -> SomeConsensusProtocol
   -> IO (Tracers RemoteAddress LocalAddress blk IO)
 
-mkDispatchTracers nodeKernel trBase trForward mbTrEKG trDataPoint trConfig p = do
+mkDispatchTracers nodeKernel trBase trForward mbTrEKG trDataPoint trConfig = do
 
     configReflection <- emptyConfigReflection
 
@@ -175,7 +173,7 @@ mkDispatchTracers nodeKernel trBase trForward mbTrEKG trDataPoint trConfig p = d
       {
         chainDBTracer = mkTracer (traceWith chainDBTr')
                       <> mkTracer (traceWith replayBlockTr')
-                      <> mkTracer (SR.traceNodeStateChainDB p nodeStateDP)
+                      <> mkTracer (SR.traceNodeStateChainDB nodeStateDP)
       , consensusTracers = consensusTr
       , churnModeTracer = mkTracer (traceWith churnModeTr)
       , nodeToClientTracers = nodeToClientTr

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
@@ -27,7 +27,6 @@ import           Cardano.Network.NodeToNode (DiffusionMode (..))
 import           Cardano.Network.OrphanInstances ()
 import           Cardano.Node.Configuration.POM (NodeConfiguration, ncProtocol)
 import           Cardano.Node.Configuration.Socket
-import           Cardano.Node.Protocol (SomeConsensusProtocol (..))
 import           Cardano.Node.Startup
 import           Cardano.Node.Types (PeerSnapshotFile (..))
 import           Cardano.Slotting.Slot (EpochSize (..))
@@ -41,7 +40,6 @@ import qualified Ouroboros.Consensus.Config as Consensus
 import           Ouroboros.Consensus.Config.SupportsNode (ConfigSupportsNode (..))
 import           Ouroboros.Consensus.HardFork.Combinator.Degenerate (HardForkLedgerConfig (..))
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
-import           Ouroboros.Consensus.Node.ProtocolInfo (ProtocolInfo (..))
 import           Ouroboros.Consensus.Shelley.Ledger.Ledger (shelleyLedgerGenesis)
 import           Ouroboros.Network.PeerSelection.LedgerPeers.Type (AfterSlot (..),
                    UseLedgerPeers (..))
@@ -61,13 +59,14 @@ import           Paths_cardano_node (version)
 
 
 getStartupInfo
-  :: NodeConfiguration
-  -> SomeConsensusProtocol
+  :: ConfigSupportsNode blk
+  => NodeConfiguration
+  -> Api.BlockType blk
+  -> Consensus.TopLevelConfig blk
   -> FilePath
   -> IO [StartupTrace blk]
-getStartupInfo nc (SomeConsensusProtocol whichP pForInfo) fp = do
+getStartupInfo nc blockType cfg fp = do
   nodeStartTime <- getCurrentTime
-  cfg <- pInfoConfig . fst <$> Api.protocolInfo @IO pForInfo
   let basicInfoCommon = BICommon $ BasicInfoCommon {
                 biProtocol = pack . show $ ncProtocol nc
               , biVersion  = pack . showVersion $ version
@@ -77,7 +76,7 @@ getStartupInfo nc (SomeConsensusProtocol whichP pForInfo) fp = do
               , biNetworkMagic = getNetworkMagic $ Consensus.configBlock cfg
               }
       protocolDependentItems =
-        case whichP of
+        case blockType of
           Api.ByronBlockType ->
             let DegenLedgerConfig cfgByron = Consensus.configLedger cfg
             in [getGenesisValuesByron cfg cfgByron]


### PR DESCRIPTION
# Description

Companion PR to https://github.com/IntersectMBO/cardano-ledger/pull/6017 to reduce heap usage.
In node 11.1 `Api.protocolInfo` is now a monadic action, stricter than its previous non-monadic version. As such, it rebuilds the ledger state every time it is invoked, which churns through heap allocations unnecessarily. This patch calls `protocolInfo` once at startup and threads it through to the places that need the info. 

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
  - `cardano-node-chairman`, `cardano-submit-api` and `cardano-testnet` instead need a
    changelog fragment in `<package>/.changes/`, because their `CHANGELOG.md` is generated
    from fragments at release time.  Copy `_TEMPLATE.yml` from that directory, or run
    `nix run github:input-output-hk/cardano-dev#herald -- new`
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
