### PR TITLE
Bump cardano-api to 11.6, cardano-rpc to 11.2, cardano-cli to 11.2.2

### DIFF
--- a/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
+++ b/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
@@ -86,7 +86,7 @@ library
   -- IOG dependencies
   --------------------------
   build-depends:
-    , cardano-api             ^>=11.5
+    , cardano-api             ^>=11.6
     , plutus-ledger-api       ^>=1.65
     , plutus-tx               ^>=1.65
     , plutus-tx-plugin        ^>=1.65

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -116,9 +116,9 @@ library
                       , attoparsec-aeson
                       , base16-bytestring
                       , bytestring
-                      , cardano-api ^>= 11.5
+                      , cardano-api ^>= 11.6
                       , cardano-binary
-                      , cardano-cli ^>= 11.2.1
+                      , cardano-cli ^>= 11.2.2
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
                       , cardano-data

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2026-08-14T13:38:07Z
-  , cardano-haskell-packages 2026-08-17T11:39:16Z
+  , cardano-haskell-packages 2026-08-25T16:32:51Z
 
 constraints:
   -- haskell.nix patch does not work for 1.6.8

--- a/cardano-node-chairman/.changes/20260825_191016_mgalazyn_bump_cardano_cli.yml
+++ b/cardano-node-chairman/.changes/20260825_191016_mgalazyn_bump_cardano_cli.yml
@@ -1,0 +1,5 @@
+pr: 6662
+kind:
+  - maintenance
+description: |
+  Bumped the `cardano-cli` dependency to `^>= 11.2.2`.

--- a/cardano-node-chairman/cardano-node-chairman.cabal
+++ b/cardano-node-chairman/cardano-node-chairman.cabal
@@ -86,5 +86,5 @@ test-suite chairman-tests
   ghc-options:          -threaded -rtsopts "-with-rtsopts=-N -T"
 
   build-tool-depends:   cardano-node:cardano-node
-                      , cardano-cli:cardano-cli ^>= 11.2.1
+                      , cardano-cli:cardano-cli ^>= 11.2.2
                       , cardano-node-chairman:cardano-node-chairman

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -133,7 +133,7 @@ library
                       , async
                       , base16-bytestring
                       , bytestring
-                      , cardano-api ^>= 11.5
+                      , cardano-api ^>= 11.6
                       , cardano-data
                       , cardano-crypto-class ^>=2.5
                       , cardano-crypto-wrapper
@@ -152,7 +152,7 @@ library
                       , cardano-protocol ^>= 0.1
                       , cardano-protocol-tpraos >= 1.4
                       , cardano-slotting >= 0.2
-                      , cardano-rpc ^>= 11.1
+                      , cardano-rpc ^>= 11.2
                       , cborg ^>= 0.2.4
                       , containers
                       , contra-tracer >= 0.2.1

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -251,7 +251,7 @@ handleNodeWithTracers cmdPc nc (SomeConsensusProtocol blockType runP) shelleyGen
                                   then DisabledBlockForging
                                   else EnabledBlockForging))
 
-  handleSimpleNode blockType shelleyGenesisHash runP pInfo mkBlockForging tracers nc cmdPc networkMagic
+  handleSimpleNode blockType shelleyGenesisHash pInfo mkBlockForging tracers nc cmdPc networkMagic
     (\nk -> do
         setNodeKernel nodeKernelData nk
         traceWith (nodeStateTracer tracers) NodeKernelOnline)
@@ -289,7 +289,6 @@ handleSimpleNode
     )
   => Api.BlockType blk
   -> Api.GenesisHashShelley
-  -> Api.ProtocolInfoArgs IO blk
   -> ProtocolInfo blk
   -> (Tracer IO KESAgentClientTrace -> IO [MkBlockForging IO blk])
   -> Tracers RemoteAddress LocalAddress blk IO
@@ -303,7 +302,7 @@ handleSimpleNode
   -- layer is initialised.  This implies this function must not block,
   -- otherwise the node won't actually start.
   -> IO ()
-handleSimpleNode blockType shelleyGenesisHash runP pInfo mkBlockForging tracers nc cmdPc networkMagic onKernel = do
+handleSimpleNode blockType shelleyGenesisHash pInfo mkBlockForging tracers nc cmdPc networkMagic onKernel = do
   logStartupWarnings
 
   logDeprecatedLedgerDBOptions
@@ -483,7 +482,7 @@ handleSimpleNode blockType shelleyGenesisHash runP pInfo mkBlockForging tracers 
                 mkNodeKernelAccess
                   (rpcTracer tracers)
                   shelleyGenesisHash
-                  runP
+                  shelleyGenesisFile
                   blockType
                   nodeKernel
                   >>= writeIORef nodeKernelAccessRef
@@ -505,6 +504,12 @@ handleSimpleNode blockType shelleyGenesisHash runP pInfo mkBlockForging tracers 
             , srnLedgerDbBackendArgs          = selectorToArgs ldbBackend (nonImmutableDbPath dbPath)
             }
  where
