### PR TITLE
Leios statistics

### DIFF
--- a/bench/locli/locli.cabal
+++ b/bench/locli/locli.cabal
@@ -123,7 +123,7 @@ library
                       , ede
                       , extra
                       , filepath
-                      , fingertree == 0.1.5.0
+                      , fingertree >= 0.1.5.0 && < 0.1.7
                       , hashable
                       , optparse-applicative
                       , ouroboros-consensus:ouroboros-consensus

--- a/cabal.project
+++ b/cabal.project
@@ -96,8 +96,8 @@ allow-older:
 source-repository-package
   type: git
   location: https://github.com/IntersectMBO/ouroboros-consensus
-  tag: 5ed44e5f25b3abb42425d0a6e44947d9fb6f6295
-  --sha256: sha256-Q4Yrd9SOA9MU+4fGcUUFiUhbtNi1lmqaA+b/OSLPl9I=
+  tag: 7316f28a5125128ba4f355a18209837ae8896162
+  --sha256: sha256-ZQDhtjEZwcu+XSRxvaMi8FaS5ImssCTPUs9DtLFrV2E=
 
 -- Points to nfrisby-pr93-lookahead-merge-commit tag
 source-repository-package
@@ -145,6 +145,14 @@ source-repository-package
     ouroboros-network
     cardano-diffusion
     network-mux
+
+source-repository-package
+  type: git
+  location: https://github.com/IntersectMBO/ouroboros-network
+  tag: 19148df7530ae81fb7e1dd99f3cebfa494f221f7
+  --sha256: sha256-cV4Kc60nQBpIE9p8Eetv7ZLK5t5Di4Dla0Y3cdvk0XY=
+  subdir:
+    window-stats
 
 -- Points to cardano-api/leios-prototype
 source-repository-package

--- a/cardano-node/cardano-node.cabal
+++ b/cardano-node/cardano-node.cabal
@@ -99,6 +99,7 @@ library
                         Cardano.Node.Tracing.NodeStartupInfo
                         Cardano.Node.Tracing.Render
                         Cardano.Node.Tracing.StateRep
+                        Cardano.Node.Tracing.Stats
                         Cardano.Node.Tracing.Tracers
                         Cardano.Node.Tracing.Tracers.BlockReplayProgress
                         Cardano.Node.Tracing.Tracers.ChainDB
@@ -182,6 +183,7 @@ library
                       , strict-sop-core
                       , sop-core
                       , sop-extras
+                      , tdigest
                       , text >= 2.0
                       , time
                       , trace-dispatcher ^>= 2.12.0
@@ -190,6 +192,7 @@ library
                       , transformers
                       , transformers-except
                       , typed-protocols:{typed-protocols, stateful} >= 1.2
+                      , window-stats:with-tdigest
                       , yaml
 
 executable cardano-node

