### PR TITLE
cardano-testnet: support gRPC over HTTP (h2c) via --enable-grpc-http

### DIFF
--- a/cardano-testnet/.changes/20260909_mgalazyn_enable_grpc_http.yml
+++ b/cardano-testnet/.changes/20260909_mgalazyn_enable_grpc_http.yml
@@ -1,0 +1,5 @@
+pr: 6685
+kind:
+  - feature
+description: |
+  The `cardano-testnet cardano` command gained `--enable-grpc-http` to enable the node gRPC endpoint over HTTP without TLS (h2c), with each node listening by default on 127.0.0.1 on a random free port; the listen address can be customised with `--grpc-listen-address`, and fixed ports can be assigned with `--grpc-listen-port-base` (testnet node *i* then listens on the base port plus *i*-1); the existing `--enable-grpc` option continues to serve gRPC over a unix socket; when gRPC is enabled, each node's gRPC endpoint is printed in the startup summary.

--- a/cardano-testnet/cardano-testnet.cabal
+++ b/cardano-testnet/cardano-testnet.cabal
@@ -76,6 +76,7 @@ library
                       , hedgehog-extras ^>= 0.10
                       , http-conduit
                       , io-classes:{si-timers}
+                      , iproute
                       , lens-aeson
                       , microlens
                       , monad-control

--- a/cardano-testnet/src/Cardano/Testnet.hs
+++ b/cardano-testnet/src/Cardano/Testnet.hs
@@ -14,6 +14,7 @@ module Cardano.Testnet (
   TestnetRuntimeOptions(..),
   TestnetEnvOptions(..),
   RpcSupport(..),
+  RpcHttpOptions(..),
   TestnetNodesWithOptions(..),
   NodeWithOptions(..),
   cardanoDefaultTestnetNodesWithOptions,
@@ -49,9 +50,11 @@ module Cardano.Testnet (
   relayNodes,
 
   TestnetNode(..),
+  NodeRpcEndpoint(..),
   isTestnetNodeSpo,
   nodeSocketPath,
   nodeRpcSocketPath,
+  nodeGrpcServer,
   ) where
 
 import           Testnet.Components.Query

--- a/cardano-testnet/src/Parsers/Cardano.hs
+++ b/cardano-testnet/src/Parsers/Cardano.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Parsers.Cardano
@@ -6,20 +7,24 @@ module Parsers.Cardano
   , parseNodeSpecs
   ) where
 
-import           Cardano.Api (AnyShelleyBasedEra (..))
+import           Cardano.Api (AnyShelleyBasedEra (..), (?!))
 
 import           Cardano.CLI.EraBased.Common.Option hiding (pNetworkId)
 import           Cardano.Prelude (readMaybe)
+import           Cardano.Rpc.Server.Config (defaultRpcListenAddress)
 
 import           Prelude
 
 import           Control.Applicative (optional, (<|>))
-import           Control.Monad (unless)
+import           Control.Monad (unless, when)
+import           Data.Char (isDigit)
 import           Data.Default.Class (def)
+import           Data.IP (IP)
 import qualified Data.List as L
 import           Data.List.NonEmpty (NonEmpty ((:|)))
 import           Data.Maybe
 import           Data.Word (Word64)
+import           Network.Socket (PortNumber)
 import           Options.Applicative (CommandFields, Mod, Parser)
 import qualified Options.Applicative as OA
 import           Options.Applicative.Types (readerAsk)
@@ -99,11 +104,51 @@ pEnableNewEpochStateLogging = OA.switch
   )
 
 pEnableRpc :: Parser RpcSupport
-pEnableRpc = OA.flag RpcDisabled RpcEnabled
-  (   OA.long "enable-grpc"
-  <>  OA.help "[EXPERIMENTAL] Enable gRPC endpoint on all of testnet nodes. The listening socket file will be the same directory as node's N2C socket."
-  <>  OA.showDefault
-  )
+pEnableRpc =
+      OA.flag' RpcEnabledUnixSocket
+        (   OA.long "enable-grpc"
+        <>  OA.help "[EXPERIMENTAL] Enable gRPC endpoint on all of testnet nodes. The listening socket file will be the same directory as node's N2C socket. Listens on a unix socket."
+        )
+  <|> RpcEnabledHttp <$>
+        (   OA.flag' ()
+              (   OA.long "enable-grpc-http"
+              <>  OA.help "[EXPERIMENTAL] Enable gRPC endpoint over HTTP without TLS (h2c) on all of testnet nodes. Listens on 127.0.0.1 on a random port per node unless --grpc-listen-address/--grpc-listen-port-base are given."
+              )
+        *>  (   RpcHttpOptions
+            <$> OA.option ipReader
+                  (   OA.long "grpc-listen-address"
+                  <>  OA.metavar "IP"
+                  <>  OA.value defaultRpcListenAddress
+                  <>  OA.showDefault
+                  <>  OA.help "IP address the gRPC HTTP endpoints of all nodes listen on. Requires --enable-grpc-http."
+                  )
+            <*> OA.optional
+                  (   OA.option portReader
+                        (   OA.long "grpc-listen-port-base"
+                        <>  OA.metavar "PORT"
+                        <>  OA.help "Base port for gRPC HTTP listeners: testnet node i listens on PORT+i-1. Random free ports are used when omitted. Requires --enable-grpc-http."
+                        )
+                  )
+            )
+        )
+  <|> pure RpcDisabled
+
+-- | Parse an IP address, mirroring cardano-node's own @--grpc-listen-address@ parser
+ipReader :: OA.ReadM IP
+ipReader = OA.eitherReader $ \raw ->
+  maybe (Left $ "Failed to parse IP address: " <> raw) Right (readMaybe raw)
+
+-- | Parse a port number. Decimal digits only (rejecting the sign/hex/whitespace a plain
+-- 'Integer' read would otherwise accept) and in range before narrowing to 'PortNumber',
+-- since a derived 'Read' on 'PortNumber' silently wraps out-of-range values.
+portReader :: OA.ReadM PortNumber
+portReader = OA.eitherReader $ \token -> do
+  when (null token || not (all isDigit token)) $
+    Left $ "Not a valid port number: " <> token
+  port :: Integer <- readMaybe token ?! ("Not a valid port number: " <> token)
+  when (1 > port || port > 65_535) $
+    Left $ "Port number out of range (1 - 65535): " <> show port
+  pure $ fromIntegral port
 
 pKesSource :: Parser PraosCredentialsSource
 pKesSource = OA.flag UseKesKeyFile UseKesSocket

