### PR TITLE
Align BlockFetch.Decision and ClientMetrics namespaces with what is emitted

### DIFF
--- a/bench/trace-schemas/newNamespaces.txt
+++ b/bench/trace-schemas/newNamespaces.txt
@@ -7,9 +7,8 @@ BlockFetch.Client.CompletedFetchBatch
 BlockFetch.Client.RejectedFetchBatch
 BlockFetch.Client.SendFetchRequest
 BlockFetch.Client.StartedFetchBatch
-BlockFetch.Decision.Accept
-BlockFetch.Decision.Decline
-BlockFetch.Decision.EmptyPeersFetch
+BlockFetch.Decision.PeerStarvedUs
+BlockFetch.Decision.PeersFetch
 BlockFetch.Remote.Receive.BatchDone
 BlockFetch.Remote.Receive.Block
 BlockFetch.Remote.Receive.ClientDone

--- a/cardano-node/ChangeLog.md
+++ b/cardano-node/ChangeLog.md
@@ -2,6 +2,15 @@
 
 ## Next version
 
+- **Bugfix:** `BlockFetch.Decision` now documents the namespaces it actually emits,
+  `PeersFetch` and `PeerStarvedUs`, instead of `Accept`, `Decline` and `EmptyPeersFetch`,
+  which no longer correspond to any message. The two real namespaces can now be named in a
+  trace configuration; previously `checkTraceConfiguration` rejected them as unknown.
+
+- **Bugfix:** `BlockFetch.Client.ClientMetrics` is recognised by `checkTraceConfiguration`.
+  It was emitted and documented, but naming it in a trace configuration produced a
+  `Config namespace error`.
+
 ## 11.1.0 -- August 2026
 
 - **Behaviour change:** snapshot options set directly under `LedgerDB` alongside a

--- a/cardano-node/src/Cardano/Node/Tracing/Consistency.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Consistency.hs
@@ -32,6 +32,7 @@ import           Cardano.Node.Tracing.Documentation (docTracersFirstPhase)
 import           Cardano.Node.Tracing.Formatting ()
 import qualified Cardano.Node.Tracing.StateRep as SR
 import           Cardano.Node.Tracing.Tracers.BlockReplayProgress
+import           Cardano.Node.Tracing.Tracers.Consensus (ClientMetrics)
 import           Cardano.Node.Tracing.Tracers.ConsensusStartupException
 import           Cardano.Node.Tracing.Tracers.KESInfo ()
 import           Cardano.Node.Tracing.Tracers.LedgerMetrics (LedgerMetrics)
