### PR TITLE
gRPC: update tests for latest v1beta UTXORPC

### DIFF
--- a/cardano-testnet/.changes/20260820_124721_mgalazyn_reenable_rpc_readgenesis_initialfunds_assertion.yml
+++ b/cardano-testnet/.changes/20260820_124721_mgalazyn_reenable_rpc_readgenesis_initialfunds_assertion.yml
@@ -1,0 +1,5 @@
+pr: 6657
+kind:
+  - test
+description: |
+  Strengthened the UTxO RPC `ReadGenesis` test: re-enabled the `initialFunds` assertion and upgraded it to an exact comparison with the funds embedded in the genesis file, checked the returned genesis hash against the Blake2b-256 hash of the Shelley genesis file, and added coverage for the `FAILED_PRECONDITION` error when the genesis file changes after node startup.

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/FetchBlock.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/FetchBlock.hs
@@ -98,12 +98,12 @@ hprop_rpc_fetch_block = integrationRetryWorkspace 2 "rpc-fetch-block" $ \tempAbs
 
     -- Call FetchBlock via gRPC
     let blockRef = def & U5c.slot .~ slot & U5c.hash .~ tipHash
-        request = def & U5c.ref .~ blockRef
+        request = def & U5c.ref .~ [blockRef]
 
     response <- H.evalIO . Rpc.withConnection def rpcServer $ \conn ->
       Rpc.nonStreaming conn (Rpc.rpc @(Rpc.Protobuf U5c.SyncService "fetchBlock")) request
 
-    let block = response ^. U5c.block
+    [block] <- H.noteShow $ response ^. U5c.block
 
     -- Verify nativeBytes is non-empty
     let rawBytes = block ^. U5c.nativeBytes
@@ -134,7 +134,7 @@ hprop_rpc_fetch_block = integrationRetryWorkspace 2 "rpc-fetch-block" $ \tempAbs
           result <-
             H.evalIO . try . Rpc.withConnection def rpcServer $ \conn ->
               Rpc.nonStreaming conn (Rpc.rpc @(Rpc.Protobuf U5c.SyncService "fetchBlock")) $
-                def & U5c.ref .~ ref
+                def & U5c.ref .~ [ref]
           case result of
             Left GrpcException{grpcError}
               | grpcError == expectedError -> pure ()
@@ -252,11 +252,12 @@ hprop_rpc_fetch_block = integrationRetryWorkspace 2 "rpc-fetch-block" $ \tempAbs
     H.note_ "Fetch the block containing the submitted transaction and verify its transactions"
 
     let txBlockRef = def & U5c.slot .~ txBlockSlot & U5c.hash .~ txBlockHash
-        txBlockRequest = def & U5c.ref .~ txBlockRef
+        txBlockRequest = def & U5c.ref .~ [txBlockRef]
     txBlockResponse <- H.evalIO . Rpc.withConnection def rpcServer $ \conn ->
       Rpc.nonStreaming conn (Rpc.rpc @(Rpc.Protobuf U5c.SyncService "fetchBlock")) txBlockRequest
 
-    let fetchedTxs = txBlockResponse ^. U5c.block . U5c.cardano . U5c.body . U5c.tx
+    [txBlock] <- H.noteShow $ txBlockResponse ^. U5c.block
+    let fetchedTxs = txBlock ^. U5c.cardano . U5c.body . U5c.tx
     H.note_ "Ensure the fetched block contains all transactions of the block"
     length fetchedTxs H.=== txBlockTxCount
 
@@ -383,11 +384,12 @@ hprop_rpc_fetch_block = integrationRetryWorkspace 2 "rpc-fetch-block" $ \tempAbs
     H.note_ "Fetch the block containing the minting transaction and verify the minted assets"
 
     let mintBlockRef = def & U5c.slot .~ mintBlockSlot & U5c.hash .~ mintBlockHash
-        mintBlockRequest = def & U5c.ref .~ mintBlockRef
+        mintBlockRequest = def & U5c.ref .~ [mintBlockRef]
     mintBlockResponse <- H.evalIO . Rpc.withConnection def rpcServer $ \conn ->
       Rpc.nonStreaming conn (Rpc.rpc @(Rpc.Protobuf U5c.SyncService "fetchBlock")) mintBlockRequest
 