--- a/cardano-testnet/src/Parsers/Run.hs
+++ b/cardano-testnet/src/Parsers/Run.hs
@@ -11,9 +11,12 @@ module Parsers.Run
   , pref
   , opts
   ) where
-import           Cardano.CLI.Environment
+import           Cardano.Api (docToText, pretty)
 
-import           Control.Monad (void)
+import           Cardano.CLI.Environment
+import           Cardano.Prelude (unlessM)
+
+import           Control.Monad (forM_, void)
 import           Data.Maybe (fromMaybe)
 import           Options.Applicative
 import qualified Options.Applicative as Opt
@@ -24,13 +27,13 @@ import           System.Directory (doesDirectoryExist)
 import           Testnet.Filepath (unTmpAbsPath)
 import           Testnet.Start.Cardano
 import           Testnet.Start.Types
+import           Testnet.Types (TestnetNode (..))
 
 import           Parsers.Cardano
 import           Parsers.Help
 import           Parsers.Version
-import           RIO (display, forever, logInfo, runSimpleApp, threadDelay)
+import           RIO (display, forever, fromString, logInfo, runSimpleApp, threadDelay)
 import           UnliftIO.Resource (runResourceT)
-import           Cardano.Prelude (unlessM)
 
 pref :: ParserPrefs
 pref =
@@ -103,8 +106,9 @@ runCardanoOptions = \case
       logInfo $ "Creating environment: " <> display (tempAbsPath conf)
       createTestnetEnv noEnvCreationOptions conf
       logInfo $ "Starting testnet in environment: " <> display (tempAbsPath conf)
-      void $ cardanoTestnet (creationNodes noEnvCreationOptions) noEnvRuntimeOptions conf
+      runtime <- cardanoTestnet (creationNodes noEnvCreationOptions) noEnvRuntimeOptions conf
       logInfo "Testnet started"
+      logGrpcEndpoints runtime
       waitForShutdown
   StartFromEnv StartFromEnvOptions{fromEnvOptions, fromEnvRuntimeOptions} -> do
     -- Run cardano-testnet in the sandbox provided by the user
@@ -114,11 +118,17 @@ runCardanoOptions = \case
     nodes <- readNodesWithOptionsFromEnv (unTmpAbsPath (tempAbsPath conf))
     runSimpleApp . runResourceT $ do
       logInfo $ "Starting testnet in environment: " <> display (tempAbsPath conf)
-      void $ cardanoTestnet nodes fromEnvRuntimeOptions
+      runtime <- cardanoTestnet nodes fromEnvRuntimeOptions
                conf{updateTimestamps = envUpdateTimestamps fromEnvOptions}
       logInfo "Testnet started"
+      logGrpcEndpoints runtime
       waitForShutdown
   where
     waitForShutdown = do
       logInfo "Waiting for shutdown (Ctrl+C)"
       forever (threadDelay 100_000)
+
+    logGrpcEndpoints runtime =
+      forM_ (testnetNodes runtime) $ \TestnetNode{nodeName, nodeRpcEndpoint} ->
+        forM_ nodeRpcEndpoint $ \endpoint ->
+          logInfo $ "gRPC endpoint of " <> fromString nodeName <> ": " <> display (docToText (pretty endpoint))

--- a/cardano-testnet/src/Testnet/Ping.hs
+++ b/cardano-testnet/src/Testnet/Ping.hs
@@ -6,6 +6,9 @@ module Testnet.Ping
   , checkSprocket
   , waitForSprocket
   , waitForPortClosed
+  , checkTcpPort
+  , waitForTcpPort
+  , randomFreePort
   , TestnetMagic
   , CNP.PingClientException
   ) where
@@ -20,6 +23,7 @@ import qualified Control.Retry as R
 import           Control.Tracer (nullTracer)
 import           Data.Either
 import           Data.IORef
+import qualified Data.IP as IP
 import           Data.Word (Word32)
 import           Network.Socket (AddrInfo (..), PortNumber)
 import qualified Network.Socket as Socket