--- a/cardano-node/src/Cardano/Node/Tracing/Stats.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Stats.hs
@@ -1,0 +1,77 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE PackageImports #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+
+module Cardano.Node.Tracing.Stats
+  ( Stats (..)
+  , mkStatsTracer
+  ) where
+
+import           "contra-tracer" Control.Tracer (Tracer (..))
+import qualified "contra-tracer" Control.Tracer as Tracer
+import           Control.Concurrent.Class.MonadMVar
+import           Control.Monad.Class.MonadTime.SI
+import           GHC.TypeLits (KnownNat, Nat, SNat)
+import           Data.TDigest (TDigest)
+import           Data.Window.DigestTimeBatched (TimedDigestWindow)
+import qualified Data.Window.DigestTimeBatched as Window
+
+
+-- | Stats type.
+--
+-- This type is parametrised by `comp :: Nat` which configures `TDigest`
+-- compression, and a custom `tag :: Type`, which allows to create different
+-- instances of `LogFormatting` and associated tracing type classes.  For
+-- example can use `window-stat` API output various percentiles as metric
+-- gauges.
+--
+-- TODO: we start adding samples when the node starts, rather than when the
+-- node is in sync.
+newtype Stats (comp :: Nat) tag = Stats { tdigestWindow :: TDigest comp }
+
+mkStatsTracer
+  :: forall m (comp :: Nat) tag a.
+     ( KnownNat comp
+     , MonadMonotonicTime m
+     , MonadMVar m
+     )
+  => DiffTime
+  -- ^ bucket duration
+  -> Int
+  -- ^ retention window
+  -> SNat comp
+  -- ^ tdigest compression
+  -> Int
+  -- ^ minimal number of samples before returning `TDigest`
+  -> Double
+  -- ^ Maximum threshold for first measurement.  This allows to ignore results
+  -- when the node is syncing and the results are heavily inflated.
+  -> (a -> Maybe Double)
+  -- ^ function which extracts value for which we build a CDF
+  -> Tracer m (Stats comp tag)
+  -- ^ Tracer which outputs statistics using `window-stat` API.
+  -> m (Tracer m a)
+mkStatsTracer d r _ minSamples threshold fn tr = do
+    v <- newMVar (Window.empty d r :: TimedDigestWindow Time comp)
+    return $ Tracer.traceMaybeM (fnM v) tr
+  where
+    fnM :: MVar m (TimedDigestWindow Time comp)
+        -> a
+        -> m (Maybe (Stats comp tag))
+    fnM v a = case fn a of
+      Nothing -> return Nothing
+      Just b ->
+        modifyMVar v $ \st -> do
+          t <- getMonotonicTime
+          let st' = if b >= threshold && Window.null st
+                      -- ignore results greater than `threashold` while the
+                      -- state is null
+                      then st
+                      else Window.insert (t, b) st
+          return (st', if Window.sampleCount st' >= minSamples
+                         then Stats <$> Window.windowDigest st'
+                         else Nothing)

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
@@ -30,6 +30,7 @@ import           Cardano.Node.Tracing
 import           Cardano.Node.Tracing.Consistency (checkNodeTraceConfiguration')
 import           Cardano.Node.Tracing.Formatting ()
 import qualified Cardano.Node.Tracing.StateRep as SR
+import           Cardano.Node.Tracing.Stats (mkStatsTracer)
 import           Cardano.Node.Tracing.Tracers.BlockReplayProgress
 import           Cardano.Node.Tracing.Tracers.ChainDB
 import           Cardano.Node.Tracing.Tracers.Consensus
@@ -64,6 +65,7 @@ import           "contra-tracer" Control.Tracer (mkTracer)
 import           Cardano.Network.OrphanInstances ()
 import           Data.Aeson (ToJSON (..))
 import           Data.Proxy (Proxy (..))
+import           GHC.TypeLits (natSing)
 import           Network.Mux.Trace (TraceLabelPeer (..))
 import qualified Network.Mux.Trace as Mux
 import           Network.Mux.Tracing ()
@@ -360,6 +362,16 @@ mkConsensusTracers configReflection trBase trForward mbTrEKG _trDataPoint trConf
                 ["Consensus", "LeiosKernel"]
     configureTracers configReflection trConfig [leiosKernelTr]
 
+    !leiosBlockTxsAcquiredStatsTr <-
+      mkStatsTracer
+        1800 -- bucket duration (seconds)
+        24 -- retention window, in buckets (12h)
+        (natSing @LeiosBlockTxsAcquiredComp)
+        45 -- minimal samples before reporting percentiles
+        20 -- all initial samples higher than 20s will be ignored
+        leiosBlockTxsAcquiredAge
+        (mkTracer (traceWith (metricsFormatter (mkMetricsTracer mbTrEKG) :: Trace IO LeiosBlockTxsAcquiredStats)))
+
     !leiosPeerTr <- mkCardanoTracer
                 trBase trForward mbTrEKG
                 ["Consensus", "LeiosPeer"]
@@ -419,8 +431,9 @@ mkConsensusTracers configReflection trBase trForward mbTrEKG _trDataPoint trConf
           traceWith txLogicTracer
       , Consensus.txCountersTracer = mkTracer $
           traceWith txCountersTracer
-      , Consensus.leiosKernelTracer = mkTracer $
-          traceWith leiosKernelTr
+      , Consensus.leiosKernelTracer =
+          mkTracer (traceWith leiosKernelTr)
+          <> leiosBlockTxsAcquiredStatsTr
       , Consensus.leiosPeerTracer = mkTracer $
           traceWith leiosPeerTr
       }

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
@@ -58,8 +58,6 @@ import qualified Ouroboros.Network.BlockFetch.ClientState as BlockFetch
 import           Ouroboros.Network.ConnectionId (ConnectionId)
 import qualified Ouroboros.Network.Diffusion as Diffusion
 