@@ -68,7 +69,7 @@ import           Ouroboros.Consensus.Protocol.Praos.AgentClient (KESAgentClientT
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import           Ouroboros.Network.Block (Point (..), SlotNo, Tip)
 import qualified Ouroboros.Network.BlockFetch.ClientState as BlockFetch
-import           Ouroboros.Network.BlockFetch.Decision
+import           Ouroboros.Network.BlockFetch.Decision.Trace (TraceDecisionEvent)
 import           Ouroboros.Network.ConnectionHandler (ConnectionHandlerTrace (..))
 import           Ouroboros.Network.ConnectionId (ConnectionId)
 import qualified Ouroboros.Network.ConnectionManager.Core as ConnectionManager
@@ -172,13 +173,13 @@ getAllNamespaces =
         chainSyncServerBlockNS = map (nsGetTuple . nsReplacePrefix ["ChainSync", "ServerBlock"])
                         (allNamespaces :: [Namespace (TraceChainSyncServerEvent blk)])
         blockFetchDecisionNS = map (nsGetTuple . nsReplacePrefix ["BlockFetch", "Decision"])
-                        (allNamespaces :: [Namespace [BlockFetch.TraceLabelPeer
-                                                      remotePeer
-                                                      (FetchDecision [Point (Header blk)])]])
+                        (allNamespaces :: [Namespace (TraceDecisionEvent remotePeer (Header blk))])
         blockFetchClientNS = map (nsGetTuple . nsReplacePrefix ["BlockFetch", "Client"])
                         (allNamespaces :: [Namespace (BlockFetch.TraceLabelPeer
                                                       remotePeer
                                                       (BlockFetch.TraceFetchClientState (Header blk)))])
+        blockFetchClientMetricsNS = map (nsGetTuple . nsReplacePrefix ["BlockFetch", "Client"])
+                        (allNamespaces :: [Namespace ClientMetrics])
         blockFetchServerNS = map (nsGetTuple . nsReplacePrefix ["BlockFetch", "Server"])
                     (allNamespaces :: [Namespace (TraceBlockFetchServerEvent blk)])
 
@@ -443,6 +444,7 @@ getAllNamespaces =
             <> blockFetchDecisionNS
             <> consensusSanityCheckNS
             <> blockFetchClientNS
+            <> blockFetchClientMetricsNS
             <> blockFetchServerNS
             <> forgeKESInfoNS
             <> txInboundNS

--- a/cardano-node/src/Cardano/Node/Tracing/Documentation.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Documentation.hs
@@ -83,7 +83,7 @@ import           Ouroboros.Consensus.Protocol.Praos.AgentClient (KESAgentClientT
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import           Ouroboros.Network.Block (Point (..), Serialised, SlotNo, Tip)
 import qualified Ouroboros.Network.BlockFetch.ClientState as BlockFetch
-import           Ouroboros.Network.BlockFetch.Decision
+import           Ouroboros.Network.BlockFetch.Decision.Trace (TraceDecisionEvent)
 import           Ouroboros.Network.ConnectionHandler (ConnectionHandlerTrace (..))
 import           Ouroboros.Network.ConnectionId (ConnectionId)
 import qualified Ouroboros.Network.ConnectionManager.Core as ConnectionManager
@@ -320,9 +320,7 @@ docTracersFirstPhase condConfigFileName = do
                 ["BlockFetch", "Decision"]
     configureTracers configReflection trConfig [blockFetchDecisionTr]
     blockFetchDecisionTrDoc <- documentTracer (blockFetchDecisionTr ::
-       Logging.Trace IO [BlockFetch.TraceLabelPeer
-                                      remotePeer
-                                      (FetchDecision [Point (Header blk)])])
+       Logging.Trace IO (TraceDecisionEvent remotePeer (Header blk)))
 
     blockFetchClientTr  <- mkCardanoTracer
                 trBase trForward mbTrEKG


### PR DESCRIPTION
# Description

Fixes #6667, taking the localized approach @mgmeier suggested there — restoring consistency across usage, documentation and configuration inside the existing pattern, rather than deriving all three from one place.

**`BlockFetch.Decision`.** `Consensus.blockFetchDecisionTracer` has carried `TraceDecisionEvent` since `ouroboros-consensus-4.1.0.0`, and `Tracers.hs:385` wires that field, so the node emits `PeersFetch` and `PeerStarvedUs`. Both declaration sites still spelled the pre-`TraceDecisionEvent` type by hand:

```haskell
Logging.Trace IO [BlockFetch.TraceLabelPeer remotePeer (FetchDecision [Point (Header blk)])]
```

whose namespaces are `EmptyPeersFetch`, `Accept` and `Decline`. So the three documented namespaces can never fire, and the two that do fire are unknown to `checkTraceConfiguration` — they cannot be re-levelled or silenced from a config file.

**`BlockFetch.Client.ClientMetrics`** had the mirror-image problem: composed onto the blockfetch client tracer in `Tracers.hs:389` and documented at the `["BlockFetch","Client"]` prefix, but absent from `getAllNamespaces`, so naming it in a configuration produced a `Config namespace error`.

Both sites are now annotated with the record's own type, `ClientMetrics` is added at the `BlockFetch.Client` prefix, and `newNamespaces.txt` is updated accordingly (`Accept`/`Decline`/`EmptyPeersFetch` out, `PeerStarvedUs`/`PeersFetch` in; the file stays C-locale sorted).

The `Ouroboros.Network.BlockFetch.Decision` import is dropped from both modules, since `FetchDecision` was its only use in either and `cabal.project` sets `-Werror`.

# Notes for the reviewer

**I could not build this.** I have no GHC/cabal toolchain available, and a cardano-node build needs libsodium/secp256k1/blst besides. Rather than guess, here is what I did check statically — please let CI be the judge:

- `ClientMetrics` is exported from `Cardano.Node.Tracing.Tracers.Consensus` (export list line 21), so the new import in `Consistency.hs` resolves.
- No import cycle: `Tracers.Consensus` does not import `Consistency`, and it was already reachable via `Consistency -> Documentation -> Tracers.Consensus`.
- Dropping the `Decision` import is safe in both modules: `FetchDecision` was its only symbol in use, while `Point` (from `Ouroboros.Network.Block`) and the qualified `BlockFetch.` (from `BlockFetch.ClientState`) are still used 12x/7x and 26x respectively, so those imports stay live.
- `TraceDecisionEvent` is spelled exactly as `Tracers/Consensus.hs:79` imports it, and applied at the arity used by the `MetaTrace` instance at line 657 and the consensus record field.
- Import lines follow the surrounding stylish-haskell alignment.

I have not run `hlint` or `stylish-haskell` either, for the same reason.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
  - The namespace consistency check is itself the test here: `checkTraceConfiguration` compares `getAllNamespaces` against the configuration, and `newNamespaces.txt` is the golden list this PR updates.
- [x] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated — not applicable, no dependency change
- [ ] CI passes. See note above: I could not run the build or the linters locally.