@@ -59,18 +63,7 @@ waitForSprocket :: MonadIO m
                 -> MT.DiffTime -- ^ interval
                 -> IO.Sprocket
                 -> m (Either IOException ())
-waitForSprocket timeout interval sprocket = liftIOAnnotated $ do
-  lastResult <- newIORef (Right ())
-  _ <- MT.timeout timeout $ loop lastResult
-  readIORef lastResult
-  where
-    loop lastResult = do
-      r <- checkSprocket sprocket
-      writeIORef lastResult r
-      when (isLeft r) $ do
-        -- repeat on error
-        MT.threadDelay interval
-        loop lastResult
+waitForSprocket timeout interval sprocket = waitFor timeout interval (checkSprocket sprocket)
 
 -- | Check if the sprocket can be connected to. Returns an exception thrown during the connection attempt.
 checkSprocket :: MonadIO m => IO.Sprocket -> m (Either IOException ())
@@ -81,12 +74,68 @@ checkSprocket sprocket = liftIOAnnotated $ do
     catch (Socket.connect sock addrAddress >> pure (pure ())) $ \e ->
       pure (Left e)
 
+-- | Repeat the check until it succeeds or the timeout expires; returns the last result.
+-- Seeded with a failure, not success, so a timeout that cancels the very first in-flight
+-- check (before it can write a result) is not mistaken for a successful check.
+waitFor :: MonadIO m
+        => MT.DiffTime -- ^ timeout
+        -> MT.DiffTime -- ^ interval
+        -> IO (Either IOException ())
+        -> m (Either IOException ())
+waitFor timeout interval check = liftIOAnnotated $ do
+  lastResult <- newIORef (Left $ userError "waitFor: timed out before any check completed")
+  _ <- MT.timeout timeout $ loop lastResult
+  readIORef lastResult
+  where
+    loop lastResult = do
+      r <- check
+      writeIORef lastResult r
+      when (isLeft r) $ do
+        MT.threadDelay interval
+        loop lastResult
+
 sprocketToAddrInfo :: IO.Sprocket -> AddrInfo
 sprocketToAddrInfo sprocket = do
   let socketAbsPath = IO.sprocketSystemName sprocket
   Socket.AddrInfo
     [] Socket.AF_UNIX Socket.Stream
     Socket.defaultProtocol (Socket.SockAddrUnix socketAbsPath) Nothing
+
+-- | Wait for a TCP endpoint to become ready. Periodically tries to connect to @(ip, port)@, with
+-- the provided interval. If there was no success within 'timeout' period, return the last
+-- exception thrown during a connection attempt.
+waitForTcpPort :: MonadIO m
+               => MT.DiffTime -- ^ timeout
+               -> MT.DiffTime -- ^ interval
+               -> IP.IP
+               -> PortNumber
+               -> m (Either IOException ())
+waitForTcpPort timeout interval ip port = waitFor timeout interval (checkTcpPort ip port)
+
+-- | Check if @(ip, port)@ can be connected to. Returns an exception thrown during the connection attempt.
+checkTcpPort :: MonadIO m => IP.IP -> PortNumber -> m (Either IOException ())
+checkTcpPort ip port = liftIOAnnotated $ do
+  let sockAddr = IP.toSockAddr (ip, port)
+      family = case ip of
+        IP.IPv4 _ -> Socket.AF_INET
+        IP.IPv6 _ -> Socket.AF_INET6
+  bracket (Socket.socket family Socket.Stream Socket.defaultProtocol) Socket.close $ \sock ->
+    -- Capture only synchronous exceptions from the connection attempt.
+    catch (Socket.connect sock sockAddr >> pure (pure ())) $ \e ->
+      pure (Left e)
+
+-- | Find a free port to bind on 'ip', picking the matching address family.
+-- Generalises hedgehog-extras' @randomPort@, which only binds 'AF_INET'.
+randomFreePort :: MonadIO m => IP.IP -> m PortNumber
+randomFreePort ip = liftIOAnnotated $
+  bracket (Socket.socket family Socket.Stream Socket.defaultProtocol) Socket.close $ \sock -> do
+    Socket.setSocketOption sock Socket.ReuseAddr 1
+    Socket.bind sock $ IP.toSockAddr (ip, 0)
+    Socket.socketPort sock
+  where
+    family = case ip of
+      IP.IPv4 _ -> Socket.AF_INET
+      IP.IPv6 _ -> Socket.AF_INET6
 
 -- | Wait until port gets closed.
 waitForPortClosed

--- a/cardano-testnet/src/Testnet/Property/Run.hs
+++ b/cardano-testnet/src/Testnet/Property/Run.hs
@@ -12,6 +12,7 @@ module Testnet.Property.Run
   , disabled
   ) where
 
+import           Cardano.Api (docToText, pretty)
 import           Cardano.Api.IO (unFile)
 
 import           Prelude
@@ -22,6 +23,8 @@ import           Control.Monad
 import           Control.Monad.Trans.Resource
 import           Data.Bool (bool)
 import           Data.String (IsString (..))
+import qualified Data.Text as T
+import qualified Data.Text.IO as Text
 import qualified System.Console.ANSI as ANSI
 import           System.Console.ANSI (Color (..), ColorIntensity (..), ConsoleLayer (..), SGR (..))
 import           System.Directory