-import           LeiosDemoTypes (TraceLeiosKernel (..))
-
 import           Codec.CBOR.Read (DeserialiseFailure)
 import           Control.Monad (unless)
 import           "contra-tracer" Control.Tracer (mkTracer)
@@ -362,15 +360,6 @@ mkConsensusTracers configReflection trBase trForward mbTrEKG _trDataPoint trConf
                 ["Consensus", "LeiosKernel"]
     configureTracers configReflection trConfig [leiosKernelTr]
 
-    !leiosMetricsTr <- do
-      tr1 <- foldTraceM (\cm lc -> pure . calculateLeiosMetrics cm lc) initialLeiosMetrics
-                (metricsFormatter
-                  (mkMetricsTracer mbTrEKG))
-      pure $ filterTrace (\(_, msg) -> case msg of 
-                         TraceLeiosAnnouncementAccepted{} -> True
-                         _ -> False)
-               tr1
-
     !leiosPeerTr <- mkCardanoTracer
                 trBase trForward mbTrEKG
                 ["Consensus", "LeiosPeer"]
@@ -432,7 +421,6 @@ mkConsensusTracers configReflection trBase trForward mbTrEKG _trDataPoint trConf
           traceWith txCountersTracer
       , Consensus.leiosKernelTracer = mkTracer $
           traceWith leiosKernelTr
-          <> traceWith leiosMetricsTr
       , Consensus.leiosPeerTracer = mkTracer $
           traceWith leiosPeerTr
       }

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers.hs
@@ -362,6 +362,16 @@ mkConsensusTracers configReflection trBase trForward mbTrEKG _trDataPoint trConf
                 ["Consensus", "LeiosKernel"]
     configureTracers configReflection trConfig [leiosKernelTr]
 
+    !leiosAnnouncementAcceptedStatsTr <-
+      mkStatsTracer
+        1800 -- bucket duration (seconds)
+        24 -- retention window, in buckets (12h)
+        (natSing @LeiosAnnouncementAcceptedComp)
+        45 -- minimal samples before reporting percentiles
+        20 -- all initial samples higher than 20s will be ignored
+        leiosAnnouncementAcceptedAge
+        (mkTracer (traceWith (metricsFormatter (mkMetricsTracer mbTrEKG) :: Trace IO LeiosAnnouncementAcceptedStats)))
+
     !leiosBlockTxsAcquiredStatsTr <-
       mkStatsTracer
         1800 -- bucket duration (seconds)
@@ -433,6 +443,7 @@ mkConsensusTracers configReflection trBase trForward mbTrEKG _trDataPoint trConf
           traceWith txCountersTracer
       , Consensus.leiosKernelTracer =
           mkTracer (traceWith leiosKernelTr)
+          <> leiosAnnouncementAcceptedStatsTr
           <> leiosBlockTxsAcquiredStatsTr
       , Consensus.leiosPeerTracer = mkTracer $
           traceWith leiosPeerTr

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
@@ -2358,7 +2358,7 @@ calculateLeiosMetrics ::
 calculateLeiosMetrics lm@LeiosMetrics {..} _lc (TraceLeiosAnnouncementAccepted _ _ fields (Just annDelay)) =
     case announcementElection fields of
       MkElId slotNo@(SlotNo slotNo_) _ ->
-        if Cdf.null lmCdfState && annDelay > 20 -- During startup wait until we are in sync
+        if Cdf.null lmCdfState
           then nothingToDo
           else
             case Cdf.processDataPoint
