### PR TITLE
Make `nix run .#cardano-testnet` self-contained

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -232,8 +232,30 @@
           };
         });
 
+      projectExes = collectExes project;
+
+      # cardano-testnet only resolves cardano-node/cardano-cli via CARDANO_NODE/CARDANO_CLI
+      # (never PATH); wrap it so `nix run` is self-contained. --set-default lets an
+      # exported CARDANO_NODE/CARDANO_CLI in the caller's shell still win.
+      cardano-testnet-wrapped = pkgs.runCommand "cardano-testnet"
+        {
+          nativeBuildInputs = [pkgs.makeWrapper];
+          inherit (projectExes.cardano-testnet) meta;
+          passthru = {unwrapped = projectExes.cardano-testnet;};
+        }
+        ''
+          mkdir -p $out/bin
+          makeWrapper ${projectExes.cardano-testnet}/bin/cardano-testnet $out/bin/cardano-testnet \
+            --set-default CARDANO_NODE ${projectExes.cardano-node}/bin/cardano-node \
+            --set-default CARDANO_CLI ${projectExes.cardano-cli}/bin/cardano-cli
+        '';
+
       exes =
-        (collectExes project)
+        projectExes
+        // {
+          cardano-testnet = cardano-testnet-wrapped;
+          cardano-testnet-thin = projectExes.cardano-testnet;
+        }
         // {
           inherit (pkgs) checkCabalProject;
         }


### PR DESCRIPTION
# Description

`nix run github:IntersectMBO/cardano-node#cardano-testnet -- cardano ...` fails at cluster start with `Could not find plan.json in the path: dist-newstyle/cache/plan.json ... define CARDANO_CLI ...`.
cardano-testnet resolves the `cardano-node` and `cardano-cli` binaries only through the `CARDANO_NODE` and `CARDANO_CLI` environment variables, with a fallback to cabal's `plan.json`.
It never consults `PATH`, so `nix shell` with all three packages does not help either.

This PR wraps the published `cardano-testnet` executable with `makeWrapper`, baking the store paths of the sibling `cardano-node` and `cardano-cli` derivations into those two variables.
The wrapper uses `--set-default`, so variables exported in the caller's shell still win.
The cabal dev workflow and the test suites are unaffected, because they set the variables themselves.

Scope:

- Only the native `packages`, `apps` and `hydraJobs.native` entries get the wrapper.
- The bare binary stays available as `cardano-testnet-thin` (and as `passthru.unwrapped` on the wrapper).
- The musl and windows cross builds and the release bundles keep the unwrapped binary, so release tarballs do not ship a script with `/nix/store` paths.

The wrapper adds cardano-node and cardano-cli to the package closure.
That is the point of the change, but it grows the download for anyone who only wanted the orchestrator binary.

No changelog fragment: herald only tracks the package subdirectories, and this change touches only the root `flake.nix`.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
  - `cardano-node-chairman`, `cardano-submit-api` and `cardano-testnet` instead need a
    changelog fragment in `<package>/.changes/`, because their `CHANGELOG.md` is generated
    from fragments at release time.  Copy `_TEMPLATE.yml` from that directory, or run
    `nix run github:input-output-hk/cardano-dev#herald -- new`
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.