@@ -34,7 +37,6 @@ import           Text.Printf (printf)
 import           Testnet.Process.RunIO
 import           Testnet.Property.Util (integration, integrationWorkspace)
 import           Testnet.Start.Types (Conf, mkConf)
-
 import           Testnet.Types (TestnetNode (..), TestnetRuntime (..), spoNodes)
 
 import           Hedgehog (Property)
@@ -93,6 +95,9 @@ runTestnet env tn = do
           ANSI.setSGR [SetColor Foreground Vivid Yellow]
           IO.putStrLn "\nFailed to find any SPO node in the testnet\n"
           ANSI.setSGR [SetColor Foreground Vivid Green]
+      forM_ (testnetNodes runtime) $ \TestnetNode{nodeName, nodeRpcEndpoint} ->
+        forM_ nodeRpcEndpoint $ \endpoint ->
+          Text.hPutStrLn IO.stdout . docToText $ pretty ("gRPC endpoint of " :: String) <> pretty (T.pack nodeName) <> pretty (": " :: String) <> pretty endpoint
       IO.putStrLn "Type CTRL-C to exit."
 
       ANSI.setSGR [Reset]

--- a/cardano-testnet/src/Testnet/Runtime.hs
+++ b/cardano-testnet/src/Testnet/Runtime.hs
@@ -225,6 +225,7 @@ startNode tp node ipv4 port _testnetMagic mNodeBin nodeCmd = GHC.withFrozenCallS
     pure $ TestnetNode
       { nodeName = node
       , poolKeys = Nothing -- they're set in the function caller, if present
+      , nodeRpcEndpoint = Nothing -- set by the caller when RPC is enabled
       , nodeIpv4 = ipv4
       , nodePort = port
       , nodeSprocket = sprocket

--- a/cardano-testnet/src/Testnet/Start/Cardano.hs
+++ b/cardano-testnet/src/Testnet/Start/Cardano.hs
@@ -51,7 +51,7 @@ import           Prelude hiding (lines)
 
 import           Control.Concurrent (myThreadId, threadDelay)
 import           Control.Exception (IOException)
-import           Control.Monad (forM, forM_, guard, unless, when)
+import           Control.Monad (forM, forM_, guard, replicateM, unless, when)
 import           Control.Monad.Catch
 import           Control.Monad.Trans.Maybe (runMaybeT)
 import           Control.Monad.Trans.Resource (MonadResource, getInternalState)
@@ -61,16 +61,19 @@ import qualified Data.ByteString.Lazy as LBS
 import           Data.Default.Class ()
 import           Data.Either
 import           Data.Functor
+import           Data.IP (IP)
 import           Data.List (sort, stripPrefix)
 import qualified Data.List.NonEmpty as NEL
 import qualified Data.Map as Map
 import           Data.Maybe (mapMaybe)
 import           Data.MonoTraversable (Element, MonoFunctor, omap)
+import qualified Data.Set as Set
 import qualified Data.Text as Text
 import           Data.Time (diffUTCTime)
 import           Data.Time.Clock (NominalDiffTime)
 import qualified Data.Time.Clock as DTC
 import qualified Data.Yaml as Yaml
+import           GHC.Exts (fromList)
 import           GHC.Stack
 import qualified System.Directory as IO
 import           System.FilePath ((</>))
@@ -81,6 +84,7 @@ import           Testnet.Components.Configuration
 import qualified Testnet.Defaults as Defaults
 import           Testnet.Filepath
 import           Testnet.Orphans ()
+import qualified Testnet.Ping as Ping
 import           Testnet.Process.RunIO (execCli', execCli_, liftIOAnnotated, mkExecConfig)
 import           Testnet.Property.Assert (assertExpectedSposInLedgerState)
 import           Testnet.Runtime as TR
@@ -326,6 +330,21 @@ cardanoTestnet
 
   let portNumbersMap = Map.fromList portNumbers
 
+  rpcPortsMap <- case cardanoEnableRpc of
+    RpcEnabledHttp RpcHttpOptions{rpcHttpListenPortBase = Just base}
+      -- Compute in Integer and narrow only after the check: PortNumber's Num is Word16 and
+      -- silently wraps, so 'base + numNodes - 1' could otherwise overflow undetected.
+      | lastPort > 65_535 ->
+          throwString $ "gRPC port base " <> show base <> " plus " <> show numNodes <> " testnet node(s) would exceed the maximum port number (65535)"
+      | otherwise -> pure . fromList . zip [1..] $ [base .. fromIntegral lastPort]
+      where
+        numNodes = length allNodes
+        lastPort = toInteger base + toInteger numNodes - 1
+    RpcEnabledHttp RpcHttpOptions{rpcHttpListenPortBase = Nothing, rpcHttpListenAddress} -> do
+      ports <- pickDistinctRandomPorts (fromList $ Map.elems portNumbersMap) rpcHttpListenAddress (length allNodes)
+      pure . fromList $ zip [1..] ports
+    _ -> pure Map.empty
+
   eTestnetNodes <- forConcurrently (zip [1..] allNodes) $ \(i, (isSpo, nodeWithOptions)) -> do
     port <- case Map.lookup i portNumbersMap of
       Just p -> pure p
@@ -366,6 +385,17 @@ cardanoTestnet
           keys@SpoNodeKeys{poolNodeKeysVrf} = mkTestnetNodeKeyPaths i
       pure (Just keys, kesSourceCliArg <> shelleyCliArgs <> byronCliArgs)
 
+    (mRpcHttpEndpoint, grpcArgs) <- case cardanoEnableRpc of
+      RpcDisabled -> pure (Nothing, [])
+      RpcEnabledUnixSocket -> pure (Nothing, ["--grpc-enable"])
+      RpcEnabledHttp RpcHttpOptions{rpcHttpListenAddress} -> do
+        rpcPort <- maybe (throwString $ "gRPC port not found for node " <> show i) pure $ Map.lookup i rpcPortsMap
+        let endpoint = NodeRpcHttp rpcHttpListenAddress rpcPort
+        pure
+          ( Just endpoint
+          , ["--grpc-enable", "--grpc-listen-address", show rpcHttpListenAddress, "--grpc-listen-port", show rpcPort]
+          )
+
     eRuntime <- runExceptT . retryOnAddressInUseError $
       startNode (TmpAbsolutePath tmpAbsPath) nodeName testnetDefaultIpv4Address port testnetMagic (nodeBin nodeWithOptions) $
         [ "run"
@@ -375,8 +405,30 @@ cardanoTestnet
         ]
         <> spoNodeCliArgs
         <> nodeExtraCliArgs nodeWithOptions
-        <> ["--grpc-enable" | RpcEnabled <- [cardanoEnableRpc]]
-    pure $ eRuntime <&> \rt -> rt{poolKeys=mKeys}
+        <> grpcArgs
+
+    -- cardano-node swallows a gRPC HTTP bind failure silently (no stderr, exit 0), so a
+    -- successfully-started node can still have a dead endpoint; probe it before trusting it.
+    when (isRight eRuntime) $
+      forM_ mRpcHttpEndpoint $ \case
+        NodeRpcUnixSocket{} -> pure () -- readiness covered by the sprocket wait
+        NodeRpcHttp ip rpcHttpPort ->
+          Ping.waitForTcpPort 120 0.2 ip rpcHttpPort >>=
+            either
+              (const . throwString $ mconcat
+                [ "gRPC HTTP endpoint of ", nodeName
+                , " did not come up on ", show ip, ":", show rpcHttpPort
+                , " - port collision?"
+                ])
+              pure
+
+    pure $ eRuntime <&> \rt -> rt
+      { poolKeys = mKeys
+      , nodeRpcEndpoint = case cardanoEnableRpc of
+          RpcDisabled -> Nothing
+          RpcEnabledUnixSocket -> Just . NodeRpcUnixSocket $ nodeRpcSocketPath rt
+          RpcEnabledHttp _ -> mRpcHttpEndpoint
+      }
 
   let (failedNodes, startedNodes) = partitionEithers eTestnetNodes
   unless (null failedNodes) $ do
@@ -504,6 +556,27 @@ idToRemoteAddressP2P portNumbersMap (NodeId i) = case Map.lookup i portNumbersMa
       port
   Nothing -> do
     throwString $ "Found node id that was unaccounted for: " ++ show i
+
+-- | Draw 'count' free ports on 'address', retrying the whole batch until distinct from each
+-- other and from 'reserved' - closed sockets return their port to the pool, so redraws can clash.
+pickDistinctRandomPorts :: ()
+  => MonadIO m
+  => HasCallStack
+  => Set.Set PortNumber -- ^ ports that must not be reused
+  -> IP
+  -> Int -- ^ how many distinct ports to draw
+  -> m [PortNumber]
+pickDistinctRandomPorts reserved address count = go (100 :: Int)
+  where
+    go attemptsLeft
+      | attemptsLeft <= 0 =
+          throwString $ "Could not find " <> show count <> " distinct free gRPC ports on " <> show address <> " after 100 attempts"
+      | otherwise = do
+          ports <- replicateM count (Ping.randomFreePort address)
+          let portsSet = fromList ports
+          if Set.size portsSet == count && Set.disjoint portsSet reserved
+            then pure ports
+            else go (attemptsLeft - 1)
 
 -- | A convenience wrapper around `createTestnetEnv` and `cardanoTestnet`
 createAndRunTestnet :: ()

--- a/cardano-testnet/src/Testnet/Start/Types.hs
+++ b/cardano-testnet/src/Testnet/Start/Types.hs
@@ -20,6 +20,7 @@ module Testnet.Start.Types
   , NumPools(..)
   , NumRelays(..)
   , RpcSupport(..)
+  , RpcHttpOptions(..)
   , creationNumPools
   , creationNumRelays
 
@@ -52,6 +53,7 @@ import           Cardano.Api hiding (cardanoEra)
 
 import           Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis)
 import           Cardano.Ledger.Conway.Genesis (ConwayGenesis)
+import           Cardano.Rpc.Server.Config (defaultRpcListenAddress)
 
 import           Prelude
 
@@ -61,12 +63,14 @@ import qualified Data.Aeson as Aeson
 import           Data.Aeson.Types (parseFail)
 import           Data.Char (toLower)
 import           Data.Default.Class
+import           Data.IP (IP)
 import           Data.List.NonEmpty (NonEmpty ((:|)))
 import qualified Data.List.NonEmpty as NEL
 import qualified Data.Text as Text
 import           Data.Word
 import           GHC.Stack
 import qualified Network.HTTP.Simple as HTTP
+import           Network.Socket (PortNumber)
 import           System.Directory (createDirectory, doesDirectoryExist, makeAbsolute)
 import           System.FilePath (addTrailingPathSeparator)
 
@@ -167,9 +171,19 @@ data CardanoTestnetCreateEnvOptions = CardanoTestnetCreateEnvOptions
   } deriving (Eq, Show)
 
 data RpcSupport