@@ -2369,10 +2369,7 @@ calculateLeiosMetrics lm@LeiosMetrics {..} _lc (TraceLeiosAnnouncementAccepted _
                    of
               Nothing -> nothingToDo
               Just (lm', lmCdfState') ->
-                lm' { lmCdfState  = lmCdfState'
-                    , lmTraceIt   = True
-                    , lmTraceVars = Cdf.size lmCdfState' >= 45 -- wait until we have at least 45 samples before providing cdf estimates
-                    , lmDelay     = realToFrac annDelay
+                lm' { lmCdfState    = lmCdfState'
                     }
   where
     nothingToDo = lm {lmTraceIt = False}

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeData #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -19,6 +20,12 @@ module Cardano.Node.Tracing.Tracers.Consensus
   , calculateBlockFetchClientMetrics
   , servedBlockLatest
   , ClientMetrics
+    -- ** LeiosBlockTxsAcquired Stats
+  , type LeiosBlockTxsAcquiredKind (..)
+  , LeiosBlockTxsAcquiredComp
+  , LeiosBlockTxsAcquiredStats
+  , leiosBlockTxsAcquiredAge
+    -- * Tx-Submission / Mempool
   , txsMempoolTimeoutSoftCounterName
   , txsSyncDurationTotalCounterName
   , impliesMempoolTimeoutSoft
@@ -33,6 +40,7 @@ import           Cardano.Node.Tracing.Era.Byron ()
 import           Cardano.Node.Tracing.Era.Shelley ()
 import           Cardano.Node.Tracing.Formatting ()
 import           Cardano.Node.Tracing.Render
+import           Cardano.Node.Tracing.Stats (Stats (..))
 import           Cardano.Node.Tracing.Tracers.ConsensusStartupException ()
 import           Cardano.Protocol.TPraos.OCert (KESPeriod (..))
 import           Cardano.Slotting.Slot (WithOrigin (..))
@@ -78,6 +86,8 @@ import           Data.Aeson (ToJSON, Value (..), object, toJSON, (.=))
 import qualified Data.Aeson as Aeson
 import           Data.Foldable (Foldable (toList))
 import qualified Data.List as List
+import           Data.Maybe (maybeToList)
+import qualified Data.TDigest as TDigest
 import qualified Data.Text as Text
 import           Data.Word (Word32, Word64)
 import           Network.TypedProtocol.Core
@@ -2342,6 +2352,35 @@ instance MetaTrace TraceLeiosKernel where
   documentFor _ = Nothing
   metricsDocFor (Namespace _ p) = maybe [] Leios.nsiMetricsDoc (Leios.leiosKernelNSByPath p)
   allNamespaces = Namespace [] <$> Leios.leiosKernelNSPaths
+
+type data LeiosBlockTxsAcquiredKind = LeiosBlockTxsAcquired
+type LeiosBlockTxsAcquiredComp = 10
+type LeiosBlockTxsAcquiredStats = Stats LeiosBlockTxsAcquiredComp LeiosBlockTxsAcquired
+
+instance LogFormatting (Stats LeiosBlockTxsAcquiredComp LeiosBlockTxsAcquired) where
+  forMachine _dtal _ = mempty
+  asMetrics Stats { tdigestWindow } =
+    [ DoubleM ("leios.eb.txs.acquired." <> n) v
+    | (p, n) <- [(0.90, "p90"), (0.95, "p95"), (0.99, "p99")]
+    , v <- maybeToList (TDigest.quantile p tdigestWindow)
+    ]
+
+instance MetaTrace (Stats LeiosBlockTxsAcquiredComp LeiosBlockTxsAcquired) where
+  namespaceFor Stats {} = Namespace [] ["LeiosMetrics", "Eb", "TxsAcquired"]
+  severityFor _ _ = Just Info
+
+  documentFor _ = Nothing
+  allNamespaces =
+    [ Namespace [] ["LeiosMetrics", "Eb", "TxsAcquired"]
+    ]
+
+-- | The elapsed time since the EB's slot onset until all of its txs were
+-- acquired, i.e. the sample fed into 'LeiosBlockTxsAcquiredStats'.
+leiosBlockTxsAcquiredAge :: TraceLeiosKernel -> Maybe Double
+leiosBlockTxsAcquiredAge = \case
+  TraceLeiosBlockTxsAcquired { ebAge } -> Just (realToFrac ebAge)
+  _                                    -> Nothing
+
 
 instance LogFormatting TraceLeiosPeer where
   forMachine _dtal = traceLeiosPeerToObject

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
@@ -25,6 +25,10 @@ module Cardano.Node.Tracing.Tracers.Consensus
   , LeiosBlockTxsAcquiredComp
   , LeiosBlockTxsAcquiredStats
   , leiosBlockTxsAcquiredAge