-    let mintFetchedTxs = mintBlockResponse ^. U5c.block . U5c.cardano . U5c.body . U5c.tx
+    [mintBlock] <- H.noteShow $ mintBlockResponse ^. U5c.block
+    let mintFetchedTxs = mintBlock ^. U5c.cardano . U5c.body . U5c.tx
     H.note_ "Ensure the fetched block contains all transactions of the block"
     length mintFetchedTxs H.=== mintBlockTxCount
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/Genesis.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/Genesis.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Cardano.Testnet.Test.Rpc.Genesis
@@ -12,13 +13,21 @@ where
 import           Cardano.Api
 import qualified Cardano.Api.Experimental as Exp
 
+import qualified Cardano.Crypto.Hash.Blake2b as Crypto
+import qualified Cardano.Crypto.Hash.Class as Crypto
 import qualified Cardano.Rpc.Client as Rpc
 import qualified Cardano.Rpc.Proto.Api.UtxoRpc.Query as U5c
 import           Cardano.Testnet
 
 import           Prelude
 
+import           Control.Applicative ((<|>))
 import           Control.Monad (void)
+import           Control.Monad.Catch (try)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Aeson
+import qualified Data.Aeson.KeyMap as Aeson
+import qualified Data.Aeson.Lens as Aeson
 import qualified Data.ByteString as BS
 import           Data.Default.Class
 import           Data.List.NonEmpty (NonEmpty ((:|)))
@@ -26,6 +35,7 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Text as Text
 import           Data.Word (Word32)
 import           Lens.Micro
+import           Network.GRPC.Spec (GrpcError (..), GrpcException (..))
 
 import           Testnet.Property.Util (integrationRetryWorkspace)
 
@@ -44,7 +54,8 @@ hprop_rpc_read_genesis = integrationRetryWorkspace 2 "rpc-read-genesis" $ \tempA
       runtimeOptions = def{runtimeEnableRpc = RpcEnabled}
 
   TestnetRuntime