-  = RpcDisabled
-  | RpcEnabled
+  = RpcDisabled -- ^ No gRPC endpoint
+  | RpcEnabledUnixSocket -- ^ gRPC over the node's default unix socket (@rpc.sock@)
+  | RpcEnabledHttp RpcHttpOptions -- ^ gRPC over HTTP\/2 without TLS (h2c)
   deriving (Eq, Show)
+
+-- | Listener options for the gRPC HTTP (h2c) endpoints
+data RpcHttpOptions = RpcHttpOptions
+  { rpcHttpListenAddress :: IP
+  , rpcHttpListenPortBase :: Maybe PortNumber -- ^ node i listens on base+i-1; random free ports when Nothing
+  } deriving (Eq, Show)
+
+instance Default RpcHttpOptions where
+  def = RpcHttpOptions defaultRpcListenAddress Nothing
 
 -- | Options for creating a testnet environment (genesis files, topology, ports).
 -- Used by both the @cardano@ and @create-env@ subcommands, and by

--- a/cardano-testnet/src/Testnet/Types.hs
+++ b/cardano-testnet/src/Testnet/Types.hs
@@ -20,8 +20,10 @@ module Testnet.Types
   , relayNodes
   , testnetSprockets
   , TestnetNode(..)
+  , NodeRpcEndpoint(..)
   , nodeSocketPath
   , nodeRpcSocketPath