+  , type LeiosAnnouncementAcceptedKind (..)
+  , LeiosAnnouncementAcceptedComp 
+  , LeiosAnnouncementAcceptedStats 
+  , leiosAnnouncementAcceptedAge
     -- * Tx-Submission / Mempool
   , txsMempoolTimeoutSoftCounterName
   , txsSyncDurationTotalCounterName
@@ -92,20 +96,11 @@ import qualified Data.Text as Text
 import           Data.Word (Word32, Word64)
 import           Network.TypedProtocol.Core
 
-<<<<<<< HEAD
 import           LeiosDemoLogic.Announcements.ElBimap (ElId (..))
 import           LeiosDemoTypes (AnnouncementFields (..), FetchArrivalBytes (..),
                    TraceLeiosKernel (..), TraceLeiosPeer (..), traceLeiosKernelToObject,
                    traceLeiosPeerToObject)
 import qualified LeiosDemoTypes as Leios
-||||||| parent of d0b50a5b6 (Revert "CDFs for EB announcements")
-import           LeiosDemoTypes (AnnouncementFields (..), TraceLeiosKernel (..), TraceLeiosPeer (..),
-                   traceLeiosKernelToObject, traceLeiosPeerToObject)
-import           LeiosDemoLogic.Announcements.ElBimap (ElId(..))
-=======
-import           LeiosDemoTypes (TraceLeiosKernel (..), TraceLeiosPeer (..),
-                   traceLeiosKernelToObject, traceLeiosPeerToObject)
->>>>>>> d0b50a5b6 (Revert "CDFs for EB announcements")
 import           LeiosUtils.CallTrace (SomeJsonCallTrace (..), callTraceToObject)
 
 enclosingValue :: ToJSON a => Enclosing' a -> Value
@@ -2325,6 +2320,34 @@ mapLeiosSeverity = \case
   Leios.LSError   -> Error
 
 
+type data LeiosAnnouncementAcceptedKind = LeiosAnnouncementAccepted
+type LeiosAnnouncementAcceptedComp = 10
+type LeiosAnnouncementAcceptedStats = Stats LeiosAnnouncementAcceptedComp LeiosAnnouncementAccepted
+
+leiosAnnouncementAcceptedAge :: TraceLeiosKernel -> Maybe Double
+leiosAnnouncementAcceptedAge = \case
+  TraceLeiosAnnouncementAccepted _ _ _ age
+    -> realToFrac <$> age
+  _ -> Nothing
+
+instance LogFormatting (Stats LeiosAnnouncementAcceptedComp LeiosAnnouncementAccepted) where
+  forMachine _dtal _ = mempty
+  asMetrics Stats { tdigestWindow } =
+    [ DoubleM ("leios.eb.announcement.delay." <> n) v
+    | (p, n) <- [(0.90, "p90"), (0.95, "p95"), (0.99, "p99")]
+    , v <- maybeToList (TDigest.quantile p tdigestWindow)
+    ]
+
+instance MetaTrace (Stats LeiosAnnouncementAcceptedComp LeiosAnnouncementAccepted) where
+  namespaceFor Stats {} = Namespace [] ["LeiosMetrics", "Eb", "Announcement"]
+  severityFor _ _ = Just Info
+
+  documentFor _ = Nothing
+  allNamespaces =
+    [ Namespace [] ["LeiosMetrics", "Eb", "Announcement"]
+    ]
+
+
 -- 'forMachine' delegates to 'traceLeiosKernelToObject' so the JSON shape matches
 -- the consensus-side tracer (per-constructor fields rather than a 'show' blob).
 instance LogFormatting TraceLeiosKernel where
