### PR TITLE
Fix for cdf announcement metrics

### DIFF
--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
@@ -2357,7 +2357,7 @@ calculateLeiosMetrics ::
 calculateLeiosMetrics lm@LeiosMetrics {..} _lc (TraceLeiosAnnouncementAccepted _ _ fields (Just annDelay)) =
     case announcementElection fields of
       MkElId slotNo@(SlotNo slotNo_) _ ->
-        if Cdf.null lmCdfState
+        if Cdf.null lmCdfState && annDelay > 20 -- During startup wait until we are in sync
           then nothingToDo
           else
             case Cdf.processDataPoint
@@ -2368,7 +2368,10 @@ calculateLeiosMetrics lm@LeiosMetrics {..} _lc (TraceLeiosAnnouncementAccepted _
                    of
               Nothing -> nothingToDo
               Just (lm', lmCdfState') ->
-                lm' { lmCdfState    = lmCdfState'
+                lm' { lmCdfState  = lmCdfState'
+                    , lmTraceIt   = True
+                    , lmTraceVars = Cdf.size lmCdfState' >= 45 -- wait until we have at least 45 samples before providing cdf estimates
+                    , lmDelay     = realToFrac annDelay
                     }
   where
     nothingToDo = lm {lmTraceIt = False}


### PR DESCRIPTION
# Description

CDFs needs to be populated once we are in sync (e.g. when announcment
delay is less than 20s old).

I confirmed the CDFs are available via prometheus:
```
$ curl 127.0.0.1:12798/metrics 2&>/dev/null | rg cardano | rg cdf
cardano_node_metrics_leios_eb_announcement_delay_cdf1400ms_real 0.875
cardano_node_metrics_leios_eb_announcement_delay_cdf2000ms_real 0.9
cardano_node_metrics_leios_eb_announcement_delay_cdf1200ms_real 0.8583333333333333
cardano_node_metrics_leios_eb_announcement_delay_cdf800ms_real 0.6416666666666667
cardano_node_metrics_leios_eb_announcement_delay_cdf1000ms_real 0.6916666666666667
cardano_node_metrics_leios_eb_announcement_delay_cdf200ms_real 7.5e-2
cardano_node_metrics_leios_eb_announcement_delay_cdf1800ms_real 0.8916666666666667
cardano_node_metrics_leios_eb_announcement_delay_cdf600ms_real 0.55
cardano_node_metrics_leios_eb_announcement_delay_cdf1600ms_real 0.8833333333333333
cardano_node_metrics_leios_eb_announcement_delay_cdf400ms_real 0.375
```

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
  - `cardano-node-chairman`, `cardano-submit-api` and `cardano-testnet` instead need a
    changelog fragment in `<package>/.changes/`, because their `CHANGELOG.md` is generated
    from fragments at release time.  Copy `_TEMPLATE.yml` from that directory, or run
    `nix run github:input-output-hk/cardano-dev#herald -- new`
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