+  , nodeGrpcServer
   , nodeConnectionInfo
   , testnetNodeConnectionInfo
   , isTestnetNodeSpo
@@ -55,12 +57,15 @@ import           Cardano.Crypto.ProtocolMagic (RequiresNetworkMagic (..))
 import           Cardano.Node.Configuration.POM
 import qualified Cardano.Node.Protocol.Byron as Byron
 import           Cardano.Node.Types
+import qualified Cardano.Rpc.Client as Rpc
 import           Cardano.Rpc.Server.Config (nodeSocketPathToRpcSocketPath)
 
 import           Prelude
 
 import           Control.Monad
 import qualified Data.Aeson as A
+import           Data.Functor ((<&>))
+import           Data.IP (IP (..))
 import           Data.List (intercalate)
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NEL
@@ -139,6 +144,7 @@ relayNodes = NEL.filter (not . isTestnetNodeSpo) . testnetNodes
 data TestnetNode = TestnetNode
   { nodeName :: !String
   , poolKeys :: Maybe SpoNodeKeys -- ^ Keys are only present for SPO nodes
+  , nodeRpcEndpoint :: Maybe NodeRpcEndpoint -- ^ Nothing when RPC is disabled
   , nodeIpv4 :: !HostAddress
   , nodePort :: !PortNumber
   , nodeSprocket :: !Sprocket
@@ -147,6 +153,22 @@ data TestnetNode = TestnetNode
   , nodeStderr :: !FilePath
   , nodeProcessHandle :: !IO.ProcessHandle
   }
+
+-- | Where a testnet node's gRPC server listens
+data NodeRpcEndpoint
+  = NodeRpcUnixSocket SocketPath
+  | NodeRpcHttp IP PortNumber
+  deriving (Eq, Show)
+
+instance Pretty NodeRpcEndpoint where
+  pretty = \case
+    NodeRpcUnixSocket socketPath -> pretty ("unix socket " :: String) <> pretty (unFile socketPath)
+    NodeRpcHttp ip port ->
+      -- A URL needs brackets around an IPv6 host; grapesy's bracket-less 'show' is used for binding instead.
+      let host = case ip of
+            IPv4 _ -> pshow ip
+            IPv6 _ -> pretty ("[" :: String) <> pshow ip <> pretty ("]" :: String)
+      in pretty ("http://" :: String) <> host <> pretty (":" :: String) <> pshow port
 
 data TestnetKesAgent = TestnetKesAgent
   { kesAgentName :: !String
@@ -168,6 +190,21 @@ nodeSocketPath = File . H.sprocketSystemName . nodeSprocket
 -- | Provide a default RPC socket path
 nodeRpcSocketPath :: TestnetNode -> SocketPath
 nodeRpcSocketPath = nodeSocketPathToRpcSocketPath . nodeSocketPath
+
+-- | gRPC client connection target of the node, when RPC is enabled
+nodeGrpcServer :: TestnetNode -> Maybe Rpc.Server
+nodeGrpcServer node = nodeRpcEndpoint node <&> \case
+  NodeRpcUnixSocket socketPath -> Rpc.ServerUnix $ unFile socketPath
+  NodeRpcHttp ip port ->
+    Rpc.ServerInsecure Rpc.Address
+      { Rpc.addressHost = show ip
+      , Rpc.addressPort = port
+      -- grapesy falls back to bare 'addressHost' for the HTTP/2 ':authority' when this is
+      -- Nothing, but RFC 3986 requires an IPv6 literal to be bracketed in that position.
+      , Rpc.addressAuthority = case ip of
+          IPv4 _ -> Nothing
+          IPv6 _ -> Just $ "[" <> show ip <> "]"
+      }
 
 -- | Connection data for a node in the testnet
 nodeConnectionInfo :: MonadTest m

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help.cli
@@ -13,7 +13,9 @@ Usage: cardano-testnet cardano
     [--output-dir DIRECTORY]
   ]
   [--enable-new-epoch-state-logging]