+  shelleyGenesisFile :: Api.ShelleyGenesisFile In
+  shelleyGenesisFile =
+    case ncProtocolConfig nc of
+      NodeProtocolConfigurationCardano _ shelleyConfig _ _ _ _ _ ->
+        File . unGenesisFile $ npcShelleyGenesisFile shelleyConfig
+
   customizeChainSyncTimeout :: ChainSyncIdleTimeout
   customizeChainSyncTimeout = case ncChainSyncIdleTimeout nc of
     NoTimeoutOverride -> Configuration.defaultChainSyncIdleTimeout

--- a/cardano-submit-api/.changes/20260825_191016_mgalazyn_bump_cardano_api_cardano_cli.yml
+++ b/cardano-submit-api/.changes/20260825_191016_mgalazyn_bump_cardano_api_cardano_cli.yml
@@ -1,0 +1,5 @@
+pr: 6662
+kind:
+  - maintenance
+description: |
+  Bumped the `cardano-api` dependency to `^>= 11.6` and the `cardano-cli` dependency to `^>= 11.2.2`.

--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -39,9 +39,9 @@ library
                       , aeson
                       , async
                       , bytestring
-                      , cardano-api ^>= 11.5
+                      , cardano-api ^>= 11.6
                       , cardano-binary
-                      , cardano-cli ^>= 11.2.1
+                      , cardano-cli ^>= 11.2.2
                       , cardano-crypto-class ^>=2.5
                       , containers
                       , ekg-core

--- a/cardano-testnet/.changes/20260825_191016_mgalazyn_bump_cardano_api_cardano_cli.yml
+++ b/cardano-testnet/.changes/20260825_191016_mgalazyn_bump_cardano_api_cardano_cli.yml
@@ -1,0 +1,5 @@
+pr: 6662
+kind:
+  - maintenance
+description: |
+  Bumped the `cardano-api` dependency to `^>= 11.6` and the `cardano-cli` dependency to `^>= 11.2.2`.

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -41,8 +41,8 @@ library
                       , annotated-exception
                       , ansi-terminal
                       , bytestring
-                      , cardano-api ^>= 11.5
-                      , cardano-cli:{cardano-cli, cardano-cli-test-lib} ^>= 11.2.1
+                      , cardano-api ^>= 11.6
+                      , cardano-cli:{cardano-cli, cardano-cli-test-lib} ^>= 11.2.2
                       , cardano-crypto-class ^>=2.5
                       , cardano-crypto-wrapper
                       , cardano-git-rev ^>= 0.2.2

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/version_cmd.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/version_cmd.cli
@@ -1,3 +1,3 @@
-built against cardano-api 11.5.0.0
-built against cardano-rpc 11.1.0.0
-built against cardano-cli 11.2.1.0
+built against cardano-api 11.6.0.0
+built against cardano-rpc 11.2.0.0
+built against cardano-cli 11.2.2.0

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1786970582,
-        "narHash": "sha256-V1jy4O3CNrd8dPvK2/c79ok4jLO5GXetugI4nvgcq/A=",
+        "lastModified": 1787677150,
+        "narHash": "sha256-Ru37zk78DtqVqO2HBFihohDfeSM2aEyp8ZIGkiDIRBc=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "c0770200fcaa899ecdef548183dfee78e17bfb57",
+        "rev": "23792e6f99c252d68f8c78b45606cbab54988367",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Description

Integrates the new cardano-api 11.6.0.0, cardano-rpc 11.2.0.0 and cardano-cli 11.2.2.0 releases.

Bump dependencies and CHaP index in cardano-node:

- **cardano-api** `^>= 11.5` to `^>= 11.6`
- **cardano-cli** `^>= 11.2.1` to `^>= 11.2.2`
- **cardano-rpc** `^>= 11.1` to `^>= 11.2`
- **CHaP index-state** bumped from `2026-08-17T11:39:16Z` to `2026-08-25T16:32:51Z`
- **CHaP flake input** updated to match the new index-state pin

### Migration fixes

- **`cardano-node/src/Cardano/Node/Run.hs`**: the cardano-rpc 11.2 `mkNodeKernelAccess` now takes the Shelley genesis file path as its third argument instead of the run parameters value.
  `handleSimpleNode` was updated to match.
  It now passes a `shelleyGenesisFile` derived from `npcShelleyGenesisFile` on the node's `NodeProtocolConfigurationCardano`, instead of `runP`.

### Changelogs

- https://github.com/IntersectMBO/cardano-api/releases/tag/cardano-api-11.6.0.0
- https://github.com/IntersectMBO/cardano-api/releases/tag/cardano-rpc-11.2.0.0
- https://github.com/IntersectMBO/cardano-cli/releases/tag/cardano-cli-11.2.2.0

Changelog fragments for `cardano-testnet`, `cardano-submit-api` and `cardano-node-chairman` are already included in this PR.
Their `pr:` fields are being updated from the placeholder `0` to `6662` and will be pushed shortly.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
  - `cardano-node-chairman`, `cardano-submit-api` and `cardano-testnet` instead need a
    changelog fragment in `<package>/.changes/`, because their `CHANGELOG.md` is generated
    from fragments at release time.  Copy `_TEMPLATE.yml` from that directory, or run
    `nix run github:input-output-hk/cardano-dev#herald -- new`
- [x] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
