### PR TITLE
Update o-c and add tracer for LeiosTally

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -92,12 +92,12 @@ allow-older:
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
 
--- Points to ouroboros-consensus/leios-prototype
+-- Points to ouroboros-consensus/jl/leios-prototype-w35-patched
 source-repository-package
   type: git
   location: https://github.com/IntersectMBO/ouroboros-consensus
-  tag: 1820edf5e496fbec5aa230a8bee56397c76f474b
-  --sha256: sha256-fKHnMyMNfPtVakRXQOEXpONh8AKNtxybaL3sMe6hdNw=
+  tag: bf1eeafff6f226affeb1de708f00a078a1657aa5
+  --sha256: sha256-uak6xmfDtKZSPhpkfCErYaaLU9ZpgDFQth52yOPRvzY=
 
 -- Points to nfrisby-pr93-lookahead-merge-commit tag
 source-repository-package

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
@@ -2465,6 +2465,12 @@ instance LogFormatting TraceLeiosKernel where
       "EB certified at slot " <> showT atSlot <> ": " <> Text.pack (show certifiedPoint)
     TraceLeiosVoted{weight}         -> "Leios voted, weight=" <> showT (fromRational @Double weight)
     TraceLeiosVoteAcquired{}        -> "Leios vote acquired"
+    TraceLeiosTally{rbHash, seatId, weight, tally, threshold} ->
+      "Leios tally for RB " <> Text.pack (show rbHash)
+        <> ": seat " <> showT (Leios.leiosSeatIndex seatId)
+        <> " added " <> showT (fromRational @Double weight)
+        <> ", now " <> showT (fromRational @Double tally)
+        <> " against a threshold of " <> showT (fromRational @Double threshold)
     TraceLeiosCertified{rbHash}     -> "Leios cert assembled for RB " <> Text.pack (show rbHash)
     TraceLeiosVoteScheduled{ebPoint, voteIn, deadlineIn} ->
       "Leios vote scheduled for " <> Text.pack (show ebPoint)
@@ -2529,6 +2535,7 @@ instance MetaTrace TraceLeiosKernel where
   namespaceFor TraceLeiosBlockCertified{}    = Namespace [] ["BlockCertified"]
   namespaceFor TraceLeiosVoted{}             = Namespace [] ["Voted"]
   namespaceFor TraceLeiosVoteAcquired{}      = Namespace [] ["VoteAcquired"]
+  namespaceFor TraceLeiosTally{}             = Namespace [] ["Tally"]
   namespaceFor TraceLeiosCertified{}         = Namespace [] ["Certified"]
   namespaceFor TraceLeiosNotVoted{}          = Namespace [] ["NotVoted"]
   namespaceFor TraceLeiosVoteScheduled{}     = Namespace [] ["VoteScheduled"]
@@ -2578,6 +2585,7 @@ instance MetaTrace TraceLeiosKernel where
     , Namespace [] ["BlockCertified"]
     , Namespace [] ["Voted"]
     , Namespace [] ["VoteAcquired"]
+    , Namespace [] ["Tally"]
     , Namespace [] ["Certified"]
     , Namespace [] ["NotVoted"]
     , Namespace [] ["VoteScheduled"]


### PR DESCRIPTION
# Description

Node-side companion to the consensus change that adds `TraceLeiosTally`, making the
Leios certification margin observable.  https://github.com/IntersectMBO/ouroboros-consensus/pull/2256

* `cabal.project` bumps the `ouroboros-consensus` source-repository-package
* `Cardano/Node/Tracing/Tracers/Consensus.hs` registers the new constructor at the three
sites the tracing framework requires: a `forHuman` clause, a `namespaceFor` mapping to
`Namespace [] ["Tally"]`, and the corresponding entry in `allNamespaces`. `forMachine`
needs nothing, since it delegates to consensus `traceLeiosKernelToObject`.

Severity falls through to `Info`, matching `Voted` and `VoteAcquired`. That makes the
trace inert under stock configs, which filter at `Notice`.