-  [--enable-grpc]
+  [ --enable-grpc
+  | --enable-grpc-http [--grpc-listen-address IP] [--grpc-listen-port-base PORT]
+  ]
   [--use-kes-agent]
   [--disable-chain-stall-watchdog]
   

--- a/cardano-testnet/test/cardano-testnet-golden/files/golden/help/cardano.cli
+++ b/cardano-testnet/test/cardano-testnet-golden/files/golden/help/cardano.cli
@@ -11,7 +11,9 @@ Usage: cardano-testnet cardano
     [--output-dir DIRECTORY]
   ]
   [--enable-new-epoch-state-logging]
-  [--enable-grpc]
+  [ --enable-grpc
+  | --enable-grpc-http [--grpc-listen-address IP] [--grpc-listen-port-base PORT]
+  ]
   [--use-kes-agent]
   [--disable-chain-stall-watchdog]
   
@@ -60,7 +62,20 @@ Available options:
                            logs/ledger-epoch-state.log
   --enable-grpc            [EXPERIMENTAL] Enable gRPC endpoint on all of testnet
                            nodes. The listening socket file will be the same
-                           directory as node's N2C socket.
+                           directory as node's N2C socket. Listens on a unix
+                           socket.
+  --enable-grpc-http       [EXPERIMENTAL] Enable gRPC endpoint over HTTP without
+                           TLS (h2c) on all of testnet nodes. Listens on
+                           127.0.0.1 on a random port per node unless
+                           --grpc-listen-address/--grpc-listen-port-base are
+                           given.
+  --grpc-listen-address IP IP address the gRPC HTTP endpoints of all nodes
+                           listen on. Requires --enable-grpc-http.
+                           (default: 127.0.0.1)
+  --grpc-listen-port-base PORT
+                           Base port for gRPC HTTP listeners: testnet node i
+                           listens on PORT+i-1. Random free ports are used when
+                           omitted. Requires --enable-grpc-http.
   --use-kes-agent          Get Praos block forging credentials from kes-agent
                            via the default socket path
   --disable-chain-stall-watchdog

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/Eval.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/Eval.hs
@@ -65,7 +65,7 @@ hprop_rpc_eval_tx = integrationRetryWorkspace 2 "rpc-eval-tx" $ \tempAbsBasePath
       sbe = convert era
       anyEra = AnyCardanoEra $ toCardanoEra sbe
       creationOptions = def{creationEra = AnyShelleyBasedEra sbe}
