### PR TITLE
gRPC: Enable HTTP endpoint with TLS support

### DIFF
--- a/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
+++ b/bench/plutus-scripts-bench/plutus-scripts-bench.cabal
@@ -86,7 +86,7 @@ library
   -- IOG dependencies
   --------------------------
   build-depends:
-    , cardano-api             ^>=11.6
+    , cardano-api             ^>=11.7
     , plutus-ledger-api       ^>=1.65
     , plutus-tx               ^>=1.65
     , plutus-tx-plugin        ^>=1.65

--- a/bench/tx-generator/tx-generator.cabal
+++ b/bench/tx-generator/tx-generator.cabal
@@ -116,7 +116,7 @@ library
                       , attoparsec-aeson
                       , base16-bytestring
                       , bytestring
-                      , cardano-api ^>= 11.6
+                      , cardano-api ^>= 11.7
                       , cardano-binary
                       , cardano-cli ^>= 11.2.2
                       , cardano-crypto-class

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2026-08-14T13:38:07Z
-  , cardano-haskell-packages 2026-09-03T10:20:53Z
+  , cardano-haskell-packages 2026-09-04T09:27:20Z
 
 constraints:
   -- haskell.nix patch does not work for 1.6.8

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -133,7 +133,7 @@ library
                       , async
                       , base16-bytestring
                       , bytestring
-                      , cardano-api ^>= 11.6
+                      , cardano-api ^>= 11.7
                       , cardano-data
                       , cardano-crypto-class ^>=2.5
                       , cardano-crypto-wrapper
@@ -152,7 +152,7 @@ library
                       , cardano-protocol ^>= 0.1
                       , cardano-protocol-tpraos >= 1.4
                       , cardano-slotting >= 0.2
-                      , cardano-rpc ^>= 11.2
+                      , cardano-rpc ^>= 11.3
                       , cborg ^>= 0.2.4
                       , containers
                       , contra-tracer >= 0.2.1

--- a/cardano-node/src/Cardano/Node/Configuration/POM.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/POM.hs
@@ -34,12 +34,13 @@ import           Cardano.Network.ConsensusMode (ConsensusMode (..), defaultConse
 import qualified Cardano.Network.Diffusion.Configuration as Cardano
 import           Cardano.Network.PeerSelection (NumberOfBigLedgerPeers (..))
 import           Cardano.Node.Configuration.LedgerDB
+import           Cardano.Node.Configuration.NodeAddress (NodeHostIPAddress (..))
 import           Cardano.Node.Configuration.Socket (SocketConfig (..))
 import           Cardano.Node.Handlers.Shutdown
 import           Cardano.Node.Protocol.Types (Protocol (..))
 import           Cardano.Node.Types
 import           Cardano.Rpc.Server.Config (PartialRpcConfig, RpcConfig, RpcConfigF (..),
-                   RpcEndpoint (..), defaultRpcListenAddress, makeRpcConfig)
+                   RpcEndpoint (..), RpcTlsFiles (..), defaultRpcListenAddress, makeRpcConfig)
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Mempool (MempoolCapacityBytesOverride (..))
 import           Ouroboros.Consensus.Node (NodeDatabasePaths (..))
@@ -413,21 +414,7 @@ instance FromJSON PartialNodeConfiguration where
         <$> v .:? "ResponderCoreAffinityPolicy"
         <*> v .:? "ForkPolicy" -- deprecated
 
-      pncRpcConfig <- do
-        enableRpc <- Last <$> v .:? "EnableRpc"
-        mSocketPath <- v .:? "RpcSocketPath"
-        mListenAddress <- v .:? "RpcListenAddress"
-        mListenPort :: Maybe Word16 <- v .:? "RpcListenPort"
-        rpcEndpoint <- case (mSocketPath, mListenAddress, mListenPort) of
-          (Just _, Just _, _) -> fail "RpcSocketPath and RpcListenAddress are mutually exclusive"
-          (Just _, _, Just _) -> fail "RpcSocketPath and RpcListenPort are mutually exclusive"
-          (Nothing, Just _, Nothing) -> fail "RpcListenAddress requires RpcListenPort to be set"
-          (Just socketPath, Nothing, Nothing) -> pure . Just $ RpcEndpointUnixSocket socketPath
-          (Nothing, _, Just listenPort) ->
-            pure . Just $
-              RpcEndpointTcp (fromMaybe defaultRpcListenAddress mListenAddress) (fromIntegral listenPort)
-          (Nothing, Nothing, Nothing) -> pure Nothing
-        pure (mempty :: PartialRpcConfig){isEnabled = enableRpc, rpcEndpoint = Last rpcEndpoint}
+      pncRpcConfig <- parsePartialRpcConfig v
 
       txSubmissionLogicVersion <- Last <$> v .:? "TxSubmissionLogicVersion"
       let parseInitDelay =
@@ -732,6 +719,46 @@ instance FromJSON PartialNodeConfiguration where
           { npcCheckpointsFile
           , npcCheckpointsFileHash
           }
+
+      parsePartialRpcConfig v = do
+        enableRpc <- Last <$> v .:? "EnableRpc"
+        mSocketPath <- v .:? "RpcSocketPath"
+        mListenAddress <- fmap unNodeHostIPAddress <$> v .:? "RpcListenAddress"
+        mListenPort :: Maybe Word16 <- v .:? "RpcListenPort"
+        mTlsFiles <- parseRpcTlsFiles v
+        rpcEndpoint <- case (mSocketPath, mListenAddress, mListenPort, mTlsFiles) of
+          (Just _, Just _, _, _) -> fail "RpcSocketPath and RpcListenAddress are mutually exclusive"
+          (Just _, _, Just _, _) -> fail "RpcSocketPath and RpcListenPort are mutually exclusive"
+          (Just _, _, _, Just _) -> fail "RpcSocketPath and TLS configuration are mutually exclusive"
+          (Just socketPath, Nothing, Nothing, Nothing) -> pure . Just $ RpcEndpointUnixSocket socketPath
+          (Nothing, Just _, Nothing, _) -> fail "RpcListenAddress requires RpcListenPort to be set"
+          (Nothing, _, Nothing, Just _) -> fail "TLS configuration requires RpcListenPort to be set"
+          (Nothing, _, Just listenPort, Just tlsFiles) ->
+            pure . Just $
+              RpcEndpointHttps (fromMaybe defaultRpcListenAddress mListenAddress) (fromIntegral listenPort) tlsFiles
+          (Nothing, _, Just listenPort, Nothing) ->
+            pure . Just $
+              RpcEndpointHttp (fromMaybe defaultRpcListenAddress mListenAddress) (fromIntegral listenPort)
+          (Nothing, Nothing, Nothing, Nothing) -> pure Nothing
+        pure (mempty :: PartialRpcConfig){isEnabled = enableRpc, rpcEndpoint = Last rpcEndpoint}
+
+      parseRpcTlsFiles v = do
+        mCertificateFile <- v .:? "RpcTlsCertificateFile"
+        mPrivateKeyFile <- v .:? "RpcTlsPrivateKeyFile"
+        mChainCertificateFiles <- v .:? "RpcTlsChainCertificateFiles"
+        case (mCertificateFile, mPrivateKeyFile) of
+          (Just certificateFile, Just privateKeyFile) ->
+            pure . Just $
+              RpcTlsFiles
+                { certificateFile
+                , privateKeyFile
+                , chainCertificateFiles = fromMaybe [] mChainCertificateFiles
+                }
+          (Nothing, Nothing)
+            | Just _ <- mChainCertificateFiles ->
+                fail "RpcTlsChainCertificateFiles requires RpcTlsCertificateFile and RpcTlsPrivateKeyFile to be set"
+            | otherwise -> pure Nothing
+          _ -> fail "RpcTlsCertificateFile and RpcTlsPrivateKeyFile must be set together"
 
 -- | Default configuration is mainnet
 defaultPartialNodeConfiguration :: PartialNodeConfiguration

