### PR TITLE
Node SRE 11.1.1 updates

### DIFF
--- a/configuration/cardano/mainnet-topology.json
+++ b/configuration/cardano/mainnet-topology.json
@@ -7,10 +7,6 @@
     {
       "address": "backbone.mainnet.cardanofoundation.org",
       "port": 3001
-    },
-    {
-      "address": "backbone.mainnet.emurgornd.com",
-      "port": 3001
     }
   ],
   "localRoots": [

--- a/flake.lock
+++ b/flake.lock
@@ -1142,11 +1142,11 @@
         "sodium": "sodium_2"
       },
       "locked": {
-        "lastModified": 1786665795,
-        "narHash": "sha256-IYKsT8+Fl4P/KQPnLhFEexK1cgtCJefoWfovvF+URlM=",
+        "lastModified": 1787718550,
+        "narHash": "sha256-Wkevfb7P201JHWpP4sbSg3HEO4YDPuCrwvARatfF2RI=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "9ebcc963cc35bf8ba974a069186dbe101dfdf395",
+        "rev": "af463a46dbe9c6e2db6b2639c0f35f5689e0c3a8",
         "type": "github"
       },
       "original": {

--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -33,10 +33,11 @@ let
   };
 
   assertNewTopology = i:
+    let topo = newTopology i; in
     assert assertMsg
-    (cfg.bootstrapPeers == [] -> any (e: e.trustable == true) (newTopology i).localRoots)
+    (cfg.bootstrapPeers == [] -> any (e: e.trustable == true) topo.localRoots)
     "When bootstrapPeers is an empty list, at least one localRoot must be trustable, otherwise cardano node will fail to start.";
-    newTopology i;
+    topo;
 
   selectTopology = i:
     if cfg.topology != null

--- a/nix/nixos/cardano-node-service.nix
+++ b/nix/nixos/cardano-node-service.nix
@@ -33,17 +33,10 @@ let
   };
 
   assertNewTopology = i:
-    let
-      checkEval = tryEval (
-        assert
-          if cfg.bootstrapPeers == [] && all (e: e.trustable != true) ((newTopology i).localRoots)
-          then false
-          else true;
-      newTopology i);
-    in
-      if checkEval.success
-      then checkEval.value
-      else abort "When bootstrapPeers is an empty list, at least one localRoot must be trustable, otherwise cardano node will fail to start.";
+    assert assertMsg
+    (cfg.bootstrapPeers == [] -> any (e: e.trustable == true) (newTopology i).localRoots)
+    "When bootstrapPeers is an empty list, at least one localRoot must be trustable, otherwise cardano node will fail to start.";
+    newTopology i;
 
   selectTopology = i:
     if cfg.topology != null


### PR DESCRIPTION
# Description

* Updates iohkNix for mainnet bootstrap peers list change
* Updates mainnet ci configuration to match
* Fix the cardano-node nixOS service to not swallow topology eval errors into an unrelated check 

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] CI passes. See note on CI.  The following CI checks are required:
- [X] Self-reviewed the diff