-      runtimeOptions = def{runtimeEnableRpc = RpcEnabled}
+      runtimeOptions = def{runtimeEnableRpc = RpcEnabledUnixSocket}
 
   TestnetRuntime
     { configurationFile

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/FetchBlock.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/FetchBlock.hs
@@ -65,7 +65,7 @@ hprop_rpc_fetch_block = integrationRetryWorkspace 2 "rpc-fetch-block" $ \tempAbs
       sbe = convert era
       eraName = eraToString sbe
       creationOptions = def{creationEra = AnyShelleyBasedEra sbe}
-      runtimeOptions = def{runtimeEnableRpc = RpcEnabled}
+      runtimeOptions = def{runtimeEnableRpc = RpcEnabledUnixSocket}
 
   tr@TestnetRuntime
     { configurationFile

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/FollowTip.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/FollowTip.hs
@@ -49,7 +49,7 @@ hprop_rpc_follow_tip = integrationRetryWorkspace 2 "rpc-follow-tip" $ \tempAbsBa
   let era = Exp.ConwayEra
       sbe = convert era
       creationOptions = def{creationEra = AnyShelleyBasedEra sbe}
-      runtimeOptions = def{runtimeEnableRpc = RpcEnabled}
+      runtimeOptions = def{runtimeEnableRpc = RpcEnabledUnixSocket}
 
   TestnetRuntime
     { testnetNodes = node0 :| _

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/Genesis.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/Genesis.hs
@@ -51,7 +51,7 @@ hprop_rpc_read_genesis = integrationRetryWorkspace 2 "rpc-read-genesis" $ \tempA
   let era = Exp.ConwayEra
       sbe = convert era
       creationOptions = def{creationEra = AnyShelleyBasedEra sbe}
-      runtimeOptions = def{runtimeEnableRpc = RpcEnabled}
+      runtimeOptions = def{runtimeEnableRpc = RpcEnabledHttp def}
 
   TestnetRuntime
     { shelleyGenesisFile
@@ -60,8 +60,7 @@ hprop_rpc_read_genesis = integrationRetryWorkspace 2 "rpc-read-genesis" $ \tempA
     } <-
     createAndRunTestnet creationOptions runtimeOptions conf
 
-  rpcSocket <- H.note . unFile $ nodeRpcSocketPath node0
-  let rpcServer = Rpc.ServerUnix rpcSocket
+  rpcServer <- H.noteShow =<< H.nothingFail (nodeGrpcServer node0)
 
   originalGenesisBytes <- H.evalIO $ BS.readFile shelleyGenesisFile
 

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/Query.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/Query.hs
@@ -61,7 +61,7 @@ hprop_rpc_query_pparams = integrationRetryWorkspace 2 "rpc-query-pparams" $ \tem
       sbe = convert era
       eraName = eraToString sbe
       creationOptions = def{creationEra = AnyShelleyBasedEra sbe}
-      runtimeOptions = def{runtimeEnableRpc = RpcEnabled}
+      runtimeOptions = def{runtimeEnableRpc = RpcEnabledUnixSocket}
 
   tr@TestnetRuntime
     { testnetMagic

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/SearchUtxos.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/SearchUtxos.hs
@@ -60,7 +60,7 @@ hprop_rpc_search_utxos = integrationRetryWorkspace 2 "rpc-search-utxos" $ \tempA
   let era = Exp.ConwayEra
       sbe = convert era
       creationOptions = def{creationEra = AnyShelleyBasedEra sbe}
-      runtimeOptions = def{runtimeEnableRpc = RpcEnabled}
+      runtimeOptions = def{runtimeEnableRpc = RpcEnabledUnixSocket}
       addressInEra = asAddressInEra sbe
 
   TestnetRuntime

--- a/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/Transaction.hs
+++ b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Rpc/Transaction.hs
@@ -49,7 +49,7 @@ hprop_rpc_transaction = integrationRetryWorkspace 2 "rpc-tx" $ \tempAbsBasePath'
   let era = Exp.ConwayEra
       sbe = convert era
       creationOptions = def{creationEra = AnyShelleyBasedEra sbe}
-      runtimeOptions = def{runtimeEnableRpc = RpcEnabled}
+      runtimeOptions = def{runtimeEnableRpc = RpcEnabledUnixSocket}
       addressInEra = asAddressInEra sbe
 
   TestnetRuntime


### PR DESCRIPTION
## Description

`cardano-testnet cardano` can now serve the node gRPC endpoint over raw HTTP/2 without TLS (h2c), next to the existing unix socket toggle. When gRPC is enabled, every node's endpoint is printed in the startup log.

```
cardano-testnet cardano
│
├── (no gRPC flag)                       gRPC disabled (default)
│
├── --enable-grpc                        gRPC over a unix socket
│                                        (rpc.sock next to each node's N2C socket)
│
└── --enable-grpc-http                   gRPC over HTTP/2 without TLS (h2c)
    │                                    default: 127.0.0.1, random free port per node
    │
    ├── --grpc-listen-address IP         listen IP for all nodes, IPv4 or IPv6
    │                                    optional, default 127.0.0.1
    │
    └── --grpc-listen-port-base PORT     base port: node i listens on PORT+i-1
                                         e.g. 7301 gives 7301,7302,7303 for the
                                         default 3 nodes
                                         optional, random free ports when omitted
```

Parser rules:
- `--enable-grpc` and `--enable-grpc-http` are mutually exclusive (parse error when both are given).
- `--grpc-listen-address` and `--grpc-listen-port-base` require `--enable-grpc-http` (`Missing: --enable-grpc-http` otherwise).
- The base port must be a plain decimal in the range 1-65535; hex and out-of-range values are rejected at parse time.
- A base port whose derived range would exceed port 65535 for the node count aborts startup before any node spawns.

Runtime behaviour:
- Startup logs one line per node, e.g. `gRPC endpoint of node1: http://127.0.0.1:7301` (IPv6 hosts are bracketed), or `gRPC endpoint of node1: unix socket <path>` with `--enable-grpc`.
- Fixed ports are derived from the base, so duplicate ports are impossible by construction. Random ports are drawn up front on the configured listen address and deduplicated against each other and the nodes' P2P ports.
- cardano-node swallows a gRPC HTTP bind failure silently (its RPC server async is not linked), so cardano-testnet probes each HTTP endpoint after node start and fails loudly on timeout instead of handing tests a dead endpoint.
- IPv6 listen addresses are supported end to end: the parser accepts bare IPv6 literals, the node binds the right address family, and the client side brackets the host both in the logged URL and in the HTTP/2 `:authority` header.
- `TestnetNode` now carries the node's gRPC endpoint (`nodeRpcEndpoint`), and `nodeGrpcServer` (exported from `Cardano.Testnet`) maps it to a grapesy client `Server` for tests. The `RPC ReadGenesis` E2E now runs over h2c; the remaining RPC tests keep covering the unix socket path.

Testing:
- Golden help files regenerated; the full `cardano-testnet-golden` suite is green.
- `RPC ReadGenesis` (h2c, random-port path) and `RPC FollowTip` (unix socket) pass with retries disabled.
- The `--grpc-listen-port-base` path and IPv6 listen addresses are covered by parse-time and startup validation plus source-level verification; no automated test drives them end to end yet.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
  - `cardano-node-chairman`, `cardano-submit-api` and `cardano-testnet` instead need a
    changelog fragment in `<package>/.changes/`, because their `CHANGELOG.md` is generated
    from fragments at release time.  Copy `_TEMPLATE.yml` from that directory, or run
    `nix run github:input-output-hk/cardano-dev#herald -- new`
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-9.6` and `ghc-9.12`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