--- a/cardano-node/src/Cardano/Node/Configuration/POM.hs
+++ b/cardano-node/src/Cardano/Node/Configuration/POM.hs
@@ -39,7 +39,7 @@ import           Cardano.Node.Handlers.Shutdown
 import           Cardano.Node.Protocol.Types (Protocol (..))
 import           Cardano.Node.Types
 import           Cardano.Rpc.Server.Config (PartialRpcConfig, RpcConfig, RpcConfigF (..),
-                   makeRpcConfig)
+                   RpcEndpoint (..), defaultRpcListenAddress, makeRpcConfig)
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Mempool (MempoolCapacityBytesOverride (..))
 import           Ouroboros.Consensus.Node (NodeDatabasePaths (..))
@@ -68,6 +68,7 @@ import           Data.Monoid (Last (..))
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Time.Clock (DiffTime, secondsToDiffTime)
+import           Data.Word (Word16)
 import           Data.Yaml (decodeFileThrow)
 import           GHC.Generics (Generic)
 import           Options.Applicative
@@ -412,11 +413,21 @@ instance FromJSON PartialNodeConfiguration where
         <$> v .:? "ResponderCoreAffinityPolicy"
         <*> v .:? "ForkPolicy" -- deprecated
 
-      pncRpcConfig <-
-        RpcConfig
-          <$> (Last <$> v .:? "EnableRpc")
-          <*> (Last <$> v .:? "RpcSocketPath")
-          <*> pure mempty
+      pncRpcConfig <- do
+        enableRpc <- Last <$> v .:? "EnableRpc"
+        mSocketPath <- v .:? "RpcSocketPath"
+        mListenAddress <- v .:? "RpcListenAddress"
+        mListenPort :: Maybe Word16 <- v .:? "RpcListenPort"
+        rpcEndpoint <- case (mSocketPath, mListenAddress, mListenPort) of
+          (Just _, Just _, _) -> fail "RpcSocketPath and RpcListenAddress are mutually exclusive"
+          (Just _, _, Just _) -> fail "RpcSocketPath and RpcListenPort are mutually exclusive"
+          (Nothing, Just _, Nothing) -> fail "RpcListenAddress requires RpcListenPort to be set"
+          (Just socketPath, Nothing, Nothing) -> pure . Just $ RpcEndpointUnixSocket socketPath
+          (Nothing, _, Just listenPort) ->
+            pure . Just $
+              RpcEndpointTcp (fromMaybe defaultRpcListenAddress mListenAddress) (fromIntegral listenPort)
+          (Nothing, Nothing, Nothing) -> pure Nothing
+        pure (mempty :: PartialRpcConfig){isEnabled = enableRpc, rpcEndpoint = Last rpcEndpoint}
 
       txSubmissionLogicVersion <- Last <$> v .:? "TxSubmissionLogicVersion"
       let parseInitDelay =

--- a/cardano-node/src/Cardano/Node/Parsers.hs
+++ b/cardano-node/src/Cardano/Node/Parsers.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE TupleSections #-}
@@ -13,9 +14,11 @@ module Cardano.Node.Parsers
   , parseHostPort
   ) where
 
+import           Cardano.Api (FileDirection (In))
+
 import           Cardano.Logging.Types
 import qualified Cardano.Logging.Types as Net
-import           Cardano.Node.Configuration.NodeAddress (File (..),
+import           Cardano.Node.Configuration.NodeAddress (File (..), NodeHostIPAddress (..),
                    NodeHostIPv4Address (NodeHostIPv4Address),
                    NodeHostIPv6Address (NodeHostIPv6Address), PortNumber, SocketPath)
 import           Cardano.Node.Configuration.POM (PartialNodeConfiguration (..), lastOption)
@@ -24,17 +27,18 @@ import           Cardano.Node.Handlers.Shutdown
 import           Cardano.Node.Types
 import           Cardano.Prelude (ConvertText (..))
 import           Cardano.Rpc.Server.Config (PartialRpcConfig, RpcConfigF (..), RpcEndpoint (..),
-                   defaultRpcListenAddress)
+                   RpcTlsFiles (..), TlsCertificate, TlsPrivateKey, defaultRpcListenAddress)
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Node
 
 import           Data.Char (isDigit)
 import           Data.Foldable
+import           Data.IP (IP)
 import           Data.Maybe (fromMaybe)
 import           Data.Monoid (Last (..))
 import           Data.Text (Text)
 import qualified Data.Text as Text
-import           Data.Word (Word16, Word32)
+import           Data.Word (Word32)
 import           Options.Applicative hiding (str, switch)
 import qualified Options.Applicative as Opt
 import qualified Options.Applicative.Help as OptI
@@ -172,10 +176,10 @@ parseHostPort str
   = if
     | null hostRev        -> Left "parseHostPort: Empty host."
     | null portRev        -> Left "parseHostPort: Empty port."
-    | all isDigit portRev
-    , Just port <- readMaybe @Word16 (reverse portRev) -> if
-      | 0 <= port, port <= 65535 -> Right (Net.RemoteSocket (Text.pack (reverse hostRev)) port)
-      | otherwise -> Left ("parseHostPort: Numeric port '" ++ show port ++ "' out of range: 0 - 65535)")
+    | all isDigit portRev ->
+        case parsePortNumber (reverse portRev) of
+          Right port -> Right (Net.RemoteSocket (Text.pack (reverse hostRev)) (fromIntegral port))
+          Left err   -> Left ("parseHostPort: " ++ err)
     | otherwise -> Left "parseHostPort: Non-numeric port."
   | otherwise
   = Left "parseHostPort: No colon found."
@@ -241,9 +245,18 @@ parseNodeHostIPv6Address str =
     (Right . NodeHostIPv6Address)
     (readMaybe str)
 
+-- | Parse either an IPv4 or an IPv6 address, unlike 'parseNodeHostIPv4Address'
+-- and 'parseNodeHostIPv6Address' which each accept only one address family.
+parseNodeHostIPAddress :: String -> Either String NodeHostIPAddress
+parseNodeHostIPAddress str =
+  maybe
+    (Left $ "Failed to parse IP address: " ++ str)
+    (Right . NodeHostIPAddress)
+    (readMaybe str)
+
 parsePort :: Parser PortNumber
 parsePort =