@@ -2360,7 +2383,7 @@ type LeiosBlockTxsAcquiredStats = Stats LeiosBlockTxsAcquiredComp LeiosBlockTxsA
 instance LogFormatting (Stats LeiosBlockTxsAcquiredComp LeiosBlockTxsAcquired) where
   forMachine _dtal _ = mempty
   asMetrics Stats { tdigestWindow } =
-    [ DoubleM ("leios.eb.txs.acquired." <> n) v
+    [ DoubleM ("leios.eb.txs.acquired.delay." <> n) v
     | (p, n) <- [(0.90, "p90"), (0.95, "p95"), (0.99, "p99")]
     , v <- maybeToList (TDigest.quantile p tdigestWindow)
     ]
@@ -2378,9 +2401,8 @@ instance MetaTrace (Stats LeiosBlockTxsAcquiredComp LeiosBlockTxsAcquired) where
 -- acquired, i.e. the sample fed into 'LeiosBlockTxsAcquiredStats'.
 leiosBlockTxsAcquiredAge :: TraceLeiosKernel -> Maybe Double
 leiosBlockTxsAcquiredAge = \case
-  TraceLeiosBlockTxsAcquired { ebAge } -> Just (realToFrac ebAge)
-  _                                    -> Nothing
-
+  TraceLeiosBlockTxsAcquired _ age -> realToFrac <$> age
+  _                                -> Nothing
 
 instance LogFormatting TraceLeiosPeer where
   forMachine _dtal = traceLeiosPeerToObject

--- a/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
+++ b/cardano-node/src/Cardano/Node/Tracing/Tracers/Consensus.hs
@@ -14,16 +14,11 @@
 {-# OPTIONS_GHC -Wno-orphans  #-}
 
 module Cardano.Node.Tracing.Tracers.Consensus
-  ( -- * ClientMetrics
+  (
     initialClientMetrics
   , calculateBlockFetchClientMetrics
   , servedBlockLatest
   , ClientMetrics
-    -- * Leios Metrics
-  , initialLeiosMetrics
-  , calculateLeiosMetrics
-  , LeiosMetrics
-    -- * Tx-Submission / Mempool
   , txsMempoolTimeoutSoftCounterName
   , txsSyncDurationTotalCounterName
   , impliesMempoolTimeoutSoft
@@ -87,11 +82,20 @@ import qualified Data.Text as Text
 import           Data.Word (Word32, Word64)
 import           Network.TypedProtocol.Core
 
+<<<<<<< HEAD
 import           LeiosDemoLogic.Announcements.ElBimap (ElId (..))
 import           LeiosDemoTypes (AnnouncementFields (..), FetchArrivalBytes (..),
                    TraceLeiosKernel (..), TraceLeiosPeer (..), traceLeiosKernelToObject,
                    traceLeiosPeerToObject)
 import qualified LeiosDemoTypes as Leios
+||||||| parent of d0b50a5b6 (Revert "CDFs for EB announcements")
+import           LeiosDemoTypes (AnnouncementFields (..), TraceLeiosKernel (..), TraceLeiosPeer (..),
+                   traceLeiosKernelToObject, traceLeiosPeerToObject)
+import           LeiosDemoLogic.Announcements.ElBimap (ElId(..))
+=======
+import           LeiosDemoTypes (TraceLeiosKernel (..), TraceLeiosPeer (..),
+                   traceLeiosKernelToObject, traceLeiosPeerToObject)
+>>>>>>> d0b50a5b6 (Revert "CDFs for EB announcements")
 import           LeiosUtils.CallTrace (SomeJsonCallTrace (..), callTraceToObject)
 
 enclosingValue :: ToJSON a => Enclosing' a -> Value
@@ -2299,132 +2303,6 @@ instance MetaTrace KESAgentClientTrace where
 -- Leios
 --------------------------------------------------------------------------------
 
--- | Leios metrics which construct CDFs for EB announcements.
-data LeiosMetrics' c = LeiosMetrics {
-    lmCdfState     :: Cdf.State SlotNo
-    -- ^ internal state which collects all data points
-  , lmCdf200msVar  :: !c
-    -- ^ count EB announcements which arrived within 200ms
-  , lmCdf400msVar  :: !c
-    -- ^ count EB announcements which arrived within 400ms
-  , lmCdf600msVar  :: !c
-    -- ^ count EB announcements which arrived within 600ms
-  , lmCdf800msVar  :: !c
-    -- ^ count EB announcements which arrived within 800ms
-  , lmCdf1000msVar :: !c
-    -- ^ count EB announcements which arrived within 1000ms
-  , lmCdf1200msVar :: !c
-    -- ^ count EB announcements which arrived within 1200ms
-  , lmCdf1400msVar :: !c
-    -- ^ count EB announcements which arrived within 1400ms
-  , lmCdf1600msVar :: !c
-    -- ^ count EB announcements which arrived within 1600ms
-  , lmCdf1800msVar :: !c
-    -- ^ count EB announcements which arrived within 1800ms
-  , lmCdf2000msVar :: !c
-    -- ^ count EB announcements which arrived within 2000ms
-  , lmDelay        :: Double
-    -- ^ last EM announcement delay value
-  , lmTraceVars    :: Bool
-  , lmTraceIt      :: Bool
-  }
-  deriving Functor
-
-type LeiosMetrics = LeiosMetrics' Cdf.Counter
-
-initialLeiosMetrics :: LeiosMetrics
-initialLeiosMetrics = LeiosMetrics {
-    lmCdfState     = Cdf.empty
-  , lmCdf200msVar  = Cdf.Counter 0.2 0
-  , lmCdf400msVar  = Cdf.Counter 0.4 0
-  , lmCdf600msVar  = Cdf.Counter 0.6 0
-  , lmCdf800msVar  = Cdf.Counter 0.8 0
-  , lmCdf1000msVar = Cdf.Counter 1.0 0
-  , lmCdf1200msVar = Cdf.Counter 1.2 0
-  , lmCdf1400msVar = Cdf.Counter 1.4 0
-  , lmCdf1600msVar = Cdf.Counter 1.6 0
-  , lmCdf1800msVar = Cdf.Counter 1.8 0
-  , lmCdf2000msVar = Cdf.Counter 2.0 0
-  , lmDelay        = 0
-  , lmTraceIt      = False
-  , lmTraceVars    = False
-  }
-
-calculateLeiosMetrics ::
-     LeiosMetrics
-  -> LoggingContext
-  -> TraceLeiosKernel
-  -> LeiosMetrics
-calculateLeiosMetrics lm@LeiosMetrics {..} _lc (TraceLeiosAnnouncementAccepted _ _ fields (Just annDelay)) =
-    case announcementElection fields of
-      MkElId slotNo@(SlotNo slotNo_) _ ->
-        if Cdf.null lmCdfState
-          then nothingToDo
-          else
-            case Cdf.processDataPoint
-                   Cdf.defaultConfig -- should come from config file
-                   (fromIntegral slotNo_, slotNo, annDelay)
-                   lmCdfState
-                   lm
-                   of
-              Nothing -> nothingToDo
-              Just (lm', lmCdfState') ->
-                lm' { lmCdfState    = lmCdfState'
-                    }
-  where
-    nothingToDo = lm {lmTraceIt = False}
-
-calculateLeiosMetrics lm _lc _ = lm
-
-instance LogFormatting LeiosMetrics where
-  forMachine _dtal _ = mempty
-  asMetrics LeiosMetrics {lmTraceIt=False} = []
-  asMetrics LeiosMetrics {..} =
-       lateAnnouncementsAllMetric
-    ++ if lmTraceVars
-        then [ cdfMetric "leios.eb.announcement.delay.cdf200ms"  lmCdf200msVar
-             , cdfMetric "leios.eb.announcement.delay.cdf400ms"  lmCdf400msVar
-             , cdfMetric "leios.eb.announcement.delay.cdf600ms"  lmCdf600msVar
-             , cdfMetric "leios.eb.announcement.delay.cdf800ms"  lmCdf800msVar
-             , cdfMetric "leios.eb.announcement.delay.cdf1000ms" lmCdf1000msVar
-             , cdfMetric "leios.eb.announcement.delay.cdf1200ms" lmCdf1200msVar
-             , cdfMetric "leios.eb.announcement.delay.cdf1400ms" lmCdf1400msVar
-             , cdfMetric "leios.eb.announcement.delay.cdf1600ms" lmCdf1600msVar
-             , cdfMetric "leios.eb.announcement.delay.cdf1800ms" lmCdf1800msVar
-             , cdfMetric "leios.eb.announcement.delay.cdf2000ms" lmCdf2000msVar
-             ]
-        else []
-    where
-      size                   = Cdf.size lmCdfState
-      cdfMetric name var     = DoubleM name (fromIntegral (Cdf.counter var) / fromIntegral size)
-      lateAnnouncementsAllMetric = [ CounterM "leios.eb.announcement.late" Nothing | lmDelay > 2 ]
-
-instance MetaTrace LeiosMetrics where
-  namespaceFor _ = Namespace [] ["LeiosMetrics"]
-  severityFor _ _ = Just Debug
-  documentFor _ = Just ""
-
-  metricsDocFor (Namespace _ ["LeiosMetrics"]) =
-      [ ("leios.eb.announcement.delay.cdf200ms", "probability for EB announcemement to complete within 200ms")
-      , ("leios.eb.announcement.delay.cdf400ms", "probability for EB announcemement to complete within 400ms")
-      , ("leios.eb.announcement.delay.cdf600ms", "probability for EB announcemement to complete within 600ms")
-      , ("leios.eb.announcement.delay.cdf800ms", "probability for EB announcemement to complete within 800ms")
-      , ("leios.eb.announcement.delay.cdf1000ms", "probability for EB announcemement to complete within 1000ms")
-      , ("leios.eb.announcement.delay.cdf1200ms", "probability for EB announcemement to complete within 1200ms")
-      , ("leios.eb.announcement.delay.cdf1400ms", "probability for EB announcemement to complete within 1400ms")
-      , ("leios.eb.announcement.delay.cdf1600ms", "probability for EB announcemement to complete within 1600ms")
-      , ("leios.eb.announcement.delay.cdf1800ms", "probability for EB announcemement to complete within 1800ms")
-      , ("leios.eb.announcement.delay.cdf2000ms", "probability for EB announcemement to complete within 2000ms")
-      , ("leios.eb.announcement.late", "number of late EB announcements that took longer than 2s")
-      ]
-  metricsDocFor _ = []
-
-  allNamespaces = [
-          Namespace [] ["LeiosMetrics"]
-        ]
-
-
-
 -- TODO Consensus defines 'Leios.LeiosSeverity' for now, but eventually
 -- 'SeverityS' will be coming from a package that Consensus can depend on, in
 -- which case this function can be removed
@@ -2435,6 +2313,7 @@ mapLeiosSeverity = \case
   Leios.LSNotice  -> Notice
   Leios.LSWarning -> Warning
   Leios.LSError   -> Error
+
 
 -- 'forMachine' delegates to 'traceLeiosKernelToObject' so the JSON shape matches
 -- the consensus-side tracer (per-constructor fields rather than a 'show' blob).


### PR DESCRIPTION
# Description

This patch introduces:

* `leios.eb.acuired.{p90,p95,p99}` percentiles
* `leios.eb.announcement.delay.{p90,p95,p99}` percentiles

The `leios.eb.announcement.delay.cdf{200,400,...,1200}ms` metrics are removed.
Having percentiles gives more preceise information.

- **Revert "CFs for EB announcements - fix"**
- **Revert "CDFs for EB announcements"**
- **LeiosBlockTxsAcquired - quantiles**
- **LeiosEbAnnouncement - quantiles**

This PR is using not yet merged IntersectMBO/ouroboros-network#5384.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
  - `cardano-node-chairman`, `cardano-submit-api` and `cardano-testnet` instead need a
    changelog fragment in `<package>/.changes/`, because their `CHANGELOG.md` is generated
    from fragments at release time.  Copy `_TEMPLATE.yml` from that directory, or run
    `nix run github:input-output-hk/cardano-dev#herald -- new`
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