-    { testnetMagic
+    { shelleyGenesisFile
+    , testnetMagic
     , testnetNodes = node0 :| _
     } <-
     createAndRunTestnet creationOptions runtimeOptions conf
@@ -52,12 +63,34 @@ hprop_rpc_read_genesis = integrationRetryWorkspace 2 "rpc-read-genesis" $ \tempA
   rpcSocket <- H.note . unFile $ nodeRpcSocketPath node0
   let rpcServer = Rpc.ServerUnix rpcSocket
 
+  originalGenesisBytes <- H.evalIO $ BS.readFile shelleyGenesisFile
+
+  H.note_ "The handler caches the parsed genesis only on a successful read (TimedCache.hs), so this hash-mismatch check must run before any successful ReadGenesis call: a successful call first would warm the cache and hide the corruption for up to five idle minutes"
+  H.evalIO $ BS.writeFile shelleyGenesisFile (originalGenesisBytes <> " ")
+
+  H.note_ "ReadGenesis fails with FAILED_PRECONDITION when the genesis file's bytes no longer match the hash the node computed at startup"
+  readGenesisHashMismatchResult <-
+    H.evalIO . try . Rpc.withConnection def rpcServer $ \conn ->
+      Rpc.nonStreaming conn (Rpc.rpc @(Rpc.Protobuf U5c.QueryService "readGenesis")) def
+  case readGenesisHashMismatchResult of
+    Left GrpcException{grpcError}
+      | grpcError == GrpcFailedPrecondition -> pure ()
+      | otherwise -> do
+          H.note_ $ "expected " <> show GrpcFailedPrecondition <> ", got: " <> show grpcError
+          H.failure
+    Right (_ :: Rpc.Proto U5c.ReadGenesisResponse) -> do
+      H.note_ $ "expected " <> show GrpcFailedPrecondition <> ", but the call succeeded"
+      H.failure
+
+  H.evalIO $ BS.writeFile shelleyGenesisFile originalGenesisBytes
+
   response <-
     H.evalIO . Rpc.withConnection def rpcServer $ \conn ->
       Rpc.nonStreaming conn (Rpc.rpc @(Rpc.Protobuf U5c.QueryService "readGenesis")) def
 
-  H.note_ "genesis is the 32-byte Shelley genesis hash"
-  H.assertWith (response ^. U5c.genesis) $ (== 32) . BS.length
+  H.note_ "genesis is the Blake2b-256 hash of the raw Shelley genesis file bytes, exactly as the node computed it at startup"
+  response ^. U5c.genesis
+    H.=== Crypto.hashToBytes (Crypto.hashWith id originalGenesisBytes :: Crypto.Hash Crypto.Blake2b_256 BS.ByteString)
 
   H.note_ "caip2 is derived from the testnet's own network magic"
   response ^. U5c.caip2 H.=== networkMagicToCaip2 (fromIntegral testnetMagic)
@@ -71,11 +104,32 @@ hprop_rpc_read_genesis = integrationRetryWorkspace 2 "rpc-read-genesis" $ \tempA
   H.assertWith (cardanoGenesis ^. U5c.systemStart) $ not . Text.null
   void $ H.nothingFail (cardanoGenesis ^. U5c.maybe'protocolParams)
 
-  -- TODO: re-enable once cardano-rpc resolves initial funds from sgExtraConfig.
-  -- cardano-cli create-testnet-data funds wallets via sgExtraConfig.secInitialFunds and leaves the legacy sgInitialFunds field empty, so the RPC response's initialFunds map is currently always empty for testnet genesis.
-  -- Handler fix pending on cardano-api branch mgalazyn/fix/rpc-initial-funds-extraconfig.
-  -- H.note_ "initialFunds is non-empty: only the uncompacted boot-time genesis carries it, and cardano-testnet funds its wallets there"
-  -- H.assertWith (cardanoGenesis ^. U5c.initialFunds) $ not . Map.null
+  H.note_ "initialFunds matches exactly the funds embedded in the genesis file: only the uncompacted boot-time genesis carries them, and cardano-testnet funds its wallets there. extraConfig.initialFunds.data wins when present; the legacy top-level initialFunds field is the fallback, so the test survives the pending cardano-cli revert (PR #1420) that moves the funds back to the top level"
+  genesisJson <- H.leftFail (Aeson.eitherDecodeStrict' originalGenesisBytes :: Either String Aeson.Value)
+  -- Mirrors the preference order of ledger's own 'resolveInjectionSource': extraConfig wins.
+  initialFundsObject <-
+    H.nothingFail $
+      (genesisJson ^? Aeson.key "extraConfig" . Aeson.key "initialFunds" . Aeson.key "data" . Aeson._Object)
+        <|> (genesisJson ^? Aeson.key "initialFunds" . Aeson._Object)
+
+  expectedInitialFunds <-
+    Map.fromList
+      <$> H.nothingFail
+        ( traverse
+            (\(addressKey, amount) -> (,) (Aeson.toText addressKey) <$> amount ^? Aeson._Integer)
+            (Aeson.toList initialFundsObject)
+        )
+
+  H.note_ "initialFunds is non-empty (regression guard for #6655: cardano-testnet must always fund its wallets)"
+  H.assertWith expectedInitialFunds $ not . Map.null
+
+  actualInitialFunds <-
+    Map.fromList
+      <$> traverse
+        (\(addressHex, amount) -> (,) addressHex . toInteger <$> H.nothingFail (amount ^. U5c.maybe'int))
+        (Map.toList (cardanoGenesis ^. U5c.initialFunds))
+
+  actualInitialFunds H.=== expectedInitialFunds
 
   H.note_ "Byron: protocolConsts, startTime, bootStakeholders"
   protocolConsts <- H.nothingFail (cardanoGenesis ^. U5c.maybe'protocolConsts)


### PR DESCRIPTION
# Description

Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
  - `cardano-node-chairman`, `cardano-submit-api` and `cardano-testnet` instead need a
    changelog fragment in `<package>/.changes/`, because their `CHANGELOG.md` is generated
    from fragments at release time.  Copy `_TEMPLATE.yml` from that directory, or run
    `nix run github:input-output-hk/cardano-dev#herald -- new`
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