-    Opt.option ((fromIntegral :: Int -> PortNumber) <$> auto) (
+    Opt.option readPortNumber (
           long "port"
        <> metavar "PORT"
        <> help "The port number"
@@ -439,7 +452,7 @@ parseStartAsNonProducingNode =
 parseRpcConfig :: Parser PartialRpcConfig
 parseRpcConfig = do
   isEnabled <- lastOption parseRpcToggle
-  rpcEndpoint <- lastOption $ parseRpcUnixSocketEndpoint <|> parseRpcTcpEndpoint
+  rpcEndpoint <- lastOption $ parseRpcUnixSocketEndpoint <|> parseRpcHttpEndpoint
   pure (mempty :: PartialRpcConfig){isEnabled, rpcEndpoint}
   where
     parseRpcToggle :: Parser Bool
@@ -456,32 +469,80 @@ parseRpcConfig = do
           "grpc-socket-path"
           "[EXPERIMENTAL] gRPC unix socket path. Defaults to rpc.sock in the same directory as the node socket. Mutually exclusive with --grpc-listen-port."
 
-    parseRpcTcpEndpoint :: Parser RpcEndpoint
-    parseRpcTcpEndpoint =
-      RpcEndpointTcp . fromMaybe defaultRpcListenAddress
+    parseRpcHttpEndpoint :: Parser RpcEndpoint
+    parseRpcHttpEndpoint =
+      mkHttpEndpoint
         <$> Opt.optional parseRpcListenAddress
         <*> Opt.option readPortNumber (mconcat
               [ long "grpc-listen-port"
               , metavar "PORT"
-              , help "[EXPERIMENTAL] TCP port the gRPC server listens on. When set, the gRPC server listens on plaintext TCP (HTTP/2 without TLS) instead of a unix socket. Mutually exclusive with --grpc-socket-path."
+              , help "[EXPERIMENTAL] TCP port the gRPC server listens on. When set, the gRPC server listens over HTTP/2 without TLS, or HTTP/2 over TLS if --grpc-tls-certificate is given, instead of a unix socket. Mutually exclusive with --grpc-socket-path."
               ])
+        <*> Opt.optional parseRpcTlsFiles
 
-    parseRpcListenAddress :: Parser Text
+    mkHttpEndpoint :: Maybe IP -> PortNumber -> Maybe RpcTlsFiles -> RpcEndpoint
+    mkHttpEndpoint mAddress port =
+      maybe (RpcEndpointHttp address port) (RpcEndpointHttps address port)
+     where
+      address = fromMaybe defaultRpcListenAddress mAddress
+
+    parseRpcListenAddress :: Parser IP
     parseRpcListenAddress =
-      strOption $ mconcat
+      unNodeHostIPAddress <$> Opt.option (eitherReader parseNodeHostIPAddress) (mconcat
         [ long "grpc-listen-address"
-        , metavar "HOST"
-        , help "[EXPERIMENTAL] Host address the gRPC server binds to. Requires --grpc-listen-port. Defaults to 127.0.0.1."
+        , metavar "IP-ADDRESS"
+        , help "[EXPERIMENTAL] IP address the gRPC server binds to. Requires --grpc-listen-port. Defaults to 127.0.0.1."
+        ])
+
+    parseRpcTlsFiles :: Parser RpcTlsFiles
+    parseRpcTlsFiles =
+      RpcTlsFiles
+        <$> parseRpcTlsCertificateFile
+        <*> parseRpcTlsPrivateKeyFile
+        <*> Opt.many parseRpcTlsChainCertificateFile
+
+    parseRpcTlsCertificateFile :: Parser (File TlsCertificate 'In)
+    parseRpcTlsCertificateFile =
+      strOption $ mconcat
+        [ long "grpc-tls-certificate"
+        , metavar "FILEPATH"
+        , help "[EXPERIMENTAL] Path to the TLS certificate file. Enables TLS; requires --grpc-tls-private-key and --grpc-listen-port."
+        , completer (bashCompleter "file")
         ]
 
--- | Read a TCP port number, rejecting values outside the 0 - 65535 range.
+    parseRpcTlsPrivateKeyFile :: Parser (File TlsPrivateKey 'In)
+    parseRpcTlsPrivateKeyFile =
+      strOption $ mconcat
+        [ long "grpc-tls-private-key"
+        , metavar "FILEPATH"
+        , help "[EXPERIMENTAL] Path to the TLS private key file. Requires --grpc-tls-certificate and --grpc-listen-port."
+        , completer (bashCompleter "file")
+        ]
+
+    parseRpcTlsChainCertificateFile :: Parser (File TlsCertificate 'In)
+    parseRpcTlsChainCertificateFile =
+      strOption $ mconcat
+        [ long "grpc-tls-chain-certificate"
+        , metavar "FILEPATH"
+        , help "[EXPERIMENTAL] Path to an additional certificate to include in the TLS chain. May be given multiple times. Requires --grpc-tls-certificate and --grpc-tls-private-key."
+        , completer (bashCompleter "file")
+        ]
+
 readPortNumber :: Opt.ReadM PortNumber
-readPortNumber = Opt.eitherReader $ \raw ->
-  case readMaybe raw :: Maybe Integer of
-    Just port
-      | 0 <= port && port <= 65535 -> Right $ fromIntegral port
-      | otherwise -> Left $ "Port number out of range (0 - 65535): " <> show port
-    Nothing -> Left $ "Not a valid port number: " <> raw
+readPortNumber = Opt.eitherReader parsePortNumber
+
+-- | Parse a port number, rejecting values outside the 0 - 65535 range.
+-- Decimal digits only - hex/octal notation, a sign, and surrounding
+-- whitespace (all otherwise accepted by a plain 'Integer' read) are rejected.
+parsePortNumber :: String -> Either String PortNumber
+parsePortNumber raw
+  | not (all isDigit raw) = Left $ "Not a valid port number: " <> raw
+  | otherwise =
+      case readMaybe raw :: Maybe Integer of
+        Just port
+          | 0 <= port && port <= 65535 -> Right $ fromIntegral port
+          | otherwise -> Left $ "Port number out of range (0 - 65535): " <> show port
+        Nothing -> Left $ "Not a valid port number: " <> raw
 
 -- | Produce just the brief help header for a given CLI option parser,
 --   without the options.

--- a/cardano-node/src/Cardano/Node/Parsers.hs
+++ b/cardano-node/src/Cardano/Node/Parsers.hs
@@ -23,7 +23,8 @@ import           Cardano.Node.Configuration.Socket
 import           Cardano.Node.Handlers.Shutdown
 import           Cardano.Node.Types
 import           Cardano.Prelude (ConvertText (..))
-import           Cardano.Rpc.Server.Config (PartialRpcConfig, RpcConfigF (..))
+import           Cardano.Rpc.Server.Config (PartialRpcConfig, RpcConfigF (..), RpcEndpoint (..),
+                   defaultRpcListenAddress)
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Node
 
@@ -438,8 +439,8 @@ parseStartAsNonProducingNode =
 parseRpcConfig :: Parser PartialRpcConfig
 parseRpcConfig = do
   isEnabled <- lastOption parseRpcToggle
-  socketPath <- lastOption parseRpcSocketPath
-  pure $ RpcConfig isEnabled socketPath mempty
+  rpcEndpoint <- lastOption $ parseRpcUnixSocketEndpoint <|> parseRpcTcpEndpoint
+  pure (mempty :: PartialRpcConfig){isEnabled, rpcEndpoint}
   where
     parseRpcToggle :: Parser Bool
     parseRpcToggle =
@@ -447,11 +448,40 @@ parseRpcConfig = do
         [ long "grpc-enable"
         , help "[EXPERIMENTAL] Enable node gRPC endpoint."
         ]
-    parseRpcSocketPath :: Parser SocketPath
-    parseRpcSocketPath =
-      parseSocketPath
-        "grpc-socket-path"
-        "[EXPERIMENTAL] gRPC socket path. Defaults to rpc.sock in the same directory as node socket."
+
+    parseRpcUnixSocketEndpoint :: Parser RpcEndpoint
+    parseRpcUnixSocketEndpoint =
+      RpcEndpointUnixSocket <$>
+        parseSocketPath
+          "grpc-socket-path"
+          "[EXPERIMENTAL] gRPC unix socket path. Defaults to rpc.sock in the same directory as the node socket. Mutually exclusive with --grpc-listen-port."
+
+    parseRpcTcpEndpoint :: Parser RpcEndpoint
+    parseRpcTcpEndpoint =
+      RpcEndpointTcp . fromMaybe defaultRpcListenAddress
+        <$> Opt.optional parseRpcListenAddress
+        <*> Opt.option readPortNumber (mconcat
+              [ long "grpc-listen-port"
+              , metavar "PORT"
+              , help "[EXPERIMENTAL] TCP port the gRPC server listens on. When set, the gRPC server listens on plaintext TCP (HTTP/2 without TLS) instead of a unix socket. Mutually exclusive with --grpc-socket-path."
+              ])
+
+    parseRpcListenAddress :: Parser Text
+    parseRpcListenAddress =
+      strOption $ mconcat
+        [ long "grpc-listen-address"
+        , metavar "HOST"
+        , help "[EXPERIMENTAL] Host address the gRPC server binds to. Requires --grpc-listen-port. Defaults to 127.0.0.1."
+        ]
+
+-- | Read a TCP port number, rejecting values outside the 0 - 65535 range.
+readPortNumber :: Opt.ReadM PortNumber
+readPortNumber = Opt.eitherReader $ \raw ->
+  case readMaybe raw :: Maybe Integer of
+    Just port
+      | 0 <= port && port <= 65535 -> Right $ fromIntegral port
+      | otherwise -> Left $ "Port number out of range (0 - 65535): " <> show port
+    Nothing -> Left $ "Not a valid port number: " <> raw
 
 -- | Produce just the brief help header for a given CLI option parser,
 --   without the options.

--- a/cardano-node/src/Cardano/Node/Run.hs
+++ b/cardano-node/src/Cardano/Node/Run.hs
@@ -141,7 +141,7 @@ import           Data.Bits
 import           Data.Bifunctor (first)
 import           Data.Either (partitionEithers)
 import           Data.Functor.Identity (Identity (..))
-import           Data.IP (toSockAddr)
+import           Data.IP (IP (..), isMatchedTo, makeAddrRange, toIPv4, toIPv6, toSockAddr)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (catMaybes, fromMaybe, mapMaybe)
@@ -156,7 +156,9 @@ import qualified Data.Text.IO as Text
 import           Data.Time.Clock (getCurrentTime)
 import           Network.DNS (Resolver)
 import           Network.Socket (Socket)
-import           System.Directory (canonicalizePath, createDirectoryIfMissing, makeAbsolute)
+import           System.Directory (canonicalizePath, createDirectoryIfMissing, doesFileExist,
+                   makeAbsolute)
+import           System.Environment (lookupEnv)
 import           System.FilePath (takeDirectory, (</>))
 import           System.IO (hPutStrLn)
 #ifdef UNIX
@@ -378,6 +380,12 @@ handleSimpleNode blockType shelleyGenesisHash pInfo mkBlockForging tracers nc cm
                                             (readTVar useLedgerVar)
                                             (const . pure $ ())
     rpcConfigVar <- newTVarIO (ncRpcConfig nc)
+
+    let RpcConfig{isEnabled = Identity rpcIsEnabled, rpcEndpoint = Identity rpcEndpointConfig} = ncRpcConfig nc
+    when (rpcIsEnabled && hasProtocolFile (ncProtocolFiles nc) && not (ncStartAsNonProducingNode nc)) $
+      traceWith (startupTracer tracers) RpcEnabledOnBlockProducer
+    when rpcIsEnabled $
+      warnRpcEndpointSecurity (startupTracer tracers) rpcEndpointConfig
 
     let nodeArgs = RunNodeArgs
           { rnGenesisConfig  = ncGenesisConfig nc
@@ -801,13 +809,19 @@ updateRpcConfiguration tracer cmdPc rpcConfigVar = do
     Left err ->
       -- reload failure, we don't do anything this time
       traceWith tracer (RpcConfigUpdateError $ pack (Exception.displayException err))
-    Right NodeConfiguration{ncRpcConfig=newConfig} ->
+    Right newNc@NodeConfiguration{ncRpcConfig=newConfig} ->
       join . atomically $ do
         oldConfig <- readTVar rpcConfigVar
         if oldConfig /= newConfig
           then do
             writeTVar rpcConfigVar newConfig
-            pure . traceWith tracer . RpcConfigUpdate . pack $ show newConfig
+            let RpcConfig{isEnabled = Identity rpcIsEnabled, rpcEndpoint = Identity rpcEndpointConfig} = newConfig
+            pure $ do
+              traceWith tracer . RpcConfigUpdate . pack $ show newConfig
+              when (rpcIsEnabled && hasProtocolFile (ncProtocolFiles newNc) && not (ncStartAsNonProducingNode newNc)) $
+                traceWith tracer RpcEnabledOnBlockProducer
+              when rpcIsEnabled $
+                warnRpcEndpointSecurity tracer rpcEndpointConfig
           else
             pure $ pure ()
 #endif
@@ -868,6 +882,59 @@ checkVRFFilePermissions _ (File vrfPrivKey) = do
   hasPermission fModeA fModeB = fModeA .&. fModeB /= gENERIC_NONE
 #endif
 
+-- | Warn about security-relevant aspects of the configured RPC endpoint:
+-- listening on a non-loopback address, TLS session key-log tracing enabled
+-- via 'SSLKEYLOGFILE', and an overly permissive TLS private key file.
+-- Unlike 'checkVRFFilePermissions' none of these ever refuse to start the
+-- node - a misconfigured RPC endpoint is not as sensitive as the
+-- block-producer's VRF key.
+warnRpcEndpointSecurity :: Tracer IO (StartupTrace blk) -> RpcEndpoint -> IO ()
+warnRpcEndpointSecurity tracer endpoint = do
+  warnIfRpcListensPublicly tracer endpoint
+  case endpoint of
+    RpcEndpointHttps _ _ tlsFiles -> do
+      warnIfTlsKeyLogEnabled tracer
+      checkRpcTlsPrivateKeyPermissions tracer tlsFiles
+    _otherEndpoint -> pure ()
+
+-- | Non-loopback predicate for 'IP' addresses (127.0.0.0/8 for IPv4, ::1 for
+-- IPv6).
+isLoopbackIp :: IP -> Bool
+isLoopbackIp (IPv4 ip4) = ip4 `isMatchedTo` makeAddrRange (toIPv4 [127, 0, 0, 0]) 8
+isLoopbackIp (IPv6 ip6) = ip6 == toIPv6 [0, 0, 0, 0, 0, 0, 0, 1]
+
+-- | Warn if the RPC endpoint is bound to a non-loopback address: the RPC
+-- server is unauthenticated, so anyone who can reach it can query the node
+-- and submit transactions.
+warnIfRpcListensPublicly :: Tracer IO (StartupTrace blk) -> RpcEndpoint -> IO ()
+warnIfRpcListensPublicly tracer = \case
+  RpcEndpointUnixSocket{} -> pure ()
+  endpoint@(RpcEndpointHttp ip _) ->
+    unless (isLoopbackIp ip) . traceWith tracer $ RpcListeningOnPublicAddress endpoint
+  endpoint@(RpcEndpointHttps ip _ _) ->
+    unless (isLoopbackIp ip) . traceWith tracer $ RpcListeningOnPublicAddress endpoint
+
+-- | Warn if 'SSLKEYLOGFILE' is set: the node will write TLS session key-log
+-- material for the RPC TLS listener to that file.
+warnIfTlsKeyLogEnabled :: Tracer IO (StartupTrace blk) -> IO ()
+warnIfTlsKeyLogEnabled tracer = do
+  mKeyLogFile <- lookupEnv "SSLKEYLOGFILE"
+  forM_ mKeyLogFile $ traceWith tracer . RpcTlsKeyLogEnabled . pack
+
+-- | Warn if the RPC TLS private key file is readable by group or others.
+-- Silently does nothing if the file does not exist: grapesy already fails
+-- loudly when it can't load the TLS credentials.
+checkRpcTlsPrivateKeyPermissions :: Tracer IO (StartupTrace blk) -> RpcTlsFiles -> IO ()
+#ifdef UNIX
+checkRpcTlsPrivateKeyPermissions tracer RpcTlsFiles{privateKeyFile = File keyPath} = do
+  exists <- doesFileExist keyPath
+  when exists $ do
+    fm <- fileMode <$> getFileStatus keyPath
+    when (fm `intersectFileModes` (groupModes `unionFileModes` otherModes) /= nullFileMode) $
+      traceWith tracer . RpcTlsPrivateKeyPermissive $ pack keyPath
+#else
+checkRpcTlsPrivateKeyPermissions _ _ = pure ()
+#endif
 
 mkDiffusionConfiguration
   :: Maybe SocketOrSocketInfo -- ^ ipv4

--- a/cardano-node/src/Cardano/Node/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Startup.hs
@@ -29,6 +29,7 @@ import           Cardano.Node.Configuration.POM (NodeConfiguration (..), ncProto
 import           Cardano.Node.Configuration.Socket
 import           Cardano.Node.Protocol (ProtocolInstantiationError)
 import           Cardano.Node.Types (PeerSnapshotFile (..))
+import           Cardano.Rpc.Server.Config (RpcEndpoint (..))
 import           Cardano.Slotting.Slot (SlotNo)
 import qualified Ouroboros.Consensus.BlockchainTime.WallClock.Types as WCT
 import           Ouroboros.Consensus.Cardano.Block
@@ -147,6 +148,14 @@ data StartupTrace blk =
   | RpcUnsupportedBlockType Text
   -- | Log RPC is forcefully disabled after a RPC server crash.
   | RpcForceDisabled
+  -- | Warn that the RPC (gRPC) server is enabled on a block-producing node.
+  | RpcEnabledOnBlockProducer
+  -- | Warn that the RPC (gRPC) server is listening on a non-loopback address.
+  | RpcListeningOnPublicAddress RpcEndpoint
+  -- | Warn that 'SSLKEYLOGFILE' is set, so the RPC TLS listener will write TLS session key-log material.
+  | RpcTlsKeyLogEnabled Text
+  -- | Warn that the RPC TLS private key file is readable by group or others.
+  | RpcTlsPrivateKeyPermissive Text
 
   | MovedTopLevelOption String
 

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Rpc.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Rpc.hs
@@ -9,16 +9,14 @@
 
 module Cardano.Node.Tracing.Tracers.Rpc () where
 
-import           Cardano.Api (File (..))
 import           Cardano.Api.Pretty
 
 import           Cardano.Logging hiding (nsInner)
 import           Cardano.Rpc.Server (TraceRpc (..), TraceRpcNodeKernelAccess (..),
                    TraceRpcQuery (..), TraceRpcSubmit (..), TraceRpcSync (..), TraceSpanEvent (..))
-import           Cardano.Rpc.Server.Config (RpcEndpoint (..))
+import           Cardano.Rpc.Server.Config ()
 
 import           Data.Aeson (Object, Value (..), (.=))
-import qualified Data.Text as Text
 
 instance LogFormatting TraceRpc where
   forMachine _dtal tr =
@@ -69,7 +67,7 @@ instance LogFormatting TraceRpc where
                 TraceRpcUnsupportedBlockType blockType -> ["blockType" .= String blockType]
           TraceRpcServerListening endpoint ->
             [ "kind" .= String "ServerListening"
-            , "endpoint" .= endpointToText endpoint
+            , "endpoint" .= docToText (pretty endpoint)
             ]
 
   forHuman = docToText . pretty
@@ -220,7 +218,3 @@ spanToObject =
   mconcat . \case
     SpanBegin spanId -> ["span" .= String "begin", "spanId" .= spanId]
     SpanEnd spanId -> ["span" .= String "end", "spanId" .= spanId]
-
-endpointToText :: RpcEndpoint -> Text
-endpointToText (RpcEndpointUnixSocket (File socketPath)) = Text.pack socketPath
-endpointToText (RpcEndpointTcp host port) = host <> ":" <> Text.pack (show port)

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Rpc.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Rpc.hs
@@ -9,13 +9,16 @@
 
 module Cardano.Node.Tracing.Tracers.Rpc () where
 
+import           Cardano.Api (File (..))
 import           Cardano.Api.Pretty
 
 import           Cardano.Logging hiding (nsInner)
 import           Cardano.Rpc.Server (TraceRpc (..), TraceRpcNodeKernelAccess (..),
                    TraceRpcQuery (..), TraceRpcSubmit (..), TraceRpcSync (..), TraceSpanEvent (..))
+import           Cardano.Rpc.Server.Config (RpcEndpoint (..))
 
 import           Data.Aeson (Object, Value (..), (.=))
+import qualified Data.Text as Text
 
 instance LogFormatting TraceRpc where
   forMachine _dtal tr =
@@ -64,6 +67,10 @@ instance LogFormatting TraceRpc where
             ["kind" .= String "NodeKernelAccess"]
               <> case nodeKernelAccessTrace of
                 TraceRpcUnsupportedBlockType blockType -> ["blockType" .= String blockType]
+          TraceRpcServerListening endpoint ->
+            [ "kind" .= String "ServerListening"
+            , "endpoint" .= endpointToText endpoint
+            ]
 
   forHuman = docToText . pretty
 
@@ -114,6 +121,7 @@ instance MetaTrace TraceRpc where
         "NodeKernelAccess"
           : case nodeKernelAccessTrace of
             TraceRpcUnsupportedBlockType _ -> ["UnsupportedBlockType"]
+      TraceRpcServerListening _ -> ["ServerListening"]
 
   severityFor (Namespace _ nsInner) _ = case nsInner of
     ["FatalError"] -> Just Error -- RPC server startup errors
@@ -134,6 +142,7 @@ instance MetaTrace TraceRpc where
     ["SyncService", "ReadTip", "Span"] -> Just Debug
     ["SyncService", "FollowTip", "Span"] -> Just Debug
     ["NodeKernelAccess", "UnsupportedBlockType"] -> Just Warning
+    ["ServerListening"] -> Just Notice -- one-off startup event, must be visible with default config
     _ -> Nothing
 
   documentFor (Namespace _ nsInner) = case nsInner of
@@ -157,6 +166,7 @@ instance MetaTrace TraceRpc where
     ["SyncService", "ReadTip", "Span"] -> Just "Span for the ReadTip SyncService method."
     ["SyncService", "FollowTip", "Span"] -> Just "Span for the FollowTip SyncService method."
     ["NodeKernelAccess", "UnsupportedBlockType"] -> Just "The block type is not supported by the RPC server."
+    ["ServerListening"] -> Just "RPC server is starting to listen on the configured endpoint."
     _ -> Nothing
 
   metricsDocFor (Namespace _ nsInner) = case nsInner of
@@ -200,6 +210,7 @@ instance MetaTrace TraceRpc where
           , ["SyncService", "FollowTip", "Span"]
           , ["QueryService", "ReadGenesis", "Span"]
           , ["NodeKernelAccess", "UnsupportedBlockType"]
+          , ["ServerListening"]
           ]
 
 -- helper functions
@@ -209,3 +220,7 @@ spanToObject =
   mconcat . \case
     SpanBegin spanId -> ["span" .= String "begin", "spanId" .= spanId]
     SpanEnd spanId -> ["span" .= String "end", "spanId" .= spanId]
+
+endpointToText :: RpcEndpoint -> Text
+endpointToText (RpcEndpointUnixSocket (File socketPath)) = Text.pack socketPath
+endpointToText (RpcEndpointTcp host port) = host <> ":" <> Text.pack (show port)

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Startup.hs
@@ -29,6 +29,7 @@ import           Cardano.Node.Configuration.POM (NodeConfiguration, ncProtocol)
 import           Cardano.Node.Configuration.Socket
 import           Cardano.Node.Startup
 import           Cardano.Node.Types (PeerSnapshotFile (..))
+import           Cardano.Rpc.Server.Config (RpcEndpoint (..))
 import           Cardano.Slotting.Slot (EpochSize (..))
 import qualified Ouroboros.Consensus.BlockchainTime.WallClock.Types as WCT
 import           Ouroboros.Consensus.Byron.ByronHFC (byronLedgerConfig)
@@ -293,6 +294,20 @@ instance ( Show (BlockNodeToNodeVersion blk)
   forMachine _dtal RpcForceDisabled =
       mconcat [ "kind" .= String "RpcForceDisabled"
                , "error" .= String (ppStartupInfoTrace RpcForceDisabled)]
+  forMachine _dtal RpcEnabledOnBlockProducer =
+      mconcat [ "kind" .= String "RpcEnabledOnBlockProducer"
+               , "message" .= String (ppStartupInfoTrace RpcEnabledOnBlockProducer)]
+  forMachine _dtal (RpcListeningOnPublicAddress endpoint) =
+      mconcat [ "kind" .= String "RpcListeningOnPublicAddress"
+               , "endpoint" .= String (Api.docToText (Api.pretty endpoint)) ]
+  forMachine _dtal t@(RpcTlsKeyLogEnabled path) =
+      mconcat [ "kind" .= String "RpcTlsKeyLogEnabled"
+               , "message" .= String (ppStartupInfoTrace t)
+               , "path" .= String path ]
+  forMachine _dtal t@(RpcTlsPrivateKeyPermissive path) =
+      mconcat [ "kind" .= String "RpcTlsPrivateKeyPermissive"
+               , "message" .= String (ppStartupInfoTrace t)
+               , "path" .= String path ]
   forMachine _dtal (MovedTopLevelOption opt) =
       mconcat [ "kind" .= String "MovedTopLevelOption"
               , "option" .= opt
@@ -366,6 +381,14 @@ instance MetaTrace  (StartupTrace blk) where
     Namespace [] ["RpcUnsupportedBlockType"]
   namespaceFor RpcForceDisabled =
     Namespace [] ["RpcForceDisabled"]
+  namespaceFor RpcEnabledOnBlockProducer =
+    Namespace [] ["RpcEnabledOnBlockProducer"]
+  namespaceFor RpcListeningOnPublicAddress {} =
+    Namespace [] ["RpcListeningOnPublicAddress"]
+  namespaceFor RpcTlsKeyLogEnabled {} =
+    Namespace [] ["RpcTlsKeyLogEnabled"]
+  namespaceFor RpcTlsPrivateKeyPermissive {} =
+    Namespace [] ["RpcTlsPrivateKeyPermissive"]
   namespaceFor MovedTopLevelOption {} =
     Namespace [] ["MovedTopLevelOption"]
 
@@ -382,6 +405,10 @@ instance MetaTrace  (StartupTrace blk) where
   severityFor (Namespace _ ["RpcConfigUpdateError"]) _ = Just Error
   severityFor (Namespace _ ["RpcUnsupportedBlockType"]) _ = Just Warning
   severityFor (Namespace _ ["RpcForceDisabled"]) _ = Just Error
+  severityFor (Namespace _ ["RpcEnabledOnBlockProducer"]) _ = Just Warning
+  severityFor (Namespace _ ["RpcListeningOnPublicAddress"]) _ = Just Warning
+  severityFor (Namespace _ ["RpcTlsKeyLogEnabled"]) _ = Just Warning
+  severityFor (Namespace _ ["RpcTlsPrivateKeyPermissive"]) _ = Just Warning
   severityFor (Namespace _ ["BlockForgingUpdateError"]) _ = Just Error
   severityFor (Namespace _ ["BlockForgingBlockTypeMismatch"]) _ = Just Error
   severityFor (Namespace _ ["MovedTopLevelOption"]) _ = Just Warning
@@ -416,6 +443,14 @@ instance MetaTrace  (StartupTrace blk) where
     ""
   documentFor (Namespace [] ["RpcForceDisabled"]) = Just
     ""
+  documentFor (Namespace [] ["RpcEnabledOnBlockProducer"]) = Just
+    "The gRPC server is enabled on a block-producing node; the RPC endpoint is unauthenticated and increases the node's attack surface; prefer running it on a relay or a separate non-producing node."
+  documentFor (Namespace [] ["RpcListeningOnPublicAddress"]) = Just
+    "The gRPC server is listening on a non-loopback address; the endpoint is unauthenticated, so anyone who can reach it can query the node and submit transactions; front it with a reverse proxy on untrusted networks."
+  documentFor (Namespace [] ["RpcTlsKeyLogEnabled"]) = Just
+    "SSLKEYLOGFILE is set, so the node will write TLS session key-log material for the RPC TLS listener; unset it unless deliberately debugging TLS."
+  documentFor (Namespace [] ["RpcTlsPrivateKeyPermissive"]) = Just
+    "The RPC TLS private key file is readable by group or others; restrict it to the owner."
   documentFor (Namespace [] ["NetworkConfigUpdate"]) = Just
     ""
   documentFor (Namespace [] ["NetworkConfigUpdateUnsupported"]) = Just
@@ -490,6 +525,10 @@ instance MetaTrace  (StartupTrace blk) where
     , Namespace [] ["RpcConfigUpdateError"]
     , Namespace [] ["RpcUnsupportedBlockType"]
     , Namespace [] ["RpcForceDisabled"]
+    , Namespace [] ["RpcEnabledOnBlockProducer"]
+    , Namespace [] ["RpcListeningOnPublicAddress"]
+    , Namespace [] ["RpcTlsKeyLogEnabled"]
+    , Namespace [] ["RpcTlsPrivateKeyPermissive"]
     , Namespace [] ["NetworkConfigUpdate"]
     , Namespace [] ["NetworkConfigUpdateUnsupported"]
     , Namespace [] ["NetworkConfigUpdateError"]
@@ -619,6 +658,42 @@ ppStartupInfoTrace (RpcConfigUpdate config) = "Performing RPC configuration upda
 ppStartupInfoTrace (RpcConfigUpdateError err) = "Error while updating RPC configuration: " <> err
 ppStartupInfoTrace (RpcUnsupportedBlockType blockType) = "RPC node kernel access is not supported for block type: " <> blockType
 ppStartupInfoTrace RpcForceDisabled = "RPC endpoint has crashed and because of that it got disabled. Enable gRPC endpoint and send SIGHUP to the node to reenable."
+ppStartupInfoTrace RpcEnabledOnBlockProducer =
+     "the gRPC server is enabled on a block-producing node; the RPC endpoint is "
+  <> "unauthenticated and increases the node's attack surface; prefer running it "
+  <> "on a relay or a separate non-producing node."
+
+ppStartupInfoTrace (RpcListeningOnPublicAddress endpoint) =
+  case endpoint of
+    RpcEndpointHttp{} ->
+        "the gRPC server listens in cleartext on a non-loopback address "
+      <> renderedEndpoint
+      <> "; the endpoint is unauthenticated - anyone who can reach it can "
+      <> "query the node and submit transactions; front it with a reverse "
+      <> "proxy on untrusted networks."
+    RpcEndpointHttps{} ->
+        "the gRPC server listens on a non-loopback address "
+      <> renderedEndpoint
+      <> "; TLS encrypts the connection but the endpoint is unauthenticated "
+      <> "- anyone who can reach it can query the node and submit "
+      <> "transactions; front it with a reverse proxy on untrusted networks."
+    -- Unreachable in practice: 'warnIfRpcListensPublicly' never traces this
+    -- for a unix socket. Kept total rather than partial.
+    RpcEndpointUnixSocket{} ->
+        "the gRPC server endpoint " <> renderedEndpoint
+      <> " was reported as listening on a non-loopback address, which should "
+      <> "not happen for a unix socket."
+  where
+    renderedEndpoint = Api.docToText (Api.pretty endpoint)
+
+ppStartupInfoTrace (RpcTlsKeyLogEnabled path) =
+     "the node will write TLS session key-log material to " <> path
+  <> " because SSLKEYLOGFILE is set; unset it unless you are deliberately "
+  <> "debugging TLS."
+
+ppStartupInfoTrace (RpcTlsPrivateKeyPermissive path) =
+     "the TLS private key " <> path
+  <> " is readable by group or others; restrict it to the owner."
 
 ppStartupInfoTrace NonP2PWarning = nonP2PWarningMessage
 

--- a/cardano-node/src/Cardano/Node/Types.hs
+++ b/cardano-node/src/Cardano/Node/Types.hs
@@ -49,7 +49,7 @@ import           Cardano.Network.ConsensusMode (ConsensusMode (..))
 import           Cardano.Network.NodeToNode (DiffusionMode (..))
 import           Cardano.Node.Configuration.Socket (SocketConfig (..))
 import           Cardano.Node.Orphans ()
-import           Cardano.Rpc.Server.Config (RpcConfigF (..))
+import           Cardano.Rpc.Server.Config (RpcConfigF (..), RpcEndpoint (..))
 
 import           Control.Exception
 import           Data.Aeson
@@ -509,11 +509,14 @@ instance AdjustFilePaths (File a b) where
   adjustFilePaths f (File p) = File $ f p
 
 instance Functor f => AdjustFilePaths (RpcConfigF f) where
-  adjustFilePaths f (RpcConfig isEnabled rpcSocketPath nodeSocketPath) =
-    RpcConfig
-      isEnabled
-      (adjustFilePaths f <$> rpcSocketPath)
-      (adjustFilePaths f <$> nodeSocketPath)
+  adjustFilePaths f rpcConfig@RpcConfig{rpcEndpoint, nodeSocketPath} =
+    rpcConfig
+      { rpcEndpoint = adjustEndpoint <$> rpcEndpoint
+      , nodeSocketPath = adjustFilePaths f <$> nodeSocketPath
+      }
+   where
+    adjustEndpoint (RpcEndpointUnixSocket socketPath) = RpcEndpointUnixSocket $ adjustFilePaths f socketPath
+    adjustEndpoint endpoint@RpcEndpointTcp{} = endpoint
 
 data VRFPrivateKeyFilePermissionError
   = OtherPermissionsExist FilePath

--- a/cardano-node/src/Cardano/Node/Types.hs
+++ b/cardano-node/src/Cardano/Node/Types.hs
@@ -49,7 +49,7 @@ import           Cardano.Network.ConsensusMode (ConsensusMode (..))
 import           Cardano.Network.NodeToNode (DiffusionMode (..))
 import           Cardano.Node.Configuration.Socket (SocketConfig (..))
 import           Cardano.Node.Orphans ()
-import           Cardano.Rpc.Server.Config (RpcConfigF (..), RpcEndpoint (..))
+import           Cardano.Rpc.Server.Config (RpcConfigF (..), RpcEndpoint (..), RpcTlsFiles (..))
 
 import           Control.Exception
 import           Data.Aeson
@@ -516,7 +516,16 @@ instance Functor f => AdjustFilePaths (RpcConfigF f) where
       }
    where
     adjustEndpoint (RpcEndpointUnixSocket socketPath) = RpcEndpointUnixSocket $ adjustFilePaths f socketPath
-    adjustEndpoint endpoint@RpcEndpointTcp{} = endpoint
+    adjustEndpoint endpoint@RpcEndpointHttp{} = endpoint
+    adjustEndpoint (RpcEndpointHttps host port tlsFiles) =
+      RpcEndpointHttps host port (adjustTlsFiles tlsFiles)
+
+    adjustTlsFiles RpcTlsFiles{certificateFile, privateKeyFile, chainCertificateFiles} =
+      RpcTlsFiles
+        { certificateFile = adjustFilePaths f certificateFile
+        , privateKeyFile = adjustFilePaths f privateKeyFile
+        , chainCertificateFiles = adjustFilePaths f <$> chainCertificateFiles
+        }
 
 data VRFPrivateKeyFilePermissionError
   = OtherPermissionsExist FilePath

--- a/cardano-node/test/Test/Cardano/Node/POM.hs
+++ b/cardano-node/test/Test/Cardano/Node/POM.hs
@@ -21,7 +21,7 @@ import           Cardano.Node.Configuration.POM
 import           Cardano.Node.Configuration.Socket
 import           Cardano.Node.Handlers.Shutdown
 import           Cardano.Node.Types
-import           Cardano.Rpc.Server.Config (RpcConfigF (..), makeRpcConfig)
+import           Cardano.Rpc.Server.Config (PartialRpcConfig, RpcConfigF (..), makeRpcConfig)
 import           Ouroboros.Consensus.Node (NodeDatabasePaths (..))
 import           Ouroboros.Consensus.Node.Genesis (disableGenesisConfig)
 import           Ouroboros.Consensus.Storage.LedgerDB.Args
@@ -436,7 +436,7 @@ prop_rpcReload_cliEnabledYamlSilent :: Property
 prop_rpcReload_cliEnabledYamlSilent =
   H.propertyOnce $ do
     let cliConfig = testPartialCliConfig
-          { pncRpcConfig = RpcConfig (Last (Just True)) mempty mempty
+          { pncRpcConfig = (mempty :: PartialRpcConfig){isEnabled = Last (Just True)}
           , pncSocketConfig = testSocketConfigWithPath
           }
         merged = defaultPartialNodeConfiguration <> testPartialYamlConfig <> cliConfig
@@ -447,7 +447,7 @@ prop_rpcReload_cliEnabledYamlSilent =
 prop_rpcReload_cliSilentYamlEnabled :: Property
 prop_rpcReload_cliSilentYamlEnabled =
   H.propertyOnce $ do
-    let yamlConfig = testPartialYamlConfig{pncRpcConfig = RpcConfig (Last (Just True)) mempty mempty}
+    let yamlConfig = testPartialYamlConfig{pncRpcConfig = (mempty :: PartialRpcConfig){isEnabled = Last (Just True)}}
         cliConfig = testPartialCliConfig{pncSocketConfig = testSocketConfigWithPath}
         merged = defaultPartialNodeConfiguration <> yamlConfig <> cliConfig
     NodeConfiguration{ncRpcConfig = RpcConfig{isEnabled}} <- evalEither $ makeNodeConfiguration merged
@@ -465,9 +465,9 @@ prop_rpcReload_bothSilent =
 prop_rpcReload_cliOverridesYaml :: Property
 prop_rpcReload_cliOverridesYaml =
   H.propertyOnce $ do
-    let yamlConfig = testPartialYamlConfig{pncRpcConfig = RpcConfig (Last (Just False)) mempty mempty}
+    let yamlConfig = testPartialYamlConfig{pncRpcConfig = (mempty :: PartialRpcConfig){isEnabled = Last (Just False)}}
         cliConfig = testPartialCliConfig
-          { pncRpcConfig = RpcConfig (Last (Just True)) mempty mempty
+          { pncRpcConfig = (mempty :: PartialRpcConfig){isEnabled = Last (Just True)}
           , pncSocketConfig = testSocketConfigWithPath
           }
         merged = defaultPartialNodeConfiguration <> yamlConfig <> cliConfig

--- a/cardano-submit-api/.changes/20260904_123655_mgalazyn_bump_cardano_api_11_7.yml
+++ b/cardano-submit-api/.changes/20260904_123655_mgalazyn_bump_cardano_api_11_7.yml
@@ -1,0 +1,5 @@
+pr: 6668
+kind:
+  - maintenance
+description: |
+  Bumped cardano-api to 11.7.

--- a/cardano-submit-api/cardano-submit-api.cabal
+++ b/cardano-submit-api/cardano-submit-api.cabal
@@ -39,7 +39,7 @@ library
                       , aeson
                       , async
                       , bytestring
-                      , cardano-api ^>= 11.6
+                      , cardano-api ^>= 11.7
                       , cardano-binary
                       , cardano-cli ^>= 11.2.2
                       , cardano-crypto-class ^>=2.5

--- a/cardano-testnet/.changes/20260904_123655_mgalazyn_bump_cardano_api_11_7.yml
+++ b/cardano-testnet/.changes/20260904_123655_mgalazyn_bump_cardano_api_11_7.yml
@@ -1,0 +1,5 @@
+pr: 6668
+kind:
+  - maintenance
+description: |
+  Bumped cardano-api to 11.7 and cardano-rpc to 11.3.

--- a/cardano-testnet/.changes/20260904_123655_mgalazyn_rpc_v1beta_spec_test_update.yml
+++ b/cardano-testnet/.changes/20260904_123655_mgalazyn_rpc_v1beta_spec_test_update.yml
@@ -1,0 +1,5 @@
+pr: 6668
+kind:
+  - test
+description: |
+  Updated the UTxO RPC `FetchBlock` test for the latest v1beta spec, where the block reference request field and the block response field became repeated.

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -41,7 +41,7 @@ library
                       , annotated-exception
                       , ansi-terminal
                       , bytestring
-                      , cardano-api ^>= 11.6
+                      , cardano-api ^>= 11.7
                       , cardano-cli:{cardano-cli, cardano-cli-test-lib} ^>= 11.2.2
                       , cardano-crypto-class ^>=2.5
                       , cardano-crypto-wrapper

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/version_cmd.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/version_cmd.cli
@@ -1,3 +1,3 @@
-built against cardano-api 11.6.0.0
-built against cardano-rpc 11.2.0.0
-built against cardano-cli 11.2.3.0
+built against cardano-api 11.7.0.0
+built against cardano-rpc 11.3.0.0
+built against cardano-cli 11.2.3.1

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/FetchBlock.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/FetchBlock.hs
@@ -98,12 +98,12 @@ hprop_rpc_fetch_block = integrationRetryWorkspace 2 "rpc-fetch-block" $ \tempAbs
 
     -- Call FetchBlock via gRPC
     let blockRef = def & U5c.slot .~ slot & U5c.hash .~ tipHash
-        request = def & U5c.ref .~ blockRef
+        request = def & U5c.ref .~ [blockRef]
 
     response <- H.evalIO . Rpc.withConnection def rpcServer $ \conn ->
       Rpc.nonStreaming conn (Rpc.rpc @(Rpc.Protobuf U5c.SyncService "fetchBlock")) request
 
-    let block = response ^. U5c.block
+    [block] <- H.noteShow $ response ^. U5c.block
 
     -- Verify nativeBytes is non-empty
     let rawBytes = block ^. U5c.nativeBytes
@@ -134,7 +134,7 @@ hprop_rpc_fetch_block = integrationRetryWorkspace 2 "rpc-fetch-block" $ \tempAbs
           result <-
             H.evalIO . try . Rpc.withConnection def rpcServer $ \conn ->
               Rpc.nonStreaming conn (Rpc.rpc @(Rpc.Protobuf U5c.SyncService "fetchBlock")) $
-                def & U5c.ref .~ ref
+                def & U5c.ref .~ [ref]
           case result of
             Left GrpcException{grpcError}
               | grpcError == expectedError -> pure ()
@@ -252,11 +252,12 @@ hprop_rpc_fetch_block = integrationRetryWorkspace 2 "rpc-fetch-block" $ \tempAbs
     H.note_ "Fetch the block containing the submitted transaction and verify its transactions"
 
     let txBlockRef = def & U5c.slot .~ txBlockSlot & U5c.hash .~ txBlockHash
-        txBlockRequest = def & U5c.ref .~ txBlockRef
+        txBlockRequest = def & U5c.ref .~ [txBlockRef]
     txBlockResponse <- H.evalIO . Rpc.withConnection def rpcServer $ \conn ->
       Rpc.nonStreaming conn (Rpc.rpc @(Rpc.Protobuf U5c.SyncService "fetchBlock")) txBlockRequest
 
-    let fetchedTxs = txBlockResponse ^. U5c.block . U5c.cardano . U5c.body . U5c.tx
+    [txBlock] <- H.noteShow $ txBlockResponse ^. U5c.block
+    let fetchedTxs = txBlock ^. U5c.cardano . U5c.body . U5c.tx
     H.note_ "Ensure the fetched block contains all transactions of the block"
     length fetchedTxs H.=== txBlockTxCount
 
@@ -383,11 +384,12 @@ hprop_rpc_fetch_block = integrationRetryWorkspace 2 "rpc-fetch-block" $ \tempAbs
     H.note_ "Fetch the block containing the minting transaction and verify the minted assets"
 
     let mintBlockRef = def & U5c.slot .~ mintBlockSlot & U5c.hash .~ mintBlockHash
-        mintBlockRequest = def & U5c.ref .~ mintBlockRef
+        mintBlockRequest = def & U5c.ref .~ [mintBlockRef]
     mintBlockResponse <- H.evalIO . Rpc.withConnection def rpcServer $ \conn ->
       Rpc.nonStreaming conn (Rpc.rpc @(Rpc.Protobuf U5c.SyncService "fetchBlock")) mintBlockRequest
 
-    let mintFetchedTxs = mintBlockResponse ^. U5c.block . U5c.cardano . U5c.body . U5c.tx
+    [mintBlock] <- H.noteShow $ mintBlockResponse ^. U5c.block
+    let mintFetchedTxs = mintBlock ^. U5c.cardano . U5c.body . U5c.tx
     H.note_ "Ensure the fetched block contains all transactions of the block"
     length mintFetchedTxs H.=== mintBlockTxCount
 

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1788439818,
-        "narHash": "sha256-+sjKSr1tFhiLrxhplOOToCjXMyWZV4ZbvYOdkqwHzBg=",
+        "lastModified": 1788515468,
+        "narHash": "sha256-MJHV5MzqL08IGQCq3U049AYXzi4SJTtu/QB6Fsip8UE=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "95889113a879bc92976bba48cf743bd78f99710f",
+        "rev": "64199d3057055b4d6ddc76482c3eef6de483838d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Description

Adds configuration for the node's gRPC server to listen over HTTP/2 instead of only a unix socket, in plaintext (h2c) or with TLS.

- New CLI flags `--grpc-listen-address`/`--grpc-listen-port` (config keys `RpcListenAddress`/`RpcListenPort`) switch the server from the unix socket to HTTP/2.
  The listen address accepts an IPv4 or IPv6 address and defaults to `127.0.0.1`.
- New CLI flags `--grpc-tls-certificate`/`--grpc-tls-private-key`/`--grpc-tls-chain-certificate` (config keys `RpcTlsCertificateFile`/`RpcTlsPrivateKeyFile`/`RpcTlsChainCertificateFiles`) switch the HTTP/2 endpoint to TLS.
- Conflicting or incomplete combinations are rejected at configuration parse time.
  For example, a unix socket path together with a listen port, or a TLS private key without a certificate.
- A new `RPC.ServerListening` trace announces the endpoint the gRPC server is listening on at startup.

Also fixes `--port` and the tracer socket CLI options.
They previously parsed port numbers with a plain `Int`/`Word16` `read` and silently wrapped out-of-range values, for example `70000` became `4464`.
They now reject out-of-range and non-decimal input.

This PR also carries two changes that cannot ship separately from the endpoint work:

- The bump to cardano-api 11.7 and cardano-rpc 11.3 (both released to CHaP today), together with the CHaP index and flake pin update.
  cardano-rpc 11.3 replaced the socket path in `RpcConfigF` with the `RpcEndpoint` type, so the bump only compiles with the endpoint changes here, and the endpoint changes only compile against 11.3.
- The UTxO RPC test update for the latest v1beta spec, previously #6666.
  The spec made the `FetchBlock` request reference and response block fields repeated, so the old test does not compile against cardano-rpc 11.3 and the updated one does not compile against 11.2.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
  - `cardano-node-chairman`, `cardano-submit-api` and `cardano-testnet` instead need a
    changelog fragment in `<package>/.changes/`, because their `CHANGELOG.md` is generated
    from fragments at release time.  Copy `_TEMPLATE.yml` from that directory, or run
    `nix run github:input-output-hk/cardano-dev#herald -- new`
- [x] